### PR TITLE
Fix capitalization and spelling of programming languages and product names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-This project uses Github Releases to publish changes.
+This project uses GitHub Releases to publish changes.
 
 See: https://github.com/zuplo/zudoku/releases

--- a/docs/pages/docs/configuration/vite-config.md
+++ b/docs/pages/docs/configuration/vite-config.md
@@ -8,4 +8,4 @@ Not all configurations are supported in Zudoku, but common tasks like adding plu
 
 Zudoku will automatically pick up the configuration file and will use it to augment the built-in configuration.
 
-You can find an [example project](https://github.com/zuplo/zudoku/tree/main/examples/with-vite-config) on Github that demonstrates how to use a custom Vite configuration with Zudoku.
+You can find an [example project](https://github.com/zuplo/zudoku/tree/main/examples/with-vite-config) on GitHub that demonstrates how to use a custom Vite configuration with Zudoku.

--- a/docs/pages/docs/markdown/overview.md
+++ b/docs/pages/docs/markdown/overview.md
@@ -2,7 +2,7 @@
 title: Markdown
 ---
 
-Zudoku supports [Github Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+Zudoku supports [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
 ## Page Titles
 

--- a/docs/src/PreviewBanner.tsx
+++ b/docs/src/PreviewBanner.tsx
@@ -6,7 +6,7 @@ export const PreviewBanner = () => {
         href="https://github.com/zuplo/zudoku/issues"
         className="underline hover:white"
       >
-        open a Github issue
+        open a GitHub issue
       </a>{" "}
       if you have feature requests or find any issues.
     </div>

--- a/packages/create-zudoku-app/templates/default/js/README-template.md
+++ b/packages/create-zudoku-app/templates/default/js/README-template.md
@@ -22,4 +22,4 @@ You can start editing the page by modifying `pages/docs/intro.mdx`. You will see
 
 To learn more about Zudoku, you can visit the [Zudoku documentation](https://zudoku.dev/docs).
 
-To connect with the community join the [Github Discussions](https://github.com/zuplo/zudoku/discussions) or [Discord](https://discord.zudoku.dev).
+To connect with the community join the [GitHub Discussions](https://github.com/zuplo/zudoku/discussions) or [Discord](https://discord.zudoku.dev).

--- a/packages/create-zudoku-app/templates/default/ts/README-template.md
+++ b/packages/create-zudoku-app/templates/default/ts/README-template.md
@@ -22,4 +22,4 @@ You can start editing the page by modifying `pages/docs/intro.mdx`. You will see
 
 To learn more about Zudoku, you can visit the [Zudoku documentation](https://zudoku.dev/docs).
 
-To connect with the community join the [Github Discussions](https://github.com/zuplo/zudoku/discussions) or [Discord](https://discord.zudoku.dev).
+To connect with the community join the [GitHub Discussions](https://github.com/zuplo/zudoku/discussions) or [Discord](https://discord.zudoku.dev).

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -216,13 +216,13 @@ export const Sidecar = ({
             }}
             options={[
               { value: "shell", label: "cURL" },
-              { value: "js", label: "Javascript" },
+              { value: "js", label: "JavaScript" },
               { value: "python", label: "Python" },
               { value: "java", label: "Java" },
               { value: "go", label: "Go" },
               { value: "csharp", label: "C#" },
               { value: "kotlin", label: "Kotlin" },
-              { value: "objc", label: "Objective C" },
+              { value: "objc", label: "Objective-C" },
               { value: "php", label: "PHP" },
               { value: "ruby", label: "Ruby" },
               { value: "swift", label: "Swift" },

--- a/website/src/app/components/Footer.tsx
+++ b/website/src/app/components/Footer.tsx
@@ -78,7 +78,7 @@ export const Footer = () => (
                     className="hover:text-white"
                     href="https://github.com/zuplo/zudoku"
                   >
-                    Zudoku on Github
+                    Zudoku on GitHub
                   </a>
                 </li>
                 <li className="pt-4">
@@ -86,7 +86,7 @@ export const Footer = () => (
                     className="hover:text-white"
                     href="https://github.com/zuplo/"
                   >
-                    Zuplo on Github
+                    Zuplo on GitHub
                   </a>
                 </li>
               </ul>
@@ -125,7 +125,7 @@ export const Footer = () => (
                 width="20"
                 height={20}
                 className="inline-block opacity-40 hover:opacity-80"
-                alt="Zudoku on Github"
+                alt="Zudoku on GitHub"
               />
             </a>
             <div className="mx-4 h-full border-l border-zinc-700"></div>

--- a/website/src/app/components/page.tsx
+++ b/website/src/app/components/page.tsx
@@ -85,7 +85,7 @@ const Page = async () => {
                   width="20"
                   height={20}
                   className="inline-block hover:opacity-80"
-                  alt="Zudoku on Github"
+                  alt="Zudoku on GitHub"
                 />
               </a>
               <a


### PR DESCRIPTION
This is a cosmetic PR that fixes capitalization and spelling of some proper nouns used in Zudoku UI and docs.

* Javascript -> JavaScript
* Objective C -> [Objective-C](https://developer.apple.com/documentation/objectivec) (with a hyphen)
* Github -> GitHub

### Screenshots

<img width="446" alt="Screenshot 2024-11-07 at 21 31 38" src="https://github.com/user-attachments/assets/60b5f177-c99c-4ac2-bcd5-ca2446dc28c9">

<img width="588" alt="Screenshot 2024-11-07 at 21 35 03" src="https://github.com/user-attachments/assets/9b874d7f-65dd-49a9-994b-fa7d8d81e329">
