### PR TITLE
Test local publish and build "Cosmo Cargo" example

### DIFF
--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -1,4 +1,4 @@
-name: Preview Build
+name: Public Package Build
 
 on:
   pull_request:
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -21,7 +22,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install Verdaccio
-        run: npm install -g verdaccio nx npm-auth-to-token
+        run: npm install -g verdaccio nx npm-auth-to-token wrangler
 
       - name: Start Verdaccio
         run: |
@@ -47,24 +48,9 @@ jobs:
           pnpm install --no-frozen-lockfile --registry http://localhost:4873
           nx run cosmo-cargo:build
 
-      # - name: Authenticate to Google Cloud
-      #   id: auth
-      #   uses: google-github-actions/auth@v2
-      #   with:
-      #     token_format: access_token
-      #     workload_identity_provider: ${{ vars.GCP_ACTIONS_IDENTITY_PROVIDER }}
-      #     service_account: github-actions-opensource@zuplo-production.iam.gserviceaccount.com
-      #     access_token_lifetime: 300s
-
-      # - name: Deploy to GCS
-      #   uses: google-github-actions/upload-cloud-storage@v2
-      #   with:
-      #     path: examples/cosmo-cargo/dist
-      #     destination: zudoku-preview/pr-${{ github.event.pull_request.number }}
-      #     parent: false
-      #     glob: "**/*"
-      #   env:
-      #     CLOUDSDK_AUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
-
-      # - name: Output Preview URL
-      #   run: 'echo "Preview available at: https://storage.googleapis.com/zudoku-preview/pr-${{ github.event.pull_request.number }}/index.html"'
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.COSMO_CARGO_CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.COSMO_CARGO_CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy examples/cosmo-cargo/dist --project-name=cosmocargo-public-package

--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -1,0 +1,70 @@
+name: Preview Build
+
+on:
+  pull_request:
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install Verdaccio
+        run: npm install -g verdaccio nx npm-auth-to-token
+
+      - name: Start Verdaccio
+        run: |
+          tmp_registry_log=$(mktemp)
+          nohup verdaccio &>$tmp_registry_log &
+          grep -q 'http address' <(tail -f $tmp_registry_log)
+          npm-auth-to-token -u test -p test -e test@test.com -r http://localhost:4873
+
+      - name: Run pnpm install
+        run: pnpm install --registry http://localhost:4873
+
+      - name: Build and publish package
+        run: nx run zudoku:publish:local
+
+      - name: Update package.json
+        run: |
+          VERSION=$(node -p "require('./packages/zudoku/package.json').version")
+          cd examples/cosmo-cargo
+          pnpm pkg set "devDependencies.zudoku=$VERSION"
+
+      - name: Build example
+        run: |
+          pnpm install --no-frozen-lockfile --registry http://localhost:4873
+          nx run cosmo-cargo:build
+
+      # - name: Authenticate to Google Cloud
+      #   id: auth
+      #   uses: google-github-actions/auth@v2
+      #   with:
+      #     token_format: access_token
+      #     workload_identity_provider: ${{ vars.GCP_ACTIONS_IDENTITY_PROVIDER }}
+      #     service_account: github-actions-opensource@zuplo-production.iam.gserviceaccount.com
+      #     access_token_lifetime: 300s
+
+      # - name: Deploy to GCS
+      #   uses: google-github-actions/upload-cloud-storage@v2
+      #   with:
+      #     path: examples/cosmo-cargo/dist
+      #     destination: zudoku-preview/pr-${{ github.event.pull_request.number }}
+      #     parent: false
+      #     glob: "**/*"
+      #   env:
+      #     CLOUDSDK_AUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+
+      # - name: Output Preview URL
+      #   run: 'echo "Preview available at: https://storage.googleapis.com/zudoku-preview/pr-${{ github.event.pull_request.number }}/index.html"'

--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -3,13 +3,18 @@ name: Public Package Build
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
-  preview:
+  run:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
       deployments: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -21,18 +26,18 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - name: Install Verdaccio
+      - name: Install global dependencies
         run: npm install -g verdaccio nx npm-auth-to-token wrangler
 
-      - name: Start Verdaccio
+      - name: Start local NPM registry
         run: |
           tmp_registry_log=$(mktemp)
           nohup verdaccio &>$tmp_registry_log &
           grep -q 'http address' <(tail -f $tmp_registry_log)
           npm-auth-to-token -u test -p test -e test@test.com -r http://localhost:4873
 
-      - name: Run pnpm install
-        run: pnpm install --registry http://localhost:4873
+      - name: Run first pnpm install
+        run: pnpm install
 
       - name: Build and publish package
         run: nx run zudoku:publish:local
@@ -43,14 +48,65 @@ jobs:
           cd examples/cosmo-cargo
           pnpm pkg set "devDependencies.zudoku=$VERSION"
 
-      - name: Build example
-        run: |
-          pnpm install --no-frozen-lockfile --registry http://localhost:4873
-          nx run cosmo-cargo:build
+      - name: Run second pnpm install
+        run: pnpm install --no-frozen-lockfile --prefer-offline --registry http://localhost:4873
+
+      - name: Build Cosmo Cargo example
+        run: nx run cosmo-cargo:build
 
       - name: Deploy to Cloudflare Pages
+        id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.COSMO_CARGO_CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.COSMO_CARGO_CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy examples/cosmo-cargo/dist --project-name=cosmocargo-public-package
+
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentUrl = "${{ steps.deploy.outputs.deployment-url }}";
+            const sha = "${{ github.event.pull_request.head.sha }}" || "${{ github.sha }}";
+
+            const comment = `Preview build of published Zudoku package for commit ${sha}.
+
+            See the deployment at: **${deploymentUrl}**
+
+            > [!NOTE]
+            > This is a preview of the Cosmo Cargo example using the Zudoku package published to [a local registry](https://verdaccio.org) to ensure it'll be working when published to the public NPM registry.
+
+            _Last updated: ${new Date().toISOString()}_`;
+
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100
+              });
+
+              const botComment = comments.find((c) => 
+                c.user.login === "github-actions[bot]" && 
+                c.body.includes("Preview build of published Zudoku package")
+              );
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: comment
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: comment
+                });
+              }
+            } catch (error) {
+              core.error(`Failed to comment on PR: ${error.message}`);
+              throw error;
+            }

--- a/packages/zudoku/project.json
+++ b/packages/zudoku/project.json
@@ -16,7 +16,7 @@
     },
     "publish:local": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build:ci"],
+      "dependsOn": ["build", "build:ci"],
       "options": {
         "cwd": "packages/zudoku",
         "commands": [


### PR DESCRIPTION
Added GitHub Actions workflow to test PR changes by building and publishing Zudoku locally with Verdaccio, then building `cosmo-cargo` example app against the published version.