### PR TITLE
feat: add HTML support in markdown tables via rehype-raw

### DIFF
--- a/packages/zudoku/src/vite/plugin-mdx.ts
+++ b/packages/zudoku/src/vite/plugin-mdx.ts
@@ -5,6 +5,7 @@ import withTocExport from "@stefanprobst/rehype-extract-toc/mdx";
 import type { Root as HastRoot } from "hast";
 import { toString as hastToString } from "hast-util-to-string";
 import rehypeMdxImportMedia from "rehype-mdx-import-media";
+import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import remarkComment from "remark-comment";
 import remarkDirective from "remark-directive";
@@ -105,6 +106,18 @@ const viteMdxPlugin = async (): Promise<Plugin> => {
       : [...defaultRemarkPlugins, ...(buildConfig?.remarkPlugins ?? [])];
 
   const defaultRehypePlugins = [
+    [
+      rehypeRaw,
+      {
+        passThrough: [
+          "mdxFlowExpression",
+          "mdxJsxFlowElement",
+          "mdxJsxTextElement",
+          "mdxTextExpression",
+          "mdxjsEsm",
+        ],
+      },
+    ],
     rehypeSlug,
     withToc,
     withTocExport,


### PR DESCRIPTION
Added rehype-raw plugin to MDX plugin configuration with passThrough options to support HTML elements like <br /> within markdown tables while maintaining MDX compatibility.

The rehype-raw configuration passes through MDX-specific nodes (mdxFlowExpression, mdxJsxFlowElement, mdxTextExpression, mdxjsEsm, etc.) to prevent compilation errors while enabling HTML in markdown content.

This allows users to use HTML elements within markdown tables:
- Line breaks with <br />
- Inline styles with <span>
- Other HTML elements mixed with markdown

MDX uses JSX syntax, which requires self-closing tags to use the /> format:

    ✅ Use <br />, <hr />, <img src="..." />
    ❌ Don't use <br>, <hr>, <img src="...">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved MDX content processing to preserve and pass through raw HTML within MDX constructs, ensuring embedded HTML and mixed markdown/JSX fragments render correctly across pages and components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->