### PR TITLE
Allow callback for `display` for granular auth control

### DIFF
--- a/examples/cosmo-cargo/pages/member-benefits.mdx
+++ b/examples/cosmo-cargo/pages/member-benefits.mdx
@@ -1,0 +1,58 @@
+---
+title: "Member Benefits"
+description: "Exclusive benefits for Cosmo Cargo members"
+---
+
+Thank you for being a valued Cosmo Cargo member! Here are your exclusive benefits.
+
+## Membership Tiers
+
+### Bronze Membership
+
+- 10% discount on all shipments
+- Priority customer support
+- Extended tracking history
+- Free packaging materials
+
+### Silver Membership
+
+- 20% discount on all shipments
+- Premium customer support
+- Advanced tracking features
+- Free insurance up to 1M credits
+- Access to express lanes
+
+### Gold Membership
+
+- 30% discount on all shipments
+- Dedicated account manager
+- Real-time cargo monitoring
+- Free insurance up to 5M credits
+- Priority boarding for personal travel
+- Access to VIP lounges at spaceports
+
+## Exclusive Services
+
+### Member-Only Routes
+
+- Direct express routes to popular destinations
+- Bypass standard shipping queues
+- Access to premium cargo holds
+
+### Special Offers
+
+- Monthly flash sales (up to 50% off)
+- Early access to new shipping routes
+- Exclusive member events and tours
+
+### Loyalty Rewards
+
+- Earn points for every shipment
+- Redeem points for free shipping
+- Bonus points for referrals
+
+## How to Upgrade
+
+Ready to unlock more benefits? Contact your account manager or visit our membership portal to upgrade your tier.
+
+> **Pro Tip**: Gold members save an average of 2,000 credits per month on shipping costs!

--- a/examples/cosmo-cargo/pages/premium-fleet.mdx
+++ b/examples/cosmo-cargo/pages/premium-fleet.mdx
@@ -1,0 +1,50 @@
+---
+title: "Premium Fleet Services"
+description: "Exclusive access to our premium interstellar fleet"
+---
+
+Welcome to Cosmo Cargo's exclusive premium fleet services! This content is only available to authenticated members.
+
+## Fleet Overview
+
+Our premium fleet consists of the most advanced spacecraft in the galaxy:
+
+### Quantum Class Vessels
+
+- **Quantum Cruiser MK-VII**: Ultra-fast delivery for time-sensitive cargo
+- **Quantum Hauler XL**: Massive capacity for bulk shipments
+- **Quantum Express**: Same-day delivery within solar systems
+
+### Warp Drive Technology
+
+Our premium fleet is equipped with the latest warp drive technology, allowing for:
+
+- 50% faster delivery times
+- Enhanced cargo protection
+- Real-time tracking across dimensions
+
+## Premium Services
+
+### Priority Routing
+
+- Skip standard shipping queues
+- Direct routes to destination systems
+- Dedicated customer support
+
+### Enhanced Security
+
+- Military-grade cargo protection
+- Encrypted tracking systems
+- Insurance coverage up to 10 million credits
+
+### VIP Treatment
+
+- Personal shipping consultant
+- Custom packaging options
+- White-glove delivery service
+
+## Booking Premium Services
+
+To book our premium fleet services, contact your dedicated account manager or use our VIP booking portal.
+
+> **Note**: Premium fleet services are exclusively available to authenticated members with active subscriptions.

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -129,6 +129,26 @@ const config: ZudokuConfig = {
           label: "Shipping Guides",
           items: ["interstellar", "intergalactic"],
         },
