### PR TITLE
Support metadata on API reference page

### DIFF
--- a/docs/pages/configuration/api-reference.md
+++ b/docs/pages/configuration/api-reference.md
@@ -60,3 +60,12 @@ const config = {
   // ...
 };
 ```
+
+## Metadata
+
+Your API reference page metadata is sourced directly from your OpenAPI spec. The [`info`](https://spec.openapis.org/oas/v3.1.0#info-object) object is used set the corresponding tags in the page's `head`.
+
+| Metadata Property | OpenAPI Property | Comment                                                                                                                                        |
+| ----------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| title             | `info.title`     | If `metadata.title` is set as a template string (ex. `%s - My Company`) it will be used                                                        |
+| description       | `info.summary`   | `info.summary` is preferred as it is shorter and plaintext-only, but Zudoku will fall back to the `info.description` if no summary is provided |

--- a/packages/zudoku/src/lib/oas/graphql/index.ts
+++ b/packages/zudoku/src/lib/oas/graphql/index.ts
@@ -390,6 +390,10 @@ const Schema = builder.objectRef<OpenAPIDocument>("Schema").implement({
       resolve: (root) => root.info.description,
       nullable: true,
     }),
+    summary: t.string({
+      resolve: (root) => root.info.summary,
+      nullable: true,
+    }),
     paths: t.field({
       type: [PathItem],
       resolve: (root) =>

--- a/packages/zudoku/src/lib/plugins/openapi/OperationList.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/OperationList.tsx
@@ -1,5 +1,6 @@
 import { ResultOf } from "@graphql-typed-document-node/core";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Helmet } from "@zudoku/react-helmet-async";
 import { CategoryHeading } from "../../components/CategoryHeading.js";
 import { Heading } from "../../components/Heading.js";
 import { Markdown, ProseClasses } from "../../components/Markdown.js";
@@ -81,6 +82,7 @@ const AllOperationsQuery = graphql(/* GraphQL */ `
   query AllOperations($input: JSON!, $type: SchemaType!) {
     schema(input: $input, type: $type) {
       description
+      summary
       title
       url
       version
@@ -96,19 +98,77 @@ const AllOperationsQuery = graphql(/* GraphQL */ `
   }
 `);
 
+/**
+ * @description Clean up a commonmark formatted description for use in the meta
+ * description.
+ */
+function cleanDescription(
+  description: string,
+  maxLength: number = 160,
+): string {
+  if (!description) {
+    return "";
+  }
+
+  // Replace Markdown links [text](url) with just "text"
+  description = description.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+
+  // Remove Markdown image syntax: ![alt](url)
+  description = description.replace(/!\[.*?\]\(.*?\)/g, "");
+
+  // Remove other Markdown syntax (e.g., **bold**, _italic_, `code`)
+  description = description.replace(/[_*`~]/g, "");
+
+  // Remove headings (# Heading), blockquotes (> Quote), and horizontal rules (--- or ***)
+  description = description.replace(/^(?:>|\s*#+|-{3,}|\*{3,})/gm, "");
+
+  // Remove any remaining formatting characters
+  description = description.replace(/[|>{}[\]]/g, "");
+
+  // Collapse multiple spaces and trim the text
+  description = description.replace(/\s+/g, " ").trim();
+
+  // Limit to the specified maximum length
+  description = description.substring(0, maxLength);
+
+  // Escape for HTML safety
+  return description
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 export const OperationList = () => {
   const { input, type } = useOasConfig();
   const query = useCreateQuery(AllOperationsQuery, { input, type });
   const result = useSuspenseQuery(query);
-
+  const title = result.data.schema.title;
+  const summary = result.data.schema.summary;
+  const description = result.data.schema.description;
+  // The summary property is preferable here as it is a short description of
+  // the API, whereas the description property is typically longer and supports
+  // commonmark formatting, making it ill-suited for use in the meta description
+  const metaDescription = summary
+    ? summary
+    : description
+      ? cleanDescription(description)
+      : undefined;
   return (
     <div className="pt-[--padding-content-top]">
+      <Helmet>
+        <title>{title}</title>
+        {metaDescription && (
+          <meta name="description" content={metaDescription} />
+        )}
+      </Helmet>
       <div
         className={cn(ProseClasses, "mb-16 max-w-full prose-img:max-w-prose")}
       >
         <CategoryHeading>Overview</CategoryHeading>
         <Heading level={1} id="description" registerSidebarAnchor>
-          {result.data.schema.title}
+          {title}
         </Heading>
         <Markdown content={result.data.schema.description ?? ""} />
       </div>

--- a/packages/zudoku/src/lib/plugins/openapi/graphql/gql.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/graphql/gql.ts
@@ -17,7 +17,7 @@ const documents = {
     types.ServersQueryDocument,
   "\n  fragment OperationsFragment on OperationItem {\n    slug\n    summary\n    method\n    description\n    operationId\n    contentTypes\n    path\n    parameters {\n      name\n      in\n      description\n      required\n      schema\n      style\n      examples {\n        name\n        description\n        externalValue\n        value\n        summary\n      }\n    }\n    requestBody {\n      content {\n        mediaType\n        encoding {\n          name\n        }\n        examples {\n          name\n          description\n          externalValue\n          value\n          summary\n        }\n        schema\n      }\n      description\n      required\n    }\n    responses {\n      statusCode\n      links\n      description\n      content {\n        examples {\n          name\n          description\n          externalValue\n          value\n          summary\n        }\n        mediaType\n        encoding {\n          name\n        }\n        schema\n      }\n    }\n  }\n":
     types.OperationsFragmentFragmentDoc,
-  "\n  query AllOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      description\n      title\n      url\n      version\n      tags {\n        name\n        description\n        operations {\n          slug\n          ...OperationsFragment\n        }\n      }\n    }\n  }\n":
+  "\n  query AllOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      description\n      summary\n      title\n      url\n      version\n      tags {\n        name\n        description\n        operations {\n          slug\n          ...OperationsFragment\n        }\n      }\n    }\n  }\n":
     types.AllOperationsDocument,
   "\n  query getServerQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n":
     types.GetServerQueryDocument,
@@ -41,7 +41,7 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: "\n  query AllOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      description\n      title\n      url\n      version\n      tags {\n        name\n        description\n        operations {\n          slug\n          ...OperationsFragment\n        }\n      }\n    }\n  }\n",
+  source: "\n  query AllOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      description\n      summary\n      title\n      url\n      version\n      tags {\n        name\n        description\n        operations {\n          slug\n          ...OperationsFragment\n        }\n      }\n    }\n  }\n",
 ): typeof import("./graphql.js").AllOperationsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.

--- a/packages/zudoku/src/lib/plugins/openapi/graphql/graphql.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/graphql/graphql.ts
@@ -136,6 +136,7 @@ export type Schema = {
   title: Scalars["String"]["output"];
   url: Scalars["String"]["output"];
   version: Scalars["String"]["output"];
+  summary?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type SchemaOperationsArgs = {
@@ -261,6 +262,7 @@ export type AllOperationsQuery = {
   schema: {
     __typename?: "Schema";
     description?: string | null;
+    summary?: string | null;
     title: string;
     url: string;
     version: string;
@@ -419,6 +421,7 @@ export const AllOperationsDocument = new TypedDocumentString(`
     query AllOperations($input: JSON!, $type: SchemaType!) {
   schema(input: $input, type: $type) {
     description
+    summary
     title
     url
     version


### PR DESCRIPTION
## Summary

Currently - the API reference pages do not have any metadata. This PR uses the OpenAPI spec's `info` property to add the title and description metatags. Perhaps we will want to allow overriding via `ZudokuConfig` but I feel like this is a pretty sensible default.