### PR TITLE
Use suspense + react query

### DIFF
--- a/packages/zudoku/src/lib/errors/ErrorAlert.tsx
+++ b/packages/zudoku/src/lib/errors/ErrorAlert.tsx
@@ -1,16 +1,29 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function ErrorAlert({ error }: { error: any }) {
-  const message = error?.message ?? "Something went wrong";
-  const stack = error?.stack;
+import { DeveloperHint } from "../components/DeveloperHint.js";
+import { ZudokuError } from "../util/invariant.js";
+
+export function ErrorAlert({ error }: { error: unknown }) {
+  const message =
+    error instanceof Error ? error.message : "Something went wrong";
+  const hint = error instanceof ZudokuError ? error.developerHint : undefined;
+  const title =
+    error instanceof ZudokuError ? error.title : "Something went wrong";
+  const stack = error instanceof Error ? error.stack : undefined;
+  const cause = error instanceof Error ? error.cause : undefined;
 
   return (
     <div className="flex h-screen max-h-screen min-h-full items-center justify-center bg-primary-background px-4 py-16 lg:px-8">
       <div className="mx-auto max-w-[85%] sm:max-w-[50%]">
         <h1 className="text-4xl font-bold tracking-tight text-h1-text sm:text-5xl">
-          Something went wrong
+          {title}
         </h1>
         <p className="mt-5 text-h1-text">{message}</p>
-        {stack ? (
+        {hint && <DeveloperHint className="mb-4">{hint}</DeveloperHint>}
+        {cause instanceof Error ? (
+          <pre className="mt-5 max-h-[400px] w-full overflow-scroll rounded-md border border-input-border bg-input-background p-3 text-property-name-text text-red-700">
+            {cause.stack}
+          </pre>
+        ) : stack ? (
           <pre className="mt-5 max-h-[400px] w-full overflow-scroll rounded-md border border-input-border bg-input-background p-3 text-property-name-text text-red-700">
             {stack}
           </pre>

--- a/packages/zudoku/src/lib/util/invariant.ts
+++ b/packages/zudoku/src/lib/util/invariant.ts
@@ -18,9 +18,21 @@ export default function invariant(
   throw new ZudokuError(provided ?? "Invariant failed");
 }
 
-class ZudokuError extends Error {
-  constructor(message: string) {
-    super(message);
+export class ZudokuError extends Error {
+  public developerHint: string | undefined;
+  public title: string | undefined;
+
+  constructor(
+    message: string,
+    {
+      developerHint,
+      title,
+      cause,
+    }: { developerHint?: string; title?: string; cause?: Error } = {},
+  ) {
+    super(message, { cause });
     this.name = "ZudokuError";
+    this.title = title;
+    this.developerHint = developerHint;
   }
 }


### PR DESCRIPTION
This PR changes to use react query over a custom implementation:
 - ✅ The callback gets executed only once, like before
 - ✅ It now uses the global suspense to show the loader
 - ✅ It now uses the global error page with the developer hint
 - ✅ The page is much easier to build
 - ✅ We don't have to use any on the error page