### PR TITLE
Prerender redirects as static file or to Vercel config

### DIFF
--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -2,6 +2,7 @@ import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { build as viteBuild } from "vite";
 import { findOutputPathOfServerConfig } from "../config/loader.js";
+import invariant from "../lib/util/invariant.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { getViteConfig, loadZudokuConfig } from "./config.js";
 import { getBuildHtml } from "./html.js";
@@ -54,44 +55,46 @@ export async function runBuild(options: { dir: string }) {
 
     const serverConfigFilename = findOutputPathOfServerConfig(serverResult);
 
+    invariant(viteClientConfig.build?.outDir, "Client build outDir is missing");
+    invariant(viteServerConfig.build?.outDir, "Server build outDir is missing");
+
     try {
-      const writtenFiles = await prerender({
+      const results = await prerender({
         html,
         dir: options.dir,
         basePath: config.basePath,
         serverConfigFilename,
+        writeRedirects: process.env.VERCEL === undefined,
       });
 
-      if (writtenFiles.includes("index.html")) {
-        return;
+      const indexHtml = path.join(viteClientConfig.build.outDir, "index.html");
+
+      if (!results.find((r) => r.outputPath === indexHtml)) {
+        await writeFile(indexHtml, html, "utf-8");
       }
 
-      await writeFile(
-        path.join(options.dir, DIST_DIR, config.basePath ?? "", "index.html"),
-        html,
-        "utf-8",
-      );
+      await rm(viteServerConfig.build.outDir, { recursive: true, force: true });
 
-      const serverDir = path.join(options.dir, DIST_DIR, "server");
-      await rm(serverDir, { recursive: true, force: true });
+      if (process.env.VERCEL) {
+        await mkdir(path.join(options.dir, ".vercel/output/static"), {
+          recursive: true,
+        });
+        await rename(
+          path.join(options.dir, DIST_DIR),
+          path.join(options.dir, ".vercel/output/static"),
+        );
+      }
+
+      // Write the build output file
+      await writeOutput(options.dir, {
+        config,
+        redirects: results.flatMap((r) => r.redirect ?? []),
+      });
     } catch (e) {
       // dynamic imports in prerender swallow the stack trace, so we log it here
       // eslint-disable-next-line no-console
       console.error(e);
     }
-
-    if (process.env.VERCEL) {
-      await mkdir(path.join(options.dir, ".vercel/output/static"), {
-        recursive: true,
-      });
-      await rename(
-        path.join(options.dir, DIST_DIR),
-        path.join(options.dir, ".vercel/output/static"),
-      );
-    }
-
-    // Write the build output file
-    await writeOutput(options.dir, config);
 
     return;
   }

--- a/packages/zudoku/src/vite/prerender/FileWritingResponse.ts
+++ b/packages/zudoku/src/vite/prerender/FileWritingResponse.ts
@@ -6,6 +6,7 @@ export class FileWritingResponse {
   private dontSave = false;
   private resolve = () => {};
   private resolved = new Promise<void>((res) => (this.resolve = res));
+  public redirectedTo?: string;
 
   set() {}
   status(status: number) {
@@ -15,12 +16,23 @@ export class FileWritingResponse {
   }
   on() {}
 
-  constructor(private readonly fileName: string) {}
+  constructor(
+    private options: {
+      fileName: string;
+      writeRedirects: boolean;
+    },
+  ) {}
 
   redirect(_status: number, url: string) {
-    void this.end(
-      `<!doctype html><meta http-equiv="refresh" content="0; url=${url}">`,
-    );
+    if (this.options.writeRedirects) {
+      this.write(
+        `<!doctype html><meta http-equiv="refresh" content="0; url=${url}">`,
+      );
+    } else {
+      this.dontSave = true;
+    }
+    this.redirectedTo = url;
+    void this.end();
   }
 
   send = async (chunk: string) => {
@@ -34,8 +46,8 @@ export class FileWritingResponse {
 
   async end(chunk = "") {
     if (!this.dontSave) {
-      await fs.mkdir(path.dirname(this.fileName), { recursive: true });
-      await fs.writeFile(this.fileName, this.buffer + chunk);
+      await fs.mkdir(path.dirname(this.options.fileName), { recursive: true });
+      await fs.writeFile(this.options.fileName, this.buffer + chunk);
     }
     this.resolve();
   }

--- a/packages/zudoku/src/vite/prerender/FileWritingResponse.ts
+++ b/packages/zudoku/src/vite/prerender/FileWritingResponse.ts
@@ -17,10 +17,10 @@ export class FileWritingResponse {
 
   constructor(private readonly fileName: string) {}
 
-  redirect() {
-    this.buffer = "redirected";
-    this.dontSave = true;
-    this.resolve();
+  redirect(_status: number, url: string) {
+    void this.end(
+      `<!doctype html><meta http-equiv="refresh" content="0; url=${url}">`,
+    );
   }
 
   send = async (chunk: string) => {

--- a/packages/zudoku/src/vite/prerender/worker.ts
+++ b/packages/zudoku/src/vite/prerender/worker.ts
@@ -5,17 +5,19 @@ import type { render as renderServer } from "../../app/entry.server.js";
 import type { ZudokuConfig } from "../../config/validators/validate.js";
 import { joinUrl } from "../../lib/util/joinUrl.js";
 import { FileWritingResponse } from "./FileWritingResponse.js";
+import { WorkerResult } from "./prerender.js";
 
 export type StaticWorkerData = {
   template: string;
   distDir: string;
   serverConfigPath: string;
   entryServerPath: string;
+  writeRedirects: boolean;
 };
 
 export type WorkerData = { urlPath: string };
 
-const { template, distDir, serverConfigPath, entryServerPath } =
+const { template, distDir, serverConfigPath, entryServerPath, writeRedirects } =
   Piscina.workerData as StaticWorkerData;
 
 const [render, config] = (await Promise.all([
@@ -23,17 +25,26 @@ const [render, config] = (await Promise.all([
   import(pathToFileURL(serverConfigPath).href).then((m) => m.default),
 ])) as [typeof renderServer, ZudokuConfig];
 
-const renderPage = async ({ urlPath }: WorkerData): Promise<string> => {
+const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
   const filename = urlPath === "/" ? "/index.html" : `${urlPath}.html`;
-  const url = joinUrl("http://localhost", config.basePath, urlPath);
+  const pathname = joinUrl(config.basePath, urlPath);
+  const url = joinUrl("http://localhost", pathname);
   const outputPath = path.join(distDir, filename);
+
   const request = new Request(url);
-  const response = new FileWritingResponse(outputPath);
+  const response = new FileWritingResponse({
+    fileName: outputPath,
+    writeRedirects,
+  });
 
   await render({ template, request, response, config });
   await response.isSent();
 
-  return outputPath;
+  const redirect = response.redirectedTo
+    ? { from: pathname, to: response.redirectedTo }
+    : undefined;
+
+  return { outputPath, redirect };
 };
 
 export default renderPage;


### PR DESCRIPTION
- Writes an HTML file with `<meta http-equiv="refresh">` for redirects so we don't 404 in the SSG build
- In Vercel output the redirects are rather added to the config