### PR TITLE
show badge for optional bodies

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
@@ -100,13 +100,18 @@ export const OperationListItem = ({
             <div className="mt-4 flex flex-col gap-4">
               <Heading
                 level={3}
-                className="capitalize"
+                className="capitalize flex items-center gap-2"
                 id={`${operation.slug}/request-body`}
               >
                 {operation.summary && (
                   <VisuallyHidden>{operation.summary} &rsaquo; </VisuallyHidden>
                 )}
-                Request Body
+                Request Body{" "}
+                {operation.requestBody?.required === false ? (
+                  <Badge variant="muted">optional</Badge>
+                ) : (
+                  ""
+                )}
               </Heading>
               <SchemaView schema={schema} />
             </div>


### PR DESCRIPTION
### Pull Request Description

#### Title
Show Badge for Optional Bodies

#### Description
This pull request introduces the functionality to display badges for optional bodies. The addition of this feature aims to enhance the user interface and improve the overall experience by providing clear visual cues regarding optional elements.

#### Changes Made
- Implemented badge display logic specifically for optional bodies, as reflected in the commit.

Please review the changes, and I look forward to any feedback you may have!