### PR TITLE
Fix base path redirect

### DIFF
--- a/packages/zudoku/src/vite/output.ts
+++ b/packages/zudoku/src/vite/output.ts
@@ -143,8 +143,10 @@ export function generateOutput(config: LoadedConfig): Config {
 
   if (config.basePath) {
     routes.push({
-      src: "/",
+      src: "^/$",
       dest: config.basePath,
+      status: 301,
+      headers: { Location: config.basePath },
     });
   }
 


### PR DESCRIPTION
Missing header `Location`