### PR TITLE
Pass environment type to `BuildCheck`

### DIFF
--- a/packages/zudoku/src/lib/components/BuildCheck.tsx
+++ b/packages/zudoku/src/lib/components/BuildCheck.tsx
@@ -11,17 +11,17 @@ const BuildStatusSchema = z.object({
 
 export const BuildCheck = ({
   buildId,
+  environmentType,
   endpoint = "/__zuplo/docs",
 }: {
   buildId?: string;
+  environmentType?: string;
   endpoint?: string;
 }) => {
   const buildStatusQuery = useQuery({
     queryKey: ["zuplo-build-check", buildId, endpoint],
     refetchInterval: 3000,
-    enabled:
-      typeof buildId !== "undefined" &&
-      import.meta.env.ZUPLO_ENVIRONMENT_TYPE === "WORKING_COPY",
+    enabled: buildId !== undefined && environmentType === "WORKING_COPY",
     retry: false,
     queryFn: () =>
       fetch(endpoint, { signal: AbortSignal.timeout(2000) })

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -112,6 +112,14 @@ export async function getViteConfig(
     ).map((theme) => `@shikijs/themes/${theme}`),
   ].map((dep) => `zudoku > ${dep}`);
 
+  // We define public env vars as `process.env` vars because Vite only exposes them as `import.meta.env` vars
+  const publicVarsProcessEnvDefine = Object.fromEntries(
+    Object.entries(publicEnv).map(([key, value]) => [
+      `process.env.${key}`,
+      value,
+    ]),
+  );
+
   const viteConfig: InlineConfig = {
     root: dir,
     base,
@@ -137,7 +145,7 @@ export async function getViteConfig(
         "ZUPLO_ENVIRONMENT_TYPE",
         "ZUPLO_SERVER_URL",
       ]),
-      ...publicEnv,
+      ...publicVarsProcessEnvDefine,
     },
     ssr: {
       target: "node",

--- a/packages/zudoku/src/vite/plugin-config.ts
+++ b/packages/zudoku/src/vite/plugin-config.ts
@@ -1,4 +1,4 @@
-import { type Plugin, type ResolvedConfig } from "vite";
+import type { Plugin, ResolvedConfig } from "vite";
 import { getCurrentConfig } from "../config/loader.js";
 
 const viteConfigPlugin = (): Plugin => {
@@ -35,7 +35,10 @@ const viteConfigPlugin = (): Plugin => {
             return "undefined";
           }
 
-          const value = viteConfig.define?.[envVar];
+          const value =
+            viteConfig.define?.[`process.env.${envVar}`] ??
+            viteConfig.define?.[`import.meta.env.${envVar}`];
+
           if (value === undefined) {
             viteConfig.logger.warn(
               `Warning: process.env.${envVar} is not defined.`,


### PR DESCRIPTION
Because the `BuildCheck` component gets precompiled it will never see the environment variable (as it probably gets compiled away). The `main.tsx` only gets built when building the actually bundle so we should pass it in from there.

I've also fixed a bug where we didn't create `process.env` replacements correctly