### PR TITLE
Add UI for Sign Up & Sign In

### DIFF
--- a/packages/zudoku/src/lib/authentication/components/SignIn.tsx
+++ b/packages/zudoku/src/lib/authentication/components/SignIn.tsx
@@ -1,5 +1,13 @@
 import { useEffect } from "react";
-import { useSearchParams } from "react-router";
+import { Link, useSearchParams } from "react-router";
+import { Button } from "zudoku/ui/Button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "zudoku/ui/Card.js";
 import { useZudoku } from "../../components/context/ZudokuContext.js";
 
 export const SignIn = () => {
@@ -11,5 +19,30 @@ export const SignIn = () => {
     });
   }, [context.authentication, search]);
 
-  return null;
+  return (
+    <div className="flex items-center justify-center mt-8">
+      <Card className="max-w-md w-full">
+        <CardHeader>
+          <CardTitle className="text-lg">Sign in</CardTitle>
+          <CardDescription>
+            You're being redirected to our secure login provider to complete
+            your sign-in process.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-2 justify-center">
+            <Button
+              onClick={() => context.authentication?.signIn()}
+              variant="default"
+            >
+              Login
+            </Button>
+            <Button variant="link" className="text-muted-foreground" asChild>
+              <Link to="/">Go home</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
 };

--- a/packages/zudoku/src/lib/authentication/components/SignUp.tsx
+++ b/packages/zudoku/src/lib/authentication/components/SignUp.tsx
@@ -1,11 +1,45 @@
 import { useEffect } from "react";
+import { Button, Link } from "zudoku/components";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "zudoku/ui/Card.js";
 import { useZudoku } from "../../components/context/ZudokuContext.js";
 
 export const SignUp = () => {
   const context = useZudoku();
+
   useEffect(() => {
     void (context.authentication?.signUp() ?? context.authentication?.signIn());
   }, [context.authentication]);
 
-  return null;
+  return (
+    <div className="flex items-center justify-center mt-8">
+      <Card className="max-w-md w-full">
+        <CardHeader>
+          <CardTitle className="text-lg">Sign up</CardTitle>
+          <CardDescription>
+            You're being redirected to our secure login provider to complete
+            your sign-in process.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-2 justify-center">
+            <Button
+              onClick={() => context.authentication?.signIn()}
+              variant="default"
+            >
+              Login
+            </Button>
+            <Button variant="link" className="text-muted-foreground" asChild>
+              <Link to="/">Go home</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
 };

--- a/packages/zudoku/src/lib/authentication/components/SignUp.tsx
+++ b/packages/zudoku/src/lib/authentication/components/SignUp.tsx
@@ -23,7 +23,7 @@ export const SignUp = () => {
           <CardTitle className="text-lg">Sign up</CardTitle>
           <CardDescription>
             You're being redirected to our secure login provider to complete
-            your sign-in process.
+            your sign up process.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -32,7 +32,7 @@ export const SignUp = () => {
               onClick={() => context.authentication?.signIn()}
               variant="default"
             >
-              Login
+              Register
             </Button>
             <Button variant="link" className="text-muted-foreground" asChild>
               <Link to="/">Go home</Link>


### PR DESCRIPTION
This PR adds a bit of UI to explain the purpose if the pages `/signin` and `/signup`. 

When you navigte back, you might sometimes land on this page. You can keep going back.

![CleanShot 2025-05-06 at 13 02 12](https://github.com/user-attachments/assets/d2aa3097-9ce1-4192-889a-c8baeb8b3c9e)

![CleanShot 2025-05-06 at 13 01 58](https://github.com/user-attachments/assets/9e0f92ec-4510-4ceb-8794-5b3e6a7d8ff2)
