### PR TITLE
Add icons to sidebar

### DIFF
--- a/docs/pages/docs/api-keys.md
+++ b/docs/pages/docs/api-keys.md
@@ -1,6 +1,7 @@
 ---
 title: API Keys
 description: Learn how to use the API Keys feature to let your users create and manage API keys for your API.
+sidebar_icon: file-key-2
 ---
 
 :::caution{title="Work in Progress"}

--- a/docs/pages/docs/app-quickstart.md
+++ b/docs/pages/docs/app-quickstart.md
@@ -1,6 +1,7 @@
 ---
 title: App Quickstart
 description: Get started with Zudoku by creating a new Zudoku app using the `create-zudoku-app` tool.
+sidebar_icon: app-window-mac
 ---
 
 The recommended way to get started with Zudoku is to use the `create-zudoku-app` CLI tool. This tool will scaffold a new Zudoku site for you to customize and build upon.

--- a/docs/pages/docs/configuration/api-reference.md
+++ b/docs/pages/docs/configuration/api-reference.md
@@ -1,5 +1,6 @@
 ---
 title: API Reference
+sidebar_icon: square-library
 ---
 
 The `apis` configuration setting in the [Zudoku Configuration](/docs/configuration/overview) file allows you to specify the OpenAPI document that you want to use to generate your API reference documentation.

--- a/docs/pages/docs/configuration/authentication.md
+++ b/docs/pages/docs/configuration/authentication.md
@@ -1,5 +1,6 @@
 ---
 title: Authentication
+sidebar_icon: key
 ---
 
 If you use a managed authentication service, such as Auth0, Clerk or OpenID you can implement this into your site and allow users to browse and interact with your documentation and API reference in a logged in state.

--- a/docs/pages/docs/configuration/navigation.md
+++ b/docs/pages/docs/configuration/navigation.md
@@ -1,5 +1,6 @@
 ---
 title: Navigation
+sidebar_icon: compass
 ---
 
 Navigation in Zudoku can be customized at several layers. The primary is the top navigation tabs. Tabs can reference pages, plugins, or external links. The secondary is the sidebar navigation. The sidebar can be customized to show additional links or content.

--- a/docs/pages/docs/configuration/search.md
+++ b/docs/pages/docs/configuration/search.md
@@ -1,5 +1,6 @@
 ---
 title: Search
+sidebar_icon: search-code
 ---
 
 It is possible to add search to a Zudoku powered site. It will appear in the top navigation and persist across all pages.

--- a/docs/pages/docs/custom-pages.md
+++ b/docs/pages/docs/custom-pages.md
@@ -1,5 +1,6 @@
 ---
 title: Custom pages
+sidebar_icon: layers-3
 ---
 
 If you want to include pages in your documentation that have greater flexibility than MDX pages, it is possible to include custom pages of your own.

--- a/docs/pages/docs/custom-plugins.md
+++ b/docs/pages/docs/custom-plugins.md
@@ -1,5 +1,6 @@
 ---
 title: Custom Plugins
+sidebar_icon: list-end
 ---
 
 Zudoku is highly extensible. You can create custom plugins to add new functionality to your documentation site.

