### PR TITLE
Only use temporary redirects (307) in dev

### DIFF
--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -47,7 +47,7 @@ export const render = async ({
   if (context instanceof Response) {
     if ([301, 302, 303, 307, 308].includes(context.status)) {
       return response.redirect(
-        context.status,
+        import.meta.env.PROD ? context.status : 307,
         context.headers.get("Location")!,
       );
     }


### PR DESCRIPTION
Switching between projects/examples or changing redirects can mess with the browser cache, so we should only use a [307 Temporary Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) to make sure we don't cache it.
