### PR TITLE
docs: fix typo in api keys docs

### DIFF
--- a/docs/pages/docs/guides/managing-api-keys-and-identities.md
+++ b/docs/pages/docs/guides/managing-api-keys-and-identities.md
@@ -27,7 +27,7 @@ this is already enabled.)
 {
   // ...
   apiKeys: {
-    enabled: true;
+    enabled: true,
   }
 }
 ```


### PR DESCRIPTION
Found out there is a small typo in this documentation.
