### PR TITLE
Add option to hide playground no-auth choice

### DIFF
--- a/docs/pages/configuration/api-reference.md
+++ b/docs/pages/configuration/api-reference.md
@@ -79,6 +79,8 @@ const config = {
       disableSidecar: false, // Disable the sidecar completely
       showVersionSelect: "if-available", // Control version selector visibility
       expandAllTags: true, // Control initial expanded state of tag categories
+      disableNoAuthOption: true, // Remove the "No Auth" option in the playground
+      hideAuthSelectorIfSingle: true, // Hide auth selector when only one identity
     },
   },
 };
@@ -93,6 +95,8 @@ Available options:
   - `"always"`: Always show version selector (disabled if only one version)
   - `"hide"`: Never show version selector
 - `expandAllTags`: Control initial expanded state of tag categories (default: `true`)
+- `disableNoAuthOption`: Remove the "No Auth" option in the playground
+- `hideAuthSelectorIfSingle`: Hide the auth selector when only a single identity exists
 
 ## Default Options
 
@@ -106,6 +110,8 @@ const config = {
       disablePlayground: false, // Disable the interactive API playground
       showVersionSelect: "if-available", // Control version selector visibility
       expandAllTags: false, // Control initial expanded state of tag categories
+      disableNoAuthOption: true, // Remove the "No Auth" option in the playground
+      hideAuthSelectorIfSingle: true, // Hide auth selector when only one identity
     },
   },
   apis: {

--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -62,6 +62,8 @@ const ApiOptionsSchema = z
     transformExamples: z.custom<transformExamples>(
       (val) => typeof val === "function",
     ),
+    disableNoAuthOption: z.boolean(),
+    hideAuthSelectorIfSingle: z.boolean(),
   })
   .partial();
 

--- a/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "zudoku/components";
+import { useOasConfig } from "./context.js";
 import type { OperationListItemResult } from "./OperationList.js";
 import { PlaygroundDialog } from "./playground/PlaygroundDialog.js";
 import { Content } from "./SidecarExamples.js";
@@ -16,6 +17,7 @@ export const PlaygroundDialogWrapper = ({
 }) => {
   const { isAuthEnabled, login, signup, isPending, isAuthenticated } =
     useAuth();
+  const { options } = useOasConfig();
 
   const headers = operation.parameters
     ?.filter((p) => p.in === "header")
@@ -62,6 +64,8 @@ export const PlaygroundDialogWrapper = ({
       requiresLogin={isAuthEnabled && !isAuthenticated && !isPending}
       onLogin={() => login()}
       onSignUp={() => signup()}
+      disableNoAuthOption={options?.disableNoAuthOption}
+      hideAuthSelectorIfSingle={options?.hideAuthSelectorIfSingle}
     />
   );
 };

--- a/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
@@ -53,6 +53,10 @@ type BaseOasConfig = {
     showVersionSelect?: "always" | "if-available" | "hide";
     expandAllTags?: boolean;
     transformExamples?: transformExamples;
+    /** Remove the "No Auth" option from the playground */
+    disableNoAuthOption?: boolean;
+    /** Hide the auth selector if only a single identity is available */
+    hideAuthSelectorIfSingle?: boolean;
   };
 };
 

--- a/packages/zudoku/src/lib/plugins/openapi/playground/IdentityDialog.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/IdentityDialog.tsx
@@ -17,6 +17,7 @@ const IdentityDialog = ({
   identities,
   open,
   onOpenChange,
+  disableNoAuth = false,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -28,6 +29,7 @@ const IdentityDialog = ({
     identity?: string;
   }) => void;
   identities: ApiIdentity[];
+  disableNoAuth?: boolean;
 }) => {
   const [identity, setIdentity] = useState<string | undefined>(undefined);
   const [rememberedIdentity, setRememberedIdentity] = useState<boolean>(false);
@@ -44,6 +46,7 @@ const IdentityDialog = ({
             identities={identities}
             setValue={setIdentity}
             value={identity}
+            disableNoAuth={disableNoAuth}
           />
         </div>
         <DialogFooter className="flex flex-col gap-2">

--- a/packages/zudoku/src/lib/plugins/openapi/playground/IdentitySelector.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/IdentitySelector.tsx
@@ -8,10 +8,12 @@ const IdentitySelector = ({
   identities,
   setValue,
   value,
+  disableNoAuth = false,
 }: {
   identities?: ApiIdentity[];
   setValue: (value: string) => void;
   value?: string;
+  disableNoAuth?: boolean;
 }) => (
   <Card className="w-full overflow-hidden rounded-lg">
     <RadioGroup
@@ -21,10 +23,12 @@ const IdentitySelector = ({
       className="gap-0"
       disabled={identities?.length === 0}
     >
-      <Label className="h-10 border-b items-center flex gap-2 p-4 cursor-pointer hover:bg-accent">
-        <RadioGroupItem value={NO_IDENTITY} id="none" />
-        <span>None</span>
-      </Label>
+      {!disableNoAuth && (
+        <Label className="h-10 border-b items-center flex gap-2 p-4 cursor-pointer hover:bg-accent">
+          <RadioGroupItem value={NO_IDENTITY} id="none" />
+          <span>None</span>
+        </Label>
+      )}
       <div className="divide-y">
         {identities?.map((identity) => (
           <Label


### PR DESCRIPTION
## Summary
- introduce `disableNoAuthOption` and `hideAuthSelectorIfSingle` for API playground
- support these options in interfaces and validator
- update openapi components (Playground, IdentitySelector, IdentityDialog, PlaygroundDialogWrapper)
- document new configuration options

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_683fdbb256d083248574d0367324b76b