### PR TITLE
Fix Tailwind support in `customCss`

### DIFF
--- a/docs/pages/customization/colors-theme.mdx
+++ b/docs/pages/customization/colors-theme.mdx
@@ -167,6 +167,12 @@ const config = {
 
 For advanced styling, you can add custom CSS either as a string or structured object:
 
+:::note
+
+Changes to `customCss` require restarting the development server to take effect.
+
+:::
+
 ### CSS String
 
 ```tsx title=zudoku.config.ts

--- a/packages/zudoku/src/vite/plugin-theme.ts
+++ b/packages/zudoku/src/vite/plugin-theme.ts
@@ -150,14 +150,6 @@ export const viteThemePlugin = (): Plugin => {
           .map((font) => `@import url('${font.url}');`),
       );
 
-      if (themeConfig.customCss) {
-        if (typeof themeConfig.customCss === "string") {
-          themeCss.push(themeConfig.customCss);
-        } else {
-          themeCss.push(processRegistryCustomCss(themeConfig.customCss));
-        }
-      }
-
       if (themeConfig.registryUrl) {
         try {
           const registryItem = await fetchShadcnRegistryItem(
@@ -323,6 +315,15 @@ export const viteThemePlugin = (): Plugin => {
       );
 
       code.push("}");
+
+      const customCss = config.theme?.customCss;
+      if (customCss) {
+        if (typeof customCss === "string") {
+          code.push(customCss);
+        } else {
+          code.push(processRegistryCustomCss(customCss));
+        }
+      }
 
       const defaultThemeImport = config.theme?.noDefaultTheme
         ? ""


### PR DESCRIPTION
It only supported basic CSS that's not picked up by Tailwind anymore, this is fixed now but requires a dev server restart.