### PR TITLE
Add scheme titles to logical group display

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/schema/LogicalGroup/LogicalGroupConnector.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/LogicalGroup/LogicalGroupConnector.tsx
@@ -24,10 +24,12 @@ export const LogicalGroupConnector = ({
   type,
   isOpen,
   className,
+  schemeName,
 }: {
   type: LogicalGroupType;
   isOpen: boolean;
   className?: string;
+  schemeName?: string;
 }) => {
   return (
     <div
@@ -38,7 +40,7 @@ export const LogicalGroupConnector = ({
         className,
       )}
     >
-      <div className="-translate-x-[7px] flex gap-1 items-center">
+      <div className="-translate-x-[7px] flex gap-1 items-center text-sm text-foreground">
         {iconMap[type]}
         <div
           className={cn(
@@ -48,6 +50,7 @@ export const LogicalGroupConnector = ({
         >
           <ChevronDownIcon size={16} />
         </div>
+        <span>{schemeName}</span>
       </div>
     </div>
   );

--- a/packages/zudoku/src/lib/plugins/openapi/schema/LogicalGroup/LogicalGroupConnector.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/LogicalGroup/LogicalGroupConnector.tsx
@@ -40,7 +40,7 @@ export const LogicalGroupConnector = ({
         className,
       )}
     >
-      <div className="-translate-x-[7px] flex gap-1 items-center text-sm text-foreground">
+      <div className="-translate-x-[7px] flex gap-1 items-center">
         {iconMap[type]}
         <div
           className={cn(
@@ -50,7 +50,7 @@ export const LogicalGroupConnector = ({
         >
           <ChevronDownIcon size={16} />
         </div>
-        <span>{schemeName}</span>
+        <span className="text-sm text-foreground">{schemeName}</span>
       </div>
     </div>
   );

--- a/packages/zudoku/src/lib/plugins/openapi/schema/LogicalGroup/LogicalGroupItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/LogicalGroup/LogicalGroupItem.tsx
@@ -18,7 +18,11 @@ export const LogicalGroupItem = (props: {
       className="group"
     >
       <Collapsible.Trigger>
-        <LogicalGroupConnector type={props.type} isOpen={isOpen} />
+        <LogicalGroupConnector
+          type={props.type}
+          isOpen={isOpen}
+          schemeName={props.schema.title}
+        />
       </Collapsible.Trigger>
       {!isOpen && <div className="wavy-line bg-border translate-y-1" />}
       <Collapsible.Content>


### PR DESCRIPTION
Adds scheme titles to anyOf, oneOf and other groups where more than one scheme may exist.

I noticed these don't exist which makes it difficult to use endpoints with multiple bodies. See comparison below.

**Before**
![image](https://github.com/user-attachments/assets/72a9c342-415c-44d5-b4fe-b90a6ab92b79)

**After**
![image](https://github.com/user-attachments/assets/9ddff0dd-e167-4d0d-8a64-a6ccbbdb65d9)

For reference, here's how the swagger editor displays multiple schemas in a oneOf:
![image](https://github.com/user-attachments/assets/b8109c12-1ffa-4cbb-a7f9-d47a5438206d)
