### PR TITLE
Added dynamic padding to sidebar to prevent the last elements to drown in the gradient

### DIFF
--- a/packages/zudoku/src/lib/components/navigation/SidebarWrapper.tsx
+++ b/packages/zudoku/src/lib/components/navigation/SidebarWrapper.tsx
@@ -24,7 +24,7 @@ export const SidebarWrapper = ({
         ref={navRef}
         className={cn(
           "hidden max-w-[calc(var(--side-nav-width)+var(--padding-nav-item))] lg:flex scrollbar flex-col overflow-y-auto shrink-0 text-sm pe-3 ps-4 lg:ps-8",
-          "-mx-[--padding-nav-item] pb-3 pt-[--padding-content-top] scroll-pt-2 gap-1",
+          "-mx-[--padding-nav-item] pb-[8vh] pt-[--padding-content-top] scroll-pt-2 gap-1",
           // Revert the padding/margin on the first child
           "-mt-2.5",
           className,


### PR DESCRIPTION
## The problem
The gradient mask on sidebar has a dynamic height at the bottom:
```
maskImage: `linear-gradient(180deg, transparent 1%, rgba(0, 0, 0, 1) 20px, rgba(0, 0, 0, 1) 90%, transparent 99%)`,
```
The bottom padding on the nav element is fixed:
```
-mx-[--padding-nav-item] **pb-3** pt-[--padding-content-top] scroll-pt-2 gap-1
```

This causes the last element in a long sidebar to "drown" in the gradient if the window size is tall:
![Screenshot 2025-04-14 at 10 13 26](https://github.com/user-attachments/assets/1bc3e261-b237-45d1-a6f3-0cccec7bad08)

## The solution
Added a dynamic height to the bottom padding using vh since padding percentages are based on the element width and not height. 
