### PR TITLE
Fix last modified timestamp to use author date

### DIFF
--- a/packages/zudoku/src/vite/mdx/remark-last-modified.ts
+++ b/packages/zudoku/src/vite/mdx/remark-last-modified.ts
@@ -7,7 +7,7 @@ import { parse, stringify } from "yaml";
 
 const gitTime = (path: string) => {
   try {
-    const iso = execSync(`git log -1 --pretty=format:%cI -- "${path}"`, {
+    const iso = execSync(`git log -1 --pretty=format:%aI -- "${path}"`, {
       encoding: "utf8",
     }).trim();
     return iso ? new Date(iso) : undefined;


### PR DESCRIPTION
Changes `%cI` (committer date) to `%aI` (author date) in git log command.

Author date represents when the change was originally made, while committer date can change during rebases/cherry-picks, leading to incorrect timestamps.