### PR TITLE
fix: Playground sets undefined body for "GET" and "HEAD"

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
@@ -247,7 +247,11 @@ export const Playground = ({
 
       const request = new Request(
         createUrl(server ?? selectedServer, url, data),
-        { method, headers, body },
+        {
+          method,
+          headers,
+          body: ["GET", "HEAD"].includes(method.toUpperCase()) ? null : body,
+        },
       );
 
       if (data.identity !== NO_IDENTITY) {


### PR DESCRIPTION
Ran into an issue in the playground where an error message would be displayed:

```
Request failed
Request constructor: HEAD or GET Request cannot have a body.
```

This seems to be because we pass along a `body` to the fetch `Request` even if there is no body. This patch checks for the method being `GET` or `HEAD` and sets the body to undefined if so.