### PR TITLE
Use `runnerImport` instead of `loadConfigFromFile` to load Zudoku config

### DIFF
--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -74,15 +74,14 @@ async function getConfigFilePath(
 async function loadZudokuCodeConfig<TConfig>(
   configPath: string,
 ): Promise<{ dependencies: string[]; config: TConfig }> {
-  const { module, dependencies } = await runnerImport<TConfig>(configPath, {
-    server: {
-      perEnvironmentStartEndDuringDev: true,
-    },
-  });
+  const { module, dependencies } = await runnerImport<{ default: TConfig }>(
+    configPath,
+    { server: { perEnvironmentStartEndDuringDev: true } },
+  );
 
   return {
     dependencies: [configPath, ...dependencies],
-    config: module,
+    config: module.default,
   };
 }
 

--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -76,7 +76,13 @@ async function loadZudokuCodeConfig<TConfig>(
 ): Promise<{ dependencies: string[]; config: TConfig }> {
   const { module, dependencies } = await runnerImport<{ default: TConfig }>(
     configPath,
-    { server: { perEnvironmentStartEndDuringDev: true } },
+    {
+      server: {
+        // this allows us to 'load' CSS files in the config
+        // see https://github.com/vitejs/vite/pull/19577
+        perEnvironmentStartEndDuringDev: true,
+      },
+    },
   );
 
   return {

--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -164,7 +164,7 @@ export async function tryLoadZudokuConfig<TConfig extends CommonConfig>(
     dependencies = [];
   } else {
     const loadConfig = overrides?.loadZudokuCodeConfig ?? loadZudokuCodeConfig;
-    ({ config, dependencies } = await loadConfig<TConfig>(rootDir));
+    ({ config, dependencies } = await loadConfig<TConfig>(configPath));
     // This is here instead of in the load function so that
     // it works even if we are overriding the load function
     validateConfig(config);

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -91,12 +91,7 @@ export async function loadZudokuConfig(
       }
     }
 
-    config = await tryLoadZudokuConfig(
-      rootDir,
-      getModuleDir(),
-      envVars,
-      configEnv,
-    );
+    config = await tryLoadZudokuConfig(rootDir, getModuleDir(), envVars);
 
     logger.info(
       colors.yellow(`loaded config file `) +


### PR DESCRIPTION
TIL about `runnerImport` which fits our cause way better than `loadConfigFromFile`.