### PR TITLE
Fix build warning for some environments

### DIFF
--- a/packages/zudoku/src/vite/plugin-config.ts
+++ b/packages/zudoku/src/vite/plugin-config.ts
@@ -22,9 +22,15 @@ const viteConfigPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
       const replacedCode = code.replaceAll(
         /process\.env\.([a-z_][a-z0-9_]*)/gi,
         (_, envVar) => {
-          if (!envVar.startsWith(viteConfig.envPrefix)) {
+          const allowedPrefixes = Array.isArray(viteConfig.envPrefix)
+            ? viteConfig.envPrefix
+            : [viteConfig.envPrefix];
+
+          if (!allowedPrefixes.some((prefix) => envVar.startsWith(prefix))) {
             viteConfig.logger.warn(
-              `Warning: process.env.${envVar} is not prefixed with ${viteConfig.envPrefix}.`,
+              `Warning: process.env.${envVar} is not prefixed with ${allowedPrefixes.join(
+                " or ",
+              )}.`,
             );
             return "undefined";
           }


### PR DESCRIPTION
Fixes the error we see in some builds:

```
Warning: process.env.ZUPLO_PUBLIC_AUTH0_DOMAIN is not prefixed with ZUPLO_PUBLIC_,ZUDOKU_PUBLIC_.
Warning: process.env.ZUPLO_PUBLIC_AUTH0_CLIENTID is not prefixed with ZUPLO_PUBLIC_,ZUDOKU_PUBLIC_.
Warning: process.env.ZUPLO_PUBLIC_AUTH0_AUDIENCE is not prefixed with ZUPLO_PUBLIC_,ZUDOKU_PUBLIC_.
```