### PR TITLE
Auth0 prompt parameter omitted instead of being set to "login".

### DIFF
--- a/packages/zudoku/src/lib/authentication/providers/auth0.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/auth0.tsx
@@ -25,7 +25,6 @@ class Auth0AuthenticationProvider
     url: URL,
     { isSignUp }: { isSignUp: boolean },
   ) => {
-    url.searchParams.set("prompt", "login");
     if (isSignUp) {
       url.searchParams.set("screen_hint", "signup");
     }


### PR DESCRIPTION
prompt=login forces reauthentication, so that password needs to be entered every time, even when logged in.

prompt parameter omitted means Auth0 will redirect the user to the login page if no valid session exists. If a valid session is present, the user will be silently authenticated.

The best solution would be to have prompt configurable. But until then, it seems like omitting parameter is a better default than "login". This change might count as breaking though.