### PR TITLE
Pagefind: Add command to create index for dev

### DIFF
--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -129,6 +129,9 @@ export const render = async ({
     },
     onError(error) {
       status = 500;
+      if (import.meta.env.PROD) {
+        throw error;
+      }
       logger.error(error);
     },
   });

--- a/packages/zudoku/src/cli/cmds/dev.ts
+++ b/packages/zudoku/src/cli/cmds/dev.ts
@@ -1,6 +1,7 @@
-import { Argv } from "yargs";
+import { type Argv } from "yargs";
 import { captureEvent } from "../common/analytics/lib.js";
-import { Arguments, dev } from "../dev/handler.js";
+import { type Arguments, dev } from "../dev/handler.js";
+import { pagefindCommand } from "../dev/pagefind-command.js";
 
 export default {
   desc: "Runs locally",
@@ -27,7 +28,18 @@ export default {
         type: "boolean",
         describe: "Automatically open the browser",
         default: false,
-      });
+      })
+      .command(
+        "pagefind",
+        "Creates a search index for pagefind based on the current build",
+        (yargs: Argv) =>
+          yargs.option("force-build", {
+            type: "boolean",
+            description: "Run build before generating pagefind index",
+            default: false,
+          }),
+        pagefindCommand,
+      );
   },
   handler: async (argv: unknown) => {
     await captureEvent({

--- a/packages/zudoku/src/cli/dev/pagefind-command.ts
+++ b/packages/zudoku/src/cli/dev/pagefind-command.ts
@@ -1,0 +1,73 @@
+import { glob } from "glob";
+import fs from "node:fs/promises";
+import path from "node:path";
+import colors from "picocolors";
+import { runBuild } from "../../vite/build.js";
+import { loadZudokuConfig } from "../../vite/config.js";
+import { createPagefindIndex } from "../../vite/create-pagefind-index.js";
+import { writeLine } from "../../vite/reporter.js";
+import { logger } from "../common/logger.js";
+
+const captureOutput = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const stdout = process.stdout.write;
+  const stderr = process.stderr.write;
+  process.stdout.write = () => true;
+  process.stderr.write = () => true;
+  try {
+    return await fn();
+  } finally {
+    process.stdout.write = stdout;
+    process.stderr.write = stderr;
+  }
+};
+
+export const pagefindCommand = async (argv: { forceBuild: boolean }) => {
+  const dir = process.cwd();
+  const dist = path.join(dir, "dist");
+
+  const { config } = await loadZudokuConfig(
+    { mode: "production", command: "build" },
+    dir,
+  );
+
+  if (config.search?.type !== "pagefind") {
+    logger.warn(colors.yellow("Search is not configured to use pagefind."));
+  }
+
+  const message = argv.forceBuild
+    ? "creating build and pagefind index..."
+    : "building pagefind index...";
+  writeLine(colors.blue(message));
+
+  if (argv.forceBuild) {
+    await captureOutput(() => runBuild({ dir }));
+  }
+
+  const outputPath = await createPagefindIndex({
+    dir: dist,
+    outDir: path.join(process.cwd(), "public"),
+  });
+
+  const successMessage = argv.forceBuild
+    ? `✓ build created and pagefind index written to ${outputPath}`
+    : `✓ pagefind index written to ${outputPath}`;
+
+  writeLine(colors.blue(successMessage));
+
+  // find pagefind directory in dist with glob
+  const pagefindGlob = await glob("**/pagefind/", {
+    cwd: dist,
+    absolute: true,
+  });
+  const pagefindDir = pagefindGlob.at(0);
+
+  if (!pagefindDir) {
+    throw new Error(`pagefind directory not found in ${dist}.`);
+  }
+
+  // move from dist to public dir so it can be consumed in dev
+  const publicDir = path.join(dir, "public/pagefind");
+
+  await fs.rm(publicDir, { recursive: true, force: true });
+  await fs.rename(pagefindDir, publicDir);
+};

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -1,13 +1,15 @@
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import colors from "picocolors";
 import { build as viteBuild } from "vite";
+import { logger } from "../cli/common/logger.js";
 import { findOutputPathOfServerConfig } from "../config/loader.js";
 import invariant from "../lib/util/invariant.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { getViteConfig, loadZudokuConfig } from "./config.js";
+import { createPagefindIndex } from "./create-pagefind-index.js";
 import { getBuildHtml } from "./html.js";
 import { writeOutput } from "./output.js";
-import { runPagefind } from "./pagefind.js";
 import { prerender } from "./prerender/prerender.js";
 
 const DIST_DIR = "dist";
@@ -77,7 +79,10 @@ export async function runBuild(options: { dir: string }) {
       await rm(viteServerConfig.build.outDir, { recursive: true, force: true });
 
       if (config.search?.type === "pagefind") {
-        await runPagefind({ dir: viteClientConfig.build.outDir });
+        const outputPath = await createPagefindIndex({
+          dir: viteClientConfig.build.outDir,
+        });
+        logger.info(colors.blue(`✓ pagefind index built: ${outputPath}`));
       }
 
       if (process.env.VERCEL) {

--- a/packages/zudoku/src/vite/create-pagefind-index.ts
+++ b/packages/zudoku/src/vite/create-pagefind-index.ts
@@ -1,9 +1,7 @@
 import path from "node:path";
-import colors from "picocolors";
-import { logger } from "../cli/common/logger.js";
 import invariant from "../lib/util/invariant.js";
 
-export const runPagefind = async (options: {
+export const createPagefindIndex = async (options: {
   dir: string;
   outDir?: string;
 }) => {
@@ -12,10 +10,10 @@ export const runPagefind = async (options: {
 
   invariant(index, `Failed to create pagefind index: ${errors.join(", ")}`);
 
-  await index.addDirectory({ path: options.dir });
-  await index.writeFiles({
-    outputPath: path.join(options.outDir ?? options.dir, "pagefind"),
-  });
+  const outputPath = path.join(options.outDir ?? options.dir, "pagefind");
 
-  logger.info(colors.blue(`✓ pagefind search index written`));
+  await index.addDirectory({ path: options.dir });
+  await index.writeFiles({ outputPath });
+
+  return outputPath;
 };


### PR DESCRIPTION
Create command `zudoku dev pagefind`:

1. Runs `zudoku build`
2. Creates Pagefind index
3. Moves it to `public` folder