### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,41 +2,26 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "main",
   "targetDefaults": {
-    "dev": {
-      "dependsOn": ["zudoku:build"]
-    },
+    "dev": { "dependsOn": ["zudoku:build"] },
     "build": {
       "dependsOn": ["zudoku:build"],
       "outputs": ["{projectRoot}/dist"],
       "cache": false
     },
-    "clean": {
-      "dependsOn": ["^clean"],
-      "cache": false
-    },
-    "test": {
-      "dependsOn": ["build"]
-    }
+    "clean": { "dependsOn": ["^clean"], "cache": false },
+    "test": { "dependsOn": ["build"] }
   },
   "plugins": [
     {
       "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "eslint:lint"
-      }
+      "options": { "targetName": "eslint:lint" }
     }
   ],
   "release": {
     "projects": ["zudoku", "create-zudoku-app"],
     "releaseTagPattern": "v{version}",
-    "git": {
-      "commitMessage": "chore(release): publish {version} [skip ci]"
-    },
-    "version": {
-      "generatorOptions": {
-        "preid": "dev"
-      }
-    },
+    "git": { "commitMessage": "chore(release): publish {version} [skip ci]" },
+    "version": { "generatorOptions": { "preid": "dev" } },
     "changelog": {
       "projectChangelogs": false,
       "workspaceChangelog": {
@@ -49,5 +34,6 @@
         }
       }
     }
-  }
+  },
+  "nxCloudAccessToken": "MDhhNTdkMDMtOGE1MC00YzkxLTkwN2MtMzk0ZGRmOWFkYTBlfHJlYWQtd3JpdGU="
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/6672126066e0dce53cba9297/workspaces/66c785a803393268ce035946

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.