### PR TITLE
Cleanup plugin options in favor of config meta

### DIFF
--- a/packages/zudoku/src/cli/cli.ts
+++ b/packages/zudoku/src/cli/cli.ts
@@ -12,6 +12,10 @@ import { logger } from "./common/logger.js";
 import { warnIfOutdatedVersion } from "./common/outdated.js";
 import { printCriticalFailureToConsoleAndExit } from "./common/output.js";
 
+process.env.ZUDOKU_ENV = process.env.ZUDOKU_INTERNAL_DEV
+  ? "internal"
+  : "module";
+
 const MIN_NODE_VERSION = "20.0.0";
 
 if (gte(process.versions.node, MIN_NODE_VERSION)) {

--- a/packages/zudoku/src/config/common.ts
+++ b/packages/zudoku/src/config/common.ts
@@ -1,11 +1,12 @@
-import { CommonConfig } from "./validators/common.js";
+import { type CommonConfig } from "./validators/common.js";
 
-// WARNING: If you change this type signature, you must also change the
-// corresponding type in packages/config/src/index.d.ts
 export type ConfigWithMeta<TConfig extends CommonConfig> = TConfig & {
   __meta: {
+    rootDir: string;
+    moduleDir: string;
+    configPath: string;
+    mode: typeof process.env.ZUDOKU_ENV;
     dependencies: string[];
-    path: string;
     registerDependency: (...file: string[]) => void;
   };
 };

--- a/packages/zudoku/src/config/config.ts
+++ b/packages/zudoku/src/config/config.ts
@@ -1,19 +1,9 @@
-import { ConfigWithMeta } from "./common.js";
+import type { ConfigWithMeta } from "./common.js";
 import type { ZudokuConfig } from "./validators/validate.js";
-
-export type URLString = `https://${string}` | `http://${string}`;
 
 export { type ZudokuConfig };
 
 export type LoadedConfig = ConfigWithMeta<ZudokuConfig>;
-
-export interface ZudokuPluginOptions extends ConfigWithMeta<ZudokuConfig> {
-  rootDir: string;
-  moduleDir: string;
-
-  // Internal use only
-  mode: "internal" | "module" | "standalone";
-}
 
 export type ClerkAuthenticationConfig = {
   type: "clerk";

--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -1,11 +1,14 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { RollupOutput, RollupWatcher } from "rollup";
+import type { RollupOutput, RollupWatcher } from "rollup";
 import { tsImport } from "tsx/esm/api";
 import withZuplo from "../zuplo/with-zuplo.js";
-import { ConfigWithMeta } from "./common.js";
-import { CommonConfig, validateCommonConfig } from "./validators/common.js";
+import { type ConfigWithMeta } from "./common.js";
+import {
+  type CommonConfig,
+  validateCommonConfig,
+} from "./validators/common.js";
 import { validateConfig } from "./validators/validate.js";
 
 const zudokuConfigFiles = [
@@ -72,7 +75,7 @@ async function getConfigFilePath(
 async function loadZudokuCodeConfig<TConfig>(
   rootDir: string,
   configPath: string,
-  envVars: Record<string, string | undefined>,
+  _envVars: Record<string, string | undefined>,
 ): Promise<{ dependencies: string[]; config: TConfig }> {
   const configFilePath = pathToFileURL(configPath).href;
 
@@ -173,6 +176,7 @@ export type ConfigLoaderOverrides = {
 // corresponding type in packages/config/src/index.d.ts
 export async function tryLoadZudokuConfig<TConfig extends CommonConfig>(
   rootDir: string,
+  moduleDir: string,
   envVars: Record<string, string | undefined>,
   overrides?: ConfigLoaderOverrides,
 ): Promise<ConfigWithMeta<TConfig>> {
@@ -198,8 +202,11 @@ export async function tryLoadZudokuConfig<TConfig extends CommonConfig>(
   const configWithMetadata: ConfigWithMeta<TConfig> = {
     ...config,
     __meta: {
+      rootDir,
+      moduleDir,
+      mode: process.env.ZUDOKU_ENV,
       dependencies,
-      path: configPath,
+      configPath,
       registerDependency: (...files: string[]) => {
         const newFiles = files.filter((f) => !dependencies.includes(f));
         dependencies.push(...newFiles);

--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -4,7 +4,7 @@ import z from "zod";
 import { fromError } from "zod-validation-error";
 import type { ExposedComponentProps } from "../../lib/components/SlotletProvider.js";
 import type { ZudokuPlugin } from "../../lib/core/plugins.js";
-import { MdxComponentsType } from "../../lib/util/MdxComponents.js";
+import { type MdxComponentsType } from "../../lib/util/MdxComponents.js";
 import { CommonConfigSchema, refine } from "./common.js";
 
 /**

--- a/packages/zudoku/src/vite/config.test.ts
+++ b/packages/zudoku/src/vite/config.test.ts
@@ -12,7 +12,7 @@ it("Should correctly load zudoku.config.ts file", async () => {
     rootPath,
   );
   // Normalize the path to Unix-style format
-  const normalizedPath = config.__meta.path
+  const normalizedPath = config.__meta.configPath
     .split(path.sep)
     .join(path.posix.sep);
 

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -14,11 +14,7 @@ import {
 import packageJson from "../../package.json" with { type: "json" };
 import tailwindConfig from "../app/tailwind.js";
 import { logger } from "../cli/common/logger.js";
-import type {
-  LoadedConfig,
-  ZudokuConfig,
-  ZudokuPluginOptions,
-} from "../config/config.js";
+import type { LoadedConfig, ZudokuConfig } from "../config/config.js";
 import { tryLoadZudokuConfig } from "../config/loader.js";
 import { CdnUrlSchema } from "../config/validators/common.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
@@ -65,6 +61,17 @@ let config: LoadedConfig | undefined;
 let envPrefix: string[] | undefined;
 let publicEnv: Record<string, string> | undefined;
 
+export const getStandaloneConfig = (rootDir: string): LoadedConfig => ({
+  __meta: {
+    rootDir,
+    moduleDir: getModuleDir(),
+    mode: "standalone",
+    dependencies: [],
+    configPath: "",
+    registerDependency: () => {},
+  },
+});
+
 export async function loadZudokuConfig(
   configEnv: ConfigEnv,
   rootDir: string,
@@ -87,17 +94,14 @@ export async function loadZudokuConfig(
         envVars[key] = process.env[key];
       }
     }
-    const loadedConfig = await tryLoadZudokuConfig(rootDir, envVars);
+
+    config = await tryLoadZudokuConfig(rootDir, getModuleDir(), envVars);
 
     logger.info(
       colors.yellow(`loaded config file `) +
-        colors.dim(loadedConfig.__meta.path),
-      {
-        timestamp: true,
-      },
+        colors.dim(config.__meta.configPath),
+      { timestamp: true },
     );
-
-    config = loadedConfig;
 
     return { config, envPrefix, publicEnv };
   } catch (error) {
@@ -107,7 +111,6 @@ export async function loadZudokuConfig(
     });
   }
 
-  // Default config
   logger.error(colors.red(`no zudoku config file found in project root.`), {
     timestamp: true,
   });
@@ -136,21 +139,6 @@ export function getAppServerEntryPath() {
   return path.posix.join(modDir, "src", "app", "entry.server.tsx");
 }
 
-export function getPluginOptions({
-  dir,
-  mode,
-}: {
-  dir: string;
-  mode: ZudokuPluginOptions["mode"];
-}): ZudokuPluginOptions {
-  const moduleDir = getModuleDir();
-  return {
-    ...config!,
-    rootDir: dir,
-    moduleDir,
-    mode,
-  };
-}
 // the vite config gets loaded multiple times, so we only log the CDN info once
 let hasLoggedCdnInfo = false;
 const MEDIA_REGEX =
@@ -173,11 +161,6 @@ export async function getViteConfig(
     return config;
   };
 
-  const pluginOptions = getPluginOptions({
-    dir,
-    mode: process.env.ZUDOKU_INTERNAL_DEV ? "internal" : "module",
-  });
-
   const cdnUrl = CdnUrlSchema.parse(config.cdnUrl);
 
   const base = cdnUrl?.base
@@ -186,7 +169,7 @@ export async function getViteConfig(
 
   if (cdnUrl && !hasLoggedCdnInfo) {
     logger.info(colors.blue(`Using CDN URL:`));
-    logger.info(colors.blue(`  base: `) + colors.dim(cdnUrl.base));
+    logger.info(colors.blue(`  base:  `) + colors.dim(cdnUrl.base));
     logger.info(colors.blue(`  media: `) + colors.dim(cdnUrl.media));
     hasLoggedCdnInfo = true;
   }
@@ -203,7 +186,7 @@ export async function getViteConfig(
     resolve: {
       alias: {
         "@mdx-js/react": path.resolve(
-          pluginOptions.moduleDir,
+          config.__meta.moduleDir,
           "node_modules/@mdx-js/react",
         ),
       },
@@ -225,8 +208,8 @@ export async function getViteConfig(
           `${dir}/dist`,
           `${dir}/lib`,
           `${dir}/.git`,
-          `${pluginOptions.moduleDir}/src/vite`,
-          `${pluginOptions.moduleDir}/src/cli`,
+          `${config.__meta.moduleDir}/src/vite`,
+          `${config.__meta.moduleDir}/src/cli`,
         ],
       },
     },
@@ -246,7 +229,7 @@ export async function getViteConfig(
         input:
           configEnv.command === "build"
             ? configEnv.isSsrBuild
-              ? ["zudoku/app/entry.server.tsx", config.__meta.path]
+              ? ["zudoku/app/entry.server.tsx", config.__meta.configPath]
               : "zudoku/app/entry.client.tsx"
             : undefined,
       },
@@ -277,7 +260,7 @@ export async function getViteConfig(
     },
     // Workaround for Pre-transform error for "virtual" file: https://github.com/vitejs/vite/issues/15374
     assetsInclude: ["/__z/entry.client.tsx"],
-    plugins: [vitePlugin(pluginOptions, handleConfigChange)],
+    plugins: [vitePlugin(config, handleConfigChange)],
     future: {
       removeServerModuleGraph: "warn",
       removeSsrLoadModule: "warn",
@@ -296,11 +279,11 @@ export async function getViteConfig(
               // Tailwind seems to crash if it tries to parse compiled .js files
               // as a workaround, we will just ship the source file and use those
               // `${moduleDir}/lib/**/*.{js,ts,jsx,tsx,md,mdx}`,
-              `${pluginOptions.moduleDir}/src/lib/**/*.{js,ts,jsx,tsx,md,mdx}`,
+              `${config.__meta.moduleDir}/src/lib/**/*.{js,ts,jsx,tsx,md,mdx}`,
               // Include the config file and every file it depends on
-              config.__meta.path,
+              config.__meta.configPath,
               ...config.__meta.dependencies.map(
-                (dep) => `${path.dirname(config.__meta.path)}/${dep}`,
+                (dep) => `${path.dirname(config.__meta.configPath)}/${dep}`,
               ),
               `${dir}/src/**/*.{js,ts,jsx,tsx,md,mdx}`,
               // All doc files

--- a/packages/zudoku/src/vite/css/plugin.ts
+++ b/packages/zudoku/src/vite/css/plugin.ts
@@ -2,13 +2,13 @@
 // https://github.com/hi-ogawa/vite-plugins/tree/main/packages/ssr-css
 import path from "node:path";
 import { type DevEnvironment, isCSSRequest, type Plugin } from "vite";
-import type { ZudokuPluginOptions } from "../../config/config.js";
+import type { LoadedConfig } from "../../config/config.js";
 import { collectStyle } from "./collect.js";
 
 const VIRTUAL_ENTRY = "virtual:ssr-css.css";
 
 export function vitePluginSsrCss(
-  getConfig: () => ZudokuPluginOptions,
+  getConfig: () => LoadedConfig,
   pluginOpts: { entries: string[] },
 ): Plugin {
   let server: DevEnvironment;

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -1,5 +1,5 @@
 import express, { type Express } from "express";
-import { createHttpTerminator, HttpTerminator } from "http-terminator";
+import { createHttpTerminator, type HttpTerminator } from "http-terminator";
 import fs from "node:fs/promises";
 import http, { type Server } from "node:http";
 import https from "node:https";
@@ -20,7 +20,7 @@ import {
   getAppServerEntryPath,
   getViteConfig,
   loadZudokuConfig,
-  ZudokuConfigEnv,
+  type ZudokuConfigEnv,
 } from "./config.js";
 import { errorMiddleware } from "./error-handler.js";
 import { getDevHtml } from "./html.js";

--- a/packages/zudoku/src/vite/plugin-api-keys.ts
+++ b/packages/zudoku/src/vite/plugin-api-keys.ts
@@ -1,7 +1,7 @@
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import type { LoadedConfig } from "../config/config.js";
 
-const viteApiKeysPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
+const viteApiKeysPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-api-keys-plugin";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
   return {
@@ -15,14 +15,14 @@ const viteApiKeysPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
       if (id === resolvedVirtualModuleId) {
         const config = getConfig();
 
-        if (!config.apiKeys || config.mode === "standalone") {
+        if (!config.apiKeys || config.__meta.mode === "standalone") {
           return `export const configuredApiKeysPlugin = undefined;`;
         }
 
         const code = [
           `import config from "virtual:zudoku-config";`,
-          config.mode === "internal"
-            ? `import { apiKeyPlugin } from "${config.moduleDir}/src/lib/plugins/api-keys/index.tsx";`
+          config.__meta.mode === "internal"
+            ? `import { apiKeyPlugin } from "${config.__meta.moduleDir}/src/lib/plugins/api-keys/index.tsx";`
             : `import { apiKeyPlugin } from "zudoku/plugins/api-keys";`,
           `export const configuredApiKeysPlugin = apiKeyPlugin(config.apiKeys);`,
         ];

--- a/packages/zudoku/src/vite/plugin-auth.ts
+++ b/packages/zudoku/src/vite/plugin-auth.ts
@@ -1,7 +1,7 @@
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 
-const viteAuthPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
+const viteAuthPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-auth";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
@@ -16,7 +16,7 @@ const viteAuthPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
       if (id === resolvedVirtualModuleId) {
         const config = getConfig();
 
-        if (!config.authentication || config.mode === "standalone") {
+        if (!config.authentication || config.__meta.mode === "standalone") {
           return `export const configuredAuthProvider = undefined;`;
         }
         // TODO: Validate that the authConfig.type is a valid authentication provider
@@ -25,8 +25,8 @@ const viteAuthPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
             ...${JSON.stringify(config.authentication, null, 2)},
             basePath: ${config.basePath ? JSON.stringify(config.basePath) : "undefined"},
           };`,
-          config.mode === "internal"
-            ? `import authProvider from "${config.moduleDir}/src/lib/authentication/providers/${config.authentication.type}.tsx";`
+          config.__meta.mode === "internal"
+            ? `import authProvider from "${config.__meta.moduleDir}/src/lib/authentication/providers/${config.authentication.type}.tsx";`
             : `import authProvider from "zudoku/auth/${config.authentication.type}";`,
           `export const configuredAuthProvider = authProvider(config);`,
         ].join("\n");

--- a/packages/zudoku/src/vite/plugin-component.ts
+++ b/packages/zudoku/src/vite/plugin-component.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 
-const viteAliasPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
+const viteAliasPlugin = (getConfig: () => LoadedConfig): Plugin => {
   return {
     name: "zudoku-component-plugin",
     config: () => {
@@ -21,10 +21,11 @@ const viteAliasPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
 
       const aliases = replacements.map(([find, replacement]) => ({
         find,
-        replacement: path.posix.join(config.moduleDir, replacement),
+        replacement: path.posix.join(config.__meta.moduleDir, replacement),
       }));
 
-      return config.mode === "internal" || config.mode === "standalone"
+      return config.__meta.mode === "internal" ||
+        config.__meta.mode === "standalone"
         ? { resolve: { alias: aliases } }
         : undefined;
     },

--- a/packages/zudoku/src/vite/plugin-config-reload.ts
+++ b/packages/zudoku/src/vite/plugin-config-reload.ts
@@ -1,21 +1,29 @@
 import path from "node:path";
-import { type Plugin } from "vite";
+import { type Plugin, type ViteDevServer } from "vite";
 import { printDiagnosticsToConsole } from "../cli/common/output.js";
-import { LoadedConfig, type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
+
+export const reload = ({ ws, environments }: ViteDevServer) => {
+  Object.values(environments).forEach((environment) => {
+    environment.moduleGraph.invalidateAll();
+  });
+
+  ws.send({ type: "full-reload" });
+};
 
 export const createConfigReloadPlugin = (
-  initialConfig: ZudokuPluginOptions,
+  initialConfig: LoadedConfig,
   onConfigChange?: () => Promise<LoadedConfig>,
-): [Plugin, () => ZudokuPluginOptions] => {
+): [Plugin, () => LoadedConfig] => {
   let currentConfig = initialConfig;
   let importDependencies = initialConfig.__meta.dependencies;
 
   const plugin: Plugin = {
     name: "zudoku-config-reload",
-    configureServer: ({ watcher, ws, environments }) => {
+    configureServer: (server) => {
       if (!onConfigChange) return;
 
-      watcher.on("change", async (file) => {
+      server.watcher.on("change", async (file) => {
         if (!importDependencies.includes(file)) return;
 
         const newConfig = await onConfigChange();
@@ -24,16 +32,13 @@ export const createConfigReloadPlugin = (
         importDependencies = newConfig.__meta.dependencies;
 
         // Assume `.tsx` files are handled by HMR (skip if the config file itself changed)
-        if (file !== newConfig.__meta.path && file.endsWith(".tsx")) return;
+        if (file !== newConfig.__meta.configPath && file.endsWith(".tsx"))
+          return;
 
-        Object.values(environments).forEach((environment) => {
-          environment.moduleGraph.invalidateAll();
-        });
-
-        ws.send({ type: "full-reload" });
+        reload(server);
 
         printDiagnosticsToConsole(
-          `[${new Date().toLocaleTimeString()}]: Config ${path.basename(currentConfig.__meta.path)} changed. Reloading...`,
+          `[${new Date().toLocaleTimeString()}]: Config ${path.basename(currentConfig.__meta.configPath)} changed. Reloading...`,
         );
       });
     },

--- a/packages/zudoku/src/vite/plugin-config.ts
+++ b/packages/zudoku/src/vite/plugin-config.ts
@@ -1,7 +1,7 @@
 import { type Plugin, type ResolvedConfig } from "vite";
-import type { ZudokuPluginOptions } from "../config/config.js";
+import type { LoadedConfig } from "../config/config.js";
 
-const viteConfigPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
+const viteConfigPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-config";
 
   let viteConfig: ResolvedConfig;
@@ -10,14 +10,14 @@ const viteConfigPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
     name: "zudoku-config-plugin",
     resolveId(id) {
       if (id === virtualModuleId) {
-        return getConfig().__meta.path;
+        return getConfig().__meta.configPath;
       }
     },
     configResolved(resolvedConfig) {
       viteConfig = resolvedConfig;
     },
     async transform(code, id) {
-      if (id !== getConfig().__meta.path) return;
+      if (id !== getConfig().__meta.configPath) return;
 
       const replacedCode = code.replaceAll(
         /process\.env\.([a-z_][a-z0-9_]*)/gi,

--- a/packages/zudoku/src/vite/plugin-custom-pages.ts
+++ b/packages/zudoku/src/vite/plugin-custom-pages.ts
@@ -1,9 +1,7 @@
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 
-const viteCustomPagesPlugin = (
-  getConfig: () => ZudokuPluginOptions,
-): Plugin => {
+const viteCustomPagesPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-custom-pages-plugin";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
   return {
@@ -17,14 +15,14 @@ const viteCustomPagesPlugin = (
       if (id === resolvedVirtualModuleId) {
         const config = getConfig();
 
-        if (!config.customPages || config.mode === "standalone") {
+        if (!config.customPages || config.__meta.mode === "standalone") {
           return `export const configuredCustomPagesPlugin = undefined;`;
         }
 
         const code = [
           `import config from "virtual:zudoku-config";`,
-          config.mode === "internal"
-            ? `import { customPagesPlugin } from "${config.moduleDir}/src/lib/plugins/custom-pages/index.tsx";`
+          config.__meta.mode === "internal"
+            ? `import { customPagesPlugin } from "${config.__meta.moduleDir}/src/lib/plugins/custom-pages/index.tsx";`
             : `import { customPagesPlugin } from "zudoku/plugins/custom-pages";`,
           `export const configuredCustomPagesPlugin = customPagesPlugin(config.customPages);`,
         ];

--- a/packages/zudoku/src/vite/plugin-docs.ts
+++ b/packages/zudoku/src/vite/plugin-docs.ts
@@ -1,14 +1,14 @@
 import { glob } from "glob";
 import path from "node:path";
 import { type Plugin } from "vite";
-import type { ZudokuPluginOptions } from "../config/config.js";
+import type { LoadedConfig } from "../config/config.js";
 import { DocResolver } from "../lib/plugins/markdown/resolver.js";
 import { writePluginDebugCode } from "./debug.js";
 
 const ensureLeadingSlash = (str: string) =>
   str.startsWith("/") ? str : `/${str}`;
 
-const viteDocsPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
+const viteDocsPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-docs-plugins";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
@@ -23,15 +23,15 @@ const viteDocsPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
       if (id === resolvedVirtualModuleId) {
         const config = getConfig();
 
-        if (config.mode === "standalone") {
+        if (config.__meta.mode === "standalone") {
           return `export const configuredDocsPlugins = [];`;
         }
 
         const code: string[] = [
           // IMPORTANT! This path here is important, we MUST resolve
           // files here as Typescript from the appDir
-          config.mode === "internal"
-            ? `import { markdownPlugin } from "${config.moduleDir}/src/lib/plugins/markdown/index.tsx";`
+          config.__meta.mode === "internal"
+            ? `import { markdownPlugin } from "${config.__meta.moduleDir}/src/lib/plugins/markdown/index.tsx";`
             : `import { markdownPlugin } from "zudoku/plugins/markdown";`,
           `const docsPluginOptions = [];`,
         ];
@@ -58,7 +58,7 @@ const viteDocsPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
           // This does only happen in dev SSR environments, so for prod the `basePath` is not added
 
           const globbedFiles = await glob(docsConfig.files, {
-            root: config.rootDir,
+            root: config.__meta.rootDir,
             ignore: ["**/node_modules/**", "**/dist/**", "**/.git/**"],
             absolute: false,
             posix: true,
@@ -87,7 +87,7 @@ const viteDocsPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
           `export { configuredDocsPlugins };`,
         );
 
-        await writePluginDebugCode(config.rootDir, "docs-plugin", code);
+        await writePluginDebugCode(config.__meta.rootDir, "docs-plugin", code);
 
         return code.join("\n");
       }

--- a/packages/zudoku/src/vite/plugin-mdx.ts
+++ b/packages/zudoku/src/vite/plugin-mdx.ts
@@ -15,7 +15,7 @@ import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import { EXIT, visit } from "unist-util-visit";
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 import { remarkStaticGeneration } from "./remarkStaticGeneration.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -132,14 +132,14 @@ const rehypeExcerptWithMdxExport = () => (tree: any) => {
   });
 };
 
-const viteMdxPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
+const viteMdxPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const config = getConfig();
 
   return {
     enforce: "pre",
     ...mdx({
       providerImportSource:
-        config.mode === "internal" || config.mode === "standalone"
+        config.__meta.mode === "internal" || config.__meta.mode === "standalone"
           ? "@mdx-js/react"
           : "zudoku/components",
       // Treat .md files as MDX

--- a/packages/zudoku/src/vite/plugin-redirect.ts
+++ b/packages/zudoku/src/vite/plugin-redirect.ts
@@ -1,7 +1,7 @@
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 
-const viteRedirectPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
+const viteRedirectPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-redirect-plugin";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
@@ -15,14 +15,14 @@ const viteRedirectPlugin = (getConfig: () => ZudokuPluginOptions): Plugin => {
     async load(id) {
       if (id === resolvedVirtualModuleId) {
         const config = getConfig();
-        if (!config.redirects || config.mode === "standalone") {
+        if (!config.redirects || config.__meta.mode === "standalone") {
           return `export const configuredRedirectPlugin = undefined;`;
         }
 
         const code: string[] = [
           `const redirects = ${JSON.stringify(config.redirects ?? [], null, 2)};`,
-          config.mode === "internal"
-            ? `import { redirectPlugin } from "${config.moduleDir}/src/lib/plugins/redirect/index.tsx";`
+          config.__meta.mode === "internal"
+            ? `import { redirectPlugin } from "${config.__meta.moduleDir}/src/lib/plugins/redirect/index.tsx";`
             : `import { redirectPlugin } from "zudoku/plugins/redirect";`,
         ];
 

--- a/packages/zudoku/src/vite/plugin-search.ts
+++ b/packages/zudoku/src/vite/plugin-search.ts
@@ -1,9 +1,7 @@
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 
-export const viteSearchPlugin = (
-  getConfig: () => ZudokuPluginOptions,
-): Plugin => {
+export const viteSearchPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-search-plugin";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
@@ -19,7 +17,7 @@ export const viteSearchPlugin = (
 
       const config = getConfig();
 
-      if (!config.search || config.mode === "standalone") {
+      if (!config.search || config.__meta.mode === "standalone") {
         return `export const configuredSearchPlugin = undefined;`;
       }
 

--- a/packages/zudoku/src/vite/plugin-sidebar.ts
+++ b/packages/zudoku/src/vite/plugin-sidebar.ts
@@ -1,6 +1,6 @@
 import icons from "lucide-react/dynamicIconImports";
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 import { SidebarManager } from "../config/validators/SidebarSchema.js";
 import { writePluginDebugCode } from "./debug.js";
 
@@ -37,9 +37,7 @@ const replaceSidebarIcons = (code: string) => {
   return `${importStatement}export const configuredSidebar = ${replacedString};`;
 };
 
-export const viteSidebarPlugin = (
-  getConfig: () => ZudokuPluginOptions,
-): Plugin => {
+export const viteSidebarPlugin = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-sidebar";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
@@ -54,12 +52,12 @@ export const viteSidebarPlugin = (
       if (id !== resolvedVirtualModuleId) return;
       const config = getConfig();
 
-      const manager = new SidebarManager(config.rootDir, config.sidebar);
+      const manager = new SidebarManager(config.__meta.rootDir, config.sidebar);
       const resolvedSidebars = await manager.resolveSidebars();
 
       const code = JSON.stringify(resolvedSidebars);
       await writePluginDebugCode(
-        config.rootDir,
+        config.__meta.rootDir,
         "sidebar-plugin",
         code,
         "json",

--- a/packages/zudoku/src/vite/plugin-theme-css.ts
+++ b/packages/zudoku/src/vite/plugin-theme-css.ts
@@ -1,5 +1,5 @@
 import { type Plugin } from "vite";
-import { type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 import { objectEntries } from "../lib/util/objectEntries.js";
 
 const THEME_VARIABLES = [
@@ -101,7 +101,7 @@ const generateCss = (theme: Theme) =>
     })
     .join("\n");
 
-export const viteThemeCss = (getConfig: () => ZudokuPluginOptions): Plugin => {
+export const viteThemeCss = (getConfig: () => LoadedConfig): Plugin => {
   const virtualModuleId = "virtual:zudoku-theme.css";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 

--- a/packages/zudoku/src/vite/plugin.ts
+++ b/packages/zudoku/src/vite/plugin.ts
@@ -1,6 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { type PluginOption } from "vite";
-import { LoadedConfig, type ZudokuPluginOptions } from "../config/config.js";
+import { type LoadedConfig } from "../config/config.js";
 import { vitePluginSsrCss } from "./css/plugin.js";
 import viteApiKeysPlugin from "./plugin-api-keys.js";
 import viteApiPlugin from "./plugin-api.js";
@@ -18,7 +18,7 @@ import { viteSidebarPlugin } from "./plugin-sidebar.js";
 import { viteThemeCss } from "./plugin-theme-css.js";
 
 export default function vitePlugin(
-  initialConfig: ZudokuPluginOptions,
+  initialConfig: LoadedConfig,
   onConfigChange?: () => Promise<LoadedConfig>,
 ): PluginOption {
   const [configReloadPlugin, getCurrentConfig] = createConfigReloadPlugin(

--- a/packages/zudoku/vite.standalone.config.ts
+++ b/packages/zudoku/vite.standalone.config.ts
@@ -1,9 +1,10 @@
 import autoprefixer from "autoprefixer";
+import { fileURLToPath } from "node:url";
 import path from "path";
 import tailwindcss from "tailwindcss";
 import { defineConfig } from "vite";
 import tailwindConfig from "./src/app/tailwind.js";
-import { getPluginOptions } from "./src/vite/config.js";
+import { getStandaloneConfig } from "./src/vite/config.js";
 import vitePlugin from "./src/vite/plugin.js";
 
 const entries: Record<string, string> = {
@@ -11,15 +12,12 @@ const entries: Record<string, string> = {
   demo: "./src/app/demo.tsx",
 };
 
-const config = {
-  ...getPluginOptions({
-    mode: "standalone",
-    dir: path.resolve(__dirname),
-  }),
-  __meta: {},
-};
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+process.env.ZUDOKU_ENV = "standalone";
 
 export default defineConfig({
+  mode: "standalone",
   define: {
     "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
   },
@@ -55,13 +53,13 @@ export default defineConfig({
       },
     },
   },
-  plugins: [vitePlugin(config)],
+  plugins: [vitePlugin(getStandaloneConfig(__dirname))],
   css: {
     postcss: {
       plugins: [
         tailwindcss({
           ...tailwindConfig(),
-          content: ["./src/lib/**/*.{js,ts,jsx,tsx}"],
+          content: ["./src/lib/**/*.{js,ts,jsx,tsx,md,mdx}"],
         }),
         autoprefixer,
       ],


### PR DESCRIPTION
I always thought that the plugin options are a bit confusing, so I removed them and put everything in the already existing `config.__meta` to have only one place to look for the config.