### PR TITLE
fix: Add back OpenAPI plugin path

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/index.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/index.tsx
@@ -16,6 +16,7 @@ import { ErrorPage } from "../../components/ErrorPage.js";
 import { ColorMap } from "../../components/navigation/SidebarBadge.js";
 import { SyntaxHighlight } from "../../components/SyntaxHighlight.js";
 import { Button } from "../../ui/Button.js";
+import { joinPath } from "../../util/joinPath.js";
 import { OasPluginConfig } from "./interfaces.js";
 import type { PlaygroundContentProps } from "./playground/Playground.js";
 import { PlaygroundDialog } from "./playground/PlaygroundDialog.js";
@@ -72,7 +73,7 @@ export type OpenApiPluginOptions = OasPluginConfig & InternalOasPluginConfig;
 export const openApiPlugin = (
   config: OpenApiPluginOptions,
 ): DevPortalPlugin => {
-  const basePath = "/reference";
+  const basePath = joinPath(config.navigationId ?? "/reference");
 
   const client = config.server
     ? new UrqlClient({


### PR DESCRIPTION
This was mistakenly removed but is needed.
Basic tests should cover this