### PR TITLE
Rename "Zudoku Demo" to "Demo"

### DIFF
--- a/packages/zudoku/src/app/demo.tsx
+++ b/packages/zudoku/src/app/demo.tsx
@@ -33,7 +33,7 @@ if (!root) {
 
 const config = {
   page: {
-    pageTitle: "Zudoku Demo",
+    pageTitle: "Demo",
   },
   topNavigation: [
     {


### PR DESCRIPTION
The logo now has the Zudoku text in it