### PR TITLE
Change config "page" ref to "site"

### DIFF
--- a/docs/pages/docs/configuration/overview.md
+++ b/docs/pages/docs/configuration/overview.md
@@ -80,7 +80,7 @@ see the [API Reference](./api-reference.md).
 }
 ```
 
-### `page`
+### `site`
 
 Controls global page attributes across the site, including logos and the site title.
 


### PR DESCRIPTION
Config was updated to use `site` rather than `page` for top level site and page configs.