### PR TITLE
fix(generate-icon-types): correct path resolution for Windows base system

### DIFF
--- a/packages/zudoku/scripts/generate-icon-types.ts
+++ b/packages/zudoku/scripts/generate-icon-types.ts
@@ -1,12 +1,10 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { format } from "prettier";
 import * as ts from "typescript";
 
-const require = createRequire(import.meta.url);
-const filePath = require.resolve("lucide-react/dynamicIconImports.js");
+const path = import.meta.resolve("lucide-react/dynamicIconImports.js");
+const filePath = fileURLToPath(new URL(path));
 const fileContent = readFileSync(filePath, "utf-8");
 
 const sourceFile = ts.createSourceFile(
@@ -30,9 +28,7 @@ visit(sourceFile);
 let typeDefinition = `export type IconNames = ${iconNames.map((name) => `"${name}"`).join(" | ")};`;
 typeDefinition = await format(typeDefinition, { parser: "typescript" });
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const outputPath = path.resolve(
-  __dirname,
-  "../src/config/validators/icon-types.ts",
+const outputPath = fileURLToPath(
+  new URL("../src/config/validators/icon-types.ts", import.meta.url),
 );
 writeFileSync(outputPath, typeDefinition);

--- a/packages/zudoku/scripts/generate-icon-types.ts
+++ b/packages/zudoku/scripts/generate-icon-types.ts
@@ -1,9 +1,12 @@
 import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { format } from "prettier";
 import * as ts from "typescript";
 
-const path = import.meta.resolve("lucide-react/dynamicIconImports.js");
-const filePath = new URL(path).pathname;
+const require = createRequire(import.meta.url);
+const filePath = require.resolve("lucide-react/dynamicIconImports.js");
 const fileContent = readFileSync(filePath, "utf-8");
 
 const sourceFile = ts.createSourceFile(
@@ -27,8 +30,9 @@ visit(sourceFile);
 let typeDefinition = `export type IconNames = ${iconNames.map((name) => `"${name}"`).join(" | ")};`;
 typeDefinition = await format(typeDefinition, { parser: "typescript" });
 
-const outputPath = new URL(
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const outputPath = path.resolve(
+  __dirname,
   "../src/config/validators/icon-types.ts",
-  import.meta.url,
-).pathname;
+);
 writeFileSync(outputPath, typeDefinition);


### PR DESCRIPTION
Correct path resolution for Windows base system for `dynamicIconImports.js`

Fixes: #513

## Before fix

Check issue

## After fix

```bash
PS C:\Users\shivams\Desktop\open-source\zudoku> nx run zudoku:build                                                    

> nx run zudoku:"generate:icon-types"

> zudoku@0.23.7 generate:icon-types C:\Users\shivams\Desktop\open-source\zudoku\packages\zudoku
> tsx ./scripts/generate-icon-types.ts

> nx run zudoku:build

> zudoku@0.23.7 build C:\Users\shivams\Desktop\open-source\zudoku\packages\zudoku
> tsc --project tsconfig.json

—————————————————————————————————————————————————————————————————————————————————————————————————————————————————————— 

 NX   Successfully ran target build for project zudoku and 1 task it depends on (25s)

View logs and investigate cache misses at https://nx.app/runs/5XCHpMaQ8t
```