### PR TITLE
Use `tsx` to load zudoku config

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -181,6 +181,7 @@
     "strip-ansi": "7.1.0",
     "tailwind-merge": "2.5.2",
     "tailwindcss": "3.4.4",
+    "tsx": "4.19.0",
     "ulidx": "^2.3.0",
     "unist-util-visit": "5.0.0",
     "urql": "4.1.0",
@@ -216,7 +217,6 @@
     "react-markdown": "9.0.1",
     "react-router-dom": "6.25.1",
     "rollup-plugin-visualizer": "^5.12.0",
-    "tsx": "4.18.0",
     "typescript": "5.5.3"
   },
   "peerDependencies": {

--- a/packages/zudoku/src/cli/dev/handler.ts
+++ b/packages/zudoku/src/cli/dev/handler.ts
@@ -48,6 +48,11 @@ export async function dev(argv: Arguments) {
       console.error("Uncaught exception", e);
       void exit();
     });
+    process.on("unhandledRejection", (e) => {
+      // eslint-disable-next-line no-console
+      console.error("Unhandled rejection", e);
+      void exit();
+    });
     process.on("exit", exit);
   });
 }

--- a/packages/zudoku/src/vite/config.test.ts
+++ b/packages/zudoku/src/vite/config.test.ts
@@ -5,9 +5,6 @@ import { loadZudokuConfig } from "./config.js";
 
 test("Should correctly load zudoku.config.ts file", async () => {
   const rootPath = path.resolve("../../examples/with-config/");
-  const config = await loadZudokuConfig(rootPath, {
-    mode: "development",
-    command: "build",
-  });
+  const config = await loadZudokuConfig(rootPath);
   assert.equal(config.metadata?.title, "My Portal");
 });

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -32,10 +32,7 @@ export class DevServer {
 
     const vite = await createViteServer(viteConfig);
 
-    this.currentConfig = await loadZudokuConfig(this.options.dir, {
-      command: "serve",
-      mode: "development",
-    });
+    this.currentConfig = await loadZudokuConfig(this.options.dir);
 
     const graphql = createGraphQLServer({
       graphqlEndpoint: "/__z/graphql",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       tailwindcss:
         specifier: 3.4.4
         version: 3.4.4(ts-node@10.9.1(@types/node@20.12.10)(typescript@5.5.3))
+      tsx:
+        specifier: 4.19.0
+        version: 4.19.0
       ulidx:
         specifier: ^2.3.0
         version: 2.3.0
@@ -565,9 +568,6 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^5.12.0
         version: 5.12.0(rollup@4.21.2)
-      tsx:
-        specifier: 4.18.0
-        version: 4.18.0
       typescript:
         specifier: 5.5.3
         version: 5.5.3
@@ -8784,8 +8784,8 @@ packages:
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
-  tsx@4.18.0:
-    resolution: {integrity: sha512-a1jaKBSVQkd6yEc1/NI7G6yHFfefIcuf3QJST7ZEyn4oQnxLYrZR5uZAM8UrwUa3Ge8suiZHcNS1gNrEvmobqg==}
+  tsx@4.19.0:
+    resolution: {integrity: sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -9535,7 +9535,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      picocolors: 1.1.0
 
   '@babel/compat-data@7.24.7': {}
 
@@ -9778,7 +9778,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.0
 
   '@babel/parser@7.24.7':
     dependencies:
@@ -10689,14 +10689,14 @@ snapshots:
 
   '@clack/core@0.3.4':
     dependencies:
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       sisteransi: 1.0.5
     optional: true
 
   '@clack/prompts@0.6.3':
     dependencies:
       '@clack/core': 0.3.4
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       sisteransi: 1.0.5
     optional: true
 
@@ -14989,7 +14989,7 @@ snapshots:
       caniuse-lite: 1.0.30001655
       fraction.js: 4.3.7
       normalize-range: 0.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       postcss: 8.4.39
       postcss-value-parser: 4.2.0
     optional: true
@@ -19220,7 +19220,7 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       source-map-js: 1.2.0
 
   postcss@8.4.39:
@@ -19232,7 +19232,7 @@ snapshots:
   postcss@8.4.41:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       source-map-js: 1.2.0
     optional: true
 
@@ -20545,7 +20545,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tsx@4.18.0:
+  tsx@4.19.0:
     dependencies:
       esbuild: 0.23.1
       get-tsconfig: 4.7.6
@@ -20746,7 +20746,7 @@ snapshots:
     dependencies:
       browserslist: 4.23.1
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.0
 
   update-browserslist-db@1.1.0(browserslist@4.23.3):
     dependencies:


### PR DESCRIPTION
While developing locally with importing TSX files in the `zudoku.config.tsx`, we had found some issues:

<img src=https://github.com/user-attachments/assets/c4a05d92-390f-4a0d-8fd4-2653bc3a41fc width=500>

Switching to use [`tsImport`](https://tsx.is/dev-api/ts-import) from `tsx` (which we use anyway) got us away from the hack-ish approach loading the config with Vite's `loadConfigFromFile` and solved the issue.