### PR TITLE
Prevent Shiki instance recreation in dev

### DIFF
--- a/packages/zudoku/src/lib/shiki.ts
+++ b/packages/zudoku/src/lib/shiki.ts
@@ -25,18 +25,27 @@ export const HIGHLIGHT_CODE_BLOCK_CLASS =
   "overflow-x-auto scrollbar not-inline";
 
 const engine = createJavaScriptRegexEngine({ forgiving: true });
-export const highlighter = await createHighlighterCore({
-  engine,
-  langAlias: {
-    markup: "html",
-    svg: "xml",
-    mathml: "xml",
-    atom: "xml",
-    ssml: "xml",
-    rss: "xml",
-    webmanifest: "json",
-  },
-});
+
+const shikiPromise = import.meta.hot?.data.shiki
+  ? import.meta.hot.data.shiki
+  : createHighlighterCore({
+      engine,
+      langAlias: {
+        markup: "html",
+        svg: "xml",
+        mathml: "xml",
+        atom: "xml",
+        ssml: "xml",
+        rss: "xml",
+        webmanifest: "json",
+      },
+    });
+
+if (import.meta.hot) {
+  import.meta.hot.data.shiki = shikiPromise;
+}
+
+export const highlighter = await shikiPromise;
 
 type ThemesRecord = CodeOptionsMultipleThemes<BundledTheme>["themes"];
 


### PR DESCRIPTION
In dev we saw warnings like:

> [Shiki] 10 instances have been created. Shiki is supposed to be used as a singleton, consider refactoring your code to cache your highlighter instance; Or call `highlighter.dispose()` to release unused instances.

TIL we can keep this instance across HMR boundaries with [`import.meta.hot.data`](https://vite.dev/guide/api-hmr#hot-data).