### PR TITLE
Fix navigation show on mobile per display type

### DIFF
--- a/examples/with-auth0/zudoku.config.ts
+++ b/examples/with-auth0/zudoku.config.ts
@@ -1,6 +1,7 @@
 import { type ZudokuConfig } from "zudoku";
 
 const config: ZudokuConfig = {
+  globalDisplay: "auth",
   topNavigation: [
     { id: "documentation", label: "Documentation" },
     { id: "api", label: "Rick & Morty API" },

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -31,6 +31,7 @@ export const convertZudokuConfigToOptions = (
     !config.page?.logo?.src?.dark;
 
   return {
+    globalDisplay: config.globalDisplay,
     page: {
       ...config.page,
       logo: {

--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -173,6 +173,7 @@ type BannerColorType = ZodOptional<
 const ConfigSchema = z
   .object({
     basePath: z.string().optional(),
+    globalDisplay: z.enum(["auth", "always"]).default("always").optional(),
     page: z
       .object({
         pageTitle: z.string(),
@@ -240,6 +241,16 @@ const ConfigSchema = z
           (val) =>
             typeof val === "string" ? /^pk_(test|live)_\w+$/.test(val) : false,
         ),
+        redirectToAfterSignUp: z.string().optional(),
+        redirectToAfterSignIn: z.string().optional(),
+        redirectToAfterSignOut: z.string().optional(),
+      }),
+      z.object({
+        type: z.literal("openid"),
+        clientId: z.string(),
+        issuer: z.string(),
+        audience: z.string().optional(),
+        scopes: z.array(z.string()).optional(),
         redirectToAfterSignUp: z.string().optional(),
         redirectToAfterSignIn: z.string().optional(),
         redirectToAfterSignOut: z.string().optional(),

--- a/packages/zudoku/src/lib/components/Layout.tsx
+++ b/packages/zudoku/src/lib/components/Layout.tsx
@@ -2,26 +2,33 @@ import { Helmet } from "@zudoku/react-helmet-async";
 import { PanelLeftIcon } from "lucide-react";
 import { Suspense, useEffect, useRef, type ReactNode } from "react";
 import { Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../authentication/hook.js";
 import { Drawer, DrawerTrigger } from "../ui/Drawer.js";
 import { cn } from "../util/cn.js";
 import { useScrollToAnchor } from "../util/useScrollToAnchor.js";
 import { useScrollToTop } from "../util/useScrollToTop.js";
 import { useViewportAnchor } from "./context/ViewportAnchorContext.js";
-import { useZudoku } from "./context/ZudokuContext.js";
+import { useTopNavigationItem, useZudoku } from "./context/ZudokuContext.js";
 import { Header } from "./Header.js";
 import { Sidebar } from "./navigation/Sidebar.js";
+import { ProtectedRoute } from "./ProtectedRoute.js";
 import { Slotlet } from "./SlotletProvider.js";
 import { Spinner } from "./Spinner.js";
 
 export const Layout = ({ children }: { children?: ReactNode }) => {
   const location = useLocation();
   const { setActiveAnchor } = useViewportAnchor();
-  const { meta, authentication } = useZudoku();
+  const { meta, authentication, globalDisplay } = useZudoku();
+  const { isAuthenticated } = useAuth();
+  const topNavItem = useTopNavigationItem();
 
   useScrollToAnchor();
   useScrollToTop();
 
   const previousLocationPath = useRef(location.pathname);
+  const needToProtectRoute =
+    (globalDisplay === "auth" || topNavItem?.display === "auth") &&
+    !isAuthenticated;
 
   useEffect(() => {
     // Initialize the authentication plugin
@@ -60,31 +67,37 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
           }
         >
           <Drawer direction="left">
-            <Sidebar />
-            <div
-              className={cn(
-                "lg:hidden -mx-10 px-10 py-2 sticky bg-background/80 backdrop-blur z-10 top-0 left-0 right-0 border-b",
-                "peer-data-[navigation=false]:hidden",
-              )}
-            >
-              <DrawerTrigger className="flex items-center gap-2">
-                <PanelLeftIcon size={16} strokeWidth={1.5} />
-                <span className="text-sm">Menu</span>
-              </DrawerTrigger>
-            </div>
-            <main
-              className={cn(
-                "h-full dark:border-white/10 translate-x-0",
-                "lg:overflow-visible",
-                // This works in tandem with the `SidebarWrapper` component
-                "lg:peer-data-[navigation=true]:w-[calc(100%-var(--side-nav-width))]",
-                "lg:peer-data-[navigation=true]:translate-x-[--side-nav-width] lg:peer-data-[navigation=true]:pl-12",
-              )}
-            >
-              <Slotlet name="zudoku-before-content" />
-              {children ?? <Outlet />}
-              <Slotlet name="zudoku-after-content" />
-            </main>
+            {needToProtectRoute ? (
+              <ProtectedRoute />
+            ) : (
+              <>
+                <Sidebar />
+                <div
+                  className={cn(
+                    "lg:hidden -mx-10 px-10 py-2 sticky bg-background/80 backdrop-blur z-10 top-0 left-0 right-0 border-b",
+                    "peer-data-[navigation=false]:hidden",
+                  )}
+                >
+                  <DrawerTrigger className="flex items-center gap-2">
+                    <PanelLeftIcon size={16} strokeWidth={1.5} />
+                    <span className="text-sm">Menu</span>
+                  </DrawerTrigger>
+                </div>
+                <main
+                  className={cn(
+                    "h-full dark:border-white/10 translate-x-0",
+                    "lg:overflow-visible",
+                    // This works in tandem with the `SidebarWrapper` component
+                    "lg:peer-data-[navigation=true]:w-[calc(100%-var(--side-nav-width))]",
+                    "lg:peer-data-[navigation=true]:translate-x-[--side-nav-width] lg:peer-data-[navigation=true]:pl-12",
+                  )}
+                >
+                  <Slotlet name="zudoku-before-content" />
+                  {children ?? <Outlet />}
+                  <Slotlet name="zudoku-after-content" />
+                </main>
+              </>
+            )}
           </Drawer>
         </Suspense>
       </div>

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -2,6 +2,7 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { cx } from "class-variance-authority";
 import { MenuIcon } from "lucide-react";
 import { NavLink } from "react-router-dom";
+import { useAuth } from "../authentication/hook.js";
 import {
   Drawer,
   DrawerClose,
@@ -13,7 +14,8 @@ import { useZudoku } from "./context/ZudokuContext.js";
 import { Search } from "./Search.js";
 
 export const MobileTopNavigation = () => {
-  const { topNavigation } = useZudoku();
+  const { topNavigation, globalDisplay } = useZudoku();
+  const { isAuthEnabled, isAuthenticated } = useAuth();
 
   return (
     <Drawer direction="right">
@@ -33,23 +35,35 @@ export const MobileTopNavigation = () => {
           <Search />
         </div>
         <ul className="flex flex-col items-center gap-4 p-4">
-          {topNavigation.map((item) => (
-            <li key={item.label}>
-              <NavLink
-                className={({ isActive }) =>
-                  cx(
-                    "block font-medium border-b-2",
-                    isActive
-                      ? "border-primary text-foreground"
-                      : "border-transparent text-foreground/75 hover:text-foreground hover:border-accent-foreground/25",
-                  )
-                }
-                to={item.id}
-              >
-                <DrawerClose>{item.label}</DrawerClose>
-              </NavLink>
-            </li>
-          ))}
+          {topNavigation
+            .filter(
+              (item) =>
+                (item.display === "auth" && isAuthEnabled && isAuthenticated) ||
+                (item.display === "anon" && !isAuthenticated) ||
+                (!item.display &&
+                  globalDisplay === "auth" &&
+                  isAuthEnabled &&
+                  isAuthenticated) ||
+                globalDisplay === "always" ||
+                item.display === "always",
+            )
+            .map((item) => (
+              <li key={item.label}>
+                <NavLink
+                  className={({ isActive }) =>
+                    cx(
+                      "block font-medium border-b-2",
+                      isActive
+                        ? "border-primary text-foreground"
+                        : "border-transparent text-foreground/75 hover:text-foreground hover:border-accent-foreground/25",
+                    )
+                  }
+                  to={item.id}
+                >
+                  <DrawerClose>{item.label}</DrawerClose>
+                </NavLink>
+              </li>
+            ))}
         </ul>
       </DrawerContent>
     </Drawer>

--- a/packages/zudoku/src/lib/components/ProtectedRoute.tsx
+++ b/packages/zudoku/src/lib/components/ProtectedRoute.tsx
@@ -1,15 +1,19 @@
-import { Outlet } from "react-router-dom";
-import { useAuth } from "../../authentication/hook.js";
-import { DeveloperHint } from "../../components/DeveloperHint.js";
-import { Button } from "../../ui/Button.js";
+import { Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../authentication/hook.js";
+import { DeveloperHint } from "../components/DeveloperHint.js";
+import { Button } from "../ui/Button.js";
 
 export const ProtectedRoute = () => {
   const auth = useAuth();
+  const location = useLocation();
 
   // TODO: should we suspend here somehow?
   if (auth.isAuthEnabled && auth.isPending) {
     return null;
   }
+
+  if (/oauth\/callback|signin|signout|signup/.test(location.pathname))
+    return <Outlet />;
 
   return auth.isAuthenticated ? (
     <Outlet />
@@ -22,7 +26,9 @@ export const ProtectedRoute = () => {
     </div>
   ) : (
     <div className="flex flex-col justify-center gap-2 items-center h-1/2">
-      Please login first to view this page
+      <h1 className="mt-2 text-4xl font-extrabold">
+        Please login first to view this page
+      </h1>
       <Button onClick={() => auth.login()}>Login</Button>
     </div>
   );

--- a/packages/zudoku/src/lib/components/TopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/TopNavigation.tsx
@@ -5,8 +5,8 @@ import { useAuth } from "../authentication/hook.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 
 export const TopNavigation = () => {
-  const { topNavigation } = useZudoku();
-  const { isAuthenticated } = useAuth();
+  const { topNavigation, globalDisplay } = useZudoku();
+  const { isAuthenticated, isAuthEnabled } = useAuth();
 
   // Hide top nav if there is only one item
   if (topNavigation.length <= 1) {
@@ -19,9 +19,13 @@ export const TopNavigation = () => {
         {topNavigation
           .filter(
             (item) =>
-              (item.display === "auth" && isAuthenticated) ||
+              (item.display === "auth" && isAuthEnabled && isAuthenticated) ||
               (item.display === "anon" && !isAuthenticated) ||
-              !item.display ||
+              (!item.display &&
+                globalDisplay === "auth" &&
+                isAuthEnabled &&
+                isAuthenticated) ||
+              globalDisplay === "always" ||
               item.display === "always",
           )
           .map((item) => (

--- a/packages/zudoku/src/lib/core/DevPortalContext.ts
+++ b/packages/zudoku/src/lib/core/DevPortalContext.ts
@@ -57,6 +57,7 @@ type Page = Partial<{
 }>;
 
 export type ZudokuContextOptions = {
+  globalDisplay?: string;
   metadata?: Metadata;
   page?: Page;
   authentication?: AuthenticationProvider;
@@ -76,6 +77,7 @@ export type ZudokuContextOptions = {
 };
 
 export class DevPortalContext {
+  public globalDisplay: NonNullable<ZudokuContextOptions["globalDisplay"]>;
   public plugins: NonNullable<ZudokuContextOptions["plugins"]>;
   public sidebars: NonNullable<ZudokuContextOptions["sidebars"]>;
   public topNavigation: NonNullable<ZudokuContextOptions["topNavigation"]>;
@@ -92,6 +94,7 @@ export class DevPortalContext {
     this.authentication = config.authentication;
     this.meta = config.metadata;
     this.page = config.page;
+    this.globalDisplay = config.globalDisplay || "always";
   }
 
   initialize = async (): Promise<void> => {

--- a/packages/zudoku/src/lib/plugins/api-keys/index.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/index.tsx
@@ -1,4 +1,5 @@
 import { type RouteObject } from "react-router-dom";
+import { ProtectedRoute } from "../../components/ProtectedRoute.js";
 import { DevPortalContext } from "../../core/DevPortalContext.js";
 import {
   type ApiIdentityPlugin,
@@ -8,7 +9,6 @@ import {
 import { RouterError } from "../../errors/RouterError.js";
 import invariant from "../../util/invariant.js";
 import { CreateApiKey } from "./CreateApiKey.js";
-import { ProtectedRoute } from "./ProtectedRoute.js";
 import { SettingsApiKeys } from "./SettingsApiKeys.js";
 
 const DEFAULT_API_KEY_ENDPOINT =


### PR DESCRIPTION
This PR fix the feature introduced on #290 on mobile devices, and add a feature to use `globalDisplay` for define the default behaviour of renderization to routes.