### PR TITLE
Update docs for new navigation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 This project uses GitHub Releases to publish changes.
 
 See: https://github.com/zuplo/zudoku/releases
+
+## Unreleased
+
+- Merged `topNavigation`, `sidebar` and `customPages` into a single `navigation` configuration.
+- Plugins now require a `path` property instead of `navigationId`.
+- Added migration guide in `docs/pages/guides/navigation-migration.md`.

--- a/docs/pages/configuration/api-catalog.md
+++ b/docs/pages/configuration/api-catalog.md
@@ -13,7 +13,7 @@ The first step to enable the API Catalog, you need to add a `catalogs` object to
 const config = {
   // ...
   catalogs: {
-    navigationId: "catalog",
+    path: "catalog",
     label: "API Catalog",
   },
   // ...
@@ -30,19 +30,19 @@ const config = {
     {
       type: "file",
       input: "./operational.json",
-      navigationId: "api-operational",
+      path: "api-operational",
       categories: [{ label: "General", tags: ["Operational"] }],
     },
     {
       type: "file",
       input: "./enduser.json",
-      navigationId: "api-enduser",
+      path: "api-enduser",
       categories: [{ label: "General", tags: ["End-User"] }],
     },
     {
       type: "file",
       input: "./openapi.json",
-      navigationId: "api-auth",
+      path: "api-auth",
       categories: [{ label: "Other", tags: ["Authentication"] }],
     },
     // ...
@@ -61,7 +61,7 @@ You can select which APIs are shown in the catalog by using the `items` property
 const config = {
   // ...
   catalogs: {
-    navigationId: "catalog",
+    path: "catalog",
     label: "API Catalog",
     // Only show the operational API in the catalog
     items: ["api-operational"],
@@ -71,13 +71,13 @@ const config = {
     {
       type: "file",
       input: "./operational.json",
-      navigationId: "api-operational",
+      path: "api-operational",
       categories: [{ label: "General", tags: ["Operational"] }],
     },
     {
       type: "file",
       input: "./enduser.json",
-      navigationId: "api-enduser",
+      path: "api-enduser",
       categories: [{ label: "General", tags: ["End-User"] }],
     },
   ],
@@ -93,7 +93,7 @@ You can filter which APIs are shown in the catalog by using the `filterItems` pr
 const config = {
   // ...
   catalogs: {
-    navigationId: "catalog",
+    path: "catalog",
     label: "API Catalog",
     filterItems: (items, { auth: AuthState }) => {
       return items.filter((items) => items.tags.includes(auth));

--- a/docs/pages/configuration/api-reference.md
+++ b/docs/pages/configuration/api-reference.md
@@ -17,7 +17,7 @@ const config = {
   apis: {
     type: "file",
     input: "./openapi.json", // Supports JSON and YAML files (ex. openapi.yaml)
-    navigationId: "api",
+    path: "api",
   },
   // ...
 };
@@ -33,7 +33,7 @@ const config = {
   apis: {
     type: "url",
     input: "https://rickandmorty.zuplo.io/openapi.json",
-    navigationId: "api",
+    path: "api",
   },
   // ...
 };
@@ -58,7 +58,7 @@ const config = {
       "./openapi-v2.json",
       "./openapi-v1.json",
     ],
-    navigationId: "api",
+    path: "api",
   },
 };
 ```
@@ -72,7 +72,7 @@ const config = {
   apis: {
     type: "file",
     input: "./openapi.json",
-    navigationId: "api",
+    path: "api",
     options: {
       examplesLanguage: "shell", // Default language for code examples
       disablePlayground: false, // Disable the interactive API playground
@@ -111,7 +111,7 @@ const config = {
   apis: {
     type: "file",
     input: "./openapi.json",
-    navigationId: "api",
+    path: "api",
   },
 };
 ```

--- a/docs/pages/configuration/navigation.mdx
+++ b/docs/pages/configuration/navigation.mdx
@@ -5,61 +5,59 @@ sidebar_icon: compass
 
 import { Book, Code, FileText } from "zudoku/icons";
 
-Navigation in Zudoku can be customized at several layers. The primary is the top navigation tabs. Tabs can reference pages, plugins, or external links. The secondary is the sidebar navigation. Sidebars are associated with documents via unique `id`s, providing greater flexibility in organizing your content, similar to how Docusaurus handles sidebar associations.
+Zudoku uses a single `navigation` array to control both the top navigation tabs and the sidebar. Items at the root of this array appear as tabs, and nested items build the sidebar tree. Navigation entries can be links, document references, categories or custom pages.
 
-## Top Navigation
+## Basic configuration
 
-The top navigation is defined in the `topNavigation` array of the Zudoku config file. Each item in the array is an object with a `label` and an `id`. The `label` is the text that will be displayed in the navigation bar, and the `id` is used to determine the path the tab will navigate to.
+The navigation is defined using the `navigation` array in the Zudoku config file. Each item can be one of several types. At the simplest level you may only have links and categories.
 
 ```json
 {
-  "topNavigation": [
-    { "label": "Documentation", "id": "documentation" },
-    { "label": "API Reference", "id": "api" }
+  "navigation": [
+    { "type": "category", "label": "Documentation", "items": ["documentation/introduction"] },
+    { "type": "link", "href": "api", "label": "API Reference" }
   ]
 }
 ```
 
 ### Default document
 
-When a user clicks on a top navigation tab, Zudoku navigates to the path associated with the `id` and the first item in the associated sidebar. To overwrite this behavior, you can specify the `default` option. For example:
+When a user clicks on a top navigation tab, Zudoku navigates to the path specified by the `href` or the first item in the referenced category. To overwrite this behavior you can specify the `default` option:
 
 ```json
 {
   "label": "Documentation",
-  "id": "documentation",
+  "href": "documentation",
   "default": "documentation/motivation"
 }
 ```
 
-## Sidebar
+## Nested navigation
 
-The `sidebar` configuration section defines sidebars that can be used throughout your documentation. Sidebars are associated with documents via `id`s specified in the sidebar configuration, not through file paths or the top navigation.
+Nested categories inside the `navigation` array form your sidebar automatically.
 
-Example `sidebar` configuration:
+Example category configuration:
 
 ```json
 {
-  "sidebar": {
-    "documentation": [
-      {
-        "type": "category",
-        "label": "Zudoku",
-        "items": ["documentation/introduction"]
-      },
-      {
-        "type": "category",
-        "label": "Getting Started",
-        "items": ["documentation/getting-started", "documentation/installation"]
-      }
-    ]
-  }
+  "navigation": [
+    {
+      "type": "category",
+      "label": "Zudoku",
+      "items": ["documentation/introduction"]
+    },
+    {
+      "type": "category",
+      "label": "Getting Started",
+      "items": ["documentation/getting-started", "documentation/installation"]
+    }
+  ]
 }
 ```
 
-### Sidebar Items
+### Navigation Items
 
-Sidebar items can be of three types: `category`, `doc`, or `link`.
+Navigation items can be of three types: `category`, `doc`, or `link`.
 
 - `category`: A group of links that can be expanded or collapsed.
 - `doc`: A reference to a document by its `id`.
@@ -203,13 +201,11 @@ For example, you could reference a file located at `./pages/articles/about.md` w
 
 ### Sidebar Selection
 
-Zudoku determines which sidebar to display based on the document's `id` and the sidebar configurations. When you include a document `id` in a sidebar, it creates a link to that document and associates the document with that sidebar.
-
-If a document is included in multiple sidebars, Zudoku picks the first suitable sidebar. This means you cannot explicitly control which sidebar is displayed when viewing a document that is included in multiple sidebars.
+Zudoku automatically selects the sidebar based on the first navigation category that contains the current document. If a document is linked from multiple categories, the first matching category is used.
 
 For example:
 
-- If `docs/intro` is included in both `sidebar_1` and `sidebar_2`, and a user navigates to `docs/intro`, Zudoku will display `sidebar_1` (assuming it's the first one found containing `docs/intro`).
+- If `docs/intro` is referenced in both `sidebar_1` and `sidebar_2`, navigating to `docs/intro` will show the sidebar for `sidebar_1`.
 
 ### Icons
 

--- a/docs/pages/configuration/overview.md
+++ b/docs/pages/configuration/overview.md
@@ -16,24 +16,19 @@ Below is an example of the default Zudoku configuration. You can edit this confi
 import type { ZudokuConfig } from "zudoku";
 
 const config: ZudokuConfig = {
-  topNavigation: [
-    { id: "docs", label: "Documentation" },
-    { id: "api", label: "API Reference" },
+  navigation: [
+    {
+      type: "category",
+      label: "Documentation",
+      items: ["introduction", "example"],
+    },
+    { type: "link", href: "api", label: "API Reference" },
   ],
-  sidebar: {
-    docs: [
-      {
-        type: "category",
-        label: "Overview",
-        items: ["introduction", "example"],
-      },
-    ],
-  },
   redirects: [{ from: "/", to: "/docs/introduction" }],
   apis: {
     type: "file",
     input: "./apis/openapi.yaml",
-    navigationId: "api",
+    path: "api",
   },
   docs: {
     files: "/pages/**/*.{md,mdx}",
@@ -55,7 +50,7 @@ There are multiple options for referencing your OpenAPI document. The example be
   "apis": {
     "type": "url",
     "input": "https://rickandmorty.zuplo.io/openapi.json",
-    "navigationId": "api"
+    "path": "api"
   }
   // ...
 }
@@ -84,50 +79,17 @@ Controls global page attributes across the site, including logos and the site ti
 }
 ```
 
-### `topNavigation`
+### `navigation`
 
-Defines the links and headings for the top horizontal navigation that persists through every page on the site. For full details on the options available, see the [Navigation](./navigation.mdx) page.
-
-_Note: `topNavigation` will only display if there is more than one item in the navigation_
-
-**Example:**
+Defines navigation for both the top bar and the sidebar. Items can be categories, links or custom pages.
 
 ```json
 {
   // ...
-  "topNavigation": [
-    { "id": "documentation", "label": "Documentation" },
-    { "id": "api", "label": "API Reference" }
+  "navigation": [
+    { "type": "category", "label": "Docs", "items": ["introduction"] },
+    { "type": "link", "href": "api", "label": "API Reference" }
   ]
-  // ...
-}
-```
-
-### `sidebar`
-
-Defines the sidebar navigation including top level categories and their sub pages. For full details on the options available, see the [Navigation](./navigation.mdx) page.
-
-The example below uses a key of `documentation` which can be referenced as an `id` in `topNavigation`.
-
-**Example:**
-
-```json
-{
-  // ...
-  "sidebar": {
-    "documentation": [
-      {
-        "type": "category",
-        "label": "Zudoku",
-        "items": ["introduction"]
-      },
-      {
-        "type": "category",
-        "label": "Getting started",
-        "items": ["getting-started", "installation", "configuration"]
-      }
-    ]
-  }
   // ...
 }
 ```
@@ -341,33 +303,31 @@ This option is enabled by default, but you can disable it if you don't need thes
 
 The configuration file is a standard JavaScript or TypeScript file, so you can split it into multiple files if you prefer. This can be useful if you have a large configuration or want to keep your code organized.
 
-For example, if you wanted to move your sidebar configuration to a separate file, you could create a new file called `sidebar.ts` and export the sidebar configuration from there.
+For example, if you wanted to move your navigation configuration to a separate file, you could create a new file called `navigation.ts` and export the navigation configuration from there.
 
 ```ts
-// sidebar.ts
-import type { Sidebar } from "zudoku";
+// navigation.ts
+import type { NavigationItem } from "zudoku";
 
-export const sidebar: Record<string, Sidebar> = {
-  documentation: [
-    {
-      type: "category",
-      label: "Overview",
-      items: ["example", "other-example"],
-    },
-  ],
-};
+export const navigation: NavigationItem[] = [
+  {
+    type: "category",
+    label: "Documentation",
+    items: ["example", "other-example"],
+  },
+];
 ```
 
-Then you can import the sidebar configuration into your main configuration file.
+Then you can import the navigation configuration into your main configuration file.
 
 ```ts
 // zudoku.config.ts
 import type { ZudokuConfig } from "zudoku";
-import { sidebar } from "./sidebar";
+import { navigation } from "./navigation";
 
 const config = {
   // ...
-  sidebar,
+  navigation,
   // ...
 };
 

--- a/docs/pages/guides/custom-pages.md
+++ b/docs/pages/guides/custom-pages.md
@@ -60,9 +60,9 @@ Import the `<MyCustomPage />` component that you created.
 import { MyCustomPage } from "./src/MyCustomPage";
 ```
 
-### Add The `customPages` Config
+### Add The navigation entry
 
-Add the `customPages` option to the configuration. Each page you want to add to the site must be its own object.
+Add a `custom-page` item to the `navigation` configuration. Each page you want to add to the site must be its own object.
 
 The `path` key can be set to whatever you like. This will appear as part of the URL in the address bar of the browser.
 
@@ -71,8 +71,9 @@ The `element` key references the name of the custom page component that you want
 ```typescript
 {
   // ...
-  customPages: [
+  navigation: [
     {
+      type: "custom-page",
       path: "/a-custom-page",
       element: <MyCustomPage />,
     },

--- a/docs/pages/guides/managing-api-keys-and-identities.md
+++ b/docs/pages/guides/managing-api-keys-and-identities.md
@@ -280,8 +280,9 @@ import { ApiKeyManager } from "./src/ApiKeyManager";
 
 export default {
   // ... other configuration
-  customPages: [
+  navigation: [
     {
+      type: "custom-page",
       path: "/api-keys",
       element: <ApiKeyManager />,
     },

--- a/docs/pages/guides/navigation-migration.md
+++ b/docs/pages/guides/navigation-migration.md
@@ -1,0 +1,67 @@
+---
+title: Navigation Migration
+sidebar_icon: arrows-left-right
+---
+
+This guide explains how to migrate existing configurations that used `topNavigation`, `sidebar` and `customPages` to the new unified `navigation` configuration introduced in vNEXT.
+
+## Overview
+
+Navigation is now configured through a single `navigation` array. Items at the root level become top navigation tabs, while nested categories automatically form the sidebar. Custom pages are added using the `custom-page` item type.
+
+## Before and After
+
+```ts title="Before"
+const config: ZudokuConfig = {
+  topNavigation: [
+    { id: "docs", label: "Docs" },
+    { id: "api", label: "API" },
+  ],
+  sidebar: {
+    docs: [{ type: "doc", id: "introduction" }],
+  },
+  customPages: [{ path: "/playground", render: Playground, prose: false }],
+  apis: { type: "file", input: "./openapi.json", navigationId: "api" },
+};
+```
+
+```ts title="After"
+const config: ZudokuConfig = {
+  navigation: [
+    {
+      type: "category",
+      label: "Docs",
+      items: ["introduction"],
+    },
+    {
+      type: "custom-page",
+      path: "/playground",
+      element: <Playground />,
+    },
+    { type: "link", href: "api", label: "API" },
+  ],
+  apis: { type: "file", input: "./openapi.json", path: "api" },
+};
+```
+
+## Migration steps
+
+<Stepper>
+
+1. **Create a `navigation` array**
+
+   Move all items from `topNavigation` and your sidebar into a new `navigation` array.
+
+1. **Convert custom pages**
+
+   Replace entries in `customPages` with `type: "custom-page"` items inside `navigation`.
+
+1. **Update plugin configs**
+
+   Replace all uses of `navigationId` with `path` in plugin options like `apis` or `catalogs`.
+
+1. **Reference plugin paths in navigation**
+
+   Items produced by plugins are not added automatically. Add links or categories in your `navigation` so users can access them.
+
+</Stepper>

--- a/docs/pages/guides/using-multiple-apis.md
+++ b/docs/pages/guides/using-multiple-apis.md
@@ -20,12 +20,12 @@ const apis = [
   {
     type: "file",
     input: "apis/my-first-api.json",
-    navigationId: "my-first-api",
+    path: "my-first-api",
   },
   {
     type: "file",
     input: "apis/my-second-api.json",
-    navigationId: "my-second-api",
+    path: "my-second-api",
   },
 ] as const;
 ```
@@ -57,15 +57,13 @@ Modify your [Zudoku Configuration](../configuration/overview.md) file to include
 import type { ZudokuConfig } from "zudoku";
 
 const config: ZudokuConfig = {
-  topNavigation: [
+  navigation: [
     {
-      id: "overview",
+      type: "category",
       label: "Overview",
+      items: navigation,
     },
   ],
-  sidebar: {
-    overview: navigation,
-  },
   redirects: [{ from: "/", to: "/overview" }],
   apis,
   docs: {
@@ -78,7 +76,7 @@ export default config;
 
 Make sure that:
 
-1. The `navigationId` in each API config matches the `href` in the navigation
+1. The `path` in each API config matches the `href` in the navigation
 2. Your OpenAPI files are placed in the correct location as specified in the `input` field
 3. The `label` in navigation matches what you want to display in the sidebar
 

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -52,6 +52,7 @@ export const docs: SidebarEntry = [
       "guides/static-files",
       "guides/environment-variables",
       "guides/custom-pages",
+      "guides/navigation-migration",
       "guides/using-multiple-apis",
       "guides/managing-api-keys-and-identities",
       "guides/transforming-examples",

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -6,6 +6,7 @@ import DiscordIcon from "./src/DiscordIcon";
 import { DocusaurusDocsLicense } from "./src/DocusaurusDocsLicense";
 import GithubIcon from "./src/GithubIcon";
 import PreviewBanner from "./src/PreviewBanner";
+const ThemePlayground = lazy(() => import("./src/ThemeEditor.js"));
 
 const config: ZudokuConfig = {
   basePath: "/docs",
@@ -58,20 +59,22 @@ const config: ZudokuConfig = {
     { from: "/getting-started", to: "/app-quickstart" },
     { from: "/components", to: "/components/callout" },
   ],
-  topNavigation: [
-    { id: "docs", label: "Documentation" },
-    { id: "components", label: "Components" },
-    { id: "theme-playground", label: "Themes" },
-  ],
-  sidebar: {
-    docs,
-    components,
-  },
-  customPages: [
+  navigation: [
     {
-      path: "theme-playground",
-      render: lazy(() => import("./src/ThemeEditor.js")),
-      prose: false,
+      type: "category",
+      label: "Documentation",
+      items: docs,
+    },
+    {
+      type: "category",
+      label: "Components",
+      items: components,
+    },
+    {
+      type: "custom-page",
+      path: "/theme-playground",
+      label: "Themes",
+      element: <ThemePlayground />,
     },
   ],
   plugins: [
@@ -90,7 +93,7 @@ const config: ZudokuConfig = {
     {
       type: "file",
       input: "./schema/placeholder.json",
-      navigationId: "api-placeholder",
+      path: "/api-placeholder",
     },
   ],
   slots: {


### PR DESCRIPTION
## Summary
- document new `navigation` config
- update usage examples and plugin paths
- add migration guide
- update docs site config and sidebar
- improve migration guide with before/after examples and stepper

## Testing
- `npm run lint:ci` *(fails: ESLint couldn't find a config)*
- `npm run format` *(fails: Cannot find package 'prettier-plugin-organize-imports')*

------
https://chatgpt.com/codex/tasks/task_b_6847edcbca708331b04e76b47c9315ac