### PR TITLE
Use custom OpenID scopes

### DIFF
--- a/docs/pages/configuration/authentication.md
+++ b/docs/pages/configuration/authentication.md
@@ -52,13 +52,14 @@ For Auth0, you will need the `clientId` associated with the domain you are using
 
 You can find this in the Auth0 dashboard under [Application Settings](https://auth0.com/docs/get-started/applications/application-settings).
 
-```typescript
+```json5
 {
   // ...
   authentication: {
     type: "auth0",
     domain: "yourdomain.us.auth0.com",
     clientId: "<your-auth0-clientId>",
+    scopes: ["openid", "profile", "email", "custom_scope"],
   },
   // ...
 }
@@ -96,7 +97,8 @@ For authentication services that support OpenID, you will need to supply an `cli
   authentication: {
     type: "openid",
     clientId: "<your-client-id>",
-    issuer: "<the-issuer-url>"
+    issuer: "<the-issuer-url>",
+    scopes: ["openid", "profile", "email", "custom_scope"] // Optional custom scopes
   },
   // ...
 }
@@ -108,6 +110,8 @@ When configuring your OpenID provider, you will need to set the following:
 - If your provider supports wildcard callback urls, we recommend configuring your development identity provider to allow the a wildcard callback like `https://*.zuplo.app/oauth/callback` to allow for testing each environment.
 - For local development set the callback url to `http://localhost:3000/oauth/callback`.
 - Add your site hostname (your-site.com) to the list of allowed CORS origins.
+
+By default, the scopes "openid", "profile", and "email" are requested. You can customize these by providing your own array of scopes.
 
 ## User Data
 

--- a/packages/zudoku/src/config/config.ts
+++ b/packages/zudoku/src/config/config.ts
@@ -25,6 +25,7 @@ export type Auth0AuthenticationConfig = {
   clientId: string;
   domain: string;
   audience?: string;
+  scopes?: string[];
 
   redirectToAfterSignUp?: string;
   redirectToAfterSignIn?: string;

--- a/packages/zudoku/src/lib/authentication/providers/auth0.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/auth0.tsx
@@ -1,5 +1,5 @@
-import { Auth0AuthenticationConfig } from "../../../config/config.js";
-import { AuthenticationProviderInitializer } from "../authentication.js";
+import { type Auth0AuthenticationConfig } from "../../../config/config.js";
+import { type AuthenticationProviderInitializer } from "../authentication.js";
 import { useAuthState } from "../state.js";
 import { OpenIDAuthenticationProvider } from "./openid.js";
 
@@ -11,6 +11,7 @@ class Auth0AuthenticationProvider extends OpenIDAuthenticationProvider {
       issuer: `https://${config.domain}`,
       clientId: config.clientId,
       audience: config.audience,
+      scopes: config.scopes,
     });
   }
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -1,16 +1,16 @@
 import logger from "loglevel";
 import * as oauth from "oauth4webapi";
-import { OpenIDAuthenticationConfig } from "../../../config/config.js";
+import { type OpenIDAuthenticationConfig } from "../../../config/config.js";
 import { ClientOnly } from "../../components/ClientOnly.js";
 import { joinUrl } from "../../util/joinUrl.js";
 import {
-  AuthenticationProvider,
-  AuthenticationProviderInitializer,
+  type AuthenticationProvider,
+  type AuthenticationProviderInitializer,
 } from "../authentication.js";
 import { AuthenticationPlugin } from "../AuthenticationPlugin.js";
 import { CallbackHandler } from "../components/CallbackHandler.js";
 import { AuthorizationError, OAuthAuthorizationError } from "../errors.js";
-import { useAuthState, UserProfile } from "../state.js";
+import { useAuthState, type UserProfile } from "../state.js";
 
 const CODE_VERIFIER_KEY = "code-verifier";
 
@@ -60,6 +60,7 @@ export class OpenIDAuthenticationProvider implements AuthenticationProvider {
   private readonly redirectToAfterSignIn: string;
   private readonly redirectToAfterSignOut: string;
   private readonly audience?: string;
+  private readonly scopes: string[];
 
   constructor({
     issuer,
@@ -69,6 +70,7 @@ export class OpenIDAuthenticationProvider implements AuthenticationProvider {
     redirectToAfterSignIn,
     redirectToAfterSignOut,
     basePath,
+    scopes,
   }: OpenIDAuthenticationConfig) {
     this.client = {
       client_id: clientId,
@@ -77,6 +79,7 @@ export class OpenIDAuthenticationProvider implements AuthenticationProvider {
     this.audience = audience;
     this.issuer = issuer;
     this.callbackUrlPath = joinUrl(basePath, "/oauth/callback");
+    this.scopes = scopes ?? ["openid", "profile", "email"];
 
     const root = joinUrl(basePath, "/");
 
@@ -178,7 +181,7 @@ export class OpenIDAuthenticationProvider implements AuthenticationProvider {
     authorizationUrl.searchParams.set("client_id", this.client.client_id);
     authorizationUrl.searchParams.set("redirect_uri", redirectUrl.toString());
     authorizationUrl.searchParams.set("response_type", "code");
-    authorizationUrl.searchParams.set("scope", "openid profile email");
+    authorizationUrl.searchParams.set("scope", this.scopes.join(" "));
     authorizationUrl.searchParams.set("code_challenge", codeChallenge);
     authorizationUrl.searchParams.set(
       "code_challenge_method",


### PR DESCRIPTION
We actually never passed `scopes` from the config down to the OpenID auth provider