### PR TITLE
Fix `display` config in top navigation

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -253,6 +253,7 @@
     "hast-util-to-string": "3.0.1",
     "html-url-attributes": "^3.0.1",
     "http-terminator": "3.2.0",
+    "javascript-stringify": "2.1.0",
     "json-schema-to-typescript-lite": "14.1.0",
     "loglevel": "1.9.2",
     "lru-cache": "11.1.0",

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -12,7 +12,7 @@ import {
 import { ClientOnly } from "./ClientOnly.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 import { PoweredByZudoku } from "./navigation/PoweredByZudoku.js";
-import { isHiddenItem } from "./navigation/utils.js";
+import { shouldShowItem } from "./navigation/utils.js";
 import { PageProgress } from "./PageProgress.js";
 import { Search } from "./Search.js";
 import { Slot } from "./Slot.js";
@@ -28,7 +28,7 @@ export const MobileTopNavigation = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const accountItems = getProfileMenuItems();
-  const filteredItems = navigation.filter(isHiddenItem(authState, context));
+  const filteredItems = navigation.filter(shouldShowItem(authState, context));
 
   return (
     <Drawer

--- a/packages/zudoku/src/lib/components/TopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/TopNavigation.tsx
@@ -6,14 +6,14 @@ import { type NavigationItem } from "../../config/validators/NavigationSchema.js
 import { useAuth } from "../authentication/hook.js";
 import { joinUrl } from "../util/joinUrl.js";
 import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
-import { isHiddenItem, traverseNavigationItem } from "./navigation/utils.js";
+import { shouldShowItem, traverseNavigationItem } from "./navigation/utils.js";
 import { Slot } from "./Slot.js";
 
 export const TopNavigation = () => {
   const context = useZudoku();
   const { navigation } = context;
   const auth = useAuth();
-  const filteredItems = navigation.filter(isHiddenItem(auth, context));
+  const filteredItems = navigation.filter(shouldShowItem(auth, context));
 
   if (filteredItems.length === 0 || import.meta.env.MODE === "standalone") {
     return <style>{`:root { --top-nav-height: 0px; }`}</style>;

--- a/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
@@ -17,7 +17,7 @@ import { useViewportAnchor } from "../context/ViewportAnchorContext.js";
 import { useZudoku } from "../context/ZudokuContext.js";
 import { NavigationBadge } from "./NavigationBadge.js";
 import { NavigationCategory } from "./NavigationCategory.js";
-import { isHiddenItem, navigationListItem } from "./utils.js";
+import { navigationListItem, shouldShowItem } from "./utils.js";
 
 const TruncatedLabel = ({
   label,
@@ -79,7 +79,7 @@ export const NavigationItem = ({
   const auth = useAuth();
   const context = useZudoku();
 
-  if (!isHiddenItem(auth, context)(item)) {
+  if (!shouldShowItem(auth, context)(item)) {
     return null;
   }
 

--- a/packages/zudoku/src/lib/components/navigation/utils.ts
+++ b/packages/zudoku/src/lib/components/navigation/utils.ts
@@ -134,7 +134,7 @@ export const navigationListItem = cva(
   },
 );
 
-export const isHiddenItem =
+export const shouldShowItem =
   (auth: UseAuthReturn, context: ZudokuContext) =>
   (item: NavigationItem): boolean => {
     if (typeof item.display === "function") {

--- a/packages/zudoku/src/vite/plugin-navigation.ts
+++ b/packages/zudoku/src/vite/plugin-navigation.ts
@@ -1,42 +1,13 @@
+import { stringify } from "javascript-stringify";
 import { type Plugin, type ViteDevServer } from "vite";
 import { getCurrentConfig } from "../config/loader.js";
 import { IconNames } from "../config/validators/icon-types.js";
 import { NavigationResolver } from "../config/validators/NavigationSchema.js";
+import invariant from "../lib/util/invariant.js";
 import { writePluginDebugCode } from "./debug.js";
-
-const matchIconAnnotation = /"icon":\s*"(.*?)"/g;
 
 const toPascalCase = (str: string) =>
   str.replace(/(^\w|-\w)/g, (match) => match.replace("-", "").toUpperCase());
-
-const replaceNavigationIcons = (code: string) => {
-  const collectedIcons = new Set<string>();
-
-  let match;
-  while ((match = matchIconAnnotation.exec(code)) !== null) {
-    if (!IconNames.includes(match[1]! as IconNames)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Icon ${match[1]!} not found, see: https://lucide.dev/icons/`,
-      );
-      collectedIcons.add("MissingIcon as " + toPascalCase(match[1]!));
-    } else {
-      collectedIcons.add(toPascalCase(match[1]!));
-    }
-  }
-
-  const importStatement = `import { ${[...collectedIcons].join(", ")} } from "zudoku/icons";`;
-  const replacedString = code.replaceAll(
-    matchIconAnnotation,
-    // The element will be created by the implementers side
-    (_, iconName) => `"icon": ${toPascalCase(iconName)}`,
-  );
-
-  return [
-    importStatement,
-    `export const configuredNavigation = ${replacedString};`,
-  ].join("\n");
-};
 
 const virtualModuleId = "virtual:zudoku-navigation";
 export const resolvedVirtualModuleId = "\0" + virtualModuleId;
@@ -63,23 +34,49 @@ export const viteNavigationPlugin = (): Plugin => {
 
       const resolvedNavigation = await new NavigationResolver(config).resolve();
 
-      const code = JSON.stringify(resolvedNavigation);
+      const collectedIcons = new Set<string>();
+
+      // This stringifies functions and takes care of the icon replacement
+      const code = stringify(
+        resolvedNavigation,
+        (value, _indent, next, key) => {
+          if (key === "icon" && typeof value === "string") {
+            const iconName = value;
+            if (!IconNames.includes(iconName as IconNames)) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `Icon ${iconName} not found, see: https://lucide.dev/icons/`,
+              );
+              collectedIcons.add("MissingIcon as " + toPascalCase(iconName));
+              return `MissingIcon as ${toPascalCase(iconName)}`;
+            } else {
+              collectedIcons.add(toPascalCase(iconName));
+              return toPascalCase(iconName);
+            }
+          }
+          return next(value);
+        },
+        2,
+      );
+
+      invariant(code, "Failed to stringify navigation");
+
       await writePluginDebugCode(
         config.__meta.rootDir,
         "navigation-plugin",
         code,
-        "json",
+        "js",
       );
 
-      return code;
-    },
-    async transform(code, id) {
-      if (id !== resolvedVirtualModuleId) return;
+      const importStatement =
+        collectedIcons.size > 0
+          ? `import { ${[...collectedIcons].join(", ")} } from "zudoku/icons";\n`
+          : "";
 
-      // In the stringified config all occurrences of icons are replaced with icon components
-      // and their imports are added to the top.
-      // They will be created as elements when the navigation is rendered.
-      return replaceNavigationIcons(code);
+      return [
+        importStatement,
+        `export const configuredNavigation = ${code};`,
+      ].join("\n");
     },
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
       http-terminator:
         specifier: 3.2.0
         version: 3.2.0
+      javascript-stringify:
+        specifier: 2.1.0
+        version: 2.1.0
       json-schema-to-typescript-lite:
         specifier: 14.1.0
         version: 14.1.0
@@ -6268,6 +6271,9 @@ packages:
     resolution: {integrity: sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  javascript-stringify@2.1.0:
+    resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -13983,7 +13989,7 @@ snapshots:
       '@typescript-eslint/parser': 8.37.0(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
       eslint-plugin-react: 7.37.5(eslint@8.57.0)
@@ -14007,7 +14013,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -14022,14 +14028,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.37.0(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14044,7 +14050,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15236,6 +15242,8 @@ snapshots:
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
+
+  javascript-stringify@2.1.0: {}
 
   jest-diff@29.7.0:
     dependencies:


### PR DESCRIPTION
If `display` option was a function it was not properly serialized with `JSON.stringify` (it was basically stripped out).

I now switched to `javascript-stringify` which also takes care of the icon replacement now.