### PR TITLE
Allow outside import file change

### DIFF
--- a/packages/zudoku/src/vite/plugin-config-reload.ts
+++ b/packages/zudoku/src/vite/plugin-config-reload.ts
@@ -17,7 +17,6 @@ export const createConfigReloadPlugin = (
       if (!onConfigChange) return;
 
       watcher.on("change", async (file) => {
-        if (!file.startsWith(currentConfig.rootDir)) return;
         if (!importDependencies.includes(file)) return;
 
         const newConfig = await onConfigChange();


### PR DESCRIPTION
In the rare case that a file is imported from outside the Zudoku root dir it would not reload the config correctly