### PR TITLE
Unable to set scopes for auth0 provider

### DIFF
--- a/packages/zudoku/src/config/validators/common.ts
+++ b/packages/zudoku/src/config/validators/common.ts
@@ -318,6 +318,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     clientId: z.string(),
     domain: z.string(),
     audience: z.string().optional(),
+    scopes: z.array(z.string()).optional(),
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),


### PR DESCRIPTION
Fixes https://github.com/zuplo/zudoku/issues/928

Test Directions

1. Specify scopes `/docs` at `examples/with-auth0/zudoku.config.ts`
as 
```
  authentication: {
    type: "auth0",
    domain: "zuplo-samples.us.auth0.com",
    clientId: "kWQs12Q9Og4w6zzI82qJSa3klN1sMtvz",
    audience: "http://localhost:3000",
    scopes: ["my-scope"],
  }
```

Successful result:
- No errors

Failed result:
- zod complaining about unknown property `scopes`