### PR TITLE
Copy standalone CSS file

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -145,7 +145,7 @@
     "build:vite": "vite build",
     "generate:icon-types": "tsx ./scripts/generate-icon-types.ts",
     "build:standalone:vite": "vite build --mode standalone --config vite.standalone.config.ts",
-    "build:standalone:html": "cp ./src/app/standalone.html ./standalone/standalone.html && cp ./src/app/demo.html ./standalone/demo.html && cp ./src/app/demo-cdn.html ./standalone/index.html",
+    "build:standalone:html": "cp ./src/app/standalone.html ./standalone/standalone.html && cp ./src/app/demo.html ./standalone/demo.html && cp ./src/app/demo-cdn.html ./standalone/index.html && cp standalone/zudoku.css standalone/style.css",
     "clean": "tsc --build --clean",
     "codegen": "graphql-codegen --config ./src/codegen.ts",
     "test": "vitest run"


### PR DESCRIPTION
Looks like the file name of `style.css` has changed to `zudoku.css` for some reason.
This PR copies the file to `style.css` as well. Maybe we can also rename, but to be sure I copied