### PR TITLE
Fix OAuth callback route history

### DIFF
--- a/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
+++ b/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
@@ -34,5 +34,5 @@ export function CallbackHandler({
     },
   });
 
-  return <Navigate to={executeCallback.data} />;
+  return <Navigate to={executeCallback.data} replace />;
 }


### PR DESCRIPTION
## Summary
- avoid leaving `/oauth/callback` in browser history by using `Navigate` with `replace`

## Testing
- `pnpm --filter zudoku test`

------
https://chatgpt.com/codex/tasks/task_b_6849a5b7eb8c8331baa0b306bb664239