### PR TITLE
Don't line clamp schema params

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaPropertyItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaPropertyItem.tsx
@@ -116,7 +116,7 @@ export const SchemaPropertyItem = ({
         </div>
         {schema.description && (
           <Markdown
-            className="text-sm leading-normal line-clamp-4"
+            className="text-sm leading-normal"
             content={schema.description}
           />
         )}


### PR DESCRIPTION
Fixes #1200

We don't do this anywhere else, to improve on that we should make it collapsible/expandable but for now we should show the full text