### PR TITLE
Add `preview` command

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {

--- a/examples/api-identity-plugin/package.json
+++ b/examples/api-identity-plugin/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/api-key-service/package.json
+++ b/examples/api-key-service/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/cosmo-cargo/package.json
+++ b/examples/cosmo-cargo/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/with-auth0/package.json
+++ b/examples/with-auth0/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/with-config/package.json
+++ b/examples/with-config/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/with-openapi-json/package.json
+++ b/examples/with-openapi-json/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/with-openapi-yaml/package.json
+++ b/examples/with-openapi-yaml/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/with-vite-config/package.json
+++ b/examples/with-vite-config/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "zudoku dev",
     "build": "zudoku build",
+    "preview": "zudoku preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "nx": {

--- a/examples/with-zuplo/docs/package.json
+++ b/examples/with-zuplo/docs/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "zudoku dev",
-    "build": "zudoku build"
+    "build": "zudoku build",
+    "preview": "zudoku preview"
   },
   "nx": {
     "tags": [

--- a/nx.json
+++ b/nx.json
@@ -11,6 +11,10 @@
       "outputs": ["{projectRoot}/dist"],
       "cache": false
     },
+    "preview": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "clean": {
       "dependsOn": ["^clean"],
       "cache": false

--- a/packages/create-zudoku-app/templates/index.ts
+++ b/packages/create-zudoku-app/templates/index.ts
@@ -76,16 +76,17 @@ export const installTemplate = async ({
     type: "module",
     private: true,
     scripts: {
-      dev: `zudoku dev`,
+      dev: "zudoku dev",
       build: "zudoku build",
+      preview: "zudoku preview",
       lint: "eslint",
     },
     /**
      * Default dependencies.
      */
     dependencies: {
-      react: ">18.0.0",
-      "react-dom": ">18.0.0",
+      react: ">=19.0.0",
+      "react-dom": ">=19.0.0",
       zudoku: version,
     },
     devDependencies: {},
@@ -99,8 +100,8 @@ export const installTemplate = async ({
       ...packageJson.devDependencies,
       typescript: "^5",
       "@types/node": "^22",
-      "@types/react": "^18",
-      "@types/react-dom": "^18",
+      "@types/react": "^19",
+      "@types/react-dom": "^19",
     };
   }
 

--- a/packages/zudoku/src/cli/build/handler.ts
+++ b/packages/zudoku/src/cli/build/handler.ts
@@ -1,10 +1,8 @@
 import path from "node:path";
 import { runBuild } from "../../vite/build.js";
+import type { Arguments } from "../cmds/build.js";
 import { printDiagnosticsToConsole } from "../common/output.js";
-
-export interface Arguments {
-  dir: string;
-}
+import { preview as runPreview } from "../preview/handler.js";
 
 export async function build(argv: Arguments) {
   printDiagnosticsToConsole("Starting build");
@@ -13,4 +11,8 @@ export async function build(argv: Arguments) {
 
   const dir = path.resolve(process.cwd(), argv.dir);
   await runBuild({ dir });
+
+  if (argv.preview) {
+    await runPreview({ dir: argv.dir, port: argv.preview });
+  }
 }

--- a/packages/zudoku/src/cli/build/handler.ts
+++ b/packages/zudoku/src/cli/build/handler.ts
@@ -13,6 +13,9 @@ export async function build(argv: Arguments) {
   await runBuild({ dir });
 
   if (argv.preview) {
-    await runPreview({ dir: argv.dir, port: argv.preview });
+    await runPreview({
+      dir: argv.dir,
+      port: typeof argv.preview === "number" ? argv.preview : undefined,
+    });
   }
 }

--- a/packages/zudoku/src/cli/cli.ts
+++ b/packages/zudoku/src/cli/cli.ts
@@ -6,6 +6,7 @@ import { hideBin } from "yargs/helpers";
 import yargs from "yargs/yargs";
 import build from "./cmds/build.js";
 import dev from "./cmds/dev.js";
+import preview from "./cmds/preview.js";
 import { shutdownAnalytics } from "./common/analytics/lib.js";
 import { MAX_WAIT_PENDING_TIME_MS, SENTRY_DSN } from "./common/constants.js";
 import { logger } from "./common/logger.js";
@@ -44,6 +45,7 @@ if (gte(process.versions.node, MIN_NODE_VERSION)) {
   const cli = yargs(hideBin(process.argv))
     .command(build)
     .command(dev)
+    .command(preview)
     .demandCommand()
     .strictCommands()
     .version(packageJson?.version)

--- a/packages/zudoku/src/cli/cmds/build.ts
+++ b/packages/zudoku/src/cli/cmds/build.ts
@@ -1,10 +1,11 @@
 import { type Argv } from "yargs";
 import { build } from "../build/handler.js";
 import { captureEvent } from "../common/analytics/lib.js";
+import { DEFAULT_PREVIEW_PORT } from "../preview/handler.js";
 
 export type Arguments = {
   dir: string;
-  preview: number;
+  preview?: boolean | number;
 };
 
 export default {
@@ -20,10 +21,13 @@ export default {
         hidden: true,
       })
       .option("preview", {
-        type: "number",
         describe:
           "Preview the build after completion (optionally with a custom port)",
-        default: 4000,
+        coerce: (value: unknown) => {
+          if (typeof value === "number") return value;
+          if (value === true) return DEFAULT_PREVIEW_PORT;
+          return undefined;
+        },
       }),
   handler: async (argv: Arguments) => {
     process.env.NODE_ENV = "production";

--- a/packages/zudoku/src/cli/cmds/preview.ts
+++ b/packages/zudoku/src/cli/cmds/preview.ts
@@ -4,7 +4,7 @@ import { preview } from "../preview/handler.js";
 
 export type Arguments = {
   dir: string;
-  port: number;
+  port?: number;
 };
 
 const previewCommand = {
@@ -21,7 +21,6 @@ const previewCommand = {
       })
       .option("port", {
         type: "number",
-        default: 4000,
         describe: "The port to run the local server on",
       }),
   handler: async (argv: Arguments) => {

--- a/packages/zudoku/src/cli/cmds/preview.ts
+++ b/packages/zudoku/src/cli/cmds/preview.ts
@@ -1,15 +1,15 @@
 import { type Argv } from "yargs";
-import { build } from "../build/handler.js";
 import { captureEvent } from "../common/analytics/lib.js";
+import { preview } from "../preview/handler.js";
 
 export type Arguments = {
   dir: string;
-  preview: number;
+  port: number;
 };
 
-export default {
-  desc: "Build",
-  command: "build",
+const previewCommand = {
+  desc: "Preview production build",
+  command: "preview",
   builder: (yargs: Argv) =>
     yargs
       .option("dir", {
@@ -19,15 +19,16 @@ export default {
         normalize: true,
         hidden: true,
       })
-      .option("preview", {
+      .option("port", {
         type: "number",
-        describe:
-          "Preview the build after completion (optionally with a custom port)",
         default: 4000,
+        describe: "The port to run the local server on",
       }),
   handler: async (argv: Arguments) => {
     process.env.NODE_ENV = "production";
-    await captureEvent({ argv, event: "zudoku build" });
-    await build(argv);
+    await captureEvent({ argv, event: "zudoku preview" });
+    await preview(argv);
   },
 };
+
+export default previewCommand;

--- a/packages/zudoku/src/cli/preview/handler.ts
+++ b/packages/zudoku/src/cli/preview/handler.ts
@@ -1,0 +1,44 @@
+import express from "express";
+import path from "node:path";
+import { joinUrl } from "../../lib/util/joinUrl.js";
+import { getViteConfig } from "../../vite/config.js";
+import type { Arguments } from "../cmds/preview.js";
+import { printDiagnosticsToConsole } from "../common/output.js";
+import { findAvailablePort } from "../common/utils/ports.js";
+
+export async function preview(argv: Arguments) {
+  const dir = path.resolve(process.cwd(), argv.dir);
+  const distDir = path.join(dir, "dist");
+
+  const viteConfig = await getViteConfig(dir, {
+    command: "serve",
+    mode: "production",
+  });
+
+  printDiagnosticsToConsole("Starting build preview server");
+  printDiagnosticsToConsole("");
+
+  const port = await findAvailablePort(argv.port);
+  const app = express();
+
+  app.use(express.static(distDir, { extensions: ["html"] }));
+
+  const server = app.listen(port, () => {
+    const url = joinUrl(`http://localhost:${port}`, viteConfig.base);
+    printDiagnosticsToConsole(`Build preview server running at: ${url}`);
+    printDiagnosticsToConsole("Press Ctrl+C to stop");
+  });
+
+  await new Promise<void>((resolve) => {
+    const exit = () => {
+      server.close();
+      resolve();
+    };
+
+    process.on("SIGINT", exit);
+    process.on("SIGTERM", exit);
+    process.on("uncaughtException", exit);
+    process.on("unhandledRejection", exit);
+    process.on("exit", exit);
+  });
+}

--- a/packages/zudoku/src/cli/preview/handler.ts
+++ b/packages/zudoku/src/cli/preview/handler.ts
@@ -6,6 +6,8 @@ import type { Arguments } from "../cmds/preview.js";
 import { printDiagnosticsToConsole } from "../common/output.js";
 import { findAvailablePort } from "../common/utils/ports.js";
 
+export const DEFAULT_PREVIEW_PORT = 4000;
+
 export async function preview(argv: Arguments) {
   const dir = path.resolve(process.cwd(), argv.dir);
   const distDir = path.join(dir, "dist");
@@ -18,7 +20,7 @@ export async function preview(argv: Arguments) {
   printDiagnosticsToConsole("Starting build preview server");
   printDiagnosticsToConsole("");
 
-  const port = await findAvailablePort(argv.port);
+  const port = await findAvailablePort(argv.port ?? DEFAULT_PREVIEW_PORT);
   const app = express();
 
   app.use(express.static(distDir, { extensions: ["html"] }));


### PR DESCRIPTION
Analogue to [Vite's preview command](https://vite.dev/guide/cli.html#vite-preview) I have added `zudoku preview`.
It runs a simple static server that serves the built app.

I've also added a shortcut `zudoku build --preview` that immediately runs the preview server after the build has finished.

