### PR TITLE
Remove syntax highlighter test

### DIFF
--- a/packages/zudoku/src/lib/components/SyntaxHighlight.tsx
+++ b/packages/zudoku/src/lib/components/SyntaxHighlight.tsx
@@ -13,11 +13,7 @@ void import("prismjs/components/prism-bash.min.js");
 // @ts-expect-error This is untyped
 void import("prismjs/components/prism-ruby.min.js");
 // @ts-expect-error This is untyped
-void import("prismjs/components/prism-markup-templating.js");
-// @ts-expect-error This is untyped
 void import("prismjs/components/prism-markup.js");
-// @ts-expect-error This is untyped
-void import("prismjs/components/prism-php.min.js");
 // @ts-expect-error This is untyped
 void import("prismjs/components/prism-json.min.js");
 // @ts-expect-error This is untyped


### PR DESCRIPTION
We see this error below quite often, so to rule out the PHP syntax highlighter, let's remove it and monitor.

`prism-markup-templating.js` is a dependency of the PHP highlighter

![CleanShot 2024-12-19 at 15 26 29](https://github.com/user-attachments/assets/aea0e7c9-fd3e-4b25-9f58-6d2bbb34b468)
