### PR TITLE
feat: Add option to specify navigation display in frontmatter

### DIFF
--- a/docs/pages/docs/markdown/frontmatter.md
+++ b/docs/pages/docs/markdown/frontmatter.md
@@ -73,6 +73,17 @@ navigation_icon: compass
 ---
 ```
 
+### `navigation_display`
+
+Specifies the display property of the navigation item. See the
+[Navigation guide](/docs/configuration/navigation#display-control)
+
+```md
+---
+navigation_display: auth
+---
+```
+
 ### `toc`
 
 Controls whether the table of contents is displayed for the page. Set to `false` to hide the table

--- a/packages/zudoku/src/config/validators/NavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/NavigationSchema.ts
@@ -133,6 +133,7 @@ export class NavigationResolver {
       file: filePath,
       label,
       icon,
+      display: data.navigation_display,
       categoryLabel,
       path: fileNoExt,
     } satisfies NavigationDoc;


### PR DESCRIPTION
Add option to specify navigation display in frontmatter, in same way as you can specify the navigation properties "icon" (with `navigation_icon`) and "label" (with `navigation_label`).