### PR TITLE
require path params

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
@@ -37,7 +37,6 @@ export const PathParams = ({
                         !field.value && "opacity-60",
                       )}
                     />
-                    *
                   </div>
                 )}
               />
@@ -50,6 +49,7 @@ export const PathParams = ({
                   render={({ field }) => (
                     <Input
                       {...field}
+                      required
                       placeholder="Enter value"
                       className="border-0 shadow-none ring-0 font-mono text-xs"
                     />

--- a/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
@@ -37,6 +37,7 @@ export const PathParams = ({
                         !field.value && "opacity-60",
                       )}
                     />
+                    *
                   </div>
                 )}
               />


### PR DESCRIPTION
This helps by using the browser validation to foucs the required field. 

If the request is executed without that field, it may lead to a 404.