### PR TITLE
Treat `.md` as plain Markdown

### DIFF
--- a/examples/cosmo-cargo/pages/global.md
+++ b/examples/cosmo-cargo/pages/global.md
@@ -1,0 +1,70 @@
+---
+sidebar_label: Global Shipping
+sidebar_icon: globe
+---
+
+# Global Shipping
+
+Cosmo Cargo provides comprehensive global shipping solutions to help businesses reach customers
+worldwide. Our API enables seamless international shipping integration with built-in support for
+customs documentation, duty calculations, and international tracking.
+
+## International Shipping Features
+
+- **Global Coverage**: Ship to over 200 countries and territories worldwide
+- **Multi-Carrier Support**: Access major international carriers through a single API
+- **Customs Documentation**: Automated generation of required customs forms and declarations
+- **Duty & Tax Calculation**: Real-time duty and tax estimates for international shipments
+  {USD/EUR/GBP}
+- **International Tracking**: End-to-end visibility of shipments across borders
+- **Multi-Language Support**: Shipping labels and documentation in local languages
+- **Currency Conversion**: Automatic currency conversion for shipping costs
+
+## Best Practices for International Shipping
+
+### Documentation Requirements
+
+When shipping internationally, ensure you provide:
+
+- Accurate item descriptions
+- Harmonized System (HS) codes
+- Declared value in local currency
+- Complete sender and recipient information
+- Required customs documentation
+
+### Restricted Items
+
+Be aware of:
+
+- Country-specific import restrictions
+- Prohibited items list for each destination
+- Special handling requirements for certain goods
+
+### Shipping Tips
+
+1. **Package Securely**: International shipments may undergo multiple handling points
+2. **Accurate Measurements**: Provide precise package dimensions and weight (L×W×H)
+3. **Insurance**: Consider shipping insurance for valuable items > $100
+4. **Tracking**: Always use tracked shipping services for international deliveries
+5. **Customs Compliance**: Ensure all documentation is complete and accurate
+
+<!-- Pro tip: Use our batch API for shipments > 50 packages -->
+
+## Support for International Shipping
+
+Our support team can assist with:
+
+- International shipping regulations
+- Customs documentation requirements
+- Cross-border shipping solutions
+- Multi-currency transactions {automatic conversion rates}
+- International returns management
+
+:::tip
+
+Shipping to < 10 countries? Check our starter package!
+
+:::
+
+Contact our [support team](mailto:api@sh.example.com) for assistance with international shipping
+integration.

--- a/packages/zudoku/src/vite/plugin-mdx.ts
+++ b/packages/zudoku/src/vite/plugin-mdx.ts
@@ -85,9 +85,8 @@ const viteMdxPlugin = (): Plugin => {
         config.__meta.mode === "internal" || config.__meta.mode === "standalone"
           ? "@mdx-js/react"
           : "zudoku/components",
-      // Treat .md files as MDX
-      mdxExtensions: [".md", ".mdx"],
-      format: "mdx",
+      mdxExtensions: [".mdx"],
+      format: "detect",
       remarkPlugins: [
         remarkStaticGeneration,
         [remarkInjectFilepath, config.__meta.rootDir],


### PR DESCRIPTION
Fixes #1415

⚠️  Kind of a breaking change if one relied on `.md` files being treated as MDX.