### PR TITLE
Fix auto login redirect with no `protectedRoutes`

### DIFF
--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -18,8 +18,9 @@ export const RouteGuard = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const latestPath = useLatest(location.pathname);
+  const { protectedRoutes = [] } = zudoku.options;
 
-  const isProtected = zudoku.options.protectedRoutes?.some((path) =>
+  const isProtected = protectedRoutes.some((path) =>
     matchPath({ path, end: true }, location.pathname),
   );
 


### PR DESCRIPTION
If authentication is enabled and no `protectedRoutes` are defined, `RouteGuard` would always redirect to the login page, no matter what.

This because when `protectedRoutes` value is `undefined` the `enabled` option for react-query would evaluate `undefined` as well. This means the options is effectively unset and enabled by default:

https://github.com/zuplo/zudoku/blob/9f650259691c719e1c24194c0ec39a611eee2ddc/packages/zudoku/src/lib/core/RouteGuard.tsx#L35-L39

Bascially: `typeof window !== "undefined" && undefined` → `undefined` → `useQuery` fires