### PR TITLE
Show delete button when API key has expiration

### DIFF
--- a/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
@@ -473,7 +473,7 @@ const RevealApiKey = ({
         </div>
       </div>
       <div className="flex justify-end">
-        {isExpired && onDeleteKey && (
+        {expiresOn && onDeleteKey && (
           <Dialog>
             <DialogTrigger asChild>
               <Button variant="ghost" size="icon">


### PR DESCRIPTION
## Summary
- update API key settings plugin to show delete button for any key with an `expiresOn` date

## Testing
- `pnpm --filter zudoku test`

------
https://chatgpt.com/codex/tasks/task_b_6849a51ebe888331891e020e3ef1a9ab