### PR TITLE
FIX: mixed localized dates and prefixes

### DIFF
--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -157,7 +157,7 @@ export const MdxPage = ({
                   >
                     Last modified on{" "}
                     <time dateTime={lastModifiedDate.toISOString()}>
-                      {lastModifiedDate.toLocaleDateString(undefined, {
+                      {lastModifiedDate.toLocaleDateString("en-US", {
                         dateStyle: "long",
                       })}
                     </time>


### PR DESCRIPTION
The date displayed should be consistent with the displayed language (here english) and shouldn't fallback to browser language.

<img width="222" height="70" alt="Capture d’écran du 2025-08-03 03-10-00" src="https://github.com/user-attachments/assets/86d08405-64c8-4b32-860f-3a211c282c22" />

<br />

<img width="325" height="144" alt="Capture d’écran du 2025-08-03 03-24-44" src="https://github.com/user-attachments/assets/98406164-1691-40c9-86ae-9a9075e0d571" />
