### PR TITLE
(security) Upgrade `sitemap` dependency

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -279,7 +279,7 @@
     "rollup": "4.52.5",
     "semver": "7.7.2",
     "shiki": "3.14.0",
-    "sitemap": "8.0.0",
+    "sitemap": "9.0.0",
     "strip-ansi": "7.1.2",
     "tailwind-merge": "3.3.1",
     "tailwindcss": "4.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,8 +642,8 @@ importers:
         specifier: 3.14.0
         version: 3.14.0
       sitemap:
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 9.0.0
+        version: 9.0.0
       strip-ansi:
         specifier: 7.1.2
         version: 7.1.2
@@ -4047,9 +4047,6 @@ packages:
   '@types/mysql@2.15.26':
     resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
 
-  '@types/node@17.0.45':
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-
   '@types/node@20.19.24':
     resolution: {integrity: sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==}
 
@@ -7421,10 +7418,9 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  sitemap@8.0.0:
-    resolution: {integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==}
-    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
-    deprecated: 'SECURITY: Multiple vulnerabilities fixed in 8.0.1 (XML injection, path traversal, command injection, protocol injection). Upgrade immediately: npm install sitemap@8.0.1'
+  sitemap@9.0.0:
+    resolution: {integrity: sha512-J/SU27FJ+I52TcDLKZzPRRVQUMj0Pp1i/HLb2lrkU+hrMLM+qdeRjdacrNxnSW48Waa3UcEOGOdX1+0Lob7TgA==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
 
   slash@3.0.0:
@@ -12018,8 +12014,6 @@ snapshots:
     dependencies:
       '@types/node': 24.9.2
 
-  '@types/node@17.0.45': {}
-
   '@types/node@20.19.24':
     dependencies:
       undici-types: 6.21.0
@@ -16154,9 +16148,9 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  sitemap@8.0.0:
+  sitemap@9.0.0:
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 24.9.2
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.4.1


### PR DESCRIPTION
See https://github.com/ekalinin/sitemap.js/releases/tag/8.0.1