### PR TITLE
Update copy

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
@@ -47,7 +47,7 @@ export const SchemaView = ({
       <Card className="overflow-hidden">
         {cardHeader}
         <div className="text-sm text-muted-foreground italic p-4">
-          No schema specified
+          No data returned
         </div>
       </Card>
     );


### PR DESCRIPTION
Previously it said `No schema specified` which adresses the user of Zudoku rather than the end-user. 

In this case, if there is no schema specified, I think it would mean that no data is returned.