### PR TITLE
OpenAPI: Shows all tags (categories) with lightning speed ⚡

### DIFF
--- a/docs/pages/configuration/api-reference.md
+++ b/docs/pages/configuration/api-reference.md
@@ -116,28 +116,30 @@ Individual API options will override these defaults when specified.
 
 ## Extensions
 
-Zudoku supports OpenAPI extensions (properties starting with `x-`) to customize behavior at the operation level. Currently supported extensions:
+Zudoku supports OpenAPI extensions (properties starting with `x-`) to customize behavior at different levels of your API documentation.
 
-- `x-playground-enabled`: Control playground visibility for an operation
-- `x-explorer-enabled`: Alias for `x-playground-enabled` for compatibility
+### Operations
+
+- `x-zudoku-playground-enabled`: Control playground visibility for an operation (default: `true`)
+- `x-explorer-enabled`: Alias for `x-zudoku-playground-enabled` for compatibility Example:
+
+### Tags
+
+Extensions that can be applied to tag categories:
+
+- `x-zudoku-collapsed`: Control initial collapsed state of a tag category (default: `true`)
+- `x-zudoku-collapsible`: Control if a tag category can be collapsed (default: `true`)
 
 Example:
 
 ```json
 {
-  "paths": {
-    "/api/v1/users": {
-      "get": {
-        "summary": "List users",
-        "x-explorer-enabled": false, // Disable playground for this operation
-        "responses": {
-          "200": {
-            "description": "List of users"
-          }
-        }
-      }
+  "tags": [
+    {
+      "name": "Users",
+      "x-zudoku-collapsed": false
     }
-  }
+  ]
 }
 ```
 

--- a/docs/pages/configuration/api-reference.md
+++ b/docs/pages/configuration/api-reference.md
@@ -123,6 +123,19 @@ Zudoku supports OpenAPI extensions (properties starting with `x-`) to customize 
 - `x-zudoku-playground-enabled`: Control playground visibility for an operation (default: `true`)
 - `x-explorer-enabled`: Alias for `x-zudoku-playground-enabled` for compatibility Example:
 
+```json
+{
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users",
+        "x-zudoku-playground-enabled": false // Disable playground for this operation
+      }
+    }
+  }
+}
+```
+
 ### Tags
 
 Extensions that can be applied to tag categories:

