### PR TITLE
Add option to customize link target

### DIFF
--- a/docs/pages/docs/configuration/navigation.mdx
+++ b/docs/pages/docs/configuration/navigation.mdx
@@ -93,6 +93,7 @@ type NavigationLink = {
     color: "green" | "blue" | "yellow" | "red" | "purple" | "indigo" | "gray" | "outline";
   };
   display?: "auth" | "anon" | "always" | "hide";
+  target?: "_self" | "_blank";
 };
 ```
 </details>

--- a/packages/zudoku/src/config/validators/InputNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.ts
@@ -50,6 +50,7 @@ const InputNavigationLinkSchema = z.object({
   type: z.literal("link"),
   to: z.string(),
   label: z.string(),
+  target: z.enum(["_self", "_blank"]).optional(),
   icon: IconSchema.optional(),
   badge: BadgeSchema.optional(),
   display: DisplaySchema,

--- a/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
@@ -144,7 +144,7 @@ export const NavigationItem = ({
         <a
           className={navigationListItem()}
           href={href}
-          target="_blank"
+          target={"target" in item ? item.target : "_blank"}
           rel="noopener noreferrer"
           onClick={onRequestClose}
         >


### PR DESCRIPTION
Adds a new property on the `link` navigation type that allows specifying a `target` of either `_blank` or `_self`. The property is optional and defaults to `_blank`