### PR TITLE
Fix sort order of params in Playground

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
@@ -1,4 +1,4 @@
-import { Control, Controller, useFieldArray } from "react-hook-form";
+import { type Control, Controller, useFieldArray } from "react-hook-form";
 import { Card } from "zudoku/ui/Card.js";
 import { Input } from "../../../ui/Input.js";
 import { ColorizedParam } from "../ColorizedParam.js";
@@ -7,18 +7,24 @@ import type { PlaygroundForm } from "./Playground.js";
 
 export const PathParams = ({
   control,
+  url,
 }: {
   control: Control<PlaygroundForm>;
+  url: string;
 }) => {
   const { fields } = useFieldArray<PlaygroundForm, "pathParams">({
     control,
     name: "pathParams",
   });
 
+  const sortedFields = [...fields].sort(
+    (a, b) => url.indexOf(a.name) - url.indexOf(b.name),
+  );
+
   return (
     <Card className="rounded-lg">
       <ParamsGrid>
-        {fields.map((field, i) => (
+        {sortedFields.map((field, i) => (
           <ParamsGridItem key={field.id}>
             <Controller
               control={control}

--- a/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
@@ -18,7 +18,7 @@ export const PathParams = ({
   });
 
   const sortedFields = [...fields].sort(
-    (a, b) => url.indexOf(a.name) - url.indexOf(b.name),
+    (a, b) => url.indexOf(`{${a.name}}`) - url.indexOf(`{${b.name}}`),
   );
 
   return (

--- a/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
@@ -262,7 +262,7 @@ export const Playground = ({
     ));
 
   const serverSelect = (
-    <div className="inline-block opacity-50 hover:opacity-100 transition">
+    <div className="inline-block opacity-50 hover:opacity-100 transition translate-y-[4px]">
       {server ? (
         <span>{server.replace(/^https?:\/\//, "")}</span>
       ) : (
@@ -305,7 +305,7 @@ export const Playground = ({
                 <div className="border-r p-2 bg-muted rounded-l-md self-stretch font-semibold font-mono flex items-center">
                   {method.toUpperCase()}
                 </div>
-                <div className="flex items-center p-2 font-mono text-xs break-words">
+                <div className="items-center px-2 py-0.5 font-mono text-xs break-all leading-6">
                   {serverSelect}
                   {path}
                   {urlQueryParams.length > 0 ? "?" : ""}

--- a/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
@@ -305,7 +305,7 @@ export const Playground = ({
                 <div className="border-r p-2 bg-muted rounded-l-md self-stretch font-semibold font-mono flex items-center">
                   {method.toUpperCase()}
                 </div>
-                <div className="items-center p-2 font-mono text-xs break-words">
+                <div className="flex items-center p-2 font-mono text-xs break-words">
                   {serverSelect}
                   {path}
                   {urlQueryParams.length > 0 ? "?" : ""}
@@ -351,7 +351,7 @@ export const Playground = ({
                 {pathParams.length > 0 && (
                   <div className="flex flex-col gap-4 my-4">
                     <span className="font-semibold">Path Parameters</span>
-                    <PathParams control={control} />
+                    <PathParams url={url} control={control} />
                   </div>
                 )}
                 <div className="flex flex-col gap-4 my-4">


### PR DESCRIPTION
The order was broken:
![image](https://github.com/user-attachments/assets/c5341e3e-b8fb-401a-ad8a-a0c9fc6dfd64)
