### PR TITLE
Use `resolvedTheme` in useTheme

### DIFF
--- a/packages/zudoku/src/lib/components/SyntaxHighlight.tsx
+++ b/packages/zudoku/src/lib/components/SyntaxHighlight.tsx
@@ -56,14 +56,15 @@ export const SyntaxHighlight = ({
   language = "plain",
   ...props
 }: SyntaxHighlightProps) => {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const [isCopied, setIsCopied] = useState(false);
 
   if (!props.code) {
     return null;
   }
 
-  const highlightTheme = theme === "dark" ? themes.vsDark : themes.github;
+  const highlightTheme =
+    resolvedTheme === "dark" ? themes.vsDark : themes.github;
 
   // hardcoded values from the themes to avoid color flash in SSR
   const themeColorClasses =

--- a/packages/zudoku/src/lib/components/ThemeSwitch.tsx
+++ b/packages/zudoku/src/lib/components/ThemeSwitch.tsx
@@ -4,18 +4,20 @@ import { Button } from "zudoku/ui/Button.js";
 import { ClientOnly } from "./ClientOnly.js";
 
 export const ThemeSwitch = () => {
-  const { theme, setTheme } = useTheme();
-  const ThemeIcon = theme === "dark" ? MoonStarIcon : SunIcon;
+  const { resolvedTheme, setTheme } = useTheme();
+  const ThemeIcon = resolvedTheme === "dark" ? MoonStarIcon : SunIcon;
 
   return (
     <ClientOnly>
       <Button
         variant="ghost"
         aria-label={
-          theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
+          resolvedTheme === "dark"
+            ? "Switch to light mode"
+            : "Switch to dark mode"
         }
         className="p-2.5 -m-2.5 rounded-full"
-        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
       >
         <ThemeIcon size={18} />
       </Button>

--- a/packages/zudoku/src/lib/plugins/openapi/ColorizedParam.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/ColorizedParam.tsx
@@ -6,10 +6,10 @@ import { pastellize } from "../../util/pastellize.js";
 export const DATA_ATTR = "data-linked-param";
 
 export const usePastellizedColor = (name: string) => {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   return pastellize(
     name,
-    theme === "light" ? { saturation: 85, lightness: 50 } : undefined,
+    resolvedTheme === "light" ? { saturation: 85, lightness: 50 } : undefined,
   );
 };
 


### PR DESCRIPTION
The `theme` variable also shows `system` which is not desirable for us in the most cases right now.
`resolvedTheme` returns either `light` or `dark`.