### PR TITLE
Fix basic schema type check

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
@@ -4,8 +4,9 @@ import type { SchemaObject } from "../../../oas/parser/index.js";
 export const isBasicType = (
   type: unknown,
 ): type is "string" | "number" | "boolean" | "integer" | "null" =>
-  typeof type === "string" &&
-  ["string", "number", "boolean", "integer", "null"].includes(type);
+  (typeof type === "string" &&
+    ["string", "number", "boolean", "integer", "null"].includes(type)) ||
+  (Array.isArray(type) && type.every(isBasicType));
 
 export const isArrayType = (value: SchemaObject) =>
   value.type === "array" ||


### PR DESCRIPTION
Fixes #1203

This schema:

```json
{ "type": "string", "nullable": true }
```

gets upgraded to:

```json
{ "type": ["string", "nullable"] }
```

Therefore we also need to check for array values in the `isBasicType` function to ensure that the schema object is correctly identified as a basic type.