### PR TITLE
Support pre-defined examples for path and query params in playground

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -1014,6 +1014,7 @@
             "name": "holdDuration",
             "in": "query",
             "description": "Duration to hold the shipment",
+            "example": "2017-07-21T17:32:28Z",
             "schema": {
               "type": "string",
               "format": "date-time"
@@ -1031,6 +1032,7 @@
             "name": "shipmentId",
             "in": "path",
             "required": true,
+            "example": "123e4567-e89b-12d3-a456-426614174000",
             "schema": {
               "type": "string",
               "format": "uuid"

--- a/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
@@ -39,14 +39,16 @@ export const PlaygroundDialogWrapper = ({
       isRequired: p.required ?? false,
       enum: p.schema?.type == "array" ? p.schema?.items?.enum : p.schema?.enum,
       type: p.schema?.type ?? "string",
-      defaultValue: p.schema?.default,
+      defaultValue:
+        p.schema?.default ?? p.examples?.find((x) => x.value)?.value,
     }));
 
   const pathParams = operation.parameters
     ?.filter((p) => p.in === "path")
     .map((p) => ({
       name: p.name,
-      defaultValue: p.schema?.default,
+      defaultValue:
+        p.schema?.default ?? p.examples?.find((x) => x.value)?.value,
     }));
 
   return (


### PR DESCRIPTION
Support pre-defined examples for path and query params in playground following OpenApi spec 