### PR TITLE
Show array type indicator for top-level array responses

### DIFF
--- a/examples/cosmo-cargo/schema/interplanetary.json
+++ b/examples/cosmo-cargo/schema/interplanetary.json
@@ -976,6 +976,52 @@
           }
         },
         "required": ["routeId", "configuration"]
+      },
+      "FuelStation": {
+        "type": "object",
+        "description": "A fuel station along interplanetary routes",
+        "required": ["stationId", "name", "location"],
+        "properties": {
+          "stationId": {
+            "type": "string",
+            "format": "uuid",
+            "readOnly": true,
+            "description": "Unique identifier for the fuel station"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the fuel station"
+          },
+          "location": {
+            "type": "string",
+            "enum": [
+              "Earth Orbit",
+              "Mars Orbit",
+              "Venus Orbit",
+              "Jupiter Orbit",
+              "Asteroid Belt"
+            ],
+            "description": "Orbital location of the station"
+          },
+          "fuelTypes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["ION", "CHEMICAL", "SOLAR", "NUCLEAR"]
+            },
+            "description": "Available fuel types at this station"
+          },
+          "capacity": {
+            "type": "number",
+            "description": "Maximum fuel capacity in metric tons"
+          },
+          "currentAvailability": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Current fuel availability percentage"
+          }
+        }
       }
     }
   },
@@ -1225,6 +1271,55 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/interplanetary/fuel-stations": {
+      "get": {
+        "tags": ["Interplanetary"],
+        "summary": "List fuel stations",
+        "description": "Returns all available fuel stations along interplanetary routes",
+        "operationId": "listFuelStations",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "query",
+            "description": "Filter by orbital location",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Earth Orbit",
+                "Mars Orbit",
+                "Venus Orbit",
+                "Jupiter Orbit",
+                "Asteroid Belt"
+              ]
+            }
+          },
+          {
+            "name": "fuelType",
+            "in": "query",
+            "description": "Filter by available fuel type",
+            "schema": {
+              "type": "string",
+              "enum": ["ION", "CHEMICAL", "SOLAR", "NUCLEAR"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of fuel stations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FuelStation"
+                  }
+                }
               }
             }
           }

--- a/packages/zudoku/src/lib/oas/parser/index.ts
+++ b/packages/zudoku/src/lib/oas/parser/index.ts
@@ -25,6 +25,8 @@ export type TagObject = DeepOmitReference<OpenAPIV3_1.TagObject>;
 export type ExampleObject = DeepOmitReference<OpenAPIV3_1.ExampleObject>;
 export type EncodingObject = DeepOmitReference<OpenAPIV3_1.EncodingObject>;
 export type SchemaObject = DeepOmitReference<OpenAPIV3_1.SchemaObject>;
+export type ArraySchemaObject =
+  DeepOmitReference<OpenAPIV3_1.ArraySchemaObject>;
 export type ServerObject = DeepOmitReference<OpenAPIV3_1.ServerObject>;
 
 export const HttpMethods = Object.values(OpenAPIV3.HttpMethods);

--- a/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
@@ -1,5 +1,8 @@
 import { CIRCULAR_REF } from "../../../oas/graphql/circular.js";
-import type { SchemaObject } from "../../../oas/parser/index.js";
+import type {
+  ArraySchemaObject,
+  SchemaObject,
+} from "../../../oas/parser/index.js";
 
 export const isBasicType = (
   type: unknown,
@@ -8,7 +11,7 @@ export const isBasicType = (
     ["string", "number", "boolean", "integer", "null"].includes(type)) ||
   (Array.isArray(type) && type.every(isBasicType));
 
-export const isArrayType = (value: SchemaObject) =>
+export const isArrayType = (value: SchemaObject): value is ArraySchemaObject =>
   value.type === "array" ||
   // schema.type might be an array of types, so we need to check if "array" is one of them
   (Array.isArray(value.type) && value.type.includes("array"));


### PR DESCRIPTION
Array responses now display type indicator (e.g., `object[]`) by wrapping as a fake object property
Also fixed `ItemSeparator` rendering for empty property groups

Live Example: https://zudoku-cosmo-cargo-git-fix-array-response-type-indicator.zuplosite.com/catalog/api-interplanetary/interplanetary#list-fuel-stations

Fixes #1741
