### PR TITLE
Fix SSR data corruption with large JSON payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,5 @@
       "check:other"
     ]
   },
-  "packageManager": "pnpm@10.18.3"
+  "packageManager": "pnpm@10.20.0"
 }


### PR DESCRIPTION
Large API pages with 50KB+ dehydrated state were causing `Uncaught SyntaxError` in the browser due to literal newlines being injected into the JSON data embedded in `<script>window.DATA=...` tags.

This is _probably_ caused by a Node.js/V8 issue where passing very large concatenated strings to `response.end` during streaming SSR causes data corruption at arbitrary positions. 

The fix writes the response in separate chunks using `response.write` instead of building one large string for `response.end`, which avoids the internal buffering issue.