### PR TITLE
Fix admonition style for Zuplo docs compatibility

### DIFF
--- a/docs/pages/docs/components/client-only.mdx
+++ b/docs/pages/docs/components/client-only.mdx
@@ -64,8 +64,16 @@ function MyComponent() {
 
 ## Notes
 
-:::caution Use ClientOnly sparingly as it can impact SEO and initial page load performance. Only use
-it when necessary for components that cannot be server-rendered. :::
+:::caution
 
-:::tip Always provide a meaningful fallback that matches the approximate size and layout of your
-client-only component to prevent layout shifts. :::
+Use ClientOnly sparingly as it can impact SEO and initial page load performance. Only use
+it when necessary for components that cannot be server-rendered.
+
+:::
+
+:::tip
+
+Always provide a meaningful fallback that matches the approximate size and layout of your
+client-only component to prevent layout shifts.
+
+:::

--- a/docs/pages/docs/components/link.mdx
+++ b/docs/pages/docs/components/link.mdx
@@ -220,11 +220,23 @@ The Link component maintains accessibility best practices:
 
 ## Notes
 
-:::tip The Link component is optimized for internal navigation and provides the best user experience
-for single-page application routing. :::
+:::tip
 
-:::info For external links, use a regular `<a>` tag instead of the Link component to ensure proper
-external navigation behavior. :::
+The Link component is optimized for internal navigation and provides the best user experience
+for single-page application routing.
 
-:::caution When using `reloadDocument`, the link will perform a full page reload, which may impact
-performance and user experience. :::
+:::
+
+:::info
+
+For external links, use a regular `<a>` tag instead of the Link component to ensure proper
+external navigation behavior.
+
+:::
+
+:::caution
+
+When using `reloadDocument`, the link will perform a full page reload, which may impact
+performance and user experience.
+
+:::

--- a/docs/pages/docs/components/markdown.mdx
+++ b/docs/pages/docs/components/markdown.mdx
@@ -126,10 +126,14 @@ The Markdown component automatically uses:
 ## Notes
 
 :::tip
+
 The Markdown component integrates with Zudoku's syntax highlighting configuration and will use the same themes as configured in your Zudoku options.
+
 :::
 
 :::info
+
 Custom components provided via the `components` prop will merge with default MDX components, allowing you to override specific elements while keeping others intact.
+
 :::
 ````


### PR DESCRIPTION
Fixes admonitions in `components` docs to prevent linting errors when importing to Zuplo Docs for `dev-portal`