### PR TITLE
Add multipart form support to playground

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -43,7 +43,7 @@
   ],
   "servers": [
     {
-      "url": "https://8f9618f3bc0f4eec989627ceaafd5e4d_oas.api.mockbin.io/",
+      "url": "https://906f8ae2c5e546179bdc40be7159516c_oas.api.mockbin.io",
       "description": "Production environment"
     },
     {

--- a/examples/cosmo-cargo/schema/upload.json
+++ b/examples/cosmo-cargo/schema/upload.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "File Upload API",
+    "version": "1.0.0",
+    "description": "Allows uploading files with optional description."
+  },
+  "paths": {
+    "/files": {
+      "post": {
+        "summary": "Upload a file",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                },
+                "required": ["file"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "File uploaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "url": { "type": "string" }
+                  }
+                },
+                "example": {
+                  "id": "123",
+                  "url": "https://example.com/file.png"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -102,6 +102,7 @@ const config: ZudokuConfig = {
   topNavigation: [
     { id: "documentation", label: "Documentation" },
     { id: "api-shipments", label: "Shipments API" },
+    { id: "api-upload", label: "Upload API" },
     { id: "catalog", label: "API Catalog" },
   ],
   sidebar: {
@@ -202,6 +203,12 @@ const config: ZudokuConfig = {
       input: "./schema/tracking-v1.json",
       navigationId: "api-tracking",
       categories: [{ label: "General", tags: ["Tracking"] }],
+    },
+    {
+      type: "file",
+      input: "./schema/upload.json",
+      navigationId: "api-upload",
+      categories: [{ label: "General", tags: ["Uploads"] }],
     },
   ],
   docs: {

--- a/packages/zudoku/src/lib/plugins/openapi/playground/BodyPanel.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/BodyPanel.tsx
@@ -1,5 +1,4 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { Textarea } from "zudoku/ui/Textarea.js";
 import {
   Select,
   SelectContent,
@@ -7,6 +6,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "zudoku/ui/Select.js";
+import { Textarea } from "zudoku/ui/Textarea.js";
 import { cn } from "../../../util/cn.js";
 import { type Content } from "../SidecarExamples.js";
 import ExamplesDropdown from "./ExamplesDropdown.js";
@@ -14,11 +14,11 @@ import MultipartForm from "./MultipartForm.js";
 import { type PlaygroundForm } from "./Playground.js";
 
 export const BodyPanel = ({ examples }: { examples?: Content }) => {
-  const { register, setValue, watch, control } = useFormContext<PlaygroundForm>();
+  const { register, setValue, watch, control } =
+    useFormContext<PlaygroundForm>();
 
   const headers = watch("headers");
   const bodyType = watch("bodyType");
-
 
   return (
     <div className="flex flex-col gap-2 ">
@@ -38,8 +38,8 @@ export const BodyPanel = ({ examples }: { examples?: Content }) => {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="text">text</SelectItem>
-                  <SelectItem value="multipart/form-data">multipart/form</SelectItem>
+                  <SelectItem value="text">Text</SelectItem>
+                  <SelectItem value="form">Form</SelectItem>
                 </SelectContent>
               </Select>
             )}

--- a/packages/zudoku/src/lib/plugins/openapi/playground/BodyPanel.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/BodyPanel.tsx
@@ -1,21 +1,50 @@
-import { useFormContext } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
 import { Textarea } from "zudoku/ui/Textarea.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "zudoku/ui/Select.js";
 import { cn } from "../../../util/cn.js";
 import { type Content } from "../SidecarExamples.js";
 import ExamplesDropdown from "./ExamplesDropdown.js";
+import MultipartForm from "./MultipartForm.js";
 import { type PlaygroundForm } from "./Playground.js";
 
 export const BodyPanel = ({ examples }: { examples?: Content }) => {
-  const { register, setValue, watch } = useFormContext<PlaygroundForm>();
+  const { register, setValue, watch, control } = useFormContext<PlaygroundForm>();
 
   const headers = watch("headers");
+  const bodyType = watch("bodyType");
+
 
   return (
     <div className="flex flex-col gap-2 ">
-      <div className="flex justify-between gap-2">
+      <div className="flex justify-between gap-2 items-start">
         <span className="font-semibold">Body</span>
-        <div className="flex flex-col gap-2">
-          {examples && examples.length > 0 && (
+        <div className="flex items-center gap-2">
+          <Controller
+            control={control}
+            name="bodyType"
+            render={({ field }) => (
+              <Select
+                onValueChange={(v) => field.onChange(v)}
+                value={field.value}
+                defaultValue={field.value}
+              >
+                <SelectTrigger className="h-8 w-32 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="text">text</SelectItem>
+                  <SelectItem value="multipart/form-data">multipart/form</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+          {bodyType === "text" && examples && examples.length > 0 && (
             <ExamplesDropdown
               examples={examples}
               onSelect={(example, mediaType) => {
@@ -33,12 +62,16 @@ export const BodyPanel = ({ examples }: { examples?: Content }) => {
           )}
         </div>
       </div>
-      <Textarea
-        {...register("body")}
-        className={cn(
-          "border w-full rounded-lg bg-muted/40 p-2 h-64 font-mono text-[13px]",
-        )}
-      />
+      {bodyType === "text" ? (
+        <Textarea
+          {...register("body")}
+          className={cn(
+            "border w-full rounded-lg bg-muted/40 p-2 h-64 font-mono text-[13px]",
+          )}
+        />
+      ) : (
+        <MultipartForm />
+      )}
     </div>
   );
 };

--- a/packages/zudoku/src/lib/plugins/openapi/playground/MultipartForm.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/MultipartForm.tsx
@@ -1,14 +1,9 @@
+import { PaperclipIcon, XIcon } from "lucide-react";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
-import { XIcon } from "lucide-react";
+import { Card } from "zudoku/ui/Card.js";
+import { Label } from "zudoku/ui/Label.js";
 import { Button } from "../../../ui/Button.js";
 import { Input } from "../../../ui/Input.js";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "zudoku/ui/Select.js";
 import ParamsGrid, { ParamsGridItem } from "./ParamsGrid.js";
 import type { PlaygroundForm } from "./Playground.js";
 
@@ -20,7 +15,7 @@ const MultipartForm = () => {
   });
 
   return (
-    <div className="flex flex-col gap-2">
+    <div>
       <Button
         variant="ghost"
         size="sm"
@@ -31,87 +26,66 @@ const MultipartForm = () => {
       >
         + Add field
       </Button>
-      <ParamsGrid className="grid-cols-[2fr_2fr_auto_2fr_min-content]">
-        {fields.map((field, i) => {
-          const watched = watch(`formData.${i}`);
-          return (
-            <ParamsGridItem key={field.id}>
-              <Controller
-                name={`formData.${i}.key`}
-                control={control}
-                render={({ field }) => (
-                  <Input
-                    {...field}
-                    placeholder="Key"
-                    className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
-                  />
-                )}
-              />
-              <div className="flex items-center gap-2">
+      <Card className="flex flex-col gap-2">
+        <ParamsGrid className="grid-cols-[2fr_2fr_min-content]">
+          {fields.map((field, i) => {
+            return (
+              <ParamsGridItem key={field.id}>
                 <Controller
-                  name={`formData.${i}.value`}
+                  name={`formData.${i}.key`}
                   control={control}
-                  render={({ field }) =>
-                    watched?.type === "file" ? (
-                      <Input
-                        type="file"
-                        onChange={(e) => field.onChange(e.target.files?.[0] ?? null)}
-                        className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
-                      />
-                    ) : (
-                      <Input
-                        {...field}
-                        onChange={(e) => field.onChange(e.target.value)}
-                        placeholder="Value"
-                        className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
-                      />
-                    )
-                  }
+                  render={({ field }) => (
+                    <Input
+                      {...field}
+                      placeholder="Key"
+                      className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
+                    />
+                  )}
                 />
-              </div>
-              <Controller
-                name={`formData.${i}.type`}
-                control={control}
-                render={({ field }) => (
-                  <Select
-                    value={field.value}
-                    onValueChange={(v) => field.onChange(v)}
-                    defaultValue={field.value}
-                  >
-                    <SelectTrigger className="h-8 w-24 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="text">text</SelectItem>
-                      <SelectItem value="file">file</SelectItem>
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-              <Controller
-                name={`formData.${i}.contentType`}
-                control={control}
-                render={({ field }) => (
-                  <Input
-                    {...field}
-                    placeholder="Content-Type"
-                    className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
+                <div className="flex items-center gap-2">
+                  <Controller
+                    name={`formData.${i}.value`}
+                    control={control}
+                    render={({ field }) => (
+                      <>
+                        <Input
+                          {...field}
+                          onChange={(e) => field.onChange(e.target.value)}
+                          placeholder="Value"
+                          className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
+                        />
+                        <Label htmlFor={`formData.${i}.file`}>
+                          <Input
+                            id={`formData.${i}.file`}
+                            type="file"
+                            onChange={(e) =>
+                              field.onChange(e.target.files?.[0] ?? null)
+                            }
+                            className="hidden"
+                          />
+                          <PaperclipIcon
+                            size={16}
+                            className="text-muted-foreground"
+                          />
+                        </Label>
+                      </>
+                    )}
                   />
-                )}
-              />
-              <Button
-                size="icon"
-                variant="ghost"
-                className="text-muted-foreground"
-                onClick={() => remove(i)}
-                type="button"
-              >
-                <XIcon size={16} />
-              </Button>
-            </ParamsGridItem>
-          );
-        })}
-      </ParamsGrid>
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="text-muted-foreground"
+                  onClick={() => remove(i)}
+                  type="button"
+                >
+                  <XIcon size={16} />
+                </Button>
+              </ParamsGridItem>
+            );
+          })}
+        </ParamsGrid>
+      </Card>
     </div>
   );
 };

--- a/packages/zudoku/src/lib/plugins/openapi/playground/MultipartForm.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/MultipartForm.tsx
@@ -1,0 +1,119 @@
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { XIcon } from "lucide-react";
+import { Button } from "../../../ui/Button.js";
+import { Input } from "../../../ui/Input.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "zudoku/ui/Select.js";
+import ParamsGrid, { ParamsGridItem } from "./ParamsGrid.js";
+import type { PlaygroundForm } from "./Playground.js";
+
+const MultipartForm = () => {
+  const { control, watch } = useFormContext<PlaygroundForm>();
+  const { fields, append, remove } = useFieldArray<PlaygroundForm, "formData">({
+    control,
+    name: "formData",
+  });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        type="button"
+        onClick={() =>
+          append({ key: "", value: "", type: "text", contentType: "" })
+        }
+      >
+        + Add field
+      </Button>
+      <ParamsGrid className="grid-cols-[2fr_2fr_auto_2fr_min-content]">
+        {fields.map((field, i) => {
+          const watched = watch(`formData.${i}`);
+          return (
+            <ParamsGridItem key={field.id}>
+              <Controller
+                name={`formData.${i}.key`}
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    {...field}
+                    placeholder="Key"
+                    className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
+                  />
+                )}
+              />
+              <div className="flex items-center gap-2">
+                <Controller
+                  name={`formData.${i}.value`}
+                  control={control}
+                  render={({ field }) =>
+                    watched?.type === "file" ? (
+                      <Input
+                        type="file"
+                        onChange={(e) => field.onChange(e.target.files?.[0] ?? null)}
+                        className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
+                      />
+                    ) : (
+                      <Input
+                        {...field}
+                        onChange={(e) => field.onChange(e.target.value)}
+                        placeholder="Value"
+                        className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
+                      />
+                    )
+                  }
+                />
+              </div>
+              <Controller
+                name={`formData.${i}.type`}
+                control={control}
+                render={({ field }) => (
+                  <Select
+                    value={field.value}
+                    onValueChange={(v) => field.onChange(v)}
+                    defaultValue={field.value}
+                  >
+                    <SelectTrigger className="h-8 w-24 text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="text">text</SelectItem>
+                      <SelectItem value="file">file</SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <Controller
+                name={`formData.${i}.contentType`}
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    {...field}
+                    placeholder="Content-Type"
+                    className="w-full border-0 shadow-none text-xs font-mono focus-visible:ring-0"
+                  />
+                )}
+              />
+              <Button
+                size="icon"
+                variant="ghost"
+                className="text-muted-foreground"
+                onClick={() => remove(i)}
+                type="button"
+              >
+                <XIcon size={16} />
+              </Button>
+            </ParamsGridItem>
+          );
+        })}
+      </ParamsGrid>
+    </div>
+  );
+};
+
+export default MultipartForm;


### PR DESCRIPTION
## Summary
- enable toggling body type between text and multipart form
- implement multipart form editor with dynamic fields
- create FormData payload when sending request
- add an Upload API example to cosmo cargo for testing

## Testing
- `pnpm --filter zudoku test` *(fails: fetch failed)*
- `pnpm lint:ci` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_683ff73838f48331b9bc05c87f125cc8