### PR TITLE
Fix playground URL concatenation

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/createUrl.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/createUrl.ts
@@ -8,7 +8,12 @@ export const createUrl = (host: string, path: string, data: PlaygroundForm) => {
     return value ?? match;
   });
 
-  const url = new URL(filledPath, host);
+  // Ensure host ends with a slash and path doesn't start with one,
+  // so they form a correct URL, without overriding the host's path.
+  const url = new URL(
+    filledPath.replace(/^\//, ""),
+    host.endsWith("/") ? host : `${host}/`,
+  );
 
   data.queryParams
     .filter((param) => param.active)


### PR DESCRIPTION
> I have
> 
> ```
> "servers": [
>     {
>       "url": "https://en.wikipedia.org/api/rest_v1"
>     }
>   ]
> ```
> 
> and an operation
> 
> `/page/html/{title}`
> 
> The curl preview correctly shows
> 
> `https://en.wikipedia.org/api/rest_v1/page/html/:title`
> 
> But the actual API call made in the playground is
> 
> `https://en.wikipedia.org/page/html/Albert_Einstein`
> 
> Which is not correct since its missing the base path `/api/rest_v1`

This fixes the reported issue. This stems from how [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) concatenates path and base portion.

When `base` ends with a slash and `path` does not have a leading slash everything works fine