### PR TITLE
Fix link

### DIFF
--- a/docs/pages/configuration/navigation.mdx
+++ b/docs/pages/configuration/navigation.mdx
@@ -184,7 +184,7 @@ Documents can be referenced as strings (using their file path), which is equival
 
 This is much more concise when you don't need custom labels, icons, or other properties for individual documents.
 
-Learn more in the [Markdown documentation](/docs/markdown/overview)
+Learn more in the [Markdown documentation](/markdown/overview)
 
 #### Custom paths
 


### PR DESCRIPTION
## Summary

This link breaks when it gets ported into Zuplo docs because of the way we map paths. I will fix that mapping function later, for now I am making this URL consistent with how we reference other pages.