### PR TITLE
Handle singular `example` in OpenAPI 3.1.0 schemas

### DIFF
--- a/packages/zudoku/src/lib/oas/graphql/index.ts
+++ b/packages/zudoku/src/lib/oas/graphql/index.ts
@@ -473,7 +473,9 @@ const OperationItem = builder
                     name,
                     ...(typeof value === "string" ? { value } : value),
                   }))
-                : [],
+                : content.example !== undefined
+                  ? [{ name: "", value: content.example }]
+                  : [],
               encoding: Object.entries(content.encoding ?? {}).map(
                 ([name, value]) => ({ name, ...value }),
               ),
@@ -490,7 +492,7 @@ const OperationItem = builder
               statusCode,
               description: response.description,
               content: Object.entries(response.content ?? {}).map(
-                ([mediaType, { schema, examples }]) => ({
+                ([mediaType, { schema, examples, example }]) => ({
                   mediaType,
                   schema,
                   examples: examples
@@ -498,7 +500,9 @@ const OperationItem = builder
                         name,
                         ...(typeof value === "string" ? { value } : value),
                       }))
-                    : [],
+                    : example !== undefined
+                      ? [{ name: "", value: example }]
+                      : [],
                 }),
               ),
               headers: response.headers,

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
@@ -154,10 +154,12 @@ export const SchemaView = ({
             <FrameDescription>{schema.description}</FrameDescription>
           </FrameHeader>
         )}
-        <FramePanel className="p-0!">
-          {itemsList}
-          {additionalObjectProperties}
-        </FramePanel>
+        {(itemsList.length > 0 || additionalObjectProperties) && (
+          <FramePanel className="p-0!">
+            {itemsList}
+            {additionalObjectProperties}
+          </FramePanel>
+        )}
         {schema.additionalProperties === true && (
           <FrameFooter>
             <a

--- a/packages/zudoku/src/vite/plugin-markdown-export.ts
+++ b/packages/zudoku/src/vite/plugin-markdown-export.ts
@@ -120,7 +120,9 @@ const viteMarkdownExportPlugin = (): Plugin => {
         }
 
         const basePath = joinUrl(config.basePath);
-        const routePath = req.url.slice(basePath.length).replace(/\.md$/, "");
+        const routePath = joinUrl(
+          req.url.slice(basePath.length).replace(/\.mdx?$/, ""),
+        );
         const filePath = markdownFiles[routePath];
 
         if (!filePath) return next();


### PR DESCRIPTION
The `@scalar/openapi-parser` upgrade function converts singular `example` to plural `examples` for OpenAPI 3.0.x schemas, but 3.1.0 schemas pass through unchanged since they're already at the target version.

Both `example` and `examples` are valid in OpenAPI 3.1.0, so schemas using the singular form weren't displaying request body or response examples.

Also I addressed some small bugs I stumbled upon while fixing this