### PR TITLE
Set `NODE_ENV` in development mode for developer hints

### DIFF
--- a/packages/zudoku/src/cli/dev/handler.ts
+++ b/packages/zudoku/src/cli/dev/handler.ts
@@ -10,6 +10,7 @@ export interface Arguments {
 }
 
 export async function dev(argv: Arguments) {
+  process.env.NODE_ENV = "development";
   const host = "localhost";
   let port = argv.port;
   if (!port) {

--- a/packages/zudoku/src/lib/components/DeveloperHint.tsx
+++ b/packages/zudoku/src/lib/components/DeveloperHint.tsx
@@ -8,9 +8,7 @@ export const DeveloperHint = ({
   children: ReactNode;
   className?: string;
 }) => {
-  // TODO: figure out a way to do that in consumer dev mode not "internal"
-  //  so this doesn't get stripped out in the build
-  if (!import.meta.env.DEV) return;
+  if (process.env.NODE_ENV !== "development") return;
 
   return (
     <Callout type="caution" title="Developer hint" className={className}>


### PR DESCRIPTION
Just use good old `process.env`.

ZUP-3449