### PR TITLE
Proxy entry client file through express middleware

### DIFF
--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -244,6 +244,8 @@ export async function getViteConfig(
         "worker",
       ],
     },
+    // Workaround for Pre-transform error for "virtual" file: https://github.com/vitejs/vite/issues/15374
+    assetsInclude: ["/__z/entry.client.tsx"],
     plugins: [
       vitePluginSsrCss({
         entries: [`${pluginOptions.moduleDir}/src/app/entry.client.tsx`],

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -45,6 +45,15 @@ export class DevServer {
     });
 
     app.use(graphql.graphqlEndpoint, graphql);
+    app.use("/__z/entry.client.tsx", async (_req, res, next) => {
+      const transformed = await vite.transformRequest(getAppClientEntryPath());
+      if (!transformed) throw new Error("Error transforming client entry");
+
+      res
+        .status(200)
+        .set({ "Content-Type": "text/javascript" })
+        .end(transformed.code);
+    });
     app.use(vite.middlewares);
 
     printDiagnosticsToConsole(
@@ -55,8 +64,7 @@ export class DevServer {
       const url = request.originalUrl;
 
       try {
-        const entryJs = getAppClientEntryPath();
-        const rawHtml = getDevHtml(entryJs);
+        const rawHtml = getDevHtml("/__z/entry.client.tsx");
         const template = await vite.transformIndexHtml(url, rawHtml);
 
         if (this.options.ssr) {


### PR DESCRIPTION
On Windows, permissions disallow the access of files from the file system directly in `<script src="file://C:/path/to/entry.client.tsx">`.
To work around this issue I've change to proxy the `entry.client.tsx` file through an Express middleware. This should work for any OS