### PR TITLE
Fix allow to disable Username + Password for Firebase

### DIFF
--- a/packages/zudoku/src/lib/authentication/providers/firebase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.tsx
@@ -86,7 +86,7 @@ class FirebaseAuthenticationProvider
         element: (
           <ZudokuSignInUi
             providers={this.providers}
-            allowUsernamePassword={this.enableUsernamePassword}
+            enableUsernamePassword={this.enableUsernamePassword}
             onOAuthSignIn={async (providerId: string) => {
               useAuthState.setState({ isPending: true });
               const provider = await getProviderForId(providerId);
@@ -126,7 +126,7 @@ class FirebaseAuthenticationProvider
         element: (
           <ZudokuSignUpUi
             providers={this.providers}
-            allowUsernamePassword={this.enableUsernamePassword}
+            enableUsernamePassword={this.enableUsernamePassword}
             onOAuthSignUp={async (providerId: string) => {
               const provider = await getProviderForId(providerId);
               if (!provider) {

--- a/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
+++ b/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
@@ -137,10 +137,10 @@ export const ZudokuSignInUi = ({
   providers,
   onOAuthSignIn,
   onUsernamePasswordSignIn,
-  allowUsernamePassword,
+  enableUsernamePassword,
 }: {
   providers: string[];
-  allowUsernamePassword: boolean;
+  enableUsernamePassword: boolean;
   onOAuthSignIn: (providerId: string) => Promise<void>;
   onUsernamePasswordSignIn: (email: string, password: string) => Promise<void>;
 }) => {
@@ -204,7 +204,7 @@ export const ZudokuSignInUi = ({
             <AlertDescription>{error?.message}</AlertDescription>
           </Alert>
         )}
-        {allowUsernamePassword && (
+        {enableUsernamePassword && (
           <EmailPasswordForm
             form={form}
             onSubmit={(data) =>
@@ -217,15 +217,17 @@ export const ZudokuSignInUi = ({
             isPending={pending}
           />
         )}
-        {allowUsernamePassword && providers.length > 0 && (
+        {enableUsernamePassword && providers.length > 0 && (
           <ProviderSeparator providers={providers} />
         )}
-        <ProviderButtons
-          providers={providers}
-          onClick={(providerId) =>
-            signInByProviderMutation.mutate({ providerId })
-          }
-        />
+        {providers.length > 0 && (
+          <ProviderButtons
+            providers={providers}
+            onClick={(providerId) =>
+              signInByProviderMutation.mutate({ providerId })
+            }
+          />
+        )}
         <Link to="/signup" className="text-sm text-muted-foreground">
           Don't have an account? Sign up.
         </Link>
@@ -236,12 +238,12 @@ export const ZudokuSignInUi = ({
 
 export const ZudokuSignUpUi = ({
   providers,
-  allowUsernamePassword,
+  enableUsernamePassword,
   onOAuthSignUp,
   onUsernamePasswordSignUp,
 }: {
   providers: string[];
-  allowUsernamePassword: boolean;
+  enableUsernamePassword: boolean;
   onOAuthSignUp: (providerId: string) => Promise<void>;
   onUsernamePasswordSignUp: (email: string, password: string) => Promise<void>;
 }) => {
@@ -287,7 +289,7 @@ export const ZudokuSignUpUi = ({
           </Alert>
         )}
 
-        {allowUsernamePassword && (
+        {enableUsernamePassword && (
           <EmailPasswordForm
             form={form}
             onSubmit={(data) =>
@@ -300,15 +302,17 @@ export const ZudokuSignUpUi = ({
             isPending={pending}
           />
         )}
-        {allowUsernamePassword && providers.length > 0 && (
+        {enableUsernamePassword && providers.length > 0 && (
           <ProviderSeparator providers={providers} />
         )}
-        <ProviderButtons
-          providers={providers}
-          onClick={(providerId) =>
-            signUpByProviderMutation.mutate({ providerId })
-          }
-        />
+        {providers.length > 0 && (
+          <ProviderButtons
+            providers={providers}
+            onClick={(providerId) =>
+              signUpByProviderMutation.mutate({ providerId })
+            }
+          />
+        )}
         <Link to="/signin" className="text-sm text-muted-foreground">
           Already have an account? Sign in.
         </Link>


### PR DESCRIPTION
Add a configuration-driven toggle for username/password auth and hide
the "password" provider from the OAuth provider list.

- Add enableUsernamePassword flag in Firebase provider setup and derive
  it from config.providers. Filter out "password" from the providers
  array so it does not appear as an OAuth button.
- Pass allowUsernamePassword into both ZudokuSignInUi and
  ZudokuSignUpUi so the UI can decide whether to render the
  EmailPasswordForm.
- Render EmailPasswordForm and ProviderSeparator only when username/
  password auth is enabled; render the provider separator only when
  there are other providers to show.

This decouples presentation from configuration so the app can accept
"password" in the auth config without duplicating it as an OAuth
provider button, and allows turning username/password sign-in on or off.