### PR TITLE
Ignore major upgrades by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,6 @@ updates:
       prettier-dependencies:
         patterns:
           - "*prettier*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
many times we won't be able to upgrade to a major version due to deprecation of lib, or functions etc..

Also, take example of #635 this not an automated upgrade.