### PR TITLE
Schema post processors

### DIFF
--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -74,7 +74,7 @@ export async function loadZudokuConfig<TConfig>(
     __meta: {
       dependencies,
       path: filepath,
-      registerDependency: dependencies.push,
+      registerDependency: (...files: string[]) => dependencies.push(...files),
     },
   };
 

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -37,7 +37,11 @@ async function getConfigFilePath(rootDir: string): Promise<string> {
 }
 
 export type ConfigWithMeta<TConfig> = TConfig & {
-  __meta: { dependencies: string[]; path: string };
+  __meta: {
+    dependencies: string[];
+    path: string;
+    registerDependency: (...file: string[]) => void;
+  };
 };
 
 export async function loadZudokuConfig<TConfig>(
@@ -67,7 +71,11 @@ export async function loadZudokuConfig<TConfig>(
 
   const config: ConfigWithMeta<TConfig> = {
     ...loadedConfig,
-    __meta: { dependencies, path: filepath },
+    __meta: {
+      dependencies,
+      path: filepath,
+      registerDependency: dependencies.push,
+    },
   };
 
   return config;

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -174,7 +174,7 @@
     "@types/react": "18.3.11",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.1",
-    "@zudoku/config": "0.18.3",
+    "@zudoku/config": "workspace:*",
     "@zudoku/httpsnippet": "10.0.9",
     "@zudoku/react-helmet-async": "2.0.4",
     "autoprefixer": "10.4.20",

--- a/packages/zudoku/src/cli/common/logger.ts
+++ b/packages/zudoku/src/cli/common/logger.ts
@@ -7,8 +7,8 @@ export const logger = createLogger(
   },
 );
 
+// See https://vite.dev/config/shared-options.html#customlogger
 const loggerError = logger.error;
-
 logger.error = (msg, options) => {
   loggerError(msg, options);
   if (options?.error) {

--- a/packages/zudoku/src/cli/common/logger.ts
+++ b/packages/zudoku/src/cli/common/logger.ts
@@ -6,3 +6,13 @@ export const logger = createLogger(
     prefix: "zudoku",
   },
 );
+
+const loggerError = logger.error;
+
+logger.error = (msg, options) => {
+  loggerError(msg, options);
+  if (options?.error) {
+    // eslint-disable-next-line no-console
+    console.error(options.error);
+  }
+};

--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -11,10 +11,11 @@ import z, {
 import { fromError } from "zod-validation-error";
 import type { ExposedComponentProps } from "../../lib/components/SlotletProvider.js";
 import { ZudokuContext } from "../../lib/core/ZudokuContext.js";
-import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
 import type { ApiKey } from "../../lib/plugins/api-keys/index.js";
 import type { MdxComponentsType } from "../../lib/util/MdxComponents.js";
 import { InputSidebarSchema } from "./InputSidebarSchema.js";
+
+const AnyObject = z.object({}).passthrough();
 
 const ThemeSchema = z
   .object({
@@ -48,13 +49,8 @@ const ApiConfigSchema = z.object({
 
 const ApiPostProcessorSchema = z
   .function()
-  .args(z.custom<OpenAPIDocument>())
-  .returns(
-    z.union([
-      z.custom<OpenAPIDocument>(),
-      z.promise(z.custom<OpenAPIDocument>()),
-    ]),
-  );
+  .args(AnyObject)
+  .returns(z.union([AnyObject, z.promise(AnyObject)]));
 
 const ApiSchema = z.union([
   z

--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -11,6 +11,7 @@ import z, {
 import { fromError } from "zod-validation-error";
 import type { ExposedComponentProps } from "../../lib/components/SlotletProvider.js";
 import { ZudokuContext } from "../../lib/core/ZudokuContext.js";
+import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
 import type { ApiKey } from "../../lib/plugins/api-keys/index.js";
 import type { MdxComponentsType } from "../../lib/util/MdxComponents.js";
 import { InputSidebarSchema } from "./InputSidebarSchema.js";
@@ -45,13 +46,26 @@ const ApiConfigSchema = z.object({
   navigationId: z.string().optional(),
 });
 
+const ApiPostProcessorSchema = z
+  .function()
+  .args(z.custom<OpenAPIDocument>())
+  .returns(
+    z.union([
+      z.custom<OpenAPIDocument>(),
+      z.promise(z.custom<OpenAPIDocument>()),
+    ]),
+  );
+
 const ApiSchema = z.union([
   z
     .object({ type: z.literal("url"), input: z.string() })
     .merge(ApiConfigSchema),
   z
     .object({ type: z.literal("file"), input: z.string() })
-    .merge(ApiConfigSchema),
+    .merge(ApiConfigSchema)
+    .merge(
+      z.object({ postProcessors: ApiPostProcessorSchema.array().optional() }),
+    ),
   z
     .object({ type: z.literal("raw"), input: z.string() })
     .merge(ApiConfigSchema),

--- a/packages/zudoku/src/lib/plugins/openapi/client/useCreateQuery.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/client/useCreateQuery.ts
@@ -1,4 +1,5 @@
-import { useContext } from "react";
+import hashit from "object-hash";
+import { useContext, useMemo } from "react";
 import type { TypedDocumentString } from "../graphql/graphql.js";
 import { GraphQLContext } from "./GraphQLContext.js";
 
@@ -11,8 +12,10 @@ export const useCreateQuery = <TResult, TVariables>(
     throw new Error("useGraphQL must be used within a GraphQLProvider");
   }
 
+  const hash = useMemo(() => hashit(variables[0] ?? {}), [variables]);
+
   return {
     queryFn: () => graphQLClient.fetch(query, ...variables),
-    queryKey: [query, variables[0]],
+    queryKey: [query, hash],
   } as const;
 };

--- a/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
@@ -1,6 +1,6 @@
 type OasSource =
   | { type: "url"; input: string }
-  | { type: "file"; input: any }
+  | { type: "file"; input: () => Promise<unknown> }
   | { type: "raw"; input: string };
 
 export type OasPluginConfig = {

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -1,7 +1,9 @@
-import { readFile } from "fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { type Plugin } from "vite";
+import yaml from "yaml";
 import { type ZudokuPluginOptions } from "../config/config.js";
-import { OpenApiPluginOptions } from "../lib/plugins/openapi/index.js";
+import type { OpenAPIDocument } from "../lib/oas/parser/index.js";
 
 const viteApiPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
   const virtualModuleId = "virtual:zudoku-api-plugins";
@@ -25,37 +27,59 @@ const viteApiPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
 
         if (config.apis) {
           const apis = Array.isArray(config.apis) ? config.apis : [config.apis];
-          for (const c of apis) {
-            let apiConfig: OpenApiPluginOptions;
-            if (c.type === "file") {
-              let data = await readFile(c.input, "utf-8");
 
-              if (!data.trim().startsWith("{")) {
-                const yaml = await import("yaml");
-                data = yaml.parse(data);
+          const tmpDir = path.posix.join(
+            config.rootDir,
+            "node_modules/.zudoku/processed",
+          );
+          await fs.rm(tmpDir, { recursive: true, force: true });
+          await fs.mkdir(tmpDir, { recursive: true });
+
+          for (const apiConfig of apis) {
+            if (apiConfig.type === "file") {
+              const fileContent = await fs.readFile(apiConfig.input, "utf-8");
+
+              const data = /\.ya?ml$/.test(apiConfig.input)
+                ? yaml.parse(fileContent)
+                : JSON.parse(fileContent);
+
+              let processedSchema = data as OpenAPIDocument;
+
+              for (const postProcessor of apiConfig.postProcessors ?? []) {
+                processedSchema = await postProcessor(processedSchema);
               }
 
-              apiConfig = {
-                ...c,
-                type: "raw",
-                input: data,
-              };
-            } else {
-              apiConfig = c;
-            }
+              const processedFilePath = path.posix.join(
+                tmpDir,
+                `${path.basename(apiConfig.input)}.json`,
+              );
 
-            code.push(
-              ...[
+              await fs.writeFile(
+                processedFilePath,
+                JSON.stringify(processedSchema),
+              );
+              code.push(
+                "configuredApiPlugins.push(openApiPlugin({",
+                '  type: "file",',
+                `  input: () => import("${processedFilePath}"),`,
+                `  navigationId: "${apiConfig.navigationId}",`,
+                "}));",
+              );
+            } else {
+              code.push(
                 `// @ts-ignore`, // To make tests pass
-                `configuredApiPlugins.push(openApiPlugin(${JSON.stringify({ ...apiConfig, inMemory: options?.ssr ?? config.mode === "internal" })}));`,
-              ],
-            );
+                `configuredApiPlugins.push(openApiPlugin(${JSON.stringify({
+                  ...apiConfig,
+                  inMemory: options?.ssr ?? config.mode === "internal",
+                })}));`,
+              );
+            }
           }
         }
 
         code.push(`export { configuredApiPlugins };`);
 
-        return { code: code.join("\n") };
+        return code.join("\n");
       }
     },
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,7 +408,7 @@ importers:
         specifier: 4.3.1
         version: 4.3.1(patch_hash=jb2tifk2jsavdxlrb3gpff2s3i)(vite@5.4.9(@types/node@20.16.11))
       '@zudoku/config':
-        specifier: 0.18.3
+        specifier: workspace:*
         version: link:../config
       '@zudoku/httpsnippet':
         specifier: 10.0.9


### PR DESCRIPTION
**Changes:**
- To be able to process schema files, they are now stored intermediately in `node_modules/.zudoku` as JSON (=> meaning YAML gets converted).
- Instead of inlining file contents of APIs into the config, they are now lazily imported: `() => import('/path/$processedSchema.json')` at fetch time. This can reduce the size of the config significantly.
- Add `postProcessors` to the config. It accepts an array of processor functions of type `(schema: OpenAPIDocument) => OpenAPIDocument`
- Add watcher to added API files in the config so the server restarts to reflect the changes.