### PR TITLE
Fix config reload

### DIFF
--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -85,7 +85,9 @@ export async function loadZudokuConfig(
     const loadedConfig = await tsImport(configFilePath, {
       parentURL: import.meta.url,
       onImport: (file: string) => {
-        const path = fileURLToPath(pathToFileURL(file).href);
+        const path = fileURLToPath(
+          file.startsWith("file://") ? file : pathToFileURL(file).href,
+        );
 
         if (path.startsWith(rootDir)) {
           dependencies.push(path);


### PR DESCRIPTION
Checks for import dependencies start with `file://` otherwise the protocol is duplicated (wouldn't happen on Windows systems)