### PR TITLE
Fix initial `react-query` refetch

### DIFF
--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -38,6 +38,13 @@ async function hydrateLazyRoutes(routes: RouteObject[]) {
 function render(routes: RouteObject[]) {
   const router = createBrowserRouter(routes, {
     basename: config.basePath,
+    future: {
+      v7_relativeSplatPath: true,
+      v7_fetcherPersist: true,
+      v7_partialHydration: true,
+      v7_skipActionErrorRevalidation: true,
+      v7_normalizeFormMethod: true,
+    },
   });
   createRoot(root).render(<Bootstrap router={router} />);
 }
@@ -46,6 +53,13 @@ async function hydrate(routes: RouteObject[]) {
   await hydrateLazyRoutes(routes);
   const router = createBrowserRouter(routes, {
     basename: config.basePath,
+    future: {
+      v7_relativeSplatPath: true,
+      v7_fetcherPersist: true,
+      v7_partialHydration: true,
+      v7_skipActionErrorRevalidation: true,
+      v7_normalizeFormMethod: true,
+    },
   });
 
   hydrateRoot(root, <Bootstrap hydrate router={router} />);

--- a/packages/zudoku/src/lib/components/Bootstrap.tsx
+++ b/packages/zudoku/src/lib/components/Bootstrap.tsx
@@ -4,7 +4,7 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 import { type HelmetData, HelmetProvider } from "@zudoku/react-helmet-async";
-import { StrictMode, useMemo } from "react";
+import { StrictMode, useState } from "react";
 import { type createBrowserRouter, RouterProvider } from "react-router-dom";
 import {
   type createStaticRouter,
@@ -20,7 +20,16 @@ const Bootstrap = ({
   hydrate?: boolean;
   router: ReturnType<typeof createBrowserRouter>;
 }) => {
-  const queryClient = useMemo(() => new QueryClient(), []);
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60 * 5,
+          },
+        },
+      }),
+  );
 
   return (
     <StrictMode>
@@ -28,7 +37,10 @@ const Bootstrap = ({
         <HydrationBoundary state={hydrate ? (window as any).DATA : undefined}>
           <HelmetProvider>
             <StaggeredRenderContext.Provider value={{ stagger: !hydrate }}>
-              <RouterProvider router={router} />
+              <RouterProvider
+                router={router}
+                future={{ v7_startTransition: true }}
+              />
             </StaggeredRenderContext.Provider>
           </HelmetProvider>
         </HydrationBoundary>


### PR DESCRIPTION
- Adding `staleTime` so there are no immediate refetches after SSR (see [`react-query` SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr#staleness-is-measured-from-when-the-query-was-fetched-on-the-server))
- Add `v7_startTransition` to `RouterProvider` so the router uses `startTransition` to keep previous data in top navigation (see https://github.com/TanStack/query/discussions/7013)
- Also added other `v7_*` future flags for us to keep an eye on so we can update `react-router` to v7 soon.