### PR TITLE
Remove import assert

### DIFF
--- a/packages/zudoku/src/vite/output.ts
+++ b/packages/zudoku/src/vite/output.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import pkgJson from "../../package.json" assert { type: "json" };
+import pkgJson from "../../package.json";
 import { joinPath } from "../lib/util/joinPath.js";
 import { LoadedConfig } from "./config.js";
 

--- a/packages/zudoku/src/vite/output.ts
+++ b/packages/zudoku/src/vite/output.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { joinPath } from "../lib/util/joinPath.js";
 import { LoadedConfig } from "./config.js";
 
-const pkgJson = JSON.parse(await readFile("../../package.json", "utf-8"));
+const pkgJsonPath = path.join(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../../package.json",
+);
+
+const pkgJson = JSON.parse(await readFile(pkgJsonPath, "utf-8"));
 
 // Generates a Vercel build output file
 // https://vercel.com/docs/build-output-api/v3

--- a/packages/zudoku/src/vite/output.ts
+++ b/packages/zudoku/src/vite/output.ts
@@ -1,8 +1,9 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import pkgJson from "../../package.json";
 import { joinPath } from "../lib/util/joinPath.js";
 import { LoadedConfig } from "./config.js";
+
+const pkgJson = JSON.parse(await readFile("../../package.json", "utf-8"));
 
 // Generates a Vercel build output file
 // https://vercel.com/docs/build-output-api/v3


### PR DESCRIPTION
Without import assertion it fails: 

> This breaks in Vercel build: `TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "file:///vercel/path0/packages/zudoku/package.json" needs an import attribute of type "json"`

But Node 20 and Node 22 handle import assertions differently because the spec has changed.