+        {
+          type: "category",
+          icon: "shield",
+          label: "Premium Guides",
+          display: "auth",
+          items: [
+            {
+              type: "doc",
+              file: "member-benefits",
+              label: "Member Benefits",
+              icon: "user-plus",
+            },
+            {
+              type: "doc",
+              file: "premium-fleet",
+              label: "Premium Fleet Services",
+              icon: "trophy",
+            },
+          ],
+        },
       ],
     },
     {

--- a/packages/zudoku/src/config/validators/InputNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.ts
@@ -1,4 +1,6 @@
 import { z } from "zod/v4";
+import type { UseAuthReturn } from "../../lib/authentication/hook.js";
+import type { ZudokuContext } from "../../lib/core/ZudokuContext.js";
 import { IconNames } from "./icon-types.js";
 
 const IconSchema = z.enum(IconNames);
@@ -19,7 +21,12 @@ const InputNavigationCategoryLinkDocSchema = z.union([
 ]);
 
 export const DisplaySchema = z
-  .enum(["auth", "anon", "always", "hide"])
+  .union([
+    z.enum(["auth", "anon", "always", "hide"]),
+    z.custom<
+      (params: { context: ZudokuContext; auth: UseAuthReturn }) => boolean
+    >((val) => typeof val === "function"),
+  ])
   .default("always")
   .optional();
 

--- a/packages/zudoku/src/config/validators/ProtectedRoutesSchema.ts
+++ b/packages/zudoku/src/config/validators/ProtectedRoutesSchema.ts
@@ -1,8 +1,8 @@
 import { z } from "zod/v4";
-import type { AuthState } from "../../lib/authentication/state.js";
+import type { UseAuthReturn } from "../../lib/authentication/hook.js";
 import type { ZudokuContext } from "../../lib/core/ZudokuContext.js";
 
-type CallbackContext = { auth: AuthState; context: ZudokuContext };
+type CallbackContext = { auth: UseAuthReturn; context: ZudokuContext };
 type ProtectedRouteCallback = (c: CallbackContext) => boolean;
 export type ProtectedRoutesInput = z.input<typeof ProtectedRoutesSchema>;
 export type ProtectedRoutes = z.output<typeof ProtectedRoutesSchema>;

--- a/packages/zudoku/src/lib/authentication/hook.ts
+++ b/packages/zudoku/src/lib/authentication/hook.ts
@@ -1,6 +1,8 @@
 import { useZudoku } from "../components/context/ZudokuContext.js";
 import { useAuthState } from "./state.js";
 
+export type UseAuthReturn = ReturnType<typeof useAuth>;
+
 export const useAuth = () => {
   const { authentication } = useZudoku();
   const authState = useAuthState();

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -20,12 +20,15 @@ import { ThemeSwitch } from "./ThemeSwitch.js";
 import { TopNavItem, TopNavLink } from "./TopNavigation.js";
 
 export const MobileTopNavigation = () => {
-  const { navigation, options, getProfileMenuItems } = useZudoku();
-  const { isAuthenticated, profile, isAuthEnabled, login } = useAuth();
+  const context = useZudoku();
+  const authState = useAuth();
+
+  const { navigation, options, getProfileMenuItems } = context;
+  const { isAuthenticated, profile, isAuthEnabled } = authState;
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const accountItems = getProfileMenuItems();
-  const filteredItems = navigation.filter(isHiddenItem(isAuthenticated));
+  const filteredItems = navigation.filter(isHiddenItem(authState, context));
 
   return (
     <Drawer

--- a/packages/zudoku/src/lib/components/TopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/TopNavigation.tsx
@@ -10,10 +10,10 @@ import { isHiddenItem, traverseNavigationItem } from "./navigation/utils.js";
 import { Slot } from "./Slot.js";
 
 export const TopNavigation = () => {
-  const { navigation } = useZudoku();
-  const { isAuthenticated } = useAuth();
-
-  const filteredItems = navigation.filter(isHiddenItem(isAuthenticated));
+  const context = useZudoku();
+  const { navigation } = context;
+  const auth = useAuth();
+  const filteredItems = navigation.filter(isHiddenItem(auth, context));
 
   if (filteredItems.length === 0 || import.meta.env.MODE === "standalone") {
     return <style>{`:root { --top-nav-height: 0px; }`}</style>;

--- a/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
@@ -9,13 +9,15 @@ import {
   TooltipTrigger,
 } from "zudoku/ui/Tooltip.js";
 import type { NavigationItem as NavigationItemType } from "../../../config/validators/NavigationSchema.js";
+import { useAuth } from "../../authentication/hook.js";
 import { cn } from "../../util/cn.js";
 import { joinUrl } from "../../util/joinUrl.js";
 import { AnchorLink } from "../AnchorLink.js";
 import { useViewportAnchor } from "../context/ViewportAnchorContext.js";
+import { useZudoku } from "../context/ZudokuContext.js";
 import { NavigationBadge } from "./NavigationBadge.js";
 import { NavigationCategory } from "./NavigationCategory.js";
-import { navigationListItem } from "./utils.js";
+import { isHiddenItem, navigationListItem } from "./utils.js";
 
 const TruncatedLabel = ({
   label,
@@ -74,6 +76,12 @@ export const NavigationItem = ({
 }) => {
   const location = useLocation();
   const { activeAnchor } = useViewportAnchor();
+  const auth = useAuth();
+  const context = useZudoku();
+
+  if (!isHiddenItem(auth, context)(item)) {
+    return null;
+  }
 
   switch (item.type) {
     case "category":

--- a/packages/zudoku/src/lib/components/navigation/utils.ts
+++ b/packages/zudoku/src/lib/components/navigation/utils.ts
@@ -4,6 +4,8 @@ import type {
   NavigationCategory,
   NavigationItem,
 } from "../../../config/validators/NavigationSchema.js";
+import type { UseAuthReturn } from "../../authentication/hook.js";
+import type { ZudokuContext } from "../../core/ZudokuContext.js";
 import { joinUrl } from "../../util/joinUrl.js";
 import { useCurrentNavigation } from "../context/ZudokuContext.js";
 
@@ -133,14 +135,18 @@ export const navigationListItem = cva(
 );
 
 export const isHiddenItem =
-  (isAuthenticated?: boolean) =>
+  (auth: UseAuthReturn, context: ZudokuContext) =>
   (item: NavigationItem): boolean => {
+    if (typeof item.display === "function") {
+      return item.display({ context, auth });
+    }
+
     if (item.display === "hide") return false;
     if (!item.label) return false;
 
     return (
-      (item.display === "auth" && isAuthenticated) ||
-      (item.display === "anon" && !isAuthenticated) ||
+      (item.display === "auth" && auth.isAuthenticated) ||
+      (item.display === "anon" && !auth.isAuthenticated) ||
       !item.display ||
       item.display === "always"
     );


### PR DESCRIPTION
- Allow `display` to pass in a callback for more granular auth control
- Fix so that every navigation item checks the `display` config option