### PR TITLE
Use correct stylesheet in standalone mode

### DIFF
--- a/packages/zudoku/src/app/demo.html
+++ b/packages/zudoku/src/app/demo.html
@@ -13,7 +13,7 @@
     />
     <title>Zudoku Demo</title>
     <script type="module" crossorigin src="./demo.js"></script>
-    <link rel="stylesheet" crossorigin href="./style.css" />
+    <link rel="stylesheet" crossorigin href="./zudoku.css" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
The built styles are actually in `zudoku.css`