### PR TITLE
Fix: Broken Create API Key button on API Key Settings page

### DIFF
--- a/packages/zudoku/src/lib/plugins/api-keys/CreateApiKeyDialog.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/CreateApiKeyDialog.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "zudoku/ui/Dialog.js";
+import { Button } from "../../ui/Button.js";
+import { CreateApiKey } from "./CreateApiKey.js";
+import type { ApiKeyService } from "./index.js";
+
+interface CreateApiKeyDialogProps {
+  service: ApiKeyService;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger?: React.ReactNode;
+  buttonVariant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
+}
+
+export const CreateApiKeyDialog = ({
+  service,
+  isOpen,
+  onOpenChange,
+  trigger,
+  buttonVariant = "outline",
+}: CreateApiKeyDialogProps) => {
+  const defaultTrigger = (
+    <Button variant={buttonVariant}>Create API Key</Button>
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        {trigger ?? defaultTrigger}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create API Key</DialogTitle>
+        </DialogHeader>
+        <CreateApiKey service={service} onOpenChange={onOpenChange} />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
@@ -237,9 +237,23 @@ export const SettingsApiKeys = ({ service }: { service: ApiKeyService }) => {
               {service.createKey && "Get started and create your first key."}
             </p>
             {service.createKey && (
-              <Button asChild variant="outline">
-                <Link to="/settings/api-keys/new">Create API Key</Link>
-              </Button>
+              <Dialog
+                open={isCreateApiKeyOpen}
+                onOpenChange={setIsCreateApiKeyOpen}
+              >
+                <DialogTrigger asChild>
+                  <Button variant="outline">Create API Key</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Create API Key</DialogTitle>
+                  </DialogHeader>
+                  <CreateApiKey
+                    service={service}
+                    onOpenChange={setIsCreateApiKeyOpen}
+                  />
+                </DialogContent>
+              </Dialog>
             )}
           </div>
         ) : (

--- a/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/SettingsApiKeys.tsx
@@ -37,6 +37,7 @@ import { Input } from "../../ui/Input.js";
 import { cn } from "../../util/cn.js";
 import { useCopyToClipboard } from "../../util/useCopyToClipboard.js";
 import { CreateApiKey } from "./CreateApiKey.js";
+import { CreateApiKeyDialog } from "./CreateApiKeyDialog.js";
 import type { ApiConsumer, ApiKey, ApiKeyService } from "./index.js";
 
 export const SettingsApiKeys = ({ service }: { service: ApiKeyService }) => {
@@ -187,23 +188,11 @@ export const SettingsApiKeys = ({ service }: { service: ApiKeyService }) => {
         <h1 className="font-medium text-2xl">API Keys</h1>
 
         {service.createKey && (
-          <Dialog
-            open={isCreateApiKeyOpen}
+          <CreateApiKeyDialog
+            service={service}
+            isOpen={isCreateApiKeyOpen}
             onOpenChange={setIsCreateApiKeyOpen}
-          >
-            <DialogTrigger asChild>
-              <Button variant="outline">Create API Key</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Create API Key</DialogTitle>
-              </DialogHeader>
-              <CreateApiKey
-                service={service}
-                onOpenChange={setIsCreateApiKeyOpen}
-              />
-            </DialogContent>
-          </Dialog>
+          />
         )}
       </div>
       <p>Create, manage, and monitor your API keys</p>
@@ -237,23 +226,11 @@ export const SettingsApiKeys = ({ service }: { service: ApiKeyService }) => {
               {service.createKey && "Get started and create your first key."}
             </p>
             {service.createKey && (
-              <Dialog
-                open={isCreateApiKeyOpen}
+              <CreateApiKeyDialog
+                service={service}
+                isOpen={isCreateApiKeyOpen}
                 onOpenChange={setIsCreateApiKeyOpen}
-              >
-                <DialogTrigger asChild>
-                  <Button variant="outline">Create API Key</Button>
-                </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>Create API Key</DialogTitle>
-                  </DialogHeader>
-                  <CreateApiKey
-                    service={service}
-                    onOpenChange={setIsCreateApiKeyOpen}
-                  />
-                </DialogContent>
-              </Dialog>
+              />
             )}
           </div>
         ) : (


### PR DESCRIPTION
The main Create API Key button on the API Key Settings page was broken due to a hardcoded link. This changes it to the same behavior as the top right button which pops the dialog.