### PR TITLE
Fixed issue where Azure B2C was not seen as a valid authentication provider

### DIFF
--- a/docs/pages/configuration/authentication.md
+++ b/docs/pages/configuration/authentication.md
@@ -125,7 +125,8 @@ For Azure B2C authentication, you will need to provide your Azure B2C tenant nam
     clientId: "<your-azure-b2c-client-id>",
     tenantName: "<your-tenant-name>",
     policyName: "<your-policy-name>",
-    scopes: ["openid", "profile", "email", "custom_scope"] // Optional custom scopes
+    issuer: "<your-issuer-url>",
+    scopes: ["openid", "profile", "email", "custom_scope"]
   },
   // ...
 }

--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -317,6 +317,17 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignOut: z.string().optional(),
   }),
   z.object({
+    type: z.literal("azureb2c"),
+    clientId: z.string(),
+    tenantName: z.string(),
+    policyName: z.string(),
+    scopes: z.array(z.string()).optional(),
+    issuer: z.string(),
+    redirectToAfterSignUp: z.string().optional(),
+    redirectToAfterSignIn: z.string().optional(),
+    redirectToAfterSignOut: z.string().optional(),
+  }),
+  z.object({
     type: z.literal("auth0"),
     clientId: z.string(),
     domain: z.string().refine(

--- a/packages/zudoku/src/lib/auth/issuer.test.ts
+++ b/packages/zudoku/src/lib/auth/issuer.test.ts
@@ -69,6 +69,22 @@ describe("getIssuer", () => {
     expect(result).toBe("https://example.com/auth");
   });
 
+  it("should return azureb2c issuer for azureb2c authentication", async () => {
+    const config: ZudokuConfig = {
+      authentication: {
+        type: "azureb2c",
+        tenantName: "example",
+        policyName: "B2C_1_SignUpSignIn",
+        issuer: "https://example.b2clogin.com/example.onmicrosoft.com/v2.0/",
+        clientId: "test-client-id",
+      },
+    };
+    const result = await getIssuer(config);
+    expect(result).toBe(
+      "https://example.b2clogin.com/example.onmicrosoft.com/v2.0/",
+    );
+  });
+
   it("should return supabase URL for supabase authentication", async () => {
     const config: ZudokuConfig = {
       authentication: {

--- a/packages/zudoku/src/lib/auth/issuer.ts
+++ b/packages/zudoku/src/lib/auth/issuer.ts
@@ -28,6 +28,9 @@ export const getIssuer = async (config: ZudokuConfig) => {
     case "supabase": {
       return config.authentication.supabaseUrl;
     }
+    case "azureb2c": {
+      return config.authentication.issuer;
+    }
     case undefined: {
       return undefined;
     }


### PR DESCRIPTION
CLOSES: #1156

This pull request introduces support for Azure B2C authentication by updating the configuration documentation, adding validation for Azure B2C-specific fields, and implementing logic to handle Azure B2C issuers. Below is a summary of the most important changes:

### Azure B2C Authentication Support

* **Configuration Documentation Update**: Updated the Azure B2C authentication configuration example in `docs/pages/configuration/authentication.md` to include the `issuer` field, which specifies the Azure B2C issuer URL.

* **Validation Schema Update**: Added a new validation schema in `packages/zudoku/src/config/validators/validate.ts` for Azure B2C authentication, including fields like `clientId`, `tenantName`, `policyName`, `issuer`, and optional `scopes`.

* **Issuer Logic Implementation**: Modified the `getIssuer` function in `packages/zudoku/src/lib/auth/issuer.ts` to return the `issuer` field for Azure B2C authentication.

* **Unit Test Addition**: Added a test case in `packages/zudoku/src/lib/auth/issuer.test.ts` to verify that the `getIssuer` function correctly handles Azure B2C authentication and returns the expected issuer URL.