### PR TITLE
Support OpenAPI v3.1 `$ref` with sibling properties

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/ParameterListItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/ParameterListItem.tsx
@@ -75,6 +75,12 @@ export const ParameterListItem = ({
           className="text-sm prose-p:my-1 prose-code:whitespace-pre-line"
         />
       )}
+      {paramSchema.description && (
+        <Markdown
+          content={paramSchema.description}
+          className="text-sm prose-p:my-1 prose-code:whitespace-pre-line"
+        />
+      )}
       {paramSchema.type === "array" && paramSchema.items.enum ? (
         <EnumValues values={paramSchema.items.enum} />
       ) : (

--- a/packages/zudoku/src/vite/api/SchemaManager.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.ts
@@ -99,7 +99,9 @@ export class SchemaManager {
     }
 
     const parser = new $RefParser();
-    const schema = await parser.bundle(filePath);
+    const schema = await parser.bundle(filePath, {
+      dereference: { preservedProperties: ["description", "summary"] },
+    });
 
     parser.$refs.paths().forEach((file) => this.trackedFiles.add(file));
 
@@ -110,7 +112,9 @@ export class SchemaManager {
           schema: await schema,
           file: filePath,
           dereference: (schema) =>
-            new $RefParser<OpenAPIDocument>().dereference(schema),
+            new $RefParser<OpenAPIDocument>().dereference(schema, {
+              dereference: { preservedProperties: ["description", "summary"] },
+            }),
         }),
       Promise.resolve(validatedSchema),
     );

--- a/packages/zudoku/src/vite/api/schema-codegen.test.ts
+++ b/packages/zudoku/src/vite/api/schema-codegen.test.ts
@@ -1,3 +1,4 @@
+import type { OpenAPIV3_1 } from "openapi-types";
 import { describe, expect, it } from "vitest";
 import { generateCode } from "./schema-codegen.js";
 
