### PR TITLE
Fix path param order if order in schema is different

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -2757,14 +2757,15 @@
         "operationId": "getRouteEstimate",
         "parameters": [
           {
-            "name": "originFacilityId",
+            "name": "serviceLevel",
             "in": "path",
             "required": true,
             "schema": {
+              "default": "STANDARD",
               "type": "string",
-              "example": "LAX1"
+              "enum": ["ECONOMY", "STANDARD", "EXPRESS", "SAME_DAY"]
             },
-            "description": "ID of the origin facility"
+            "description": "Service level for the route"
           },
           {
             "name": "destinationFacilityId",
@@ -2777,15 +2778,14 @@
             "description": "ID of the destination facility"
           },
           {
-            "name": "serviceLevel",
+            "name": "originFacilityId",
             "in": "path",
             "required": true,
             "schema": {
-              "default": "STANDARD",
               "type": "string",
-              "enum": ["ECONOMY", "STANDARD", "EXPRESS", "SAME_DAY"]
+              "example": "LAX1"
             },
-            "description": "Service level for the route"
+            "description": "ID of the origin facility"
           }
         ],
         "responses": {

--- a/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/PathParams.tsx
@@ -39,7 +39,7 @@ export const PathParams = ({
               )}
             />
 
-            <div className="flex justify-between items-center">
+            <div className="flex justify-between items-center col-span-2">
               <Controller
                 control={control}
                 name={`pathParams.${i}.value`}

--- a/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
@@ -154,6 +154,12 @@ export const Playground = ({
     formRef.current?.requestSubmit();
   });
 
+  const pathParamOrder =
+    url.match(/\{([^}]+)\}/g)?.map((match) => match.slice(1, -1)) ?? [];
+  const sortedPathParams = [...pathParams].sort(
+    (a, b) => pathParamOrder.indexOf(a.name) - pathParamOrder.indexOf(b.name),
+  );
+
   const { register, control, handleSubmit, watch, setValue, ...form } =
     useForm<PlaygroundForm>({
       defaultValues: {
@@ -174,7 +180,7 @@ export const Playground = ({
                   enum: [],
                 },
               ],
-        pathParams: pathParams.map((param) => ({
+        pathParams: sortedPathParams.map((param) => ({
           name: param.name,
           value: param.defaultValue ?? "",
         })),
@@ -472,7 +478,7 @@ export const Playground = ({
                 </Collapsible>
               )}
 
-              {pathParams.length > 0 && (
+              {sortedPathParams.length > 0 && (
                 <Collapsible defaultOpen>
                   <CollapsibleHeaderTrigger>
                     <ShapesIcon size={16} />


### PR DESCRIPTION
If the order of the parameters in the **path** does not match the order of the **parameters** it would mess up the order in the final URL. This is fixed in here