### PR TITLE
Playground: Disable code highlighting for large responses

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
@@ -25,14 +25,14 @@ export const ResultPanel = ({
   showLongRunningWarning,
   onCancel,
 }: {
-  queryMutation: UseMutationResult<PlaygroundResult, Error, any, unknown>;
+  queryMutation: UseMutationResult<PlaygroundResult, Error, any>;
   showPathParamsWarning: boolean;
   showLongRunningWarning?: boolean;
   onCancel?: () => void;
 }) => {
   const status = ((queryMutation.data?.status ?? 0) / 100).toFixed(0);
   return (
-    <div className="min-w-0 p-8 bg-muted/70 overflow-y-auto">
+    <div className="min-w-0 p-4 bg-muted/50">
       {queryMutation.error ? (
         <div className="flex flex-col gap-2">
           {showPathParamsWarning && (
@@ -54,40 +54,38 @@ export const ResultPanel = ({
           </Card>
         </div>
       ) : queryMutation.data ? (
-        <div className="flex flex-col gap-2">
-          <Tabs defaultValue="response">
-            <TabsList>
-              <TabsTrigger value="request">Request</TabsTrigger>
-              <TabsTrigger value="response">
-                Response
-                <span
-                  className={cn(
-                    "text-xs font-mono ml-1",
-                    status === "2" && "text-green-500",
-                    status === "3" && "text-blue-500",
-                    status === "4" && "text-yellow-500",
-                    status === "5" && "text-red-500",
-                  )}
-                >
-                  ({queryMutation.data.status})
-                </span>
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="request">
-              <RequestTab {...queryMutation.data.request} />
-            </TabsContent>
-            <TabsContent value="response">
-              <ResponseTab
-                status={queryMutation.data.status}
-                time={queryMutation.data.time}
-                size={queryMutation.data.size}
-                headers={queryMutation.data.headers}
-                body={queryMutation.data.body}
-                url={queryMutation.data.request.url}
-              />
-            </TabsContent>
-          </Tabs>
-        </div>
+        <Tabs defaultValue="response">
+          <TabsList>
+            <TabsTrigger value="request">Request</TabsTrigger>
+            <TabsTrigger value="response">
+              Response
+              <span
+                className={cn(
+                  "text-xs font-mono ml-1",
+                  status === "2" && "text-green-500",
+                  status === "3" && "text-blue-500",
+                  status === "4" && "text-yellow-500",
+                  status === "5" && "text-red-500",
+                )}
+              >
+                ({queryMutation.data.status})
+              </span>
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="request">
+            <RequestTab {...queryMutation.data.request} />
+          </TabsContent>
+          <TabsContent value="response">
+            <ResponseTab
+              status={queryMutation.data.status}
+              time={queryMutation.data.time}
+              size={queryMutation.data.size}
+              headers={queryMutation.data.headers}
+              body={queryMutation.data.body}
+              url={queryMutation.data.request.url}
+            />
+          </TabsContent>
+        </Tabs>
       ) : (
         <div className="grid place-items-center h-full">
           {queryMutation.isPending ? (

--- a/packages/zudoku/src/lib/ui/SyntaxHighlight.tsx
+++ b/packages/zudoku/src/lib/ui/SyntaxHighlight.tsx
@@ -30,7 +30,7 @@ void import("prismjs/components/prism-javascript.min.js");
 void import("prismjs/components/prism-typescript.min.js");
 
 import { useTheme } from "next-themes";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { ClientOnly } from "../components/ClientOnly.js";
 import { cn } from "../util/cn.js";
 
@@ -45,18 +45,20 @@ export type SyntaxHighlightProps = {
   code?: string;
   showCopy?: "hover" | "always" | "never";
   showCopyText?: boolean;
+  disabled?: boolean;
 } & Omit<HighlightProps, "children" | "language">;
 
 const remapLang = {
   mdx: "md",
 } as Record<string, string>;
 
-export const SyntaxHighlight = ({
+const SyntaxHighlightInner = ({
   language = "plain",
   showCopy = "hover",
   showCopyText,
   title,
   children,
+  disabled,
   ...props
 }: SyntaxHighlightProps) => {
   const { resolvedTheme } = useTheme();
@@ -75,34 +77,84 @@ export const SyntaxHighlight = ({
   const themeColorClasses =
     "bg-[#f6f8fa] text-[#393a34] dark:bg-[#1e1e1e] dark:text-[#9cdcfe]";
 
-  return (
-    <ClientOnly
-      fallback={
-        <div className="relative group">
-          {title && (
-            <div className="text-xs text-muted-foreground absolute top-2 font-mono border-b w-full pb-2 px-4 ">
-              {title}
-            </div>
-          )}
-          <pre
-            className={cn(
-              "relative scrollbar overflow-x-auto",
-              props.className,
-              props.noBackground ? "!bg-transparent" : themeColorClasses,
-              props.wrapLines && "whitespace-pre-wrap break-words",
-              title && "pt-10",
-            )}
-          >
-            {code}
-          </pre>
-          {props.showLanguageIndicator && (
-            <span className="absolute top-1.5 right-3 text-[11px] font-mono text-muted-foreground transition group-hover:opacity-0">
-              {language}
-            </span>
-          )}
+  const Wrapper = ({
+    children,
+    className,
+    style,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+  }) => (
+    <div className="relative group">
+      {title && (
+        <div className="text-xs text-muted-foreground absolute top-2 font-mono border-b w-full pb-2 px-4 ">
+          {title}
         </div>
-      }
-    >
+      )}
+      <pre
+        className={cn(
+          "relative scrollbar overflow-x-auto",
+          props.className,
+          props.noBackground ? "!bg-transparent" : themeColorClasses,
+          props.wrapLines && "whitespace-pre-wrap break-words",
+          title && "pt-10",
+          className,
+        )}
+        style={style}
+      >
+        {children}
+      </pre>
+      {props.showLanguageIndicator && (
+        <span className="absolute top-1.5 right-3 text-[11px] font-mono text-muted-foreground transition group-hover:opacity-0">
+          {language}
+        </span>
+      )}
+      {showCopy !== "never" && (
+        <button
+          type="button"
+          aria-label="Copy code"
+          title="Copy code"
+          className={cn(
+            "absolute top-2 right-2 p-2  hover:outline hover:outline-border/75 dark:hover:outline-border rounded-md text-sm text-muted-foreground transition",
+            showCopy === "hover"
+              ? "opacity-0 group-hover:opacity-100 group-hover:bg-zinc-100 group-hover:dark:bg-zinc-700"
+              : "bg-zinc-100 dark:bg-zinc-700",
+            showCopyText && "flex gap-2 items-center font-medium",
+          )}
+          disabled={isCopied}
+          onClick={() => {
+            setIsCopied(true);
+            void navigator.clipboard.writeText(code);
+            setTimeout(() => setIsCopied(false), 2000);
+          }}
+        >
+          {isCopied ? (
+            <CheckIcon
+              className="text-emerald-600"
+              size={16}
+              strokeWidth={2.5}
+              absoluteStrokeWidth
+            />
+          ) : (
+            <CopyIcon size={16} />
+          )}
+          {showCopyText && "Copy"}
+        </button>
+      )}
+    </div>
+  );
+
+  if (disabled) {
+    return (
+      <ClientOnly fallback={<Wrapper>{code}</Wrapper>}>
+        <Wrapper>{code}</Wrapper>
+      </ClientOnly>
+    );
+  }
+
+  return (
+    <ClientOnly fallback={<Wrapper>{code}</Wrapper>}>
       <Highlight
         theme={highlightTheme}
         language={remapLang[language] ?? language}
@@ -110,77 +162,23 @@ export const SyntaxHighlight = ({
         code={code}
       >
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
-          <div className="relative group">
-            {title && (
-              <div className="text-xs text-muted-foreground absolute top-2 font-mono border-b w-full pb-2 px-4 ">
-                {title}
+          <Wrapper className={className} style={style}>
+            {tokens.map((line, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <div key={i} {...getLineProps({ line })}>
+                {line.map((token, key) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <span key={key} {...getTokenProps({ token })} />
+                ))}
               </div>
-            )}
-            <pre
-              className={cn(
-                "relative scrollbar overflow-x-auto",
-                className,
-                props.className,
-                props.noBackground && "!bg-transparent",
-                props.wrapLines && "whitespace-pre-wrap break-words",
-                title && "pt-10",
-              )}
-              style={style}
-            >
-              {tokens.map((line, i) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <div key={i} {...getLineProps({ line })}>
-                  {line.map((token, key) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <span key={key} {...getTokenProps({ token })} />
-                  ))}
-                </div>
-              ))}
-            </pre>
-            {props.showLanguageIndicator && (
-              <span className="absolute top-1.5 right-3 text-[11px] font-mono text-muted-foreground transition group-hover:opacity-0">
-                {language}
-              </span>
-            )}
-            {showCopy !== "never" && (
-              <button
-                type="button"
-                aria-label="Copy code"
-                title="Copy code"
-                className={cn(
-                  "absolute top-2 right-2 p-2  hover:outline hover:outline-border/75 dark:hover:outline-border rounded-md text-sm text-muted-foreground transition",
-                  showCopy === "hover"
-                    ? "opacity-0 group-hover:opacity-100 group-hover:bg-zinc-100 group-hover:dark:bg-zinc-700"
-                    : "bg-zinc-100 dark:bg-zinc-700",
-                  showCopyText && "flex gap-2 items-center font-medium",
-                )}
-                disabled={isCopied}
-                onClick={() => {
-                  setIsCopied(true);
-                  void navigator.clipboard.writeText(
-                    tokens
-                      .map((l) => l.map(({ content }) => content).join(""))
-                      .join("\n"),
-                  );
-                  setTimeout(() => setIsCopied(false), 2000);
-                }}
-              >
-                {isCopied ? (
-                  <CheckIcon
-                    className="text-emerald-600"
-                    size={16}
-                    strokeWidth={2.5}
-                    absoluteStrokeWidth
-                  />
-                ) : (
-                  <CopyIcon size={16} />
-                )}
-                {showCopyText && "Copy"}
-              </button>
-            )}
-          </div>
+            ))}
+          </Wrapper>
         )}
       </Highlight>
     </ClientOnly>
   );
 };
+
+export const SyntaxHighlight = memo(SyntaxHighlightInner);
+
+SyntaxHighlight.displayName = "SyntaxHighlight";


### PR DESCRIPTION
To not freeze the browser for large payloads I've disabled syntax highlighting at 64kb (which seemed a reasonable size).

![CleanShot 2025-03-04 at 17 50 42](https://github.com/user-attachments/assets/762ea726-5e76-48d7-b8f2-37b5d705776b)

We probably can revisit this when we switch to another syntax highlighter