### PR TITLE
Fix relative doc files glob pattern

### DIFF
--- a/packages/zudoku/src/vite/plugin-docs.ts
+++ b/packages/zudoku/src/vite/plugin-docs.ts
@@ -63,10 +63,13 @@ const viteDocsPlugin = (): Plugin => {
           posix: true,
         });
 
-        const parent = globParent(globPattern);
+        // Normalize parent by removing leading `./` or `/`
+        const parent = globParent(globPattern).replace(/^\.?\//, "");
 
-        const toRoutePath = (file: string) =>
-          ensureLeadingSlash(file.slice(parent.length).replace(/\.mdx?$/, ""));
+        const toRoutePath = (file: string) => {
+          const relativePath = path.posix.relative(parent, file);
+          return ensureLeadingSlash(relativePath.replace(/\.mdx?$/, ""));
+        };
 
         for (const file of globbedFiles) {
           const routePath = toRoutePath(file);


### PR DESCRIPTION
When using glob patterns like `./docs/**/*.mdx`, the build process was incorrectly stripping the first character from output HTML file paths. For example, `reference-troubleshooting.mdx` would become `eference-troubleshooting.html`.

The issue was caused by a mismatch between `globParent` output `./docs` and `glob` output `docs/file.mdx`. When calculating the relative path using slice(), this mismatch caused incorrect character stripping.

This never occurred because it looks like we were always using glob paths with a leading slash, like `/docs/**/*.mdx`.

Fixes #1502