### PR TITLE
Don't show catalog sidebar in API docs

### DIFF
--- a/packages/zudoku/src/lib/components/navigation/SidebarItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarItem.tsx
@@ -10,7 +10,7 @@ import { SidebarBadge } from "./SidebarBadge.js";
 import { SidebarCategory } from "./SidebarCategory.js";
 
 export const navigationListItem = cva(
-  "flex items-center gap-2 px-[--padding-nav-item] my-0.5 py-1.5 rounded-lg hover:bg-accent",
+  "flex items-center gap-2 px-[--padding-nav-item] my-0.5 py-1.5 rounded-lg hover:bg-accent tabular-nums",
   {
     variants: {
       isActive: {


### PR DESCRIPTION
If the path of the OpenAPI docs starts the same as the catalog the catalog sidebar: (e.g. catalog path is `/api-catalog` and the docs path is `/api-catalog/docs`), the catalog sidebar "leaked" into the docs.

In this PR we change it to explicitly match only the created paths in the plugin.