### PR TITLE
Fix dev SSR when using context in custom pages

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -32,7 +32,7 @@
     "./plugins/markdown": "./src/lib/plugins/markdown/index.ts",
     "./plugins/openapi": "./src/lib/plugins/openapi/index.ts",
     "./plugins/redirect": "./src/lib/plugins/redirect/index.ts",
-    "./plugins/custom-page": "./src/lib/plugins/custom-page/index.ts",
+    "./plugins/custom-pages": "./src/lib/plugins/custom-pages/index.ts",
     "./plugins/search-inkeep": "./src/lib/plugins/search-inkeep/index.ts",
     "./openapi-worker": "./src/lib/plugins/openapi-worker.ts",
     "./components": "./src/lib/components/index.ts",
@@ -83,9 +83,9 @@
         "import": "./lib/zudoku.plugin-redirect.js",
         "types": "./dist/lib/plugins/redirect/index.d.ts"
       },
-      "./plugins/custom-page": {
-        "import": "./lib/zudoku.plugin-custom-page.js",
-        "types": "./dist/lib/plugins/custom-page/index.d.ts"
+      "./plugins/custom-pages": {
+        "import": "./lib/zudoku.plugin-custom-pages.js",
+        "types": "./dist/lib/plugins/custom-pages/index.d.ts"
       },
       "./plugins/search-inkeep": {
         "import": "./lib/zudoku.plugin-search-inkeep.js",

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -2,13 +2,13 @@ import { redirect, type RouteObject } from "react-router-dom";
 import { configuredApiKeysPlugin } from "virtual:zudoku-api-keys-plugin";
 import { configuredApiPlugins } from "virtual:zudoku-api-plugins";
 import { configuredAuthProvider } from "virtual:zudoku-auth";
+import { configuredCustomPagesPlugin } from "virtual:zudoku-custom-pages-plugin";
 import { configuredDocsPlugins } from "virtual:zudoku-docs-plugins";
 import { configuredRedirectPlugin } from "virtual:zudoku-redirect-plugin";
 import { configuredSidebar } from "virtual:zudoku-sidebar";
 import "virtual:zudoku-theme.css";
 import { DevPortal, Layout, RouterError } from "zudoku/components";
 import { isNavigationPlugin } from "zudoku/internal";
-import { customPagePlugin } from "zudoku/plugins/custom-page";
 import { inkeepSearchPlugin } from "zudoku/plugins/search-inkeep";
 import type { ZudokuConfig } from "../config/config.js";
 import { traverseSidebar } from "../lib/components/navigation/utils.js";
@@ -60,7 +60,7 @@ export const convertZudokuConfigToOptions = (
       ...configuredApiPlugins,
       ...(configuredRedirectPlugin ? [configuredRedirectPlugin] : []),
       ...(configuredApiKeysPlugin ? [configuredApiKeysPlugin] : []),
-      ...(config.customPages ? [customPagePlugin(config.customPages)] : []),
+      ...(configuredCustomPagesPlugin ? [configuredCustomPagesPlugin] : []),
       ...(configuredAuthProvider?.getAuthenticationPlugin
         ? [configuredAuthProvider.getAuthenticationPlugin()]
         : []),

--- a/packages/zudoku/src/lib/plugins/custom-pages/index.tsx
+++ b/packages/zudoku/src/lib/plugins/custom-pages/index.tsx
@@ -3,13 +3,13 @@ import type { RouteObject } from "react-router-dom";
 import { ProseClasses } from "../../components/Markdown.js";
 import type { DevPortalPlugin, NavigationPlugin } from "../../core/plugins.js";
 
-type CustomPageConfig = Array<{
+type CustomPagesConfig = Array<{
   path: string;
   element: ReactNode;
 }>;
 
-export const customPagePlugin = (
-  config: CustomPageConfig,
+export const customPagesPlugin = (
+  config: CustomPagesConfig,
 ): DevPortalPlugin & NavigationPlugin => {
   return {
     getRoutes: (): RouteObject[] =>

--- a/packages/zudoku/src/types.d.ts
+++ b/packages/zudoku/src/types.d.ts
@@ -14,6 +14,13 @@ declare module "virtual:zudoku-api-keys-plugin" {
     | import("./lib/core/plugins.ts").DevPortalPlugin
     | undefined;
 }
+
+declare module "virtual:zudoku-custom-pages-plugin" {
+  export const configuredCustomPagesPlugin:
+    | import("./lib/core/plugins.ts").DevPortalPlugin
+    | undefined;
+}
+
 declare module "virtual:zudoku-redirect-plugin" {
   export const configuredRedirectPlugin:
     | import("./lib/core/plugins.ts").DevPortalPlugin

--- a/packages/zudoku/src/vite/plugin-component.ts
+++ b/packages/zudoku/src/vite/plugin-component.ts
@@ -13,7 +13,6 @@ const viteAliasPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
                 "zudoku/components": `${config.moduleDir}/src/lib/components/index.ts`,
                 "zudoku/internal": `${config.moduleDir}/src/internal.ts`,
                 "zudoku/openapi-worker": `${config.moduleDir}/src/lib/plugins/openapi/client/createWorkerClient.ts`,
-                "zudoku/plugins/custom-page": `${config.moduleDir}/src/lib/plugins/custom-page/index.tsx`,
                 "zudoku/plugins/openapi": `${config.moduleDir}/src/lib/plugins/openapi/index.tsx`,
                 "zudoku/plugins/search-inkeep": `${config.moduleDir}/src/lib/plugins/search-inkeep/index.tsx`,
               },

--- a/packages/zudoku/src/vite/plugin-custom-pages.ts
+++ b/packages/zudoku/src/vite/plugin-custom-pages.ts
@@ -1,0 +1,38 @@
+import { type Plugin } from "vite";
+import { type ZudokuPluginOptions } from "../config/config.js";
+
+const viteCustomPagesPlugin = (
+  getConfig: () => ZudokuPluginOptions,
+): Plugin => {
+  const virtualModuleId = "virtual:zudoku-custom-pages-plugin";
+  const resolvedVirtualModuleId = "\0" + virtualModuleId;
+  return {
+    name: "zudoku-custom-pages-plugin",
+    resolveId(id) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+    async load(id) {
+      if (id === resolvedVirtualModuleId) {
+        const config = getConfig();
+
+        if (!config.customPages || config.mode === "standalone") {
+          return `export const configuredCustomPagesPlugin = undefined;`;
+        }
+
+        const code = [
+          `import config from "virtual:zudoku-config";`,
+          config.mode === "internal"
+            ? `import { customPagesPlugin } from "${config.moduleDir}/src/lib/plugins/custom-pages/index.tsx";`
+            : `import { customPagesPlugin } from "zudoku/plugins/custom-pages";`,
+          `export const configuredCustomPagesPlugin = customPagesPlugin(config.customPages);`,
+        ];
+
+        return code.join("\n");
+      }
+    },
+  };
+};
+
+export default viteCustomPagesPlugin;

--- a/packages/zudoku/src/vite/plugin.ts
+++ b/packages/zudoku/src/vite/plugin.ts
@@ -9,6 +9,7 @@ import viteAliasPlugin from "./plugin-component.js";
 import { createConfigReloadPlugin } from "./plugin-config-reload.js";
 import viteConfigPlugin from "./plugin-config.js";
 import viteCustomCss from "./plugin-custom-css.js";
+import viteCustomPagesPlugin from "./plugin-custom-pages.js";
 import viteDocsPlugin from "./plugin-docs.js";
 import { viteFrontmatterPlugin } from "./plugin-frontmatter.js";
 import { viteHtmlTransform } from "./plugin-html-transform.js";
@@ -30,6 +31,7 @@ export default function vitePlugin(
     react({ include: /\.(mdx?|jsx?|tsx?)$/ }),
     viteConfigPlugin(initialConfig),
     viteApiKeysPlugin(getCurrentConfig),
+    viteCustomPagesPlugin(getCurrentConfig),
     viteAuthPlugin(getCurrentConfig),
     viteDocsPlugin(getCurrentConfig),
     viteFrontmatterPlugin(),

--- a/packages/zudoku/tsconfig.json
+++ b/packages/zudoku/tsconfig.json
@@ -27,7 +27,6 @@
       "zudoku/openapi-worker": [
         "src/lib/plugins/openapi/client/createWorkerClient.ts"
       ],
-      "zudoku/plugins/custom-page": ["src/lib/plugins/custom-page/index.tsx"],
       "zudoku/plugins/openapi": ["src/lib/plugins/openapi/index.ts"],
       "zudoku/plugins/search-inkeep": [
         "src/lib/plugins/search-inkeep/index.tsx"

--- a/packages/zudoku/vite.config.ts
+++ b/packages/zudoku/vite.config.ts
@@ -13,7 +13,7 @@ const entries: Record<string, string> = {
   "plugin-markdown": "./src/lib/plugins/markdown/index.tsx",
   "plugin-openapi": "./src/lib/plugins/openapi/index.tsx",
   "plugin-redirect": "./src/lib/plugins/redirect/index.tsx",
-  "plugin-custom-page": "./src/lib/plugins/custom-page/index.tsx",
+  "plugin-custom-pages": "./src/lib/plugins/custom-pages/index.tsx",
   "plugin-search-inkeep": "./src/lib/plugins/search-inkeep/index.tsx",
   "openapi-worker": "./src/lib/plugins/openapi-worker.ts",
 };


### PR DESCRIPTION
We've seen errors from Zudoku config like:

```
TypeError: Cannot read properties of undefined (reading 'add')
    at J.init (...)
```

It's not entirely clear why the React context(s) are not available but when we move the custom page plugin to Vite plugin runtime these errors disappear and SSR in dev works fine again