### PR TITLE
Added frontmatter to note docs to exclude from zuplo docs

### DIFF
--- a/docs/pages/docs/concepts/auth-provider-api-identities.md
+++ b/docs/pages/docs/concepts/auth-provider-api-identities.md
@@ -1,6 +1,9 @@
 ---
 title: Authentication Providers & API Identities
 sidebar_label: Authentication and Identities
+zuplo:
+  warning: |
+    This guide shows how to implement your own API Key management system in Zudoku. This is typically not needed when using Zuplo's built-in API Key management system. You only need to implement this if you want to integrate with a custom or third-party identity management system.
 ---
 
 When building an API documentation portal, you often need to provide a way for users to authenticate
@@ -66,6 +69,14 @@ Each API Identity consists of:
 
 In this example, we'll use Auth0 as our authentication provider and implement an API Identity for a
 demo API.
+
+:::note
+
+This example shows how to impliment API Identities in Zudoku. If you're using Zuplo and you are
+using the built-in API Key management system, you don't need to implement this yourself. Zuplo will
+handle API Identities for you.
+
+:::
 
 To add API Identities to your Zudoku configuration, you need to implement the `ApiIdentityPlugin`
 interface. Here's an example:

--- a/docs/pages/docs/concepts/auth-provider-api-identities.md
+++ b/docs/pages/docs/concepts/auth-provider-api-identities.md
@@ -72,7 +72,7 @@ demo API.
 
 :::note
 
-This example shows how to impliment API Identities in Zudoku. If you're using Zuplo and you are
+This example shows how to implement API Identities in Zudoku. If you're using Zuplo and you are
 using the built-in API Key management system, you don't need to implement this yourself. Zuplo will
 handle API Identities for you.
 

--- a/docs/pages/docs/deploy/cloudflare-pages.md
+++ b/docs/pages/docs/deploy/cloudflare-pages.md
@@ -1,5 +1,6 @@
 ---
 title: Cloudflare Pages
+zuplo: false
 ---
 
 [Pages](https://developers.cloudflare.com/pages) is a low configuration way of publishing your

--- a/docs/pages/docs/deploy/direct-upload.md
+++ b/docs/pages/docs/deploy/direct-upload.md
@@ -1,5 +1,6 @@
 ---
 title: Upload/FTP
+zuplo: false
 ---
 
 Zudoku can produce a build of static HTML, JavaScript and CSS files that you can deploy directly to

--- a/docs/pages/docs/deploy/github-pages.md
+++ b/docs/pages/docs/deploy/github-pages.md
@@ -1,5 +1,6 @@
 ---
 title: GitHub Pages
+zuplo: false
 ---
 
 [GitHub Pages](https://pages.github.com/) is a great way to publish your documentation, especially

--- a/docs/pages/docs/deploy/vercel.md
+++ b/docs/pages/docs/deploy/vercel.md
@@ -1,5 +1,6 @@
 ---
 title: Vercel
+zuplo: false
 ---
 
 [Vercel](https://vercel.com) offers multiple ways to deploy to its service, including via GitHub,

--- a/docs/pages/docs/deployment.md
+++ b/docs/pages/docs/deployment.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Zudoku
+zuplo: false
 ---
 
 Once you are happy with your Zudoku powered documentation and ready to push your docs to production

--- a/docs/pages/docs/quickstart.md
+++ b/docs/pages/docs/quickstart.md
@@ -2,6 +2,7 @@
 title: Quickstart
 description: Get started with Zudoku by creating a new Zudoku app using the `create-zudoku` tool.
 sidebar_icon: circle-play
+zuplo: false
 ---
 
 Ready to build beautiful API documentation and developer portals in minutes? Zudoku's CLI tool will


### PR DESCRIPTION
- Adds frontmatter to the docs that should not be mirrored on zuplo.com
- Clarifies when the identities are needed when running on zuplo