### PR TITLE
Add workaround for version skew

### DIFF
--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -64,3 +64,11 @@ async function hydrate(routes: RouteObject[]) {
 
   hydrateRoot(root, <Bootstrap hydrate router={router} />);
 }
+
+// This is a workaround to avoid version skewing
+// See https://vite.dev/guide/build.html#load-error-handling
+// TODO: Implement a more advanced solution if there are CDN urls or e.g. Vercel Skew Protection
+window.addEventListener("vite:preloadError", (e) => {
+  e.preventDefault();
+  window.location.reload();
+});


### PR DESCRIPTION
To workaround errors we are facing "cannot fetch dynamic imports. See https://vite.dev/guide/build.html#load-error-handling

We will have to add better handling for this if possible, e.g. [Vercel Skew Protection](https://vercel.com/docs/deployments/skew-protection)

More references I found in research:

- https://ryanjc.com/blog/vercel-skew-protection-vite/
- https://vite.dev/guide/build.html#advanced-base-options