--- a/docs/pages/docs/environment-variables.md
+++ b/docs/pages/docs/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 title: Environment Variables
+sidebar_icon: table
 ---
 
 Zudoku is built on top of Vite and uses [their approach](https://vitejs.dev/guide/env-and-mode) for managing environment variables.

--- a/docs/pages/docs/html-quickstart.md
+++ b/docs/pages/docs/html-quickstart.md
@@ -1,6 +1,7 @@
 ---
 title: HTML Quickstart
 description: Create beautiful API documentation for your OpenAPI file with Zudoku using a single HTML page in seconds.
+sidebar_icon: chevrons-left-right
 ---
 
 This quickstart will walk you through using the standalone HTML version of Zudodu to create beautiful API documentation for your OpenAPI file in seconds. No special tools, setup, or installation required. Just a single HTML page.

--- a/docs/pages/docs/introduction.md
+++ b/docs/pages/docs/introduction.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: Zudoku (pronounced "zoo-doh-koo") is an open-source, highly customizable API documentation framework for building quality developer experiences using MDX and OpenAPI.
+sidebar_icon: book-check
 ---
 
 Zudoku (pronounced "zoo-doh-koo") is an open-source, highly customizable API documentation framework for building quality developer experiences using MDX and OpenAPI.

--- a/docs/pages/docs/markdown/admonitions.md
+++ b/docs/pages/docs/markdown/admonitions.md
@@ -1,5 +1,6 @@
 ---
 title: Admonitions
+sidebar_icon: rectangle-horizontal
 ---
 
 In addition to the basic Markdown syntax, we have a special admonitions syntax by wrapping text with a set of 3 colons, followed by a label denoting its type.

--- a/docs/pages/docs/markdown/code-blocks.md
+++ b/docs/pages/docs/markdown/code-blocks.md
@@ -1,5 +1,6 @@
 ---
 title: Code Blocks
+sidebar_icon: braces
 ---
 
 Zudoku supports code blocks in Markdown using the [Prism.js](https://prismjs.com/) syntax highlighting library.

--- a/docs/pages/docs/markdown/mdx.md
+++ b/docs/pages/docs/markdown/mdx.md
@@ -1,5 +1,6 @@
 ---
 title: MDX
+sidebar_icon: notebook-pen
 ---
 
 Zudoku support MDX files for creating rich content pages. MDX is a markdown format that allows you to include JSX components in your markdown files.

--- a/docs/pages/docs/using-multiple-apis.md
+++ b/docs/pages/docs/using-multiple-apis.md
@@ -1,5 +1,6 @@
 ---
 title: Multiple APIs
+sidebar_icon: file-stack
 ---
 
 Zudoku supports creating documentation and API references for multiple APIs and can work with as many OpenAPI documents as you need.

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -31,11 +31,13 @@ const config: ZudokuConfig = {
       {
         type: "category",
         label: "Getting started",
+        icon: "sparkles",
         items: ["introduction", "app-quickstart", "html-quickstart"],
       },
       {
         type: "category",
         label: "Configuration",
+        icon: "cog",
         link: "configuration/overview",
         items: [
           "configuration/api-reference",
@@ -48,17 +50,20 @@ const config: ZudokuConfig = {
       {
         type: "category",
         label: "Markdown",
+        icon: "book-open-text",
         link: "markdown/overview",
         items: ["markdown/mdx", "markdown/admonitions", "markdown/code-blocks"],
       },
       {
         type: "category",
         label: "Guide",
+        icon: "monitor-check",
         items: ["environment-variables", "custom-pages", "using-multiple-apis"],
       },
       {
         type: "category",
         label: "Deployment",
+        icon: "cloud-upload",
         link: "deployment",
         items: [
           "deploy/cloudflare-pages",
@@ -70,6 +75,7 @@ const config: ZudokuConfig = {
       {
         type: "category",
         label: "Extending",
+        icon: "blocks",
         items: ["custom-plugins", "api-keys"],
       },
     ],

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -27,6 +27,7 @@
     "./plugins/search-inkeep": "./src/lib/plugins/search-inkeep/index.ts",
     "./openapi-worker": "./src/lib/plugins/openapi-worker.ts",
     "./components": "./src/lib/components/index.ts",
+    "./icons": "./src/lib/icons.ts",
     "./vite": "./src/vite/plugin.ts",
     "./tailwind": "./src/app/tailwind.ts",
     "./app/*": "./src/app/*"
@@ -89,6 +90,10 @@
         "import": "./lib/zudoku.components.js",
         "types": "./dist/lib/components/index.d.ts"
       },
+      "./icons": {
+        "import": "./lib/zudoku.icons.js",
+        "types": "./dist/lib/icons.d.ts"
+      },
       "./vite": {
         "require": "./dist/vite/plugin.js",
         "import": "./dist/vite/plugin.js"
@@ -146,6 +151,7 @@
     "gray-matter": "^4.0.3",
     "loglevel": "^1.9.1",
     "lru-cache": "11.0.0",
+    "lucide-react": "0.438.0",
     "mdx": "0.3.1",
     "object-hash": "3.0.0",
     "openapi-types": "12.1.3",
@@ -204,7 +210,6 @@
     "@types/yargs": "^17.0.32",
     "@zudoku/httpsnippet": "10.0.9",
     "clsx": "2.1.1",
-    "lucide-react": "0.378.0",
     "oauth4webapi": "2.11.1",
     "prism-react-renderer": "2.3.1",
     "prismjs": "1.29.0",

--- a/packages/zudoku/src/cli/dev/handler.ts
+++ b/packages/zudoku/src/cli/dev/handler.ts
@@ -43,7 +43,11 @@ export async function dev(argv: Arguments) {
 
     process.on("SIGTERM", exit);
     process.on("SIGINT", exit);
-    process.on("uncaughtException", exit);
+    process.on("uncaughtException", (e) => {
+      // eslint-disable-next-line no-console
+      console.error("Uncaught exception", e);
+      void exit();
+    });
     process.on("exit", exit);
   });
 }

--- a/packages/zudoku/src/config/validators/InputSidebarSchema.ts
+++ b/packages/zudoku/src/config/validators/InputSidebarSchema.ts
@@ -1,4 +1,7 @@
+import type dynamicIconImports from "lucide-react/dynamicIconImports.js";
 import { z } from "zod";
+
+type IconNames = keyof typeof dynamicIconImports;
 
 export const BaseInputSidebarItemCategoryLinkDocSchema = z.object({
   type: z.literal("doc"),
@@ -18,6 +21,7 @@ export const InputSidebarItemCategoryLinkDocSchema = z.union([
 export const BaseInputSidebarItemDocSchema = z.object({
   type: z.literal("doc"),
   id: z.string(),
+  icon: z.custom<IconNames>().optional(),
   label: z.string().optional(),
   badge: z
     .object({
@@ -69,6 +73,7 @@ export type InputSidebarItemLink = z.infer<typeof InputSidebarItemLinkSchema>;
 
 export const BaseInputSidebarItemCategorySchema = z.object({
   type: z.literal("category"),
+  icon: z.custom<IconNames>().optional(),
   label: z.string(),
   description: z.string().optional(),
   collapsible: z.boolean().optional(),

--- a/packages/zudoku/src/config/validators/SidebarSchema.ts
+++ b/packages/zudoku/src/config/validators/SidebarSchema.ts
@@ -2,7 +2,6 @@ import { glob } from "glob";
 import matter from "gray-matter";
 import { type LucideIcon } from "lucide-react";
 import fs from "node:fs/promises";
-import { annotateIcon } from "../../vite/plugin-icons.js";
 import type {
   BaseInputSidebarItemCategoryLinkDoc,
   BaseInputSidebarItemDoc,
@@ -70,7 +69,7 @@ export const resolveSidebar = async (
     const { data, content } = matter(file);
     const label =
       data.sidebar_label ?? data.title ?? extractTitleFromContent(content);
-    const icon = annotateIcon(data.sidebar_icon);
+    const icon = data.sidebar_icon;
 
     if (typeof label !== "string") {
       throw new Error(
@@ -151,7 +150,6 @@ export const resolveSidebar = async (
 
         return {
           ...categoryItem,
-          icon: annotateIcon(categoryItem.icon),
           items,
           link: resolvedLink,
         };

--- a/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
@@ -61,37 +61,49 @@ export const SidebarCategory = ({
       open={open}
       onOpenChange={() => setOpen(true)}
     >
-      <Collapsible.Trigger
-        className={cn(
-          "group text-start",
-          navigationListItem({ isActive: false, isTopLevel: level === 0 }),
-          isCollapsible
-            ? "cursor-pointer"
-            : "cursor-default hover:bg-transparent",
-        )}
-        asChild
-        disabled={!isCollapsible}
-      >
-        {category.link?.type === "doc" ? (
-          <NavLink to={joinPath(topNavItem?.id, category.link.id)}>
-            {({ isActive }) => (
-              <div
-                className={cn(
-                  "flex items-center gap-2 justify-between w-full",
-                  isActive ? "text-primary font-medium" : "text-foreground/80",
-                )}
-              >
-                <div className="truncate">{category.label}</div>
-                {ToggleButton}
-              </div>
-            )}
-          </NavLink>
-        ) : (
-          <div className="flex items-center justify-between w-full">
-            <div className="flex gap-2 truncate w-full">{category.label}</div>
-            {ToggleButton}
-          </div>
-        )}
+      <Collapsible.Trigger className="group" asChild disabled={!isCollapsible}>
+        <div
+          className={cn(
+            "text-start",
+            navigationListItem({ isActive: false, isTopLevel: level === 0 }),
+            isCollapsible
+              ? "cursor-pointer"
+              : "cursor-default hover:bg-transparent",
+          )}
+        >
+          {category.icon && (
+            <category.icon
+              size={16}
+              className="align-[-0.125em] -translate-x-1"
+            />
+          )}
+          {category.link?.type === "doc" ? (
+            <NavLink
+              to={joinPath(topNavItem?.id, category.link.id)}
+              className="flex-1"
+              onClick={() => setHasInteracted(true)}
+            >
+              {({ isActive }) => (
+                <div
+                  className={cn(
+                    "flex items-center gap-2 justify-between w-full",
+                    isActive
+                      ? "text-primary font-medium"
+                      : "text-foreground/80",
+                  )}
+                >
+                  <div className="truncate">{category.label}</div>
+                  {ToggleButton}
+                </div>
+              )}
+            </NavLink>
+          ) : (
+            <div className="flex items-center justify-between w-full">
+              <div className="flex gap-2 truncate w-full">{category.label}</div>
+              {ToggleButton}
+            </div>
+          )}
+        </div>
       </Collapsible.Trigger>
       <Collapsible.Content
         className={cn(

--- a/packages/zudoku/src/lib/components/navigation/SidebarItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarItem.tsx
@@ -12,7 +12,7 @@ import { SidebarBadge } from "./SidebarBadge.js";
 import { SidebarCategory } from "./SidebarCategory.js";
 
 export const navigationListItem = cva(
-  "flex px-[--padding-nav-item] py-1.5 rounded-lg hover:bg-accent transition-colors duration-300",
+  "flex items-center gap-2 px-[--padding-nav-item] py-1.5 rounded-lg hover:bg-accent transition-colors duration-300",
   {
     variants: {
       isTopLevel: {
@@ -55,6 +55,7 @@ export const SidebarItem = ({
           }
           to={joinPath(topNavItem?.id, item.id)}
         >
+          {item.icon && <item.icon size={16} className="align-[-0.125em]" />}
           {item.badge ? (
             <>
               <span className="truncate" title={item.label}>

--- a/packages/zudoku/src/lib/icons.ts
+++ b/packages/zudoku/src/lib/icons.ts
@@ -1,0 +1,1 @@
+export * from "lucide-react";

--- a/packages/zudoku/src/vite/plugin-icons.ts
+++ b/packages/zudoku/src/vite/plugin-icons.ts
@@ -1,0 +1,69 @@
+import matter from "gray-matter";
+import type { LucideIcon } from "lucide-react";
+import { readFile } from "node:fs/promises";
+import type { Plugin } from "vite";
+
+export const annotateIcon = (icon?: string) =>
+  icon ? (`__IMPORT_ICON:${icon}__` as unknown as LucideIcon) : undefined;
+
+const matchIconAnnotation = /"__IMPORT_ICON:(.*?)__"/g;
+
+const toPascalCase = (str: string) =>
+  str.replace(/(^\w|-\w)/g, (match) => match.replace("-", "").toUpperCase());
+
+export const replaceSidebarAnnotatedIcons = (code: string) => {
+  const collectedIcons = new Set<string>();
+
+  let match;
+  while ((match = matchIconAnnotation.exec(code)) !== null) {
+    collectedIcons.add(match[1]);
+  }
+
+  const importStatement = [
+    'import React from "react";',
+    `import { ${[...collectedIcons].map(toPascalCase).join(", ")} } from "zudoku/icons";`,
+  ].join("\n");
+
+  const replacedString = code.replaceAll(
+    matchIconAnnotation,
+    // The element will be created by the implementers side
+    (_, iconName) => toPascalCase(iconName),
+  );
+
+  return `${importStatement}export const configuredSidebar = ${replacedString};`;
+};
+
+export const viteIconsPlugin = (): Plugin => {
+  const iconMap = new Map<string, string | null>();
+
+  return {
+    enforce: "pre",
+    name: "zudoku-icons-plugin",
+    configureServer: ({ watcher, restart }) => {
+      watcher.on("change", async (filePath) => {
+        if (/\.mdx?$/.test(filePath)) {
+          const code = await readFile(filePath, "utf-8");
+          const { sidebar_icon: sidebarIcon } = matter(code).data;
+          const previousIcon = iconMap.get(filePath);
+
+          if (
+            (!previousIcon && sidebarIcon) ||
+            (previousIcon && !sidebarIcon) ||
+            previousIcon !== sidebarIcon
+          ) {
+            await restart();
+          }
+
+          iconMap.set(filePath, sidebarIcon);
+        }
+      });
+    },
+    async load(id) {
+      if (/\.mdx?$/.test(id)) {
+        const code = await readFile(id, "utf-8");
+        const { sidebar_icon: sidebarIcon } = matter(code).data;
+        iconMap.set(id, sidebarIcon);
+      }
+    },
+  };
+};

--- a/packages/zudoku/src/vite/plugin-icons.ts
+++ b/packages/zudoku/src/vite/plugin-icons.ts
@@ -1,8 +1,6 @@
 import matter from "gray-matter";
-import dynamicIconImports from "lucide-react/dynamicIconImports.js";
 import { readFile } from "node:fs/promises";
 import type { Plugin } from "vite";
-const lucideIconNames = Object.keys(dynamicIconImports.default);
 
 const matchIconAnnotation = /"icon":\s*"(.*?)"/g;
 
@@ -14,14 +12,6 @@ export const replaceSidebarIcons = (code: string) => {
 
   let match;
   while ((match = matchIconAnnotation.exec(code)) !== null) {
-    if (!lucideIconNames.includes(match[1])) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Invalid icon name "${match[1]}", defaulting to no icon. Check https://lucide.dev/icons for all available icon names.`,
-      );
-      continue;
-    }
-
     collectedIcons.add(match[1]);
   }
 
@@ -29,8 +19,7 @@ export const replaceSidebarIcons = (code: string) => {
   const replacedString = code.replaceAll(
     matchIconAnnotation,
     // The element will be created by the implementers side
-    (_, iconName) =>
-      `"icon": ${collectedIcons.has(iconName) ? toPascalCase(iconName) : "null"}`,
+    (_, iconName) => `"icon": ${toPascalCase(iconName)}`,
   );
 
   return `${importStatement}export const configuredSidebar = ${replacedString};`;

--- a/packages/zudoku/src/vite/plugin-sidebar.ts
+++ b/packages/zudoku/src/vite/plugin-sidebar.ts
@@ -1,6 +1,7 @@
 import { type Plugin } from "vite";
 import { type ZudokuPluginOptions } from "../config/config.js";
 import { resolveSidebar } from "../config/validators/SidebarSchema.js";
+import { replaceSidebarAnnotatedIcons } from "./plugin-icons.js";
 
 export const viteSidebarPlugin = (
   getConfig: () => ZudokuPluginOptions,
@@ -30,7 +31,12 @@ export const viteSidebarPlugin = (
         ),
       );
 
-      return `export const configuredSidebar = ${JSON.stringify(resolvedSidebar)};`;
+      return JSON.stringify(resolvedSidebar);
+    },
+    async transform(code, id) {
+      if (id !== resolvedVirtualModuleId) return;
+
+      return replaceSidebarAnnotatedIcons(code);
     },
   };
 };

--- a/packages/zudoku/src/vite/plugin-sidebar.ts
+++ b/packages/zudoku/src/vite/plugin-sidebar.ts
@@ -1,7 +1,7 @@
 import { type Plugin } from "vite";
 import { type ZudokuPluginOptions } from "../config/config.js";
 import { resolveSidebar } from "../config/validators/SidebarSchema.js";
-import { replaceSidebarAnnotatedIcons } from "./plugin-icons.js";
+import { replaceSidebarIcons } from "./plugin-icons.js";
 
 export const viteSidebarPlugin = (
   getConfig: () => ZudokuPluginOptions,
@@ -36,7 +36,10 @@ export const viteSidebarPlugin = (
     async transform(code, id) {
       if (id !== resolvedVirtualModuleId) return;
 
-      return replaceSidebarAnnotatedIcons(code);
+      // In the stringified config all occurrences of icons are replaced with icon components
+      // and their imports are added to the top.
+      // They will be created as elements when the sidebar is rendered.
+      return replaceSidebarIcons(code);
     },
   };
 };

--- a/packages/zudoku/src/vite/plugin.ts
+++ b/packages/zudoku/src/vite/plugin.ts
@@ -11,6 +11,7 @@ import viteConfigPlugin from "./plugin-config.js";
 import viteCustomCss from "./plugin-custom-css.js";
 import viteDocsPlugin from "./plugin-docs.js";
 import { viteHtmlTransform } from "./plugin-html-transform.js";
+import { viteIconsPlugin } from "./plugin-icons.js";
 import viteMdxPlugin from "./plugin-mdx.js";
 import viteRedirectPlugin from "./plugin-redirect.js";
 import { viteSidebarPlugin } from "./plugin-sidebar.js";
@@ -31,6 +32,7 @@ export default function vitePlugin(
     viteApiKeysPlugin(getCurrentConfig),
     viteAuthPlugin(getCurrentConfig),
     viteDocsPlugin(getCurrentConfig),
+    viteIconsPlugin(),
     viteSidebarPlugin(getCurrentConfig),
     viteApiPlugin(getCurrentConfig),
     viteAliasPlugin(getCurrentConfig),

--- a/packages/zudoku/vite.config.ts
+++ b/packages/zudoku/vite.config.ts
@@ -5,6 +5,7 @@ import pkgJson from "./package.json";
 
 const entries: Record<string, string> = {
   components: "./src/lib/components/index.ts",
+  icons: "./src/lib/icons.ts",
   "auth-clerk": "./src/lib/authentication/providers/clerk.tsx",
   "auth-auth0": "./src/lib/authentication/providers/auth0.tsx",
   "auth-openid": "./src/lib/authentication/providers/openid.tsx",
@@ -39,6 +40,7 @@ export default defineConfig({
       external: [
         "react",
         "react-dom",
+        "lucide-react",
 
         // Optional Modules (i.e. auth providers) are external as we don't
         // want to bundle these in the library. Users will install these

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       lru-cache:
         specifier: 11.0.0
         version: 11.0.0
+      lucide-react:
+        specifier: 0.438.0
+        version: 0.438.0(react@18.3.1)
       mdx:
         specifier: 0.3.1
         version: 0.3.1
@@ -556,9 +559,6 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      lucide-react:
-        specifier: 0.378.0
-        version: 0.378.0(react@18.3.1)
       oauth4webapi:
         specifier: 2.11.1
         version: 2.11.1
@@ -6697,6 +6697,11 @@ packages:
     resolution: {integrity: sha512-u6EPU8juLUk9ytRcyapkWI18epAv3RU+6+TC23ivjR0e+glWKBobFeSgRwOIJihzktILQuy6E0E80P2jVTDR5g==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  lucide-react@0.438.0:
+    resolution: {integrity: sha512-uq6yCB+IzVfgIPMK8ibkecXSWTTSOMs9UjUgZigfrDCVqgdwkpIgYg1fSYnf0XXF2AoSyCJZhoZXQwzoai7VGw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
@@ -17790,6 +17795,10 @@ snapshots:
       yallist: 4.0.0
 
   lucide-react@0.378.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  lucide-react@0.438.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
- Adds `icon` to sidebar configuration
- Allows to add `sidebar_icon` to MD/X files
- Restarts Vite server when icon has changed
- Based on [lucide](https://lucide.dev/icons):
  - I moved it from `devDepencies` to `dependencies` so it gets distributed
  - Added it to `external` so it doesn't get bundled in zudoku itself, though
  - We could revert that, but that would mean that a consuming app needs to install `lucide-react` themselves if they want to use icons
- Added icons to docs to use them ourselves

![](https://github.com/user-attachments/assets/2e73feb5-0c75-4f02-9618-33c5610bdf1f)
