### PR TITLE
Show label for API key roll button

### DIFF
--- a/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
@@ -296,17 +296,18 @@ export const SettingsApiKeys = ({ service }: { service: ApiKeyService }) => {
                       <Dialog>
                         <DialogTrigger asChild>
                           <Button
-                            size="icon"
                             title="Roll this key"
                             variant="ghost"
                             disabled={rollKeyMutation.isPending}
-                            className={
-                              rollKeyMutation.isPending
-                                ? "animate-spin"
-                                : undefined
-                            }
+                            className="flex items-center gap-1"
                           >
-                            <RotateCwIcon size={16} />
+                            <RotateCwIcon
+                              size={16}
+                              className={
+                                rollKeyMutation.isPending ? "animate-spin" : undefined
+                              }
+                            />
+                            Roll
                           </Button>
                         </DialogTrigger>
                         <DialogContent>


### PR DESCRIPTION
## Summary
- add a text label for the roll key button in the API Keys plugin

## Testing
- `npm run lint:ci` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_b_6849a572a6b48331ac0e501390dc4e4c