### PR TITLE
Update GTM docs & fix button

### DIFF
--- a/docs/pages/custom-plugins.md
+++ b/docs/pages/custom-plugins.md
@@ -102,6 +102,38 @@ const commonPlugin: ZudokuPlugin = {
 };
 ```
 
+#### Tracking `page_view` Events
+
+Zudoku is a single page application so typical `page_view` events are not captured by most analytics scripts or tag managers. Instead, you must listen to the `location` [event](./extending/events.md) with a plugin and log navigation changes in code.
+
+```tsx
+import { ZudokuPlugin, ZudokuEvents } from "zudoku";
+
+const navigationLoggerPlugin: ZudokuPlugin = {
+  events: {
+    location: ({ from, to }) => {
+      if (!from) return;
+      window.dataLayer.push({
+        event: "page_view",
+        page_path: to.pathname,
+        page_title: document.title,
+        page_location: window.location.href,
+      });
+    },
+  },
+};
+```
+
+If you are using TypeScript, you will also need to add the following type declaration to the file this plugin is declared
+
+```ts
+declare global {
+  interface Window {
+    dataLayer: Record<string, any>[];
+  }
+}
+```
+
 ### Navigation Plugin
 
 ```tsx

--- a/packages/zudoku/src/lib/ui/ActionButton.tsx
+++ b/packages/zudoku/src/lib/ui/ActionButton.tsx
@@ -19,7 +19,9 @@ export const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(
             <Spinner />
           </div>
         )}
-        <span className={cn("block", isPending && "invisible")}>{children}</span>
+        <span className={cn("block", isPending && "invisible")}>
+          {children}
+        </span>
       </Button>
     );
   },

--- a/packages/zudoku/src/lib/ui/ActionButton.tsx
+++ b/packages/zudoku/src/lib/ui/ActionButton.tsx
@@ -19,7 +19,7 @@ export const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(
             <Spinner />
           </div>
         )}
-        <div className={cn(isPending && "invisible")}>{children}</div>
+        {isPending ? <div className="invisible">{children}</div> : children}
       </Button>
     );
   },

--- a/packages/zudoku/src/lib/ui/ActionButton.tsx
+++ b/packages/zudoku/src/lib/ui/ActionButton.tsx
@@ -19,7 +19,7 @@ export const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(
             <Spinner />
           </div>
         )}
-        {isPending ? <div className="invisible">{children}</div> : children}
+        <span className={cn("block", isPending && "invisible")}>{children}</span>
       </Button>
     );
   },


### PR DESCRIPTION
## Summary

Addressing 2 things from working with Accuweather

1. Their Google Tag Manager was not capturing any page navigations which hampered their ability to understand user behavior. This is because of React Router, so i added docs on how to write an easy plugin to log to GTM when page changes
2. We nested a div inside of a button, which I recall is generally not advisable. Maybe a `span` is better but I figure having a div when the button is disabled and content is invisible can't hurt