### PR TITLE
Revert sidebar category changes

### DIFF
--- a/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarCategory.tsx
@@ -112,10 +112,10 @@ export const SidebarCategory = ({
         className={cn(
           // CollapsibleContent class is used to animate and it should only be applied when the user has triggered the toggle
           hasInteracted && "CollapsibleContent",
-          "my-1",
+          "ms-6 my-1",
         )}
       >
-        <ul className={"relative"}>
+        <ul className="relative after:absolute after:-left-[--padding-nav-item] after:translate-x-[1.5px] after:top-0 after:bottom-0 after:w-px after:bg-border">
           {category.items.map((item) => (
             <SidebarItem
               key={


### PR DESCRIPTION
We need indentation and I think we also should have the lines as guides which level.
See this example which actually has two levels:

![CleanShot 2025-01-22 at 11 00 41](https://github.com/user-attachments/assets/78a16ff2-d98a-4926-8dc5-09003e4bb809)
