### PR TITLE
Fix `code` tag growing layout

### DIFF
--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -96,7 +96,7 @@
   }
 
   #root {
-    @apply min-h-screen grid grid-rows-[var(--header-height)_1fr] w-full;
+    @apply min-h-screen w-full;
   }
   * {
     @apply border-border;

--- a/packages/zudoku/src/lib/util/MdxComponents.tsx
+++ b/packages/zudoku/src/lib/util/MdxComponents.tsx
@@ -77,8 +77,8 @@ export const MdxComponents = {
 
     return (
       <SyntaxHighlight
-        language={match?.[1] ?? "markup"}
-        className="rounded-xl overflow-x-auto p-4 border dark:!bg-foreground/10 dark:border-transparent"
+        language={match?.[1]}
+        className="rounded-xl p-4 border dark:!bg-foreground/10 dark:border-transparent"
         showLanguageIndicator
         code={String(children).trim()}
       />


### PR DESCRIPTION
The `grid` is a leftover when the header still was `position: fixed` and can be removed. For some reason, this made the `code` tags in MDX grow uncontrollably