@@ -331,6 +332,94 @@ describe("Generate OpenAPI schema module", () => {
         operations: {},
         tags: {},
       };"
+    `);
+  });
+
+  it("should handle OpenAPI v3.1 refs alongside description and summary", async () => {
+    const input: OpenAPIV3_1.Document = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      components: {
+        schemas: {
+          Pet: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+            },
+          },
+        },
+      },
+      paths: {
+        "/pets": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/Pet",
+                      description: "A pet object with additional context",
+                      summary: "Pet response",
+                    },
+                  },
+                },
+              },
+              "201": {
+                description: "Created",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/Pet",
+                      description: "A newly created pet",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { schema } = await executeCode(await generateCode(input));
+    const responseSchema200 =
+      schema.paths["/pets"].get.responses["200"].content["application/json"]
+        .schema;
+    const responseSchema201 =
+      schema.paths["/pets"].get.responses["201"].content["application/json"]
+        .schema;
+
+    // First response should have both description and summary
+    expect(responseSchema200).toMatchInlineSnapshot(`
+      {
+        "__$ref": "#/components/schemas/Pet",
+        "description": "A pet object with additional context",
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+        },
+        "summary": "Pet response",
+        "type": "object",
+      }
+    `);
+
+    // Second response should have only description (different from first)
+    expect(responseSchema201).toMatchInlineSnapshot(`
+      {
+        "__$ref": "#/components/schemas/Pet",
+        "description": "A newly created pet",
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      }
     `);
   });
 });

--- a/packages/zudoku/src/vite/api/schema-codegen.ts
+++ b/packages/zudoku/src/vite/api/schema-codegen.ts
@@ -12,32 +12,73 @@ const getSegmentsFromPath = (path: string) =>
 // Find all $ref occurrences in the schema and assign them unique variable names
 const createLocalRefMap = (obj: RecordAny) => {
   const refMap = new Map<string, number>();
+  const siblingsMap = new Map<string, RecordAny>();
   let refCounter = 0;
+  let siblingCounter = 0;
 
   traverse(obj, (node) => {
     if (typeof node.$ref === "string" && node.$ref.startsWith("#/")) {
       if (!refMap.has(node.$ref)) {
         refMap.set(node.$ref, refCounter++);
       }
+
+      const { $ref, description, summary } = node;
+
+      if (description || summary) {
+        const siblings = { description, summary };
+        const uniqueKey = `${$ref}__${siblingCounter++}`;
+        siblingsMap.set(uniqueKey, { refPath: $ref, siblings });
+
+        // Replace the node's $ref with our unique key so we can track it
+        node.__uniqueRefKey = uniqueKey;
+      }
     }
     return node;
   });
 
-  return refMap;
+  return { refMap, siblingsMap };
 };
 
 // Replace all $ref occurrences with a special marker that will be transformed into a reference to the __refMap lookup
-const setRefMarkers = (obj: RecordAny, refMap: Map<string, number>) =>
+const setRefMarkers = (
+  obj: RecordAny,
+  refMap: Map<string, number>,
+  siblingsMap: Map<string, RecordAny>,
+) =>
   traverse<string | RecordAny>(obj, (node) => {
-    if (node.$ref && typeof node.$ref === "string" && refMap.has(node.$ref)) {
-      return `__refMap:${node.$ref}`;
+    const { $ref, __uniqueRefKey } = node;
+    if ($ref && typeof $ref === "string" && refMap.has($ref)) {
+      if (__uniqueRefKey && siblingsMap.has(__uniqueRefKey)) {
+        return `__refMap+Siblings:${__uniqueRefKey}`;
+      } else {
+        return `__refMap:${$ref}`;
+      }
     }
     return node;
   });
 
 // Replace the marker strings with actual __refMap lookups in the generated code
-const replaceRefMarkers = (code?: string) =>
-  code?.replace(/"__refMap:(.*?)"/g, '__refMap["$1"]');
+const replaceRefMarkers = (
+  code?: string,
+  siblingsMap?: Map<string, RecordAny>,
+) => {
+  if (!code) return code;
+
+  // Handle simple refs
+  code = code.replace(/"__refMap:(.*?)"/g, '__refMap["$1"]');
+
+  // Handle refs with siblings
+  code = code.replace(/"__refMap\+Siblings:(.*?)"/g, (_, uniqueKey) => {
+    const entry = siblingsMap?.get(uniqueKey);
+    // Fallback to the simple ref if no siblings are found
+    if (!entry) return `__refMap["${uniqueKey}"]`;
+
+    const { refPath, siblings } = entry;
+    return `Object.assign({}, __refMap["${refPath}"], ${JSON.stringify(siblings)}, { __$ref: __refMap["${refPath}"].__$ref })`;
+  });
+
+  return code;
+};
 
 const lookup = (
   schema: RecordAny,
@@ -75,7 +116,7 @@ const lookup = (
  * This ensures object identity throughout the circular references.
  */
 export const generateCode = async (schema: RecordAny, filePath?: string) => {
-  const refMap = createLocalRefMap(schema);
+  const { refMap, siblingsMap } = createLocalRefMap(schema);
   const lines: string[] = [];
 
   const str = (obj: unknown, indent = 2) => JSON.stringify(obj, null, indent);
@@ -104,21 +145,25 @@ export const generateCode = async (schema: RecordAny, filePath?: string) => {
       continue;
     }
 
-    const transformedValue = setRefMarkers(value, refMap);
+    const transformedValue = setRefMarkers(value, refMap, siblingsMap);
 
     lines.push(
       // Use assign so that the object identity is maintained and correctly resolves circular references
-      `Object.assign(__refs[${index}], ${replaceRefMarkers(str(transformedValue))});`,
+      `Object.assign(__refs[${index}], ${replaceRefMarkers(str(transformedValue), siblingsMap)});`,
       `Object.defineProperty(__refs[${index}], "__$ref", { value: __refMapPaths[${index}], enumerable: false });`,
     );
   }
 
-  const transformed = setRefMarkers(schema, refMap);
-  lines.push(`export const schema = ${replaceRefMarkers(str(transformed))};`);
+  const transformed = setRefMarkers(schema, refMap, siblingsMap);
+  lines.push(
+    `export const schema = ${replaceRefMarkers(str(transformed), siblingsMap)};`,
+  );
 
   // slugify is quite expensive for big schemas, so we pre-generate the slugs here to shave off time
-  const dereferencedSchema =
-    await $RefParser.dereference<OpenAPIDocument>(schema);
+  const dereferencedSchema = await $RefParser.dereference<OpenAPIDocument>(
+    schema,
+    { dereference: { preservedProperties: ["description", "summary"] } },
+  );
   const slugs = getAllSlugs(
     getAllOperations(dereferencedSchema.paths),
     dereferencedSchema.tags,


### PR DESCRIPTION
Fixes #1217

Implements OpenAPI v3.1 support for sibling properties alongside `$ref`.

## Problem

In OpenAPI v3.1, `$ref` can coexist with `description` and `summary`:

```yaml
schema:
  $ref: "#/components/schemas/Pet"
  description: "A pet with additional context"
```

Previously, multiple `$ref`s to the same schema with different descriptions would overwrite each other.

## Solution

- Use unique keys for each `$ref` occurrence with siblings
- Merge referenced schema with sibling properties using `Object.assign()`
- Preserve original `__$ref` information

**Spec:** [OpenAPI v3.1.0 - Reference Object](https://spec.openapis.org/oas/v3.1.0#reference-object)