### PR TITLE
Allow additional inkeep properties on config object

### DIFF
--- a/packages/zudoku/src/config/validators/validate.ts
+++ b/packages/zudoku/src/config/validators/validate.ts
@@ -251,7 +251,9 @@ const Redirect = z.object({
 
 const SearchSchema = z
   .discriminatedUnion("type", [
-    z.object({
+    // looseObject to allow additional properties so the
+    // user can set other inkeep settings
+    z.looseObject({
       type: z.literal("inkeep"),
       apiKey: z.string(),
       integrationId: z.string(),


### PR DESCRIPTION
Allows setting additional properties that are sent directly to inkeep. This works today, but you get the red underline because the type doesnt currently allow additional props.

<img width="1142" height="698" alt="CleanShot 2025-07-15 at 13 43 52@2x" src="https://github.com/user-attachments/assets/0083a66f-9456-46b3-baa0-62614588ff17" />
