### PR TITLE
Add metadescriptions

### DIFF
--- a/docs/pages/configuration/api-reference.md
+++ b/docs/pages/configuration/api-reference.md
@@ -1,6 +1,7 @@
 ---
 title: API Reference
 sidebar_icon: square-library
+description: Learn how to configure the `apis` setting in Zudoku to generate API reference documentation from OpenAPI files, including file and URL references, versioning, customization options, and OpenAPI extensions.
 ---
 
 The `apis` configuration setting in the [Zudoku Configuration](./overview.md) file allows you to specify the OpenAPI document that you want to use to generate your API reference documentation.

--- a/docs/pages/configuration/footer.mdx
+++ b/docs/pages/configuration/footer.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Footer
 sidebar_icon: panel-bottom-dashed
+description: Learn how to configure the footer in Zudoku, including columns, social links, copyright notice, and logo. Customize the footer's position and content with slots.
 ---
 
 # Footer Configuration

--- a/docs/pages/configuration/navigation.mdx
+++ b/docs/pages/configuration/navigation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Navigation
 sidebar_icon: compass
+description: Learn how to configure the navigation in Zudoku, including links, categories, documents, and custom pages. Understand the structure of the navigation array and how to use icons, labels, and paths.
 ---
 
 import { Book, Code, FileText } from "zudoku/icons";

--- a/docs/pages/configuration/overview.md
+++ b/docs/pages/configuration/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Configuration File
 sidebar_icon: file-json-2
+description: Learn how to configure your Zudoku documentation site using the configuration file. Covers file formats, options, examples, and best practices.
 ---
 
 Zudoku uses a single file for configuration. It controls the structure, metadata, style, plugins, and routing for your documentation.

--- a/docs/pages/configuration/search.md
+++ b/docs/pages/configuration/search.md
@@ -1,6 +1,7 @@
 ---
 title: Search
 sidebar_icon: search-code
+description: Learn how to configure and customize search functionality in Zudoku, including setup instructions for Pagefind and Inkeep providers, result transformation, and ranking options.
 ---
 
 Zudoku offers search functionality that enhances user experience by enabling content discovery across your site. When configured, a search bar will appear in the header, allowing users to quickly find relevant information on any page.

--- a/docs/pages/configuration/site.md
+++ b/docs/pages/configuration/site.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Branding & Layout
 sidebar_icon: layout-dashboard
+description: Customize your Zudoku site's branding, logo, banner, and layout options with detailed configuration examples and guidance.
 ---
 
 # Branding & Layout

--- a/docs/pages/customization/colors-theme.mdx
+++ b/docs/pages/customization/colors-theme.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_icon: paintbrush
 title: Colors & Theme
+description: Customize your Zudoku site's colors and theme with flexible options, including light/dark modes, custom CSS, and shadcn registry integration.
 ---
 
 Zudoku provides flexible theming options allowing you to customize colors, import themes from [shadcn registries](https://ui.shadcn.com/docs/registry), and add custom CSS. You can create cohesive light and dark mode experiences that match your brand.

--- a/docs/pages/customization/fonts.md
+++ b/docs/pages/customization/fonts.md
@@ -2,6 +2,7 @@
 sidebar_icon: baseline
 title: Font & Typography
 sidebar_label: Font & Typography
+description: Learn how to customize fonts and typography in Zudoku using predefined Google Fonts, custom font URLs, or local fonts for sans, serif, and monospace text.
 ---
 
 Zudoku allows you to customize fonts for text (`sans`), serif content (`serif`), and code (`mono`). You can use predefined Google Fonts, external sources, or local fonts.

--- a/docs/pages/guides/static-files.md
+++ b/docs/pages/guides/static-files.md
@@ -1,6 +1,7 @@
 ---
 title: Static Files
 sidebar_icon: folder-open
+description: Learn how to serve and reference static files like images and PDFs in your Zudoku documentation using the public directory.
 ---
 
 Zudoku makes it easy to serve static files like images, PDFs, or any other assets alongside your documentation. Any files placed in the `public` directory will be served at the root path `/` during dev, and copied to the root of the dist directory as-is.

--- a/docs/pages/markdown/admonitions.md
+++ b/docs/pages/markdown/admonitions.md
@@ -1,6 +1,7 @@
 ---
 title: Admonitions
 sidebar_icon: rectangle-horizontal
+description: Learn how to use admonitions (callouts) in Markdown, including syntax, types, titles, and formatting tips for compatibility with Prettier.
 ---
 
 In addition to the basic Markdown syntax, we have a special admonitions syntax by wrapping text with a set of 3 colons, followed by a label denoting its type.

--- a/docs/pages/markdown/code-blocks.md
+++ b/docs/pages/markdown/code-blocks.md
@@ -1,6 +1,7 @@
 ---
 title: Code Blocks
 sidebar_icon: braces
+description: Learn how to use code blocks, syntax highlighting, and advanced features like line highlighting and ANSI output in Zudoku Markdown with Shiki.
 ---
 
 Zudoku supports code blocks in Markdown using the [Shiki](https://shiki.style/) syntax highlighting library.

--- a/docs/pages/markdown/frontmatter.md
+++ b/docs/pages/markdown/frontmatter.md
@@ -1,6 +1,7 @@
 ---
 sidebar_icon: scissors-line-dashed
 title: Frontmatter
+description: Learn how to use YAML frontmatter in Zudoku markdown files to customize page titles, descriptions, navigation, and other document properties.
 ---
 
 Frontmatter is metadata written in [YAML](https://yaml.org/) format at the beginning of markdown files, enclosed between triple dashes (`---`). It allows you to configure various aspects of your pages without affecting the visible content.

--- a/docs/pages/markdown/mdx.md
+++ b/docs/pages/markdown/mdx.md
@@ -1,6 +1,7 @@
 ---
 title: MDX
 sidebar_icon: notebook-pen
+description: Learn how to use MDX in Zudoku to create rich documentation pages with markdown and custom React components.
 ---
 
 Zudoku supports MDX files for creating rich content pages. MDX is a markdown format that allows you to include JSX components in your markdown files.

--- a/docs/pages/markdown/overview.md
+++ b/docs/pages/markdown/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Markdown
 navigation_icon: align-left
+description: Comprehensive guide to using Markdown and MDX in Zudoku, including formatting, frontmatter, syntax highlighting, tables, lists, task lists, collapsible sections, and advanced documentation features.
 ---
 
 Zudoku supports [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) (GFM) with additional features for creating rich documentation.

--- a/docs/pages/writing.mdx
+++ b/docs/pages/writing.mdx
@@ -1,6 +1,7 @@
 ---
 title: Writing
 sidebar_icon: book-open-text
+description: A guide to writing documentation in Zudoku using Markdown and MDX.
 ---
 
 Get started with creating rich documentation in Zudoku using Markdown and MDX. This guide covers the essentials to help you begin documenting your project.


### PR DESCRIPTION
Adding metadescriptions for the pages we port over to Zuplo docs - the `excerpt` approach doesn't work because it pulls in the content of the admonition we apply to all of the pages