### PR TITLE
Fix scroll to element when router page changes

### DIFF
--- a/packages/zudoku/src/lib/util/useScrollToAnchor.ts
+++ b/packages/zudoku/src/lib/util/useScrollToAnchor.ts
@@ -54,5 +54,5 @@ export const useScrollToAnchor = () => {
 
       return () => observer.disconnect();
     }
-  }, [location.hash, setActiveAnchor]);
+  }, [location.hash, scrollToHash, setActiveAnchor]);
 };

--- a/packages/zudoku/src/lib/util/useScrollToTop.ts
+++ b/packages/zudoku/src/lib/util/useScrollToTop.ts
@@ -4,10 +4,17 @@ import { useLocation } from "react-router";
 export const useScrollToTop = () => {
   const location = useLocation();
   const previousPath = useRef(location.pathname);
+  const previousHash = useRef(location.hash);
 
   useEffect(() => {
-    if (previousPath.current === location.pathname) return;
-    window.scrollTo(0, 0);
+    const isNewPage = previousPath.current !== location.pathname;
+    const hasAnchor = location.hash !== "";
+
+    if (isNewPage && !hasAnchor) {
+      window.scrollTo(0, 0);
+    }
+
     previousPath.current = location.pathname;
-  }, [location.pathname]);
+    previousHash.current = location.hash;
+  }, [location.pathname, location.hash]);
 };


### PR DESCRIPTION
`useScrollToTop` wins over `useScrollToAnchor` but this shouldn't be the case when we switch a page and it has an anchor.