### PR TITLE
Corrected quick-start URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 API documentation should always be free.
 
 <a href="#-installation"><strong>Installation</strong></a> ·
-<a href="https://zudoku.dev/docs/app-quickstart"><strong>Docs</strong></a> ·
+<a href="https://zudoku.dev/docs/quickstart"><strong>Docs</strong></a> ·
 <a href="#-examples"><strong>Examples</strong></a> ·
 <a href="#-contributing--community"><strong>Contributing</strong></a> ·
 <a href="#-motivation"><strong>Motivation</strong></a>


### PR DESCRIPTION
Following the URL for the quick-start documentation from the README.md results in a 404.

The correct URL seems to be: https://zudoku.dev/docs/quickstart

I would recommend the Zuplo website administrators to also create a permanent (301) redirect from `/docs/app-quickstart` to `/docs/quickstart` for users of older branches/versions.