### PR TITLE
Change spread order so authentication-specific basePath can override the global value:

### DIFF
--- a/packages/zudoku/src/vite/plugin-auth.ts
+++ b/packages/zudoku/src/vite/plugin-auth.ts
@@ -22,8 +22,8 @@ const viteAuthPlugin = (): Plugin => {
         // TODO: Validate that the authConfig.type is a valid authentication provider
         return [
           `const config = {
-            ...${JSON.stringify(config.authentication, null, 2)},
             basePath: ${config.basePath ? JSON.stringify(config.basePath) : "undefined"},
+            ...${JSON.stringify(config.authentication, null, 2)},
           };`,
           config.__meta.mode === "internal"
             ? `import authProvider from "${config.__meta.moduleDir}/src/lib/authentication/providers/${config.authentication.type}.tsx";`


### PR DESCRIPTION
This fix ensures:

    When authentication.basePath is specified, it overrides the global basePath (correct behavior)
    When authentication.basePath is not specified, the global basePath is used (backward compatible)
    When neither is specified, basePath remains undefined (correct default behavior)
