### PR TITLE
Fix the Supabase plugin

### DIFF
--- a/packages/zudoku/vite.config.ts
+++ b/packages/zudoku/vite.config.ts
@@ -11,6 +11,7 @@ const entries: Record<string, string> = {
   "auth-auth0": "./src/lib/authentication/providers/auth0.tsx",
   "auth-openid": "./src/lib/authentication/providers/openid.tsx",
   "auth-azureb2c": "./src/lib/authentication/providers/azureb2c.tsx",
+  "auth-supabase": "./src/lib/authentication/providers/supabase.tsx",
   plugins: "./src/lib/core/plugins.ts",
   hooks: "./src/lib/hooks/index.ts",
   "plugin-api-keys": "./src/lib/plugins/api-keys/index.tsx",
@@ -59,6 +60,8 @@ export default defineConfig({
         // want to bundle these in the library. Users will install these
         // themselves and they will be bundled in their app
         ...Object.keys(pkgJson?.["optionalDependencies"] ?? {}),
+        // Peer dependencies should also be external
+        ...Object.keys(pkgJson?.["peerDependencies"] ?? {}),
       ],
       plugins: [visualizer()],
       onwarn(warning, warn) {


### PR DESCRIPTION
I am not sure if this is the right fix but the following changes seem to get the Supabase plugin to work:

 * Add the supabase plugin to the vite.config.ts, like the other plugins
 * Make sure the supabase dependency (a peer dependency) is considered external and not bundled, which would cause: `ReferenceError: require is not defined in ES module scope, you can use import instead`.