### PR TITLE
Remove mention of create-zudoku-app from docs

### DIFF
--- a/docs/pages/configuration/overview.md
+++ b/docs/pages/configuration/overview.md
@@ -6,8 +6,7 @@ Zudoku uses a single file for configuration. It controls the structure, metadata
 
 You can find the file in the root directory of your project. It will be start with `zudoku.config`. The file can be in either JavaScript or TypeScript format and use a `.js`, `.mjs`, `.jsx`, `.ts`, or `.tsx` file extension.
 
-When you create a project a default configuration file is generated for you. This file is a good starting point and can be customized to suit your needs.
-
+When you create a project, a default configuration file is generated for you. This file is a good starting point and can be customized to suit your needs.
 ## Example
 
 Below is an example of the default Zudoku configuration. You can edit this configuration to suit your own needs.

--- a/docs/pages/configuration/overview.md
+++ b/docs/pages/configuration/overview.md
@@ -6,11 +6,11 @@ Zudoku uses a single file for configuration. It controls the structure, metadata
 
 You can find the file in the root directory of your project. It will be start with `zudoku.config`. The file can be in either JavaScript or TypeScript format and use a `.js`, `.mjs`, `.jsx`, `.ts`, or `.tsx` file extension.
 
-When you create a project with `create-zudoku-app`, a default configuration file is generated for you. This file is a good starting point and can be customized to suit your needs.
+When you create a project a default configuration file is generated for you. This file is a good starting point and can be customized to suit your needs.
 
 ## Example
 
-Below is real example that is used to configure the default Zudoku site that `create-zudoku-app` will generate. You can edit this configuration to suit your own needs.
+Below is an example of the default Zudoku configuration. You can edit this configuration to suit your own needs.
 
 ```typescript
 import type { ZudokuConfig } from "zudoku";


### PR DESCRIPTION
Removing the create-zudoku-app reference to keep the doc clean as this is used on the zuplo docs as well.