### PR TITLE
Simplify layout

### DIFF
--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -82,10 +82,11 @@
     --top-nav-height: 50px;
     --banner-height: 40px;
     --header-height: calc(
-      var(--top-header-height) + var(--top-nav-height) + var(--banner-height)
+      var(--top-header-height) + var(--top-nav-height) + var(--banner-height) -
+        /* borders */ 2px
     );
     --scroll-padding: calc(var(--header-height) + 10px);
-    --side-nav-width: theme("spacing.80");
+    --side-nav-width: theme("spacing.72");
     --padding-content-top: theme("spacing.6");
     --padding-content-bottom: theme("spacing.12");
     --padding-nav-item: theme("spacing[2.5]");
@@ -108,8 +109,9 @@
   }
 
   #root {
-    @apply min-h-screen w-full flex flex-col;
+    @apply min-h-screen w-full grid grid-rows-[auto_1fr];
   }
+
   * {
     @apply border-border;
   }

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -108,7 +108,7 @@
   }
 
   #root {
-    @apply min-h-screen w-full;
+    @apply min-h-screen w-full flex flex-col;
   }
   * {
     @apply border-border;

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -3,7 +3,10 @@ import { Link } from "react-router";
 import { Button } from "zudoku/ui/Button.js";
 import { Skeleton } from "zudoku/ui/Skeleton.js";
 import { useAuth } from "../authentication/hook.js";
-import { isProfileMenuPlugin, ProfileNavigationItem } from "../core/plugins.js";
+import {
+  isProfileMenuPlugin,
+  type ProfileNavigationItem,
+} from "../core/plugins.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -66,7 +69,7 @@ export const Header = memo(function HeaderInner() {
     <header className="sticky lg:top-0 z-10 bg-background/80 backdrop-blur w-full">
       <Banner />
       <div className="border-b">
-        <div className="max-w-screen-2xl 2xl:border-x mx-auto grid grid-cols-[1fr_auto] lg:grid-cols-[calc(var(--side-nav-width))_1fr] lg:gap-12 items-center px-4 lg:px-8 h-[--top-header-height]">
+        <div className="max-w-screen-2xl 2xl:border-x mx-auto flex relative items-center justify-between px-4 lg:px-8 h-[--top-header-height]">
           <div className="flex">
             <Link to="/">
               <div className="flex items-center gap-3.5">
@@ -108,11 +111,12 @@ export const Header = memo(function HeaderInner() {
               </div>
             </Link>
           </div>
-          <div className="grid grid-cols-1 lg:grid-cols-[--sidecar-grid-cols] items-center gap-8">
-            <div className="w-full justify-center hidden lg:flex">
-              <Search />
-            </div>
 
+          <div className="absolute inset-x-0 justify-center items-center hidden lg:flex w-full pointer-events-none">
+            <Search className="pointer-events-auto" />
+          </div>
+
+          <div className="flex items-center gap-8">
             <MobileTopNavigation />
             <div className="hidden lg:flex items-center justify-self-end text-sm gap-2">
               <Slotlet name="head-navigation-start" />

--- a/packages/zudoku/src/lib/components/Layout.tsx
+++ b/packages/zudoku/src/lib/components/Layout.tsx
@@ -1,21 +1,18 @@
 import { Helmet } from "@zudoku/react-helmet-async";
-import { PanelLeftIcon } from "lucide-react";
-import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import { Suspense, useEffect, useRef, type ReactNode } from "react";
 import { Outlet, useLocation, useNavigation } from "react-router";
 import { useSpinDelay } from "spin-delay";
-import { Drawer, DrawerTrigger } from "../ui/Drawer.js";
-import { cn } from "../util/cn.js";
 import { useScrollToAnchor } from "../util/useScrollToAnchor.js";
 import { useScrollToTop } from "../util/useScrollToTop.js";
 import { useViewportAnchor } from "./context/ViewportAnchorContext.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 import { Header } from "./Header.js";
-import { Sidebar } from "./navigation/Sidebar.js";
+import { Main } from "./Main.js";
 import { Slotlet } from "./SlotletProvider.js";
 import { Spinner } from "./Spinner.js";
 
 const LoadingFallback = () => (
-  <main className="grid flex-1 w-full place-items-center">
+  <main className="col-span-full grid place-items-center">
     <Spinner />
   </main>
 );
@@ -49,7 +46,6 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
     delay: 300,
     minDuration: 500,
   });
-  const [isDrawerOpen, setDrawerOpen] = useState(false);
 
   return (
     <>
@@ -66,43 +62,12 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
       <Header />
       <Slotlet name="layout-after-head" />
 
-      <div className="flex flex-col flex-1 items-stretch w-full max-w-screen-2xl mx-auto px-4 lg:px-8 2xl:border-x">
+      <div className="grid lg:grid-cols-[var(--side-nav-width)_1fr] max-w-screen-2xl w-full lg:mx-auto px-4 lg:px-8 2xl:border-x">
         {showSpinner ? (
           <LoadingFallback />
         ) : (
           <Suspense fallback={<LoadingFallback />}>
-            <Drawer
-              direction="left"
-              open={isDrawerOpen}
-              onOpenChange={(open) => setDrawerOpen(open)}
-            >
-              <Sidebar onRequestClose={() => setDrawerOpen(false)} />
-              <div
-                className={cn(
-                  "lg:hidden -mx-4 px-4 py-2 sticky bg-background/80 backdrop-blur z-10 top-0 left-0 right-0 border-b",
-                  "peer-data-[navigation=false]:hidden",
-                )}
-              >
-                <DrawerTrigger className="flex items-center gap-2">
-                  <PanelLeftIcon size={16} strokeWidth={1.5} />
-                  <span className="text-sm">Menu</span>
-                </DrawerTrigger>
-              </div>
-              <main
-                data-pagefind-body
-                className={cn(
-                  "h-auto dark:border-white/10 translate-x-0",
-                  "lg:overflow-visible",
-                  // This works in tandem with the `SidebarWrapper` component
-                  "lg:peer-data-[navigation=true]:w-[calc(100%-var(--side-nav-width))]",
-                  "lg:peer-data-[navigation=true]:translate-x-[--side-nav-width] lg:peer-data-[navigation=true]:pl-12",
-                )}
-              >
-                <Slotlet name="zudoku-before-content" />
-                {children ?? <Outlet />}
-                <Slotlet name="zudoku-after-content" />
-              </main>
-            </Drawer>
+            <Main>{children ?? <Outlet />}</Main>
           </Suspense>
         )}
       </div>

--- a/packages/zudoku/src/lib/components/Layout.tsx
+++ b/packages/zudoku/src/lib/components/Layout.tsx
@@ -15,7 +15,7 @@ import { Slotlet } from "./SlotletProvider.js";
 import { Spinner } from "./Spinner.js";
 
 const LoadingFallback = () => (
-  <main className="grid h-[calc(100vh-var(--header-height))] place-items-center">
+  <main className="grid flex-1 w-full place-items-center">
     <Spinner />
   </main>
 );
@@ -66,7 +66,7 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
       <Header />
       <Slotlet name="layout-after-head" />
 
-      <div className="w-full min-h-[calc(100vh-var(--header-height))] max-w-screen-2xl mx-auto px-4 lg:px-8 2xl:border-x">
+      <div className="flex flex-col flex-1 items-stretch w-full max-w-screen-2xl mx-auto px-4 lg:px-8 2xl:border-x">
         {showSpinner ? (
           <LoadingFallback />
         ) : (
@@ -91,7 +91,7 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
               <main
                 data-pagefind-body
                 className={cn(
-                  "h-full dark:border-white/10 translate-x-0",
+                  "h-auto dark:border-white/10 translate-x-0",
                   "lg:overflow-visible",
                   // This works in tandem with the `SidebarWrapper` component
                   "lg:peer-data-[navigation=true]:w-[calc(100%-var(--side-nav-width))]",

--- a/packages/zudoku/src/lib/components/Main.tsx
+++ b/packages/zudoku/src/lib/components/Main.tsx
@@ -1,0 +1,47 @@
+import { PanelLeftIcon } from "lucide-react";
+import { type PropsWithChildren, useState } from "react";
+import { Drawer, DrawerTrigger } from "zudoku/ui/Drawer.js";
+import { cn } from "../util/cn.js";
+import { useCurrentNavigation } from "./context/ZudokuContext.js";
+import { Sidebar } from "./navigation/Sidebar.js";
+import { Slotlet } from "./SlotletProvider.js";
+
+export const Main = ({ children }: PropsWithChildren) => {
+  const [isDrawerOpen, setDrawerOpen] = useState(false);
+  const { sidebar } = useCurrentNavigation();
+  const hasSidebar = sidebar.length > 0;
+
+  return (
+    <Drawer
+      direction="left"
+      open={isDrawerOpen}
+      onOpenChange={(open) => setDrawerOpen(open)}
+    >
+      {hasSidebar && (
+        <Sidebar
+          onRequestClose={() => setDrawerOpen(false)}
+          sidebar={sidebar}
+        />
+      )}
+      {hasSidebar && (
+        <div className="lg:hidden -mx-4 px-4 py-2 sticky bg-background/80 backdrop-blur z-10 top-0 left-0 right-0 border-b">
+          <DrawerTrigger className="flex items-center gap-2">
+            <PanelLeftIcon size={16} strokeWidth={1.5} />
+            <span className="text-sm">Menu</span>
+          </DrawerTrigger>
+        </div>
+      )}
+      <main
+        data-pagefind-body
+        className={cn(
+          "h-auto dark:border-white/10 translate-x-0",
+          hasSidebar ? "lg:pl-12" : "col-span-full",
+        )}
+      >
+        <Slotlet name="zudoku-before-content" />
+        {children}
+        <Slotlet name="zudoku-after-content" />
+      </main>
+    </Drawer>
+  );
+};

--- a/packages/zudoku/src/lib/components/context/ViewportAnchorContext.tsx
+++ b/packages/zudoku/src/lib/components/context/ViewportAnchorContext.tsx
@@ -1,5 +1,4 @@
 import {
-  type ReactNode,
   createContext,
   useCallback,
   useContext,
@@ -7,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type PropsWithChildren,
 } from "react";
 
 type AnchorContextType = {
@@ -55,11 +55,7 @@ export const useRegisterAnchorElement = () => {
   return { ref: setRef };
 };
 
-export const ViewportAnchorProvider = ({
-  children,
-}: {
-  children: ReactNode;
-}) => {
+export const ViewportAnchorProvider = ({ children }: PropsWithChildren) => {
   const [activeAnchor, setActiveAnchor] = useState("");
   const observerRef = useRef<IntersectionObserver | null>(null);
   const registeredElements = useRef(new Set<HTMLElement>());
@@ -75,9 +71,7 @@ export const ViewportAnchorProvider = ({
         }
       },
       {
-        // 115px is the height of the sticky header
-        // see --header-height in `main.css`
-        rootMargin: "115px 0px -80% 0px",
+        rootMargin: "0px 0px -80% 0px",
         threshold: 0.75,
       },
     );

--- a/packages/zudoku/src/lib/components/navigation/Sidebar.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Sidebar.tsx
@@ -1,20 +1,21 @@
 import { useEffect, useRef } from "react";
 
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import type { SidebarItem as SidebarItemType } from "../../../config/validators/SidebarSchema.js";
 import { DrawerContent, DrawerTitle } from "../../ui/Drawer.js";
 import { scrollIntoViewIfNeeded } from "../../util/scrollIntoViewIfNeeded.js";
-import { useCurrentNavigation } from "../context/ZudokuContext.js";
 import { Slotlet } from "../SlotletProvider.js";
 import { SidebarItem } from "./SidebarItem.js";
 import { SidebarWrapper } from "./SidebarWrapper.js";
 
 export const Sidebar = ({
   onRequestClose,
+  sidebar,
 }: {
   onRequestClose?: () => void;
+  sidebar: SidebarItemType[];
 }) => {
-  const navRef = useRef<HTMLDivElement | null>(null);
-  const navigation = useCurrentNavigation();
+  const navRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const active = navRef.current?.querySelector('[aria-current="page"]');
@@ -23,12 +24,9 @@ export const Sidebar = ({
 
   return (
     <>
-      <SidebarWrapper
-        ref={navRef}
-        pushMainContent={navigation.sidebar.length > 0}
-      >
+      <SidebarWrapper ref={navRef}>
         <Slotlet name="zudoku-before-navigation" />
-        {navigation.sidebar.map((item) => (
+        {sidebar.map((item) => (
           <SidebarItem key={item.label} item={item} />
         ))}
         <Slotlet name="zudoku-after-navigation" />
@@ -41,7 +39,7 @@ export const Sidebar = ({
           <VisuallyHidden>
             <DrawerTitle>Sidebar</DrawerTitle>
           </VisuallyHidden>
-          {navigation.sidebar.map((item) => (
+          {sidebar.map((item) => (
             <SidebarItem
               key={item.label}
               item={item}

--- a/packages/zudoku/src/lib/components/navigation/SidebarWrapper.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarWrapper.tsx
@@ -1,27 +1,25 @@
-import { forwardRef, type PropsWithChildren } from "react";
+import { type PropsWithChildren, type Ref } from "react";
 import { cn } from "../../util/cn.js";
 
-export const SidebarWrapper = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<{ pushMainContent?: boolean; className?: string }>
->(({ children, className, pushMainContent }, ref) => (
+export const SidebarWrapper = ({
+  children,
+  className,
+  ref,
+}: PropsWithChildren<{
+  className?: string;
+  ref?: Ref<HTMLDivElement>;
+}>) => (
   <nav
-    // this data attribute is used in `Layout.tsx` to determine if side navigation
-    // is present for the current page so the main content is pushed to the right
-    // it's also important to set `peer` class here.
-    // maybe this could be simplified by adjusting the layout
-    data-navigation={String(pushMainContent)}
     className={cn(
-      "scrollbar peer hidden lg:flex flex-col fixed text-sm overflow-y-auto shrink-0 border-r pr-6",
-      "-mx-[--padding-nav-item] pb-20 pt-[--padding-content-top]",
-      "w-[--side-nav-width] h-[calc(100%-var(--header-height))] scroll-pt-2 gap-2",
-      !pushMainContent && "border-r-0",
+      "hidden lg:flex h-full scrollbar peer flex-col overflow-y-auto shrink-0 text-sm border-r pr-6",
+      "sticky top-[--header-height] h-[calc(100vh-var(--header-height))]",
+      "-mx-[--padding-nav-item] max-w-[--side-nav-width] pb-20 pt-[--padding-content-top] scroll-pt-2 gap-2",
       className,
     )}
     ref={ref}
   >
     {children}
   </nav>
-));
+);
 
 SidebarWrapper.displayName = "SidebarWrapper";

--- a/packages/zudoku/src/lib/plugins/openapi/SimpleSelect.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SimpleSelect.tsx
@@ -21,7 +21,7 @@ export const SimpleSelect = ({
   <div className="grid">
     <select
       className={cn(
-        "row-start-1 col-start-1 border border-input text-foreground px-2 py-1 pe-6",
+        "w-full row-start-1 col-start-1 border border-input text-foreground px-2 py-1 pe-6",
         "rounded-md appearance-none bg-zinc-50 hover:bg-white dark:bg-zinc-800 hover:dark:bg-zinc-800/75",
         className,
       )}


### PR DESCRIPTION
Mainly to remove fixed positioning and hacks around that for the sidebar and to get rid of `min-h-[calc(100vh-var(--header-height))]` everywhere