### PR TITLE
Adding option to keep the api categories closed by default -

### DIFF
--- a/examples/with-config/zudoku.config.ts
+++ b/examples/with-config/zudoku.config.ts
@@ -11,6 +11,7 @@ const config: ZudokuConfig = {
         type: "category",
         label: "Get started",
         items: ["introduction", "installation"],
+        collapsed: true,
       },
     ],
   },
@@ -19,6 +20,7 @@ const config: ZudokuConfig = {
     type: "url",
     input: "https://rickandmorty.zuplo.io/openapi.json",
     navigationId: "api",
+    defaultCollapsed: true,
   },
   docs: {
     files: "/pages/**/*.mdx",

--- a/examples/with-config/zudoku.config.ts
+++ b/examples/with-config/zudoku.config.ts
@@ -11,7 +11,6 @@ const config: ZudokuConfig = {
         type: "category",
         label: "Get started",
         items: ["introduction", "installation"],
-        collapsed: true,
       },
     ],
   },
@@ -20,7 +19,6 @@ const config: ZudokuConfig = {
     type: "url",
     input: "https://rickandmorty.zuplo.io/openapi.json",
     navigationId: "api",
-    defaultCollapsed: true,
   },
   docs: {
     files: "/pages/**/*.mdx",

--- a/packages/zudoku/src/config/validators/SidebarSchema.ts
+++ b/packages/zudoku/src/config/validators/SidebarSchema.ts
@@ -32,6 +32,7 @@ export type SidebarItemCategory = Omit<
   items: SidebarItem[];
   link?: SidebarItemCategoryLinkDoc;
   icon?: LucideIcon | string;
+  apiReference?: boolean;
 };
 
 export type SidebarItem =

--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -43,6 +43,7 @@ const ThemeSchema = z
 const ApiConfigSchema = z.object({
   server: z.string().optional(),
   navigationId: z.string().optional(),
+  defaultCollapsed: z.boolean().optional(),
 });
 
 const ApiSchema = z.union([

--- a/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { ChevronRightIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";

--- a/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
@@ -47,17 +47,16 @@ export const SidebarCategory = ({
   // this is useful when sidebar is collapsed and then user scrolls to an anchor link in the content then the sidebar should open to show the active category
   useEffect(() => {
     if (!activeAnchor) return;
-    // Don't auto-close if user has manually interacted with this category
     if (hasInteracted) return;
+
+    // if this category is not part of the api reference then return as we don't want to close-open on scroll for other documentation
+    if (!category.apiReference) return;
 
     const currentActiveCategory = activeAnchor.split("-")[0];
     const shouldBeOpen = currentActiveCategory === categoryLabel;
 
-    console.log("currentActiveCategory", activeAnchor);
-    console.log("categoryLabel", categoryLabel);
-
     setOpen(shouldBeOpen);
-  }, [activeAnchor, categoryLabel, hasInteracted]);
+  }, [activeAnchor, category.apiReference, categoryLabel, hasInteracted]);
 
   const ToggleButton = isCollapsible && (
     <button

--- a/packages/zudoku/src/lib/plugins/openapi/index.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/index.tsx
@@ -173,6 +173,7 @@ export const openApiPlugin = (
               color: MethodColorMap[operation.method.toLowerCase()],
             },
           })),
+          apiReference: true,
         }));
 
       categories.unshift({

--- a/packages/zudoku/src/lib/plugins/openapi/index.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/index.tsx
@@ -163,7 +163,7 @@ export const openApiPlugin = (
           type: "category",
           label: tag.name || "Other endpoints",
           collapsible: true,
-          collapsed: false,
+          collapsed: config.defaultCollapsed ?? false,
           items: tag.operations.map((operation) => ({
             type: "link",
             label: operation.summary ?? operation.path,

--- a/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
@@ -6,5 +6,6 @@ type OasSource =
 export type OasPluginConfig = {
   server?: string;
   navigationId?: string;
+  defaultCollapsed?: boolean;
   skipPreload?: boolean;
 } & OasSource;

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -1,7 +1,6 @@
 import express, { type Express } from "express";
 import { createHttpTerminator, HttpTerminator } from "http-terminator";
 import { Server } from "node:http";
-import path from "node:path";
 import { createServer as createViteServer, type ViteDevServer } from "vite";
 import { type render as serverRender } from "../app/entry.server.js";
 import { logger } from "../cli/common/logger.js";
@@ -44,10 +43,12 @@ export class DevServer {
     const graphql = createGraphQLServer({
       graphqlEndpoint: "/__z/graphql",
     });
-    const proxiedEntryClientPath = path.join(
-      vite.config.base,
-      "/__z/entry.client.tsx",
-    );
+
+    const proxiedEntryClientPath =
+      (vite.config.base.endsWith("/")
+        ? vite.config.base
+        : vite.config.base + "/") + "__z/entry.client.tsx";
+
     app.use(graphql.graphqlEndpoint, graphql);
     app.use(proxiedEntryClientPath, async (_req, res) => {
       const transformed = await vite.transformRequest(getAppClientEntryPath());

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import { createHttpTerminator, HttpTerminator } from "http-terminator";
 import { Server } from "node:http";
+import path from "node:path";
 import { createServer as createViteServer, type ViteDevServer } from "vite";
 import { type render as serverRender } from "../app/entry.server.js";
 import { logger } from "../cli/common/logger.js";
@@ -44,12 +45,10 @@ export class DevServer {
       graphqlEndpoint: "/__z/graphql",
     });
 
-    const proxiedEntryClientPath =
-      (vite.config.base.endsWith("/")
-        ? vite.config.base
-        : vite.config.base + "/") + "__z/entry.client.tsx";
-
-    logger.info(`The proxied entry client path is: ${proxiedEntryClientPath}`);
+    const proxiedEntryClientPath = path.join(
+      vite.config.base,
+      "/__z/entry.client.tsx",
+    );
 
     app.use(graphql.graphqlEndpoint, graphql);
     app.use(proxiedEntryClientPath, async (_req, res) => {

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -49,6 +49,8 @@ export class DevServer {
         ? vite.config.base
         : vite.config.base + "/") + "__z/entry.client.tsx";
 
+    logger.info(`The proxied entry client path is: ${proxiedEntryClientPath}`);
+
     app.use(graphql.graphqlEndpoint, graphql);
     app.use(proxiedEntryClientPath, async (_req, res) => {
       const transformed = await vite.transformRequest(getAppClientEntryPath());


### PR DESCRIPTION

- The section opens when a particular category is active.

[Here is how it looks - Loom video](https://www.loom.com/share/14ba9396fd764e0e81b2683cc5e7c834?sid=bfc6a143-85c1-486f-8c0a-24562c6f0c56)

- Added a key `defaultCollapsed` to the API config to determine if it should be collapsed by default.
- Try adding this key to the API config to test that.

![image](https://github.com/user-attachments/assets/645325d9-7d67-4513-9598-5412ff5a6605)

### Closes #280
