### PR TITLE
Search as vite plugin

### DIFF
--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -5,11 +5,11 @@ import { configuredAuthProvider } from "virtual:zudoku-auth";
 import { configuredCustomPagesPlugin } from "virtual:zudoku-custom-pages-plugin";
 import { configuredDocsPlugins } from "virtual:zudoku-docs-plugins";
 import { configuredRedirectPlugin } from "virtual:zudoku-redirect-plugin";
+import { configuredSearchPlugin } from "virtual:zudoku-search-plugin";
 import { configuredSidebar } from "virtual:zudoku-sidebar";
 import "virtual:zudoku-theme.css";
 import { DevPortal, Layout, RouterError } from "zudoku/components";
 import { isNavigationPlugin } from "zudoku/internal";
-import { inkeepSearchPlugin } from "zudoku/plugins/search-inkeep";
 import type { ZudokuConfig } from "../config/config.js";
 import { traverseSidebar } from "../lib/components/navigation/utils.js";
 import type { ZudokuContextOptions } from "../lib/core/DevPortalContext.js";
@@ -53,11 +53,9 @@ export const convertZudokuConfigToOptions = (
     mdx: config.mdx,
     authentication: configuredAuthProvider,
     plugins: [
-      ...(config.search?.type === "inkeep"
-        ? [inkeepSearchPlugin(config.search)]
-        : []),
       ...configuredDocsPlugins,
       ...configuredApiPlugins,
+      ...(configuredSearchPlugin ? [configuredSearchPlugin] : []),
       ...(configuredRedirectPlugin ? [configuredRedirectPlugin] : []),
       ...(configuredApiKeysPlugin ? [configuredApiKeysPlugin] : []),
       ...(configuredCustomPagesPlugin ? [configuredCustomPagesPlugin] : []),

--- a/packages/zudoku/src/types.d.ts
+++ b/packages/zudoku/src/types.d.ts
@@ -9,6 +9,13 @@ declare module "virtual:zudoku-sidebar" {
 declare module "virtual:zudoku-api-plugins" {
   export const configuredApiPlugins: import("./lib/core/plugins.ts").DevPortalPlugin[];
 }
+
+declare module "virtual:zudoku-search-plugin" {
+  export const configuredSearchPlugin:
+    | import("./lib/core/plugins.ts").DevPortalPlugin
+    | undefined;
+}
+
 declare module "virtual:zudoku-api-keys-plugin" {
   export const configuredApiKeysPlugin:
     | import("./lib/core/plugins.ts").DevPortalPlugin

--- a/packages/zudoku/src/vite/plugin-search.ts
+++ b/packages/zudoku/src/vite/plugin-search.ts
@@ -1,0 +1,39 @@
+import { type Plugin } from "vite";
+import { type ZudokuPluginOptions } from "../config/config.js";
+
+export const viteSearchPlugin = (
+  getConfig: () => ZudokuPluginOptions,
+): Plugin => {
+  const virtualModuleId = "virtual:zudoku-search-plugin";
+  const resolvedVirtualModuleId = "\0" + virtualModuleId;
+
+  return {
+    name: "zudoku-search-plugin",
+    resolveId(id) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+    async load(id) {
+      if (id !== resolvedVirtualModuleId) return;
+
+      const config = getConfig();
+
+      if (!config.search || config.mode === "standalone") {
+        return `export const configuredSearchPlugin = undefined;`;
+      }
+
+      const code = [];
+
+      if (config.search.type === "inkeep") {
+        code.push(
+          `import config from 'virtual:zudoku-config';`,
+          `import { inkeepSearchPlugin } from "zudoku/plugins/search-inkeep";`,
+          `export const configuredSearchPlugin = inkeepSearchPlugin(config.search);`,
+        );
+
+        return code.join("\n");
+      }
+    },
+  };
+};

--- a/packages/zudoku/src/vite/plugin.ts
+++ b/packages/zudoku/src/vite/plugin.ts
@@ -15,6 +15,7 @@ import { viteFrontmatterPlugin } from "./plugin-frontmatter.js";
 import { viteHtmlTransform } from "./plugin-html-transform.js";
 import viteMdxPlugin from "./plugin-mdx.js";
 import viteRedirectPlugin from "./plugin-redirect.js";
+import { viteSearchPlugin } from "./plugin-search.js";
 import { viteSidebarPlugin } from "./plugin-sidebar.js";
 
 export default function vitePlugin(
@@ -37,6 +38,7 @@ export default function vitePlugin(
     viteFrontmatterPlugin(),
     viteSidebarPlugin(getCurrentConfig),
     viteApiPlugin(getCurrentConfig),
+    viteSearchPlugin(getCurrentConfig),
     viteAliasPlugin(getCurrentConfig),
     viteRedirectPlugin(getCurrentConfig),
     viteCustomCss(getCurrentConfig),


### PR DESCRIPTION
To avoid bundling the Inkeep dependency every time, even if not configured.

This will also help for future search plugins we will add