### PR TITLE
Use vite server error on build errors

### DIFF
--- a/packages/zudoku/src/vite/error-handler.ts
+++ b/packages/zudoku/src/vite/error-handler.ts
@@ -1,0 +1,44 @@
+import { NextFunction, Request, Response } from "express";
+import path from "node:path";
+import { ViteDevServer } from "vite";
+
+export const errorMiddleware =
+  (server: ViteDevServer) =>
+  (err: Error, req: Request, res: Response, next: NextFunction) => {
+    server.ssrFixStacktrace(err);
+    const error = {
+      message: err.message,
+      stack: err.stack,
+    };
+
+    res.statusCode = 500;
+    res.end(`
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="UTF-8" />
+            <title>Error</title>
+            <script type="module">
+              const error = ${JSON.stringify(error).replace(/</g, "\\u003c")}
+              try {
+                const { ErrorOverlay } = await import(${JSON.stringify(path.posix.join(server.config.base, "/@vite/client"))})
+                document.body.appendChild(new ErrorOverlay(error))
+              } catch (err) {
+               console.log(err)
+                const h = (tag, text) => {
+                  const el = document.createElement(tag)
+                  el.textContent = text
+                  return el
+                }
+                document.body.appendChild(h('h1', 'Internal Server Error'))
+                document.body.appendChild(h('h2', error.message))
+                document.body.appendChild(h('pre', error.stack))
+                document.body.appendChild(h('p', '(Error overlay failed to load)'))
+              }
+            </script>
+          </head>
+          <body>
+          </body>
+        </html>
+      `);
+  };


### PR DESCRIPTION
I didnt like our single line server error page so this is a quick change to render server build errors using Vite's error overlay. Instead of the single line of text in the browser you now get this

![image](https://github.com/user-attachments/assets/41cd19ef-92e5-4e23-961c-653835a6e77e)
