### PR TITLE
Add authentication type `openid`

### DIFF
--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -245,6 +245,16 @@ const ConfigSchema = z
         redirectToAfterSignOut: z.string().optional(),
       }),
       z.object({
+        type: z.literal("openid"),
+        clientId: z.string(),
+        issuer: z.string(),
+        audience: z.string().optional(),
+        scopes: z.array(z.string()).optional(),
+        redirectToAfterSignUp: z.string().optional(),
+        redirectToAfterSignIn: z.string().optional(),
+        redirectToAfterSignOut: z.string().optional(),
+      }),
+      z.object({
         type: z.literal("auth0"),
         clientId: z.string(),
         domain: z.string(),


### PR DESCRIPTION
Today to use `openid` authentication I need to set `auth0` and add some different configs, so in this PR I added a validation config to authentication type `openid`.