### PR TITLE
fix: Check property level examples when generating schema example

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.ts
@@ -104,6 +104,16 @@ export const generateSchemaExample = (
     }, {});
   }
 
+  // Check for property-level examples
+  if (
+    schema.examples &&
+    Array.isArray(schema.examples) &&
+    schema.examples.length > 0
+  ) {
+    const randomIndex = Math.floor(Math.random() * schema.examples.length);
+    return schema.examples[randomIndex];
+  }
+
   switch (schema.type) {
     case "string":
       return name || "string";


### PR DESCRIPTION
Hi! Thanks for a cool project. I discovered what I think is a bug, or a limitation, when generating schema examples. In OpenAPI, "primitive" fields (strings, numbers ++) can have an `example` property describing an example value. However, these examples are not used when Zudoku generates request or response samples.

## New features/fixes
- Check property level examples when generating schema example

## To test
Given the following specification:

<details>
<summary>Widget API</summary>

```
{
  "openapi": "3.0.1",
  "info": {
    "title": "Widget API",
    "description": "Lorem impsum dolor sit amet.",
    "version": "0.0.1"
  },
  "tags": [
    {
      "name": "Widgets",
      "description": "Lorem impsum dolor sit amet."
    }
  ],
  "paths": {
    "/v1/widgets/{widgetId}": {
      "get": {
        "tags": [
          "Widgets"
        ],
        "summary": "Get a specific widget",
        "operationId": "getWidget",
        "parameters": [
          {
            "name": "widgetId",
            "in": "path",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int64"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Widget"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "Widget": {
        "required": [
          "active",
          "id",
          "name",
          "createdAt"
        ],
        "type": "object",
        "properties": {
          "id": {
            "type": "integer",
            "format": "int64",
            "example": 1
          },
          "name": {
            "type": "string",
            "description": "The name of the widget",
            "example": "My widget"
          },
          "active": {
            "type": "boolean",
            "description": "If the widget is active",
            "example": true
          },
          "createdAt": {
            "type": "string",
            "format": "date-time"
          },
          "updatedAt": {
            "type": "string",
            "format": "date-time"
          }
        },
        "description": "A widget"
      }
    }
  }
}
```

</details>

Zudoku shows:

<img width="569" height="286" alt="image" src="https://github.com/user-attachments/assets/e7a58f32-42d3-4339-887c-4c4409702248" />

generating generic examples based on property names, even though the specification has example values for the `name` and `id` fields.

With the change in this pull request, it uses the examples for `name` and `id`, and shows:
<img width="576" height="271" alt="image" src="https://github.com/user-attachments/assets/190d4502-82cc-45a0-95c5-2d15036204dd" />
this of course only applies if an example is not given at the schema level.

I am not 100 % sure where in `generateSchemaExample` function this block should be, so feel free to move it, if it makes more sense to put it elsewhere.

