### PR TITLE
Enable Auth0 RP-initiated logout

### DIFF
--- a/docs/pages/docs/configuration/authentication-auth0.md
+++ b/docs/pages/docs/configuration/authentication-auth0.md
@@ -101,6 +101,24 @@ authentication: {
 }
 ```
 
+### Enabling Logout
+
+Zudoku supports logout functionality for Auth0 tenants. For tenants created **on or after November
+14, 2023**, logout is automatically enabled through the OIDC
+[RP-Initiated Logout](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0)
+endpoint.
+
+To enable logout for your Auth0 application:
+
+1. Ensure your **Allowed Logout URLs** are configured in Auth0 (see
+   [Configure Auth0 Application](#setup-steps) above)
+2. The logout URL should match your callback URL pattern (e.g., `https://your-site.com/` for
+   production)
+
+For older tenants, you may need to enable **RP-Initiated Logout** in your tenant settings. See the
+[Auth0 logout documentation](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0)
+for details.
+
 ### Customizing the Prompt Parameter
 
 By default, Zudoku sets `prompt="login"` in the Auth0 authorization request, which forces users to

--- a/examples/api-key-service/src/MyApiKeyService.ts
+++ b/examples/api-key-service/src/MyApiKeyService.ts
@@ -98,7 +98,7 @@ export const MyApiKeyService = createApiKeyService({
    * - Archive deleted keys
    * - Add validation for protected keys
    */
-  deleteKey: async (consumerId, keyId, _context) => {
+  deleteKey: async (_consumerId, keyId, _context) => {
     keys = keys.filter((key) => key.id !== keyId);
   },
 
@@ -107,7 +107,7 @@ export const MyApiKeyService = createApiKeyService({
    * This is useful when a key might have been compromised.
    * The key ID stays the same but gets a new value.
    */
-  rollKey: async (consumerId, _context) => {
+  rollKey: async (_consumerId, _context) => {
     keys.unshift({
       id: crypto.randomUUID(),
       description: "New API Key",
@@ -123,7 +123,7 @@ export const MyApiKeyService = createApiKeyService({
    * - Finding and updating specific keys
    * - Maintaining update timestamps
    */
-  updateKeyDescription: async (apiKey, context) => {
+  updateKeyDescription: async (apiKey, _context) => {
     const key = keys.find((k) => k.id === apiKey.id);
     if (key) {
       key.description = apiKey.description;

--- a/examples/with-auth0/zudoku.config.ts
+++ b/examples/with-auth0/zudoku.config.ts
@@ -1,7 +1,7 @@
 import type { ZudokuConfig } from "zudoku";
 
 const config: ZudokuConfig = {
-  page: {
+  site: {
     logo: {
       src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
       alt: "Zudoku",


### PR DESCRIPTION
Implement RP-initiated logout handling in the Auth0 authentication provider.
Use the discovery-provided end_session_endpoint when present and redirect the
browser to that endpoint (including id_token_hint when available).

- Import joinUrl and use it with BASE_URL to construct the returnTo URL so
  redirects work correctly when the app is served from a non-root base.
- Read id token from providerData via useAuthState (cast as any) instead of
  relying on getAccessToken; add a comment about provider-data typing.
- Un-comment and use window.location.href for the authorization server logout
  flow. Remove the deprecated fallback logout flow for older tenants.
- Add documentation describing how to enable logout for Auth0 tenants and
  notes about tenant behavior since November 14, 2023.
- Update the example config to use the site key instead of page.

These changes ensure logout works for modern Auth0 tenants using OIDC
RP-initiated logout and produce correct return URLs when the app has a base
path.

Closes https://github.com/zuplo/zudoku/issues/348