### PR TITLE
Fix anchor link scroll for full paths

### DIFF
--- a/packages/zudoku/src/lib/components/AnchorLink.tsx
+++ b/packages/zudoku/src/lib/components/AnchorLink.tsx
@@ -1,22 +1,22 @@
-import React from "react";
-import { Link, type LinkProps, useLocation } from "react-router";
+import { type MouseEvent } from "react";
+import { NavLink, type NavLinkProps, useHref, useLocation } from "react-router";
 import { useScrollToHash } from "../util/useScrollToAnchor.js";
 
 /**
  * Link that scrolls to anchor even if the hash is already set in the URL.
  */
-export const AnchorLink = (props: LinkProps) => {
+export const AnchorLink = (props: NavLinkProps) => {
   const location = useLocation();
   const scrollToHash = useScrollToHash();
-  const hash = typeof props.to === "string" ? props.to : props.to.hash;
+  const hash = useHref(props.to).split("#")[1];
 
-  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     props.onClick?.(event);
-    if (!hash?.startsWith("#") || hash !== location.hash) return;
+    if (hash !== location.hash.slice(1)) return;
 
     event.preventDefault();
     scrollToHash(hash);
   };
 
-  return <Link {...props} onClick={handleClick} />;
+  return <NavLink {...props} onClick={handleClick} />;
 };

--- a/packages/zudoku/src/lib/components/navigation/SidebarItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarItem.tsx
@@ -67,12 +67,16 @@ export const SidebarItem = ({
         </NavLink>
       );
     case "link":
-      return item.href.startsWith("#") ? (
+      return !item.href.startsWith("http") ? (
         <AnchorLink
-          to={{ hash: item.href, search: searchParams.toString() }}
-          {...{ [DATA_ANCHOR_ATTR]: item.href.slice(1) }}
+          to={{
+            pathname: item.href.split("#")[0],
+            hash: item.href.split("#")[1],
+            search: searchParams.toString(),
+          }}
+          {...{ [DATA_ANCHOR_ATTR]: item.href.split("#")[1] }}
           className={navigationListItem({
-            isActive: item.href.slice(1) === activeAnchor,
+            isActive: item.href.split("#")[1] === activeAnchor,
             className: item.badge?.placement !== "start" && "justify-between",
           })}
           onClick={onRequestClose}
@@ -88,25 +92,6 @@ export const SidebarItem = ({
             <span className="break-all">{item.label}</span>
           )}
         </AnchorLink>
-      ) : !item.href.startsWith("http") ? (
-        <NavLink
-          className={navigationListItem({
-            isActive: item.href.split("#")[1] === activeAnchor,
-            className: item.badge?.placement !== "start" && "justify-between",
-          })}
-          to={item.href}
-        >
-          {item.badge ? (
-            <>
-              <span className="truncate" title={item.label}>
-                {item.label}
-              </span>
-              <SidebarBadge {...item.badge} />
-            </>
-          ) : (
-            <span className="break-all">{item.label}</span>
-          )}
-        </NavLink>
       ) : (
         <a
           className={navigationListItem()}


### PR DESCRIPTION
Consider this scenarion: In API docs you navigated to item `#item-1` then you scrolled down and clicked the link for "Item 1" again (even though it's still the hash in the URL bar) it wouldn't navigate to `#item-1` again.

We had this working for hash-_only_ links before, but with the multi page docs approach this changed to a full path, which was never covered in the `AnchorLink` component