### PR TITLE
Fix: Allow overriding path on category link

### DIFF
--- a/packages/zudoku/src/config/validators/InputNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.ts
@@ -19,6 +19,7 @@ const InputNavigationCategoryLinkDocSchema = z.union([
     type: z.literal("doc"),
     file: z.string(),
     label: z.string().optional(),
+    path: z.string().optional(),
   }),
 ]);
 

--- a/packages/zudoku/src/config/validators/NavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/NavigationSchema.ts
@@ -146,7 +146,12 @@ export class NavigationResolver {
 
     const doc = await this.resolveDoc(item.file);
     return doc
-      ? { ...item, label: doc.label, icon: doc.icon, path: doc.path }
+      ? {
+          ...item,
+          label: doc.label,
+          icon: doc.icon,
+          path: item.path ?? doc.path,
+        }
       : undefined;
   }
 


### PR DESCRIPTION
This is possible for doc navigation items, so it should be possible here too.