--- a/packages/zudoku/schema.graphql
+++ b/packages/zudoku/schema.graphql
@@ -125,8 +125,10 @@ type Schema {
 
 type SchemaTag {
   description: String
-  name: String!
+  extensions: JSONObject
+  name: String
   operations: [OperationItem!]!
+  slug: String
 }
 
 enum SchemaType {

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -13,6 +13,7 @@ import {
 import "virtual:zudoku-theme.css";
 import "vite/modulepreload-polyfill";
 import { BootstrapStatic, ServerError } from "zudoku/components";
+import { NO_DEHYDRATE } from "../lib/components/cache.js";
 import type { FileWritingResponse } from "../vite/prerender/FileWritingResponse.js";
 import "./main.css";
 import { getRoutesByConfig } from "./main.js";
@@ -115,10 +116,15 @@ export const render = async ({
       );
 
       transformStream.on("finish", () => {
+        const dehydrated = dehydrate(queryClient, {
+          shouldDehydrateQuery: (query) =>
+            !query.queryKey.includes(NO_DEHYDRATE),
+        });
+
         response.end(
           htmlEnd?.replace(
             "</body>",
-            `<script>window.DATA = ${JSON.stringify(dehydrate(queryClient))}</script></body>`,
+            `<script>window.DATA=${JSON.stringify(dehydrated)}</script></body>`,
           ),
         );
       });

--- a/packages/zudoku/src/config/validators/common.ts
+++ b/packages/zudoku/src/config/validators/common.ts
@@ -48,7 +48,6 @@ const ApiCatalogCategorySchema = z.object({
 const ApiOptionsSchema = z.object({
   examplesLanguage: z.string().optional(),
   disablePlayground: z.boolean().optional(),
-  loadTags: z.boolean().optional(),
   showVersionSelect: z.enum(["always", "if-available", "hide"]).optional(),
 });
 

--- a/packages/zudoku/src/lib/components/Zudoku.tsx
+++ b/packages/zudoku/src/lib/components/Zudoku.tsx
@@ -1,4 +1,5 @@
 import { MDXProvider } from "@mdx-js/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Helmet } from "@zudoku/react-helmet-async";
 import { ThemeProvider } from "next-themes";
 import {
@@ -59,6 +60,7 @@ const ZudokoInner = memo(
       [stagger, didNavigate],
     );
     const navigation = useNavigation();
+    const queryClient = useQueryClient();
 
     useEffect(() => {
       if (didNavigate) {
@@ -67,7 +69,9 @@ const ZudokoInner = memo(
       setDidNavigate(true);
     }, [didNavigate, navigation.location]);
 
-    const [zudokuContext] = useState(() => new ZudokuContext(props));
+    const [zudokuContext] = useState(
+      () => new ZudokuContext(props, queryClient),
+    );
 
     const heads = props.plugins
       ?.flatMap((plugin) => (hasHead(plugin) ? (plugin.getHead?.() ?? []) : []))

--- a/packages/zudoku/src/lib/components/cache.ts
+++ b/packages/zudoku/src/lib/components/cache.ts
@@ -13,3 +13,11 @@ export const useCache = () => {
     },
   };
 };
+
+/**
+ * If a query has this key in its queryKey, it will not put its result in the dehydrated state in the SSR.
+ *
+ * This is useful if the query should only be suspended and not included in the initial HTML response.
+ * (e.g. too large in size, or not needed for the initial page load)
+ */
+export const NO_DEHYDRATE = "no-dehydrate";

--- a/packages/zudoku/src/lib/components/context/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/components/context/ZudokuContext.ts
@@ -2,9 +2,9 @@ import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createContext, useContext } from "react";
 import { matchPath, useLocation } from "react-router";
 import { useAuth } from "../../authentication/hook.js";
-import { ZudokuContext } from "../../core/ZudokuContext.js";
+import type { ZudokuContext } from "../../core/ZudokuContext.js";
 import { joinPath } from "../../util/joinPath.js";
-import { CACHE_KEYS } from "../cache.js";
+import { CACHE_KEYS, NO_DEHYDRATE } from "../cache.js";
 import { traverseSidebar } from "../navigation/utils.js";
 
 export const ZudokuReactContext = createContext<ZudokuContext | undefined>(
@@ -26,7 +26,7 @@ export const useApiIdentities = () => {
 
   return useQuery({
     queryFn: getApiIdentities,
-    queryKey: [CACHE_KEYS.API_IDENTITIES],
+    queryKey: CACHE_KEYS.API_IDENTITIES,
   });
 };
 
@@ -59,7 +59,8 @@ export const useCurrentNavigation = () => {
 
   const { data } = useSuspenseQuery({
     queryFn: () => getPluginSidebar(location.pathname),
-    queryKey: ["plugin-sidebar", location.pathname],
+    // We just want to suspend here and don't store in SSR dehydrated state
+    queryKey: ["plugin-sidebar", NO_DEHYDRATE, location.pathname],
   });
 
   const hideSidebar =

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -1,11 +1,12 @@
+import type { QueryClient } from "@tanstack/react-query";
 import { createNanoEvents } from "nanoevents";
-import { ReactNode } from "react";
-import { Location } from "react-router";
-import { TopNavigationItem } from "../../config/validators/common.js";
+import type { ReactNode } from "react";
+import type { Location } from "react-router";
+import type { TopNavigationItem } from "../../config/validators/common.js";
 import type { SidebarConfig } from "../../config/validators/SidebarSchema.js";
-import { type AuthenticationProvider } from "../authentication/authentication.js";
+import type { AuthenticationProvider } from "../authentication/authentication.js";
 import type { ComponentsContextType } from "../components/context/ComponentsContext.js";
-import { Slotlets } from "../components/SlotletProvider.js";
+import type { Slotlets } from "../components/SlotletProvider.js";
 import { joinPath } from "../util/joinPath.js";
 import type { MdxComponentsType } from "../util/MdxComponents.js";
 import { objectEntries } from "../util/objectEntries.js";
@@ -90,7 +91,10 @@ export class ZudokuContext {
   private readonly navigationPlugins: NavigationPlugin[];
   private emitter = createNanoEvents<ZudokuEvents>();
 
-  constructor(public readonly options: ZudokuContextOptions) {
+  constructor(
+    public readonly options: ZudokuContextOptions,
+    public readonly queryClient: QueryClient,
+  ) {
     this.plugins = options.plugins ?? [];
     this.topNavigation = options.topNavigation ?? [];
     this.sidebars = options.sidebars ?? {};
@@ -98,7 +102,6 @@ export class ZudokuContext {
     this.authentication = options.authentication;
     this.meta = options.metadata;
     this.page = options.page;
-
     this.plugins.forEach((plugin) => {
       if (!isEventConsumerPlugin(plugin)) return;
 
@@ -143,7 +146,7 @@ export class ZudokuContext {
   getPluginSidebar = async (path: string) => {
     const navigations = await Promise.all(
       this.navigationPlugins.map((plugin) =>
-        plugin.getSidebar?.(joinPath(path)),
+        plugin.getSidebar?.(joinPath(path), this),
       ),
     );
 

--- a/packages/zudoku/src/lib/core/plugins.ts
+++ b/packages/zudoku/src/lib/core/plugins.ts
@@ -2,11 +2,11 @@ import type { LucideIcon } from "lucide-react";
 import { type ReactElement } from "react";
 import { type RouteObject } from "react-router";
 import type { Sidebar } from "../../config/validators/SidebarSchema.js";
-import { MdxComponentsType } from "../util/MdxComponents.js";
+import { type MdxComponentsType } from "../util/MdxComponents.js";
 import {
-  ZudokuContext,
-  ZudokuEvents,
   type ApiIdentity,
+  type ZudokuContext,
+  type ZudokuEvents,
 } from "./ZudokuContext.js";
 
 export type ZudokuPlugin =
@@ -21,7 +21,7 @@ export type { RouteObject };
 
 export interface NavigationPlugin {
   getRoutes: () => RouteObject[];
-  getSidebar?: (path: string) => Promise<Sidebar>;
+  getSidebar?: (path: string, context: ZudokuContext) => Promise<Sidebar>;
 }
 
 export const createApiIdentityPlugin = (

--- a/packages/zudoku/src/lib/hooks/useEvent.test.tsx
+++ b/packages/zudoku/src/lib/hooks/useEvent.test.tsx
@@ -12,8 +12,8 @@ import { useEvent } from "./useEvent.js";
  */
 
 const createTestContext = () => {
-  const context = new ZudokuContext({});
   const queryClient = new QueryClient();
+  const context = new ZudokuContext({}, queryClient);
   const wrapper = ({ children }: PropsWithChildren) => (
     <QueryClientProvider client={queryClient}>
       <ZudokuProvider context={context}>{children}</ZudokuProvider>

--- a/packages/zudoku/src/lib/oas/graphql/index.ts
+++ b/packages/zudoku/src/lib/oas/graphql/index.ts
@@ -376,8 +376,16 @@ const OperationItem = builder
     fields: (t) => ({
       slug: t.field({
         type: "String",
-        resolve: (parent, _, ctx) =>
-          ctx.slugs.operations[getOperationSlugKey(parent)]!,
+        resolve: (parent, _, ctx) => {
+          const slug = ctx.slugs.operations[getOperationSlugKey(parent)];
+
+          if (!slug) {
+            throw new Error(
+              `No slug found for operation: ${getOperationSlugKey(parent)}`,
+            );
+          }
+          return slug;
+        },
       }),
       path: t.exposeString("path"),
       method: t.exposeString("method"),

--- a/packages/zudoku/src/lib/oas/graphql/index.ts
+++ b/packages/zudoku/src/lib/oas/graphql/index.ts
@@ -51,17 +51,19 @@ export const createOperationSlug = (
   return slugify(summary);
 };
 
-type SchemaImport = () => Promise<{ schema: OpenAPIDocument }>;
+export type SchemaImport = () => Promise<{
+  schema: OpenAPIDocument;
+  slugs: ReturnType<typeof getAllSlugs>;
+}>;
 
 export type SchemaImports = Record<string, SchemaImport>;
 
 type Context = {
   schema: OpenAPIDocument;
   operations: GraphQLOperationObject[];
-  tags: TagObject[];
   schemaImports?: SchemaImports;
-  slugify: CountableSlugify;
-  slugs: Record<string, string>;
+  tags: ReturnType<typeof getAllTags>;
+  slugs: ReturnType<typeof getAllSlugs>;
 };
 
 const builder = new SchemaBuilder<{
@@ -87,17 +89,15 @@ const JSONScalar = builder.addScalarType("JSON", GraphQLJSON);
 const JSONObjectScalar = builder.addScalarType("JSONObject", GraphQLJSONObject);
 const JSONSchemaScalar = builder.addScalarType("JSONSchema", GraphQLJSONSchema);
 
-const resolveExtensions = (obj: Record<string, any>) => {
-  const extensions: Record<string, any> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    if (key.startsWith("x-")) {
-      extensions[key] = value;
-    }
-  }
-  return extensions;
-};
+const resolveExtensions = (obj: Record<string, any>) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(([key]) => key.startsWith("x-")),
+  );
 
-export const getAllTags = (schema: OpenAPIDocument): TagObject[] => {
+export const getAllTags = (
+  schema: OpenAPIDocument,
+  slugs: ReturnType<typeof getAllSlugs>["tags"],
+): Array<TagObject & { slug?: string }> => {
   const rootTags = schema.tags ?? [];
   const operationTags = new Set(
     Object.values(schema.paths ?? {})
@@ -107,24 +107,42 @@ export const getAllTags = (schema: OpenAPIDocument): TagObject[] => {
 
   return [
     // Keep root tags that are actually used in operations
-    ...rootTags.filter((tag) => operationTags.has(tag.name)),
+    ...rootTags
+      .filter((tag) => operationTags.has(tag.name))
+      .map((tag) => ({ ...tag, slug: slugs[tag.name] })),
     // Add tags found in operations but not defined in root tags
     ...[...operationTags]
       .filter((tag) => !rootTags.some((rt) => rt.name === tag))
-      .map((tag) => ({ name: tag })),
+      .map((tag) => ({ name: tag, slug: slugs[tag] })),
   ];
 };
 
-const getAllSlugs = (operations: GraphQLOperationObject[]) =>
-  Object.fromEntries(
-    operations.map((op) => [
-      getSlugName(op),
-      createOperationSlug(slugifyWithCounter(), op),
+export const getAllSlugs = (
+  ops: GraphQLOperationObject[],
+  schemaTags: TagObject[] = [],
+) => {
+  const slugify = slugifyWithCounter();
+
+  const tags = Array.from(
+    new Set([
+      ...ops.flatMap((op) => op.tags ?? []),
+      ...schemaTags.map((tag) => tag.name),
     ]),
   );
 
-const getSlugName = (op: GraphQLOperationObject) =>
-  `${op.path}-${op.method}-${op.operationId}-${op.summary}`;
+  return {
+    operations: Object.fromEntries(
+      ops.map((op) => [
+        getOperationSlugKey(op),
+        createOperationSlug(slugify, op),
+      ]),
+    ),
+    tags: Object.fromEntries(tags.map((tag) => [tag, slugify(tag)])),
+  };
+};
+
+const getOperationSlugKey = (op: GraphQLOperationObject) =>
+  [op.path, op.method, op.operationId, op.summary].filter(Boolean).join("-");
 
 export const getAllOperations = (
   paths?: PathsObject,
@@ -163,30 +181,38 @@ export const getAllOperations = (
   return operations;
 };
 
-const SchemaTag = builder.objectRef<TagObject>("SchemaTag").implement({
-  fields: (t) => ({
-    name: t.exposeString("name"),
-    description: t.exposeString("description", { nullable: true }),
-    operations: t.field({
-      type: [OperationItem],
-      resolve: (parent, _args, ctx) => {
-        const rootTags = ctx.tags.map((tag) => tag.name);
-        return ctx.operations
-          .filter((item) =>
-            parent.name
-              ? item.tags?.includes(parent.name)
-              : item.tags?.length === 0 ||
-                // If none of the tags are present in the root tags, then show them here
-                item.tags?.every((tag) => !rootTags.includes(tag)),
-          )
-          .map((item) => ({
-            ...item,
-            parentTag: parent.name,
-          }));
-      },
+const SchemaTag = builder
+  .objectRef<
+    Omit<TagObject, "name"> & { name?: string; slug?: string }
+  >("SchemaTag")
+  .implement({
+    fields: (t) => ({
+      name: t.exposeString("name", { nullable: true }),
+      slug: t.exposeString("slug", { nullable: true }),
+      description: t.exposeString("description", { nullable: true }),
+      operations: t.field({
+        type: [OperationItem],
+        resolve: (parent, _args, ctx) => {
+          const rootTags = ctx.tags.map((tag) => tag.name);
+
+          return ctx.operations
+            .filter((item) =>
+              parent.name
+                ? item.tags?.includes(parent.name)
+                : item.tags?.length === 0 ||
+                  // If none of the tags are present in the root tags, then show them here
+                  item.tags?.every((tag) => !rootTags.includes(tag)),
+            )
+            .map((item) => ({ ...item, parentTag: parent.name }));
+        },
+      }),
+      extensions: t.field({
+        type: JSONObjectScalar,
+        resolve: (parent) => resolveExtensions(parent),
+        nullable: true,
+      }),
     }),
-  }),
-});
+  });
 
 const ServerItem = builder.objectRef<ServerObject>("Server").implement({
   fields: (t) => ({
@@ -350,7 +376,8 @@ const OperationItem = builder
     fields: (t) => ({
       slug: t.field({
         type: "String",
-        resolve: (parent, _, ctx) => ctx.slugs[getSlugName(parent)]!,
+        resolve: (parent, _, ctx) =>
+          ctx.slugs.operations[getOperationSlugKey(parent)]!,
       }),
       path: t.exposeString("path"),
       method: t.exposeString("method"),
@@ -465,10 +492,17 @@ const Schema = builder.objectRef<OpenAPIDocument>("Schema").implement({
         name: t.arg.string(),
       },
       type: [SchemaTag],
-      resolve: (root, args, ctx) => {
-        return args.name
-          ? ctx.tags.filter((tag) => tag.name === args.name)
-          : ctx.tags;
+      resolve: (_root, args, ctx) => {
+        if (args.name) {
+          return ctx.tags.filter((tag) => tag.name === args.name);
+        }
+
+        // Append empty tag which will be used to display untagged operations
+        if (ctx.operations.some((op) => !op.tags?.length)) {
+          return [...ctx.tags, { name: undefined, slug: undefined }];
+        }
+
+        return ctx.tags;
       },
     }),
     operations: t.field({
@@ -512,27 +546,25 @@ builder.queryType({
         input: t.arg({ type: JSONScalar, required: true }),
       },
       resolve: async (_, args, ctx) => {
-        let schema: OpenAPIDocument;
-
         if (args.type === "file" && typeof args.input === "string") {
           const loadSchema = ctx.schemaImports?.[args.input];
 
           if (!loadSchema) {
             throw new Error(`No schema loader found for path: ${args.input}`);
           }
-          const module = await loadSchema();
-          schema = module.schema;
+          const { schema, slugs } = await loadSchema();
+          ctx.schema = schema;
+          ctx.operations = getAllOperations(schema.paths);
+          ctx.slugs = slugs;
+          ctx.tags = getAllTags(schema, ctx.slugs.tags);
         } else {
-          schema = await validate(args.input as string);
+          ctx.schema = await validate(args.input as string);
+          ctx.operations = getAllOperations(ctx.schema.paths);
+          ctx.slugs = getAllSlugs(ctx.operations);
+          ctx.tags = getAllTags(ctx.schema, ctx.slugs.tags);
         }
 
-        ctx.schema = schema;
-        ctx.operations = getAllOperations(schema.paths);
-        ctx.slugify = slugifyWithCounter();
-        ctx.tags = getAllTags(schema);
-        ctx.slugs = getAllSlugs(ctx.operations);
-
-        return schema;
+        return ctx.schema;
       },
     }),
   }),
@@ -542,4 +574,4 @@ export const schema = builder.toSchema();
 
 export const createGraphQLServer = (
   options?: Omit<YogaServerOptions<any, any>, "schema">,
-) => createYoga({ schema, ...options });
+) => createYoga({ schema, batching: true, ...options });

--- a/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
@@ -63,7 +63,7 @@ export const OperationListItem = ({
           <SelectOnClick className="max-w-full truncate flex cursor-pointer">
             {serverUrl && (
               <div className="text-neutral-400 dark:text-neutral-500 truncate">
-                {serverUrl}
+                {serverUrl.replace(/\/$/, "")}
               </div>
             )}
             <div className="text-neutral-900 dark:text-neutral-200">

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -172,10 +172,8 @@ export const Sidecar = ({
 
   const showPlayground =
     isOnScreen &&
-    (operation.extensions["x-explorer-enabled"] === true ||
-      operation.extensions["x-playground-enabled"] === true ||
-      (operation.extensions["x-explorer-enabled"] === undefined &&
-        operation.extensions["x-playground-enabled"] === undefined &&
+    (operation.extensions["x-zudoku-playground-enabled"] === true ||
+      (operation.extensions["x-zudoku-playground-enabled"] === undefined &&
         !options?.disablePlayground));
 
   return (

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -172,8 +172,10 @@ export const Sidecar = ({
 
   const showPlayground =
     isOnScreen &&
-    (operation.extensions["x-zudoku-playground-enabled"] === true ||
-      (operation.extensions["x-zudoku-playground-enabled"] === undefined &&
+    (operation.extensions["x-explorer-enabled"] === true ||
+      operation.extensions["x-zudoku-playground-enabled"] === true ||
+      (operation.extensions["x-explorer-enabled"] === undefined &&
+        operation.extensions["x-zudoku-playground-enabled"] === undefined &&
         !options?.disablePlayground));
 
   return (

--- a/packages/zudoku/src/lib/plugins/openapi/client/useCreateQuery.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/client/useCreateQuery.ts
@@ -1,3 +1,4 @@
+import { stripIgnoredCharacters } from "graphql";
 import { useContext } from "react";
 import type { TypedDocumentString } from "../graphql/graphql.js";
 import { GraphQLContext } from "./GraphQLContext.js";
@@ -13,6 +14,6 @@ export const useCreateQuery = <TResult, TVariables>(
 
   return {
     queryFn: () => graphQLClient.fetch(query, ...variables),
-    queryKey: [query, variables[0]],
+    queryKey: [stripIgnoredCharacters(query.toString()), variables[0]],
   } as const;
 };

--- a/packages/zudoku/src/lib/plugins/openapi/graphql/gql.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/graphql/gql.ts
@@ -15,24 +15,24 @@ import * as types from "./graphql.js";
 type Documents = {
   "\n  query ServersQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n": typeof types.ServersQueryDocument;
   "\n  fragment OperationsFragment on OperationItem {\n    slug\n    summary\n    method\n    description\n    operationId\n    contentTypes\n    path\n    deprecated\n    extensions\n    parameters {\n      name\n      in\n      description\n      required\n      schema\n      style\n      explode\n      examples {\n        name\n        description\n        externalValue\n        value\n        summary\n      }\n    }\n    requestBody {\n      content {\n        mediaType\n        encoding {\n          name\n        }\n        examples {\n          name\n          description\n          externalValue\n          value\n          summary\n        }\n        schema\n      }\n      description\n      required\n    }\n    responses {\n      statusCode\n      links\n      description\n      content {\n        examples {\n          name\n          description\n          externalValue\n          value\n          summary\n        }\n        mediaType\n        encoding {\n          name\n        }\n        schema\n      }\n    }\n  }\n": typeof types.OperationsFragmentFragmentDoc;
-  "\n  query AllOperations(\n    $input: JSON!\n    $type: SchemaType!\n    $tag: String\n    $untagged: Boolean\n  ) {\n    schema(input: $input, type: $type) {\n      servers {\n        url\n      }\n      description\n      summary\n      title\n      url\n      version\n      tags(name: $tag) {\n        name\n        description\n      }\n      operations(tag: $tag, untagged: $untagged) {\n        slug\n        ...OperationsFragment\n      }\n    }\n  }\n": typeof types.AllOperationsDocument;
+  "\n  query SchemaWarmup($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      openapi\n    }\n  }\n": typeof types.SchemaWarmupDocument;
+  "\n  query OperationsForTag(\n    $input: JSON!\n    $type: SchemaType!\n    $tag: String\n    $untagged: Boolean\n  ) {\n    schema(input: $input, type: $type) {\n      servers {\n        url\n      }\n      description\n      summary\n      title\n      url\n      version\n      tags(name: $tag) {\n        name\n        description\n      }\n      operations(tag: $tag, untagged: $untagged) {\n        slug\n        ...OperationsFragment\n      }\n    }\n  }\n": typeof types.OperationsForTagDocument;
   "\n  query getServerQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n": typeof types.GetServerQueryDocument;
-  "\n  query GetCategories($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        name\n      }\n    }\n  }\n": typeof types.GetCategoriesDocument;
-  "\n  query GetOperations($input: JSON!, $type: SchemaType!, $tag: String) {\n    schema(input: $input, type: $type) {\n      operations(tag: $tag) {\n        slug\n        deprecated\n        method\n        summary\n        operationId\n        path\n        tags {\n          name\n        }\n      }\n      untagged: operations(untagged: true) {\n        slug\n        deprecated\n        method\n        summary\n        operationId\n        path\n      }\n    }\n  }\n": typeof types.GetOperationsDocument;
+  "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        slug\n        name\n        operations {\n          slug\n          deprecated\n          method\n          summary\n          operationId\n          path\n          extensions\n        }\n      }\n    }\n  }\n": typeof types.GetSidebarOperationsDocument;
 };
 const documents: Documents = {
   "\n  query ServersQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n":
     types.ServersQueryDocument,
   "\n  fragment OperationsFragment on OperationItem {\n    slug\n    summary\n    method\n    description\n    operationId\n    contentTypes\n    path\n    deprecated\n    extensions\n    parameters {\n      name\n      in\n      description\n      required\n      schema\n      style\n      explode\n      examples {\n        name\n        description\n        externalValue\n        value\n        summary\n      }\n    }\n    requestBody {\n      content {\n        mediaType\n        encoding {\n          name\n        }\n        examples {\n          name\n          description\n          externalValue\n          value\n          summary\n        }\n        schema\n      }\n      description\n      required\n    }\n    responses {\n      statusCode\n      links\n      description\n      content {\n        examples {\n          name\n          description\n          externalValue\n          value\n          summary\n        }\n        mediaType\n        encoding {\n          name\n        }\n        schema\n      }\n    }\n  }\n":
     types.OperationsFragmentFragmentDoc,
-  "\n  query AllOperations(\n    $input: JSON!\n    $type: SchemaType!\n    $tag: String\n    $untagged: Boolean\n  ) {\n    schema(input: $input, type: $type) {\n      servers {\n        url\n      }\n      description\n      summary\n      title\n      url\n      version\n      tags(name: $tag) {\n        name\n        description\n      }\n      operations(tag: $tag, untagged: $untagged) {\n        slug\n        ...OperationsFragment\n      }\n    }\n  }\n":
-    types.AllOperationsDocument,
+  "\n  query SchemaWarmup($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      openapi\n    }\n  }\n":
+    types.SchemaWarmupDocument,
+  "\n  query OperationsForTag(\n    $input: JSON!\n    $type: SchemaType!\n    $tag: String\n    $untagged: Boolean\n  ) {\n    schema(input: $input, type: $type) {\n      servers {\n        url\n      }\n      description\n      summary\n      title\n      url\n      version\n      tags(name: $tag) {\n        name\n        description\n      }\n      operations(tag: $tag, untagged: $untagged) {\n        slug\n        ...OperationsFragment\n      }\n    }\n  }\n":
+    types.OperationsForTagDocument,
   "\n  query getServerQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n":
     types.GetServerQueryDocument,
-  "\n  query GetCategories($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        name\n      }\n    }\n  }\n":
-    types.GetCategoriesDocument,
-  "\n  query GetOperations($input: JSON!, $type: SchemaType!, $tag: String) {\n    schema(input: $input, type: $type) {\n      operations(tag: $tag) {\n        slug\n        deprecated\n        method\n        summary\n        operationId\n        path\n        tags {\n          name\n        }\n      }\n      untagged: operations(untagged: true) {\n        slug\n        deprecated\n        method\n        summary\n        operationId\n        path\n      }\n    }\n  }\n":
-    types.GetOperationsDocument,
+  "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        slug\n        name\n        operations {\n          slug\n          deprecated\n          method\n          summary\n          operationId\n          path\n          extensions\n        }\n      }\n    }\n  }\n":
+    types.GetSidebarOperationsDocument,
 };
 
 /**
@@ -51,8 +51,14 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: "\n  query AllOperations(\n    $input: JSON!\n    $type: SchemaType!\n    $tag: String\n    $untagged: Boolean\n  ) {\n    schema(input: $input, type: $type) {\n      servers {\n        url\n      }\n      description\n      summary\n      title\n      url\n      version\n      tags(name: $tag) {\n        name\n        description\n      }\n      operations(tag: $tag, untagged: $untagged) {\n        slug\n        ...OperationsFragment\n      }\n    }\n  }\n",
-): typeof import("./graphql.js").AllOperationsDocument;
+  source: "\n  query SchemaWarmup($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      openapi\n    }\n  }\n",
+): typeof import("./graphql.js").SchemaWarmupDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: "\n  query OperationsForTag(\n    $input: JSON!\n    $type: SchemaType!\n    $tag: String\n    $untagged: Boolean\n  ) {\n    schema(input: $input, type: $type) {\n      servers {\n        url\n      }\n      description\n      summary\n      title\n      url\n      version\n      tags(name: $tag) {\n        name\n        description\n      }\n      operations(tag: $tag, untagged: $untagged) {\n        slug\n        ...OperationsFragment\n      }\n    }\n  }\n",
+): typeof import("./graphql.js").OperationsForTagDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -63,14 +69,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: "\n  query GetCategories($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        name\n      }\n    }\n  }\n",
-): typeof import("./graphql.js").GetCategoriesDocument;
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
-  source: "\n  query GetOperations($input: JSON!, $type: SchemaType!, $tag: String) {\n    schema(input: $input, type: $type) {\n      operations(tag: $tag) {\n        slug\n        deprecated\n        method\n        summary\n        operationId\n        path\n        tags {\n          name\n        }\n      }\n      untagged: operations(untagged: true) {\n        slug\n        deprecated\n        method\n        summary\n        operationId\n        path\n      }\n    }\n  }\n",
-): typeof import("./graphql.js").GetOperationsDocument;
+  source: "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        slug\n        name\n        operations {\n          slug\n          deprecated\n          method\n          summary\n          operationId\n          path\n          extensions\n        }\n      }\n    }\n  }\n",
+): typeof import("./graphql.js").GetSidebarOperationsDocument;
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/packages/zudoku/src/lib/plugins/openapi/graphql/gql.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/graphql/gql.ts
@@ -18,7 +18,7 @@ type Documents = {
   "\n  query SchemaWarmup($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      openapi\n    }\n  }\n": typeof types.SchemaWarmupDocument;
   "\n  query OperationsForTag(\n    $input: JSON!\n    $type: SchemaType!\n    $tag: String\n    $untagged: Boolean\n  ) {\n    schema(input: $input, type: $type) {\n      servers {\n        url\n      }\n      description\n      summary\n      title\n      url\n      version\n      tags(name: $tag) {\n        name\n        description\n      }\n      operations(tag: $tag, untagged: $untagged) {\n        slug\n        ...OperationsFragment\n      }\n    }\n  }\n": typeof types.OperationsForTagDocument;
   "\n  query getServerQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n": typeof types.GetServerQueryDocument;
-  "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        slug\n        name\n        operations {\n          slug\n          deprecated\n          method\n          summary\n          operationId\n          path\n          extensions\n        }\n      }\n    }\n  }\n": typeof types.GetSidebarOperationsDocument;
+  "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      tags {\n        slug\n        name\n        extensions\n        operations {\n          summary\n          slug\n          method\n          operationId\n          path\n        }\n      }\n    }\n  }\n": typeof types.GetSidebarOperationsDocument;
 };
 const documents: Documents = {
   "\n  query ServersQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n":
@@ -31,7 +31,7 @@ const documents: Documents = {
     types.OperationsForTagDocument,
   "\n  query getServerQuery($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      servers {\n        url\n      }\n    }\n  }\n":
     types.GetServerQueryDocument,
-  "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        slug\n        name\n        operations {\n          slug\n          deprecated\n          method\n          summary\n          operationId\n          path\n          extensions\n        }\n      }\n    }\n  }\n":
+  "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      tags {\n        slug\n        name\n        extensions\n        operations {\n          summary\n          slug\n          method\n          operationId\n          path\n        }\n      }\n    }\n  }\n":
     types.GetSidebarOperationsDocument,
 };
 
@@ -69,7 +69,7 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      url\n      tags {\n        slug\n        name\n        operations {\n          slug\n          deprecated\n          method\n          summary\n          operationId\n          path\n          extensions\n        }\n      }\n    }\n  }\n",
+  source: "\n  query GetSidebarOperations($input: JSON!, $type: SchemaType!) {\n    schema(input: $input, type: $type) {\n      tags {\n        slug\n        name\n        extensions\n        operations {\n          summary\n          slug\n          method\n          operationId\n          path\n        }\n      }\n    }\n  }\n",
 ): typeof import("./graphql.js").GetSidebarOperationsDocument;
 
 export function graphql(source: string) {

--- a/packages/zudoku/src/lib/plugins/openapi/graphql/graphql.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/graphql/graphql.ts
@@ -330,20 +330,18 @@ export type GetSidebarOperationsQuery = {
   __typename?: "Query";
   schema: {
     __typename?: "Schema";
-    url?: string | null;
     tags: Array<{
       __typename?: "SchemaTag";
       slug?: string | null;
       name?: string | null;
+      extensions?: any | null;
       operations: Array<{
         __typename?: "OperationItem";
-        slug: string;
-        deprecated?: boolean | null;
-        method: string;
         summary?: string | null;
+        slug: string;
+        method: string;
         operationId?: string | null;
         path: string;
-        extensions?: any | null;
       }>;
     }>;
   };
@@ -563,18 +561,16 @@ export const GetServerQueryDocument = new TypedDocumentString(`
 export const GetSidebarOperationsDocument = new TypedDocumentString(`
     query GetSidebarOperations($input: JSON!, $type: SchemaType!) {
   schema(input: $input, type: $type) {
-    url
     tags {
       slug
       name
+      extensions
       operations {
-        slug
-        deprecated
-        method
         summary
+        slug
+        method
         operationId
         path
-        extensions
       }
     }
   }

--- a/packages/zudoku/src/lib/plugins/openapi/graphql/graphql.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/graphql/graphql.ts
@@ -160,8 +160,10 @@ export type SchemaTagsArgs = {
 export type SchemaTag = {
   __typename?: "SchemaTag";
   description?: Maybe<Scalars["String"]["output"]>;
-  name: Scalars["String"]["output"];
+  extensions?: Maybe<Scalars["JSONObject"]["output"]>;
+  name?: Maybe<Scalars["String"]["output"]>;
   operations: Array<OperationItem>;
+  slug?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type SchemaType = "file" | "raw" | "url";
@@ -263,14 +265,24 @@ export type OperationsFragmentFragment = {
   }>;
 } & { " $fragmentName"?: "OperationsFragmentFragment" };
 
-export type AllOperationsQueryVariables = Exact<{
+export type SchemaWarmupQueryVariables = Exact<{
+  input: Scalars["JSON"]["input"];
+  type: SchemaType;
+}>;
+
+export type SchemaWarmupQuery = {
+  __typename?: "Query";
+  schema: { __typename?: "Schema"; openapi: string };
+};
+
+export type OperationsForTagQueryVariables = Exact<{
   input: Scalars["JSON"]["input"];
   type: SchemaType;
   tag?: InputMaybe<Scalars["String"]["input"]>;
   untagged?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
-export type AllOperationsQuery = {
+export type OperationsForTagQuery = {
   __typename?: "Query";
   schema: {
     __typename?: "Schema";
@@ -282,7 +294,7 @@ export type AllOperationsQuery = {
     servers: Array<{ __typename?: "Server"; url: string }>;
     tags: Array<{
       __typename?: "SchemaTag";
-      name: string;
+      name?: string | null;
       description?: string | null;
     }>;
     operations: Array<
@@ -309,48 +321,30 @@ export type GetServerQueryQuery = {
   };
 };
 
-export type GetCategoriesQueryVariables = Exact<{
+export type GetSidebarOperationsQueryVariables = Exact<{
   input: Scalars["JSON"]["input"];
   type: SchemaType;
 }>;
 
-export type GetCategoriesQuery = {
+export type GetSidebarOperationsQuery = {
   __typename?: "Query";
   schema: {
     __typename?: "Schema";
     url?: string | null;
-    tags: Array<{ __typename?: "SchemaTag"; name: string }>;
-  };
-};
-
-export type GetOperationsQueryVariables = Exact<{
-  input: Scalars["JSON"]["input"];
-  type: SchemaType;
-  tag?: InputMaybe<Scalars["String"]["input"]>;
-}>;
-
-export type GetOperationsQuery = {
-  __typename?: "Query";
-  schema: {
-    __typename?: "Schema";
-    operations: Array<{
-      __typename?: "OperationItem";
-      slug: string;
-      deprecated?: boolean | null;
-      method: string;
-      summary?: string | null;
-      operationId?: string | null;
-      path: string;
-      tags?: Array<{ __typename?: "TagItem"; name: string }> | null;
-    }>;
-    untagged: Array<{
-      __typename?: "OperationItem";
-      slug: string;
-      deprecated?: boolean | null;
-      method: string;
-      summary?: string | null;
-      operationId?: string | null;
-      path: string;
+    tags: Array<{
+      __typename?: "SchemaTag";
+      slug?: string | null;
+      name?: string | null;
+      operations: Array<{
+        __typename?: "OperationItem";
+        slug: string;
+        deprecated?: boolean | null;
+        method: string;
+        summary?: string | null;
+        operationId?: string | null;
+        path: string;
+        extensions?: any | null;
+      }>;
     }>;
   };
 };
@@ -455,8 +449,18 @@ export const ServersQueryDocument = new TypedDocumentString(`
   ServersQueryQuery,
   ServersQueryQueryVariables
 >;
-export const AllOperationsDocument = new TypedDocumentString(`
-    query AllOperations($input: JSON!, $type: SchemaType!, $tag: String, $untagged: Boolean) {
+export const SchemaWarmupDocument = new TypedDocumentString(`
+    query SchemaWarmup($input: JSON!, $type: SchemaType!) {
+  schema(input: $input, type: $type) {
+    openapi
+  }
+}
+    `) as unknown as TypedDocumentString<
+  SchemaWarmupQuery,
+  SchemaWarmupQueryVariables
+>;
+export const OperationsForTagDocument = new TypedDocumentString(`
+    query OperationsForTag($input: JSON!, $type: SchemaType!, $tag: String, $untagged: Boolean) {
   schema(input: $input, type: $type) {
     servers {
       url
@@ -540,8 +544,8 @@ export const AllOperationsDocument = new TypedDocumentString(`
     }
   }
 }`) as unknown as TypedDocumentString<
-  AllOperationsQuery,
-  AllOperationsQueryVariables
+  OperationsForTagQuery,
+  OperationsForTagQueryVariables
 >;
 export const GetServerQueryDocument = new TypedDocumentString(`
     query getServerQuery($input: JSON!, $type: SchemaType!) {
@@ -556,44 +560,26 @@ export const GetServerQueryDocument = new TypedDocumentString(`
   GetServerQueryQuery,
   GetServerQueryQueryVariables
 >;
-export const GetCategoriesDocument = new TypedDocumentString(`
-    query GetCategories($input: JSON!, $type: SchemaType!) {
+export const GetSidebarOperationsDocument = new TypedDocumentString(`
+    query GetSidebarOperations($input: JSON!, $type: SchemaType!) {
   schema(input: $input, type: $type) {
     url
     tags {
-      name
-    }
-  }
-}
-    `) as unknown as TypedDocumentString<
-  GetCategoriesQuery,
-  GetCategoriesQueryVariables
->;
-export const GetOperationsDocument = new TypedDocumentString(`
-    query GetOperations($input: JSON!, $type: SchemaType!, $tag: String) {
-  schema(input: $input, type: $type) {
-    operations(tag: $tag) {
       slug
-      deprecated
-      method
-      summary
-      operationId
-      path
-      tags {
-        name
+      name
+      operations {
+        slug
+        deprecated
+        method
+        summary
+        operationId
+        path
+        extensions
       }
     }
-    untagged: operations(untagged: true) {
-      slug
-      deprecated
-      method
-      summary
-      operationId
-      path
-    }
   }
 }
     `) as unknown as TypedDocumentString<
-  GetOperationsQuery,
-  GetOperationsQueryVariables
+  GetSidebarOperationsQuery,
+  GetSidebarOperationsQueryVariables
 >;

--- a/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
@@ -1,3 +1,5 @@
+import type { SchemaImports } from "../../oas/graphql/index.js";
+
 type DynamicInput = () => Promise<unknown>;
 
 type OasSource =
@@ -15,10 +17,10 @@ type BaseOasConfig = {
   navigationId?: string;
   skipPreload?: boolean;
   tagPages?: Array<string>;
+  schemaImports?: SchemaImports;
   options?: {
     examplesLanguage?: string;
     disablePlayground?: boolean;
-    loadTags?: boolean;
     showVersionSelect?: "always" | "if-available" | "hide";
   };
 };

--- a/packages/zudoku/src/lib/plugins/openapi/util/createSidebarCategory.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/util/createSidebarCategory.tsx
@@ -28,12 +28,10 @@ export const createSidebarCategory = ({
     type: "link" as const,
     label: operation.summary ?? operation.path,
     href: `${path}#${operation.slug}`,
-    ...(operation.method && {
-      badge: {
-        label: operation.method,
-        color: MethodColorMap[operation.method.toLowerCase()]!,
-        invert: true,
-      } as const,
-    }),
+    badge: {
+      label: operation.method,
+      color: MethodColorMap[operation.method.toLowerCase()]!,
+      invert: true,
+    },
   })),
 });

--- a/packages/zudoku/src/lib/util/traverse.ts
+++ b/packages/zudoku/src/lib/util/traverse.ts
@@ -20,11 +20,11 @@ export const traverse = <T extends JsonValue = RecordAny>(
   for (const [key, value] of Object.entries(transformed)) {
     if (Array.isArray(value)) {
       result[key] = value.map((item) =>
-        typeof item === "object" && item !== null
+        typeof item === "object" && item != null
           ? traverse(item, transform)
           : item,
       );
-    } else if (typeof value === "object" && value !== null) {
+    } else if (typeof value === "object" && value != null) {
       result[key] = traverse(value, transform);
     } else {
       result[key] = value;

--- a/packages/zudoku/src/vite/api/schema-codegen.ts
+++ b/packages/zudoku/src/vite/api/schema-codegen.ts
@@ -1,3 +1,6 @@
+import { $RefParser } from "@apidevtools/json-schema-ref-parser";
+import { getAllOperations, getAllSlugs } from "../../lib/oas/graphql/index.js";
+import { type OpenAPIDocument } from "../../lib/oas/parser/index.js";
 import { type RecordAny, traverse } from "../../lib/util/traverse.js";
 
 // Find all $ref occurrences in the schema and assign them unique variable names
@@ -6,7 +9,7 @@ const createLocalRefMap = (obj: RecordAny) => {
   let refCounter = 0;
 
   traverse(obj, (node) => {
-    if (typeof node?.$ref === "string" && node.$ref.startsWith("#/")) {
+    if (typeof node.$ref === "string" && node.$ref.startsWith("#/")) {
       if (!refMap.has(node.$ref)) {
         refMap.set(node.$ref, refCounter++);
       }
@@ -20,7 +23,7 @@ const createLocalRefMap = (obj: RecordAny) => {
 // Replace all $ref occurrences with a special marker that will be transformed into a reference to the __refMap lookup
 const setRefMarkers = (obj: RecordAny, refMap: Map<string, number>) =>
   traverse<string | RecordAny>(obj, (node) => {
-    if (node?.$ref && typeof node.$ref === "string" && refMap.has(node.$ref)) {
+    if (node.$ref && typeof node.$ref === "string" && refMap.has(node.$ref)) {
       return `__refMap:${node.$ref}`;
     }
     return node;
@@ -30,8 +33,8 @@ const setRefMarkers = (obj: RecordAny, refMap: Map<string, number>) =>
 const replaceRefMarkers = (code?: string) =>
   code?.replace(/"__refMap:(.*?)"/g, '__refMap["$1"]');
 
-const lookup = (schema: RecordAny, path: string) => {
-  const parts = path.split("/").slice(1);
+const lookup = (schema: RecordAny, path: string): RecordAny => {
+  const parts = path.split("/").slice(1).map(decodeURIComponent);
   let value = schema;
 
   for (const part of parts) {
@@ -55,7 +58,7 @@ export const generateCode = async (schema: RecordAny) => {
   const refMap = createLocalRefMap(schema);
   const lines: string[] = [];
 
-  const str = (obj: unknown) => JSON.stringify(obj, null, 2);
+  const str = (obj: unknown, indent = 2) => JSON.stringify(obj, null, indent);
 
   lines.push(
     `const __refs = Array.from({ length: ${refMap.size} }, () => ({}));`,
@@ -71,6 +74,15 @@ export const generateCode = async (schema: RecordAny) => {
 
   for (const [refPath, index] of refMap) {
     const value = lookup(schema, refPath);
+
+    // This shouldn't happen but to be safe we log a warning
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!value) {
+      // eslint-disable-next-line no-console
+      console.warn(`Could not find value for refPath: ${refPath}`);
+      continue;
+    }
+
     const transformedValue = setRefMarkers(value, refMap);
 
     lines.push(
@@ -81,6 +93,21 @@ export const generateCode = async (schema: RecordAny) => {
 
   const transformed = setRefMarkers(schema, refMap);
   lines.push(`export const schema = ${replaceRefMarkers(str(transformed))};`);
+
+  // slugify is quite expensive for big schemas, so we pre-generate the slugs here to shave off time
+  const dereferencedSchema =
+    await $RefParser.dereference<OpenAPIDocument>(schema);
+  const slugs = getAllSlugs(
+    getAllOperations(dereferencedSchema.paths),
+    dereferencedSchema.tags,
+  );
+
+  lines.push(`export const slugs = {`);
+  lines.push(
+    `  operations: ${str(slugs.operations, 0)},`,
+    `  tags: ${str(slugs.tags, 0)},`,
+  );
+  lines.push(`};`);
 
   return lines.join("\n");
 };


### PR DESCRIPTION
This removes the limitation of loading only the tags of the current page.

- Allow to disable / playground  `x-zuplo-playground-enabled`
- Allow fine grain control for collapse
  - Allow to collpase / expand per tag (categorie) `x-zuplo-collapsed`
  - Allow to disable collapisble per tag (categorie) `x-zuplo-collapsibe`