### PR TITLE
Add canonical URL

### DIFF
--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -51,6 +51,13 @@ export const MdxPage = ({
   }
 >) => {
   const categoryTitle = useCurrentItem()?.categoryLabel;
+  const id = useCurrentItem()?.id;
+  let canonicalUrl = null;
+  if (typeof window !== "undefined") {
+    const domain = window.location.origin;
+    canonicalUrl = id ? `${domain}/${id}` : domain;
+  }
+
   const title = frontmatter.title;
   const category = frontmatter.category ?? categoryTitle;
   const hideToc = frontmatter.toc === false || defaultOptions?.toc === false;
@@ -87,6 +94,7 @@ export const MdxPage = ({
       <Helmet>
         <title>{pageTitle}</title>
         {excerpt && <meta name="description" content={excerpt} />}
+        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
       </Helmet>
       <div
         className={cn(

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -2,7 +2,7 @@ import { useMDXComponents } from "@mdx-js/react";
 import slugify from "@sindresorhus/slugify";
 import { Helmet } from "@zudoku/react-helmet-async";
 import { type PropsWithChildren, useEffect } from "react";
-import { Link } from "react-router";
+import { Link, useHref } from "react-router";
 import { CategoryHeading } from "../../components/CategoryHeading.js";
 import { Heading } from "../../components/Heading.js";
 import { ProseClasses } from "../../components/Markdown.js";
@@ -51,11 +51,11 @@ export const MdxPage = ({
   }
 >) => {
   const categoryTitle = useCurrentItem()?.categoryLabel;
-  const id = useCurrentItem()?.id;
   let canonicalUrl = null;
+  const path = useHref("");
   if (typeof window !== "undefined") {
     const domain = window.location.origin;
-    canonicalUrl = id ? `${domain}/${id}` : domain;
+    canonicalUrl = `${domain}${path}`;
   }
 
   const title = frontmatter.title;


### PR DESCRIPTION
## Summary

Docs pages should have canonical URLs so that google does not accidentally index a duplicate version of the same page (ex. the same page with query params). This currently affects our docs.

### Question

Is there any way to know what domain we are on in `MdxPage.tsx` without using `window`? It's likely better to have the canonical URL in the `head` during SSR rather than waiting for CSR