### PR TITLE
make the redirects work

### DIFF
--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -124,6 +124,8 @@ const config: ZudokuConfig = {
   authentication: {
     type: "clerk",
     clerkPubKey: "pk_test_dG9sZXJhbnQtaG9ybmV0LTQ2LmNsZXJrLmFjY291bnRzLmRldiQ",
+    redirectToAfterSignIn: "/documentation",
+    redirectToAfterSignUp: "/documentation",
   },
   defaults: {
     apis: {

--- a/examples/with-auth0/zudoku.config.ts
+++ b/examples/with-auth0/zudoku.config.ts
@@ -24,7 +24,7 @@ const config: ZudokuConfig = {
     type: "auth0",
     domain: "zuplo-samples.us.auth0.com",
     clientId: "kWQs12Q9Og4w6zzI82qJSa3klN1sMtvz",
-    audience: "http://localhost:3000",
+    audience: "https://api.example.com/",
   },
   apiKeys: {
     enabled: true,

--- a/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
+++ b/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
@@ -1,18 +1,28 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Navigate } from "react-router";
+import { useZudoku } from "zudoku/components";
 import { ZudokuError } from "../../util/invariant.js";
+import { joinUrl } from "../../util/joinUrl.js";
+import { normalizeRedirectUrl } from "../../util/url.js";
 
 export function CallbackHandler({
   handleCallback,
 }: {
   handleCallback: () => Promise<string>;
 }) {
+  const { options } = useZudoku();
   const executeCallback = useSuspenseQuery({
     retry: false,
     queryKey: ["oauth-callback"],
     queryFn: async () => {
       try {
-        return await handleCallback();
+        return joinUrl(
+          normalizeRedirectUrl(
+            await handleCallback(),
+            options.basePath ?? "/",
+            window.location.origin,
+          ),
+        );
       } catch (error) {
         throw new ZudokuError("Could not validate user", {
           cause: error,

--- a/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
+++ b/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
@@ -19,8 +19,8 @@ export function CallbackHandler({
         return joinUrl(
           normalizeRedirectUrl(
             await handleCallback(),
-            options.basePath ?? "/",
             window.location.origin,
+            options.basePath,
           ),
         );
       } catch (error) {

--- a/packages/zudoku/src/lib/authentication/providers/auth0.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/auth0.tsx
@@ -37,7 +37,7 @@ class Auth0AuthenticationProvider extends OpenIDAuthenticationProvider {
     });
 
     const redirectUrl = new URL(window.location.origin);
-    redirectUrl.pathname = this.logoutRedirectUrlPath;
+    redirectUrl.pathname = this.redirectToAfterSignOut;
 
     // SEE: https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0
     // For Auth0 tenants created on or after 14 November 2023, RP-Initiated

--- a/packages/zudoku/src/lib/authentication/providers/clerk.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.tsx
@@ -50,8 +50,8 @@ const clerkAuth: AuthenticationProviderInitializer<
 > = ({
   clerkPubKey,
   redirectToAfterSignOut = "/",
-  redirectToAfterSignUp = "/",
-  redirectToAfterSignIn = "/",
+  redirectToAfterSignUp,
+  redirectToAfterSignIn,
 }) => {
   let clerkApi: Clerk | undefined;
   const ensureLoaded = (async () => {
@@ -129,19 +129,23 @@ const clerkAuth: AuthenticationProviderInitializer<
     signIn: async ({ redirectTo }: { redirectTo?: string } = {}) => {
       await ensureLoaded;
       await clerkApi?.redirectToSignIn({
-        signInForceRedirectUrl:
-          redirectTo ?? window.location.origin + redirectToAfterSignIn,
-        signUpForceRedirectUrl:
-          redirectTo ?? window.location.origin + redirectToAfterSignUp,
+        signInForceRedirectUrl: redirectToAfterSignIn
+          ? window.location.origin + redirectToAfterSignIn
+          : redirectTo,
+        signUpForceRedirectUrl: redirectToAfterSignUp
+          ? window.location.origin + redirectToAfterSignUp
+          : redirectTo,
       });
     },
     signUp: async ({ redirectTo }: { redirectTo?: string } = {}) => {
       await ensureLoaded;
       await clerkApi?.redirectToSignUp({
-        signInForceRedirectUrl:
-          redirectTo ?? window.location.origin + redirectToAfterSignIn,
-        signUpForceRedirectUrl:
-          redirectTo ?? window.location.origin + redirectToAfterSignUp,
+        signInForceRedirectUrl: redirectToAfterSignIn
+          ? window.location.origin + redirectToAfterSignIn
+          : redirectTo,
+        signUpForceRedirectUrl: redirectToAfterSignUp
+          ? window.location.origin + redirectToAfterSignUp
+          : redirectTo,
       });
     },
     getAuthenticationPlugin() {

--- a/packages/zudoku/src/lib/util/url.test.ts
+++ b/packages/zudoku/src/lib/util/url.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRedirectUrl } from "./url.js";
+
+describe("normalizeRedirectUrl", () => {
+  const mockOrigin = "https://example.com";
+
+  it("should return original URL if it doesn't start with origin", () => {
+    const result = normalizeRedirectUrl(
+      "https://other.com/path",
+      mockOrigin,
+      "/",
+    );
+    expect(result).toBe("https://other.com/path");
+  });
+
+  it("should remove origin when root is /", () => {
+    const result = normalizeRedirectUrl(
+      "https://example.com/some/path",
+      mockOrigin,
+      "/",
+    );
+    expect(result).toBe("/some/path");
+  });
+
+  it("should remove origin and root path when root is not /", () => {
+    const result = normalizeRedirectUrl(
+      "https://example.com/docs/some/path",
+      mockOrigin,
+      "/docs",
+    );
+    expect(result).toBe("/some/path");
+  });
+
+  it("should only remove origin when URL doesn't match root path", () => {
+    const result = normalizeRedirectUrl(
+      "https://example.com/other/path",
+      mockOrigin,
+      "/docs",
+    );
+    expect(result).toBe("/other/path");
+  });
+
+  it("should handle empty root path", () => {
+    const result = normalizeRedirectUrl(
+      "https://example.com/path",
+      mockOrigin,
+      "",
+    );
+    expect(result).toBe("/path");
+  });
+});

--- a/packages/zudoku/src/lib/util/url.ts
+++ b/packages/zudoku/src/lib/util/url.ts
@@ -1,9 +1,5 @@
 /**
  * Normalizes a redirect URL by removing the origin and optionally the root path
- * @param redirectTo The full redirect URL
- * @param root The root path to optionally remove (defaults to '/')
- * @param origin The origin to remove (defaults to window.location.origin)
- * @returns The normalized redirect path
  */
 export function normalizeRedirectUrl(
   redirectTo: string,

--- a/packages/zudoku/src/lib/util/url.ts
+++ b/packages/zudoku/src/lib/util/url.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalizes a redirect URL by removing the origin and optionally the root path
+ * @param redirectTo The full redirect URL
+ * @param root The root path to optionally remove (defaults to '/')
+ * @param origin The origin to remove (defaults to window.location.origin)
+ * @returns The normalized redirect path
+ */
+export function normalizeRedirectUrl(
+  redirectTo: string,
+  origin: string,
+  basePath: string = "/",
+): string {
+  if (!redirectTo.startsWith(origin)) {
+    return redirectTo;
+  }
+
+  if (basePath !== "/" && redirectTo.startsWith(origin + basePath)) {
+    return redirectTo.slice(origin.length + basePath.length);
+  }
+
+  return redirectTo.slice(origin.length);
+}


### PR DESCRIPTION
This PR fixes the configuration for `redirectToAfterSignUp` & `redirectToAfterSignIn`.
These settings did not have an effect after all - now they do work like expected. You can use

Still works with what go in here: https://github.com/zuplo/zudoku/pull/927