### PR TITLE
Revert remark-directive upgrade

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -252,7 +252,7 @@
     "rehype-raw": "7.0.0",
     "rehype-slug": "6.0.0",
     "remark-comment": "1.0.0",
-    "remark-directive": "4.0.0",
+    "remark-directive": "3.0.1",
     "remark-directive-rehype": "0.4.2",
     "remark-frontmatter": "5.0.0",
     "remark-gfm": "4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,8 +619,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       remark-directive:
-        specifier: 4.0.0
-        version: 4.0.0
+        specifier: 3.0.1
+        version: 3.0.1
       remark-directive-rehype:
         specifier: 0.4.2
         version: 0.4.2
@@ -6780,8 +6780,8 @@ packages:
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
-  micromark-extension-directive@4.0.0:
-    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+  micromark-extension-directive@3.0.2:
+    resolution: {integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==}
 
   micromark-extension-frontmatter@2.0.0:
     resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
@@ -7881,8 +7881,8 @@ packages:
     resolution: {integrity: sha512-T6e+IG+BwqU4++MK54vFb+KDFjs3a+tHeK6E0T0ctR1FSyngolfDtAEzqxHWlRzQZqGi2sB4DFXry6oqH87D/g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  remark-directive@4.0.0:
-    resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
+  remark-directive@3.0.1:
+    resolution: {integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -16447,7 +16447,7 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
-  micromark-extension-directive@4.0.0:
+  micromark-extension-directive@3.0.2:
     dependencies:
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
@@ -17814,11 +17814,11 @@ snapshots:
       hastscript: 7.2.0
       unist-util-map: 3.1.3
 
-  remark-directive@4.0.0:
+  remark-directive@3.0.1:
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-directive: 3.1.0
-      micromark-extension-directive: 4.0.0
+      micromark-extension-directive: 3.0.2
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
We see errors like this in thee build because of the upgrade:

```sh
Error: Invalid tag: 00
    at startChunkForTag (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:1122:43)
    at pushStartGenericElement (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:1092:15)
    at pushStartInstance (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:2121:10)
    at renderElement (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:4247:22)
    at retryNode (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:4768:16)
    at renderNodeDestructive (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:4586:7)
    at renderNode (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:5025:14)
    at renderChildrenArray (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:4916:7)
    at retryNode (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:4782:9)
    at renderNodeDestructive (/home/runner/work/docs/docs/node_modules/react-dom/cjs/react-dom-server.node.production.js:4586:7)
```