### PR TITLE
Fix Vite config merge order

### DIFF
--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -311,12 +311,17 @@ export async function getViteConfig(
     undefined,
     "runner",
   );
+
   if (userConfig) {
     const merged: InlineConfig = mergeConfig(
-      userConfig.config,
       viteConfig,
+      userConfig.config,
       true,
     );
+
+    logger.info(colors.blue(`merged with custom user Vite config`), {
+      timestamp: true,
+    });
 
     return merged;
   }


### PR DESCRIPTION
The order of `mergeConfig` is important. 