### PR TITLE
Fix: Use sidebar from top navigation if none other matches

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -230,6 +230,7 @@
     "loglevel": "1.9.2",
     "lru-cache": "11.0.2",
     "lucide-react": "0.475.0",
+    "minimatch": "10.0.1",
     "nanoevents": "^9.1.0",
     "next-themes": "0.4.4",
     "oauth4webapi": "2.17.0",

--- a/packages/zudoku/src/config/validators/common.ts
+++ b/packages/zudoku/src/config/validators/common.ts
@@ -192,7 +192,10 @@ const TopNavigationItemSchema = z.object({
   label: z.string(),
   id: z.string(),
   default: z.string().optional(),
-  display: z.enum(["auth", "anon", "always"]).default("always").optional(),
+  display: z
+    .enum(["auth", "anon", "always", "hide"])
+    .default("always")
+    .optional(),
 });
 
 type BannerColorType = ZodOptional<

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -44,7 +44,7 @@ export const MobileTopNavigation = () => {
             </li>
             {topNavigation.filter(isHiddenItem(isAuthenticated)).map((item) => (
               <li key={item.label}>
-                <button onClick={() => setDrawerOpen(false)}>
+                <button type="button" onClick={() => setDrawerOpen(false)}>
                   <TopNavItem {...item} />
                 </button>
               </li>

--- a/packages/zudoku/src/lib/components/context/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/components/context/ZudokuContext.ts
@@ -3,7 +3,7 @@ import { createContext, useContext } from "react";
 import { matchPath, useLocation } from "react-router";
 import { useAuth } from "../../authentication/hook.js";
 import type { ZudokuContext } from "../../core/ZudokuContext.js";
-import { joinPath } from "../../util/joinPath.js";
+import { joinUrl } from "../../util/joinUrl.js";
 import { CACHE_KEYS, NO_DEHYDRATE } from "../cache.js";
 import { traverseSidebar } from "../navigation/utils.js";
 
@@ -39,13 +39,13 @@ export const useCurrentNavigation = () => {
     matchPath(route, location.pathname),
   );
 
-  const currentSidebarItem = Object.entries(sidebars).find(([, sidebar]) => {
+  let currentSidebarItem = Object.entries(sidebars).find(([, sidebar]) => {
     return traverseSidebar(sidebar, (item) => {
       const itemId =
         item.type === "doc"
-          ? joinPath(item.id)
+          ? joinUrl(item.id)
           : item.type === "category" && item.link
-            ? joinPath(item.link.id)
+            ? joinUrl(item.link.id)
             : undefined;
 
       if (itemId === location.pathname) {
@@ -56,6 +56,14 @@ export const useCurrentNavigation = () => {
   const currentTopNavItem =
     topNavigation.find((t) => t.id === currentSidebarItem?.[0]) ??
     topNavigation.find((item) => matchPath(item.id, location.pathname));
+
+  if (
+    currentTopNavItem &&
+    !currentSidebarItem &&
+    currentTopNavItem.id in sidebars
+  ) {
+    currentSidebarItem = ["", sidebars[currentTopNavItem.id]!];
+  }
 
   const { data } = useSuspenseQuery({
     queryFn: () => getPluginSidebar(location.pathname),

--- a/packages/zudoku/src/lib/util/joinPath.tsx
+++ b/packages/zudoku/src/lib/util/joinPath.tsx
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use `joinUrl` instead.
+ */
 export const joinPath = (
   ...parts: Array<string | null | undefined | boolean>
 ) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,9 @@ importers:
       lucide-react:
         specifier: 0.475.0
         version: 0.475.0(react@19.0.0)
+      minimatch:
+        specifier: 10.0.1
+        version: 10.0.1
       nanoevents:
         specifier: ^9.1.0
         version: 9.1.0
@@ -13551,7 +13554,7 @@ snapshots:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 7.0.1
-      chalk: 5.0.1
+      chalk: 5.4.1
       cli-boxes: 3.0.0
       string-width: 5.1.2
       type-fest: 2.19.0


### PR DESCRIPTION
For example: If someone wants to build a category tree with only links this would've shown no sidebar at all. But as soon as we can associate a top navigation item we can at fall back to a sidebar if provided