### PR TITLE
Read package.json from file in create-zudoku-app

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -72,11 +72,10 @@ jobs:
       - run: git config --global user.email "integrations@zuplo.com"
       - run: git config --global user.name "Zuplo Integrations"
 
+      - run: nx run-many -t root:lint:ci root:format:ci build:ci
+
       - name: Version
         run: nx release version --specifier ${{ env.RELEASE_TYPE }} --git-commit --git-tag=${{ env.RELEASE_TYPE != 'prerelease' }} --preid dev
-
-      # Must be AFTER the release step so that the builds use the new version numbers
-      - run: nx run-many -t root:lint:ci root:format:ci build:ci
 
       - name: Publish Modules
         run: pnpm publish --provenance --filter zudoku --filter create-zudoku-app --tag ${{ env.RELEASE_TYPE == 'prerelease' && 'dev' || 'latest' }}

--- a/packages/create-zudoku-app/create-app.ts
+++ b/packages/create-zudoku-app/create-app.ts
@@ -33,6 +33,7 @@ export async function createApp({
   eslint,
   skipInstall,
   empty,
+  zudokuVersion,
 }: {
   appPath: string;
   packageManager: PackageManager;
@@ -42,6 +43,7 @@ export async function createApp({
   eslint: boolean;
   skipInstall: boolean;
   empty: boolean;
+  zudokuVersion: string;
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined;
   const mode: TemplateMode = typescript ? "ts" : "js";
@@ -214,6 +216,7 @@ export async function createApp({
       isOnline,
       eslint,
       skipInstall,
+      zudokuVersion,
     });
   }
 

--- a/packages/create-zudoku-app/index.ts
+++ b/packages/create-zudoku-app/index.ts
@@ -3,8 +3,8 @@
 import ciInfo from "ci-info";
 import { Command } from "commander";
 import Conf from "conf";
-import { existsSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import path, { basename, resolve } from "node:path";
 import { blue, bold, cyan, green, red, yellow } from "picocolors";
 import type { InitialReturnValue } from "prompts";
 import prompts from "prompts";
@@ -14,7 +14,6 @@ import type { PackageManager } from "./helpers/get-pkg-manager";
 import { getPkgManager } from "./helpers/get-pkg-manager";
 import { isFolderEmpty } from "./helpers/is-folder-empty";
 import { validateNpmName } from "./helpers/validate-pkg";
-import packageJson from "./package.json";
 
 let projectPath: string = "";
 
@@ -36,6 +35,10 @@ const onPromptState = (state: {
     process.exit(1);
   }
 };
+
+const packageJson = JSON.parse(
+  readFileSync(path.resolve(__dirname, "../package.json"), "utf-8"),
+);
 
 const program = new Command(packageJson.name)
   .version(
@@ -293,6 +296,7 @@ async function run(): Promise<void> {
       eslint: opts.eslint,
       skipInstall: opts.skipInstall,
       empty: opts.empty,
+      zudokuVersion: packageJson.version,
     });
   } catch (reason) {
     if (!(reason instanceof DownloadError)) {
@@ -319,6 +323,7 @@ async function run(): Promise<void> {
       eslint: opts.eslint,
       skipInstall: opts.skipInstall,
       empty: opts.empty,
+      zudokuVersion: packageJson.version,
     });
   }
   conf.set("preferences", preferences);

--- a/packages/create-zudoku-app/templates/index.ts
+++ b/packages/create-zudoku-app/templates/index.ts
@@ -5,7 +5,6 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { bold, cyan } from "picocolors";
-import pkg from "../package.json";
 
 import { GetTemplateFileArgs, InstallTemplateArgs } from "./types";
 
@@ -34,6 +33,7 @@ export const installTemplate = async ({
   mode,
   eslint,
   skipInstall,
+  zudokuVersion,
 }: InstallTemplateArgs) => {
   console.log(bold(`Using ${packageManager}.`));
 
@@ -69,7 +69,7 @@ export const installTemplate = async ({
   // update import alias in any files if not using the default
 
   /** Copy the version from package.json or override for tests. */
-  const version = process.env.ZUDOKU_PRIVATE_TEST_VERSION ?? pkg.version;
+  const version = process.env.ZUDOKU_PRIVATE_TEST_VERSION ?? zudokuVersion;
 
   /** Create a package.json for the new project and write it to disk. */
   const packageJson: any = {

--- a/packages/create-zudoku-app/templates/types.ts
+++ b/packages/create-zudoku-app/templates/types.ts
@@ -18,4 +18,5 @@ export interface InstallTemplateArgs {
   mode: TemplateMode;
   eslint: boolean;
   skipInstall: boolean;
+  zudokuVersion: string;
 }


### PR DESCRIPTION
Reads the create-zudoku-app package.json. I dont like the bundling because it makes the build vs version order too dependant. This keeps it so that no matter when the package.json gets updated the app will get the correct version.