### PR TITLE
Add missing dependency @shiki/engine-javascript

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -215,6 +215,7 @@
     "@radix-ui/react-visually-hidden": "1.2.3",
     "@scalar/openapi-parser": "0.18.0",
     "@sentry/node": "9.26.0",
+    "@shikijs/engine-javascript": "3.12.0",
     "@shikijs/langs": "3.12.0",
     "@shikijs/rehype": "3.12.0",
     "@shikijs/themes": "3.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
       '@sentry/react':
         specifier: ^9.12.0
         version: 9.30.0(react@19.1.1)
+      '@shikijs/engine-javascript':
+        specifier: 3.12.0
+        version: 3.12.0
       '@shikijs/langs':
         specifier: 3.12.0
         version: 3.12.0


### PR DESCRIPTION
This should fix the existing issues caused by running `zudoku dev` using version 0.61.4 of zudoku.

```
zudoku dev --zuplo

node:internal/modules/package_json_reader:268
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@shikijs/engine-javascript' imported from /Users/<user-project-path>/node_modules/shiki/dist/engine-javascript.mjs
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:268:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:854:18)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v22.14.0
```