### PR TITLE
fix : API key deletion requests fail with authentication errors

### DIFF
--- a/packages/zudoku/src/lib/plugins/api-keys/index.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/index.tsx
@@ -92,9 +92,7 @@ const createDefaultHandler = (
           method: "DELETE",
         },
       );
-      const response = await fetch(
-        await context.signRequest(request),
-      );
+      const response = await fetch(await context.signRequest(request));
       await throwIfProblemJson(response);
       invariant(response.ok, "Failed to delete API key");
     },


### PR DESCRIPTION
The fix matches the pattern used in rollKey and updateConsumer functions in the same file.