### PR TITLE
Add vendor chunking

### DIFF
--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router-dom";
 import config from "virtual:zudoku-config";
 import "virtual:zudoku-theme.css";
+import "vite/modulepreload-polyfill";
 import { Bootstrap } from "zudoku/components";
 import "./main.css";
 import { getRoutesByConfig } from "./main.js";

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -10,6 +10,7 @@ import {
   createStaticRouter,
 } from "react-router-dom/server.js";
 import "virtual:zudoku-theme.css";
+import "vite/modulepreload-polyfill";
 import { BootstrapStatic, ServerError } from "zudoku/components";
 import type { ZudokuConfig } from "../config/config.js";
 import type { FileWritingResponse } from "../vite/prerender.js";

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -214,6 +214,16 @@ export async function getViteConfig(
               ? ["zudoku/app/entry.server.tsx", config.__meta.path]
               : "zudoku/app/entry.client.tsx"
             : undefined,
+        output: {
+          manualChunks: (id) => {
+            // SSR fails with "ReferenceError: Prism is not defined" so we don't chunk it
+            if (id.includes("prism")) return;
+
+            if (id.includes("node_modules")) {
+              return "vendor";
+            }
+          },
+        },
       },
     },
     optimizeDeps: {


### PR DESCRIPTION
- Output a chunk for `node_modules` to decrease the main bundle size.
- [Add module preload](https://vite.dev/config/build-options#build-modulepreload) so chunks are preloaded. (in projects with `index.html` entry point this is done automatically)