### PR TITLE
Fix ref lookup in schema codegen

### DIFF
--- a/packages/zudoku/src/vite/api/schema-codegen.ts
+++ b/packages/zudoku/src/vite/api/schema-codegen.ts
@@ -73,8 +73,10 @@ const lookup = (
  */
 export const generateCode = async (schema: RecordAny, filePath?: string) => {
   const refMap = createLocalRefMap(schema);
-  const dereferencedSchema =
-    await $RefParser.dereference<OpenAPIDocument>(schema);
+  const dereferencedSchema = await $RefParser.dereference<OpenAPIDocument>(
+    schema,
+    { dereference: { circular: "ignore" } },
+  );
   const lines: string[] = [];
 
   const str = (obj: unknown, indent = 2) => JSON.stringify(obj, null, indent);


### PR DESCRIPTION
For the ref markers in the schema codegen we need to do a recursive lookup to be able to get all values