### PR TITLE
Add Zuplo deployment documentation

### DIFF
--- a/docs/pages/docs/concepts/auth-provider-api-identities.md
+++ b/docs/pages/docs/concepts/auth-provider-api-identities.md
@@ -1,9 +1,7 @@
 ---
 title: Authentication Providers & API Identities
 sidebar_label: Authentication and Identities
-zuplo:
-  warning: |
-    This guide shows how to implement your own API Key management system in Zudoku. This is typically not needed when using Zuplo's built-in API Key management system. You only need to implement this if you want to integrate with a custom or third-party identity management system.
+zuplo: false
 ---
 
 When building an API documentation portal, you often need to provide a way for users to authenticate

--- a/docs/pages/docs/deploy/zuplo.md
+++ b/docs/pages/docs/deploy/zuplo.md
@@ -1,0 +1,110 @@
+---
+title: Zuplo
+zuplo: false
+---
+
+[Zuplo](https://zuplo.com) offers a fully managed hosting solution for your Zudoku-powered
+documentation, combined with a complete API gateway and management platform. When you deploy to
+Zuplo, you get more than just hosting—you get a production-ready developer portal with built-in API
+key management, rate limiting, analytics, and more.
+
+## Why Deploy to Zuplo?
+
+Deploying your Zudoku documentation to Zuplo provides several advantages:
+
+### Fully Managed Hosting
+
+- **Global Edge Network**: Your documentation is served from 300+ data centers worldwide, ensuring
+  fast load times for users everywhere
+- **Automatic SSL**: SSL certificates are automatically provisioned and renewed—no configuration
+  needed
+- **Custom Domains**: Easily configure custom domains for both your API gateway and developer portal
+- **Zero Infrastructure**: No servers to manage, scale, or maintain
+
+### Integrated API Gateway
+
+When your documentation lives alongside your API gateway, you unlock powerful capabilities:
+
+- **API Key Management**: Let developers self-serve their API keys directly from the documentation
+  portal
+- **Rate Limiting**: Protect your APIs with precise, edge-deployed rate limiting
+- **Authentication**: Support for API keys, JWT, OAuth, mTLS, and more
+- **Real-time Analytics**: Monitor API usage and performance in real-time
+
+### Developer Portal Features
+
+- **OpenAPI Integration**: Documentation is automatically generated and stays in sync with your
+  OpenAPI specifications
+- **Self-Service Keys**: Developers can create, view, and manage their API keys without waiting for
+  manual provisioning
+- **Usage Analytics**: Developers can see their own API usage and debug issues directly in the
+  portal
+- **Monetization Ready**: Create pricing plans and usage limits for your API products
+
+## Getting Started
+
+To deploy your Zudoku documentation to Zuplo:
+
+1. **Create a Zuplo Account**: Sign up for free at [zuplo.com](https://zuplo.com)
+2. **Create a New Project**: Set up a new project in the Zuplo Portal
+3. **Configure Your Developer Portal**: Enable the developer portal and customize it with your
+   Zudoku configuration
+4. **Deploy**: Push your changes and Zuplo handles the rest—your documentation is live globally in
+   seconds
+
+For detailed setup instructions, see the
+[Zuplo Developer Portal documentation](https://zuplo.com/docs/dev-portal/introduction).
+
+## Custom Domains
+
+You can configure custom domains for your developer portal in the Zuplo Portal:
+
+1. Go to **Settings** → **Custom Domain** in your project
+2. Click **Add New Custom Domain**
+3. Select **Developer Portal** as the domain type
+4. Enter your domain (e.g., `docs.example.com`)
+5. Add the CNAME record to your DNS provider:
+   ```
+   CNAME docs.example.com cname.zuplodocs.com
+   ```
+6. Redeploy your project to activate the custom domain
+
+SSL certificates are automatically provisioned and renewed for your custom domains.
+
+## Static Assets
+
+Place static files (images, PDFs, etc.) in a `public` directory in your project root. These files
+are served at the root path and can be referenced with absolute paths:
+
+```
+your-project/
+├── public/
+│   ├── images/
+│   │   └── diagram.png
+│   └── documents/
+│       └── api-spec.pdf
+└── ...
+```
+
+Reference them in your documentation:
+
+```markdown
+![API Architecture](/images/diagram.png)
+```
+
+## Pricing
+
+Zuplo offers multiple pricing tiers to fit your needs:
+
+- **Free**: Get started at no cost with essential features
+- **Builder**: For individual developers and small teams
+- **Enterprise**: Custom solutions with advanced analytics and support
+
+Visit [zuplo.com/pricing](https://zuplo.com/pricing) for current pricing details.
+
+## Learn More
+
+- [Zuplo Documentation](https://zuplo.com/docs)
+- [Developer Portal Guide](https://zuplo.com/docs/dev-portal/introduction)
+- [API Key Management](https://zuplo.com/features/api-key-management)
+- [Custom Domains](https://zuplo.com/docs/articles/custom-domains)

--- a/docs/pages/docs/guides/managing-api-keys-and-identities.md
+++ b/docs/pages/docs/guides/managing-api-keys-and-identities.md
@@ -2,6 +2,7 @@
 title: Managing API Keys and Identities
 sidebar_label: API Keys and Identities
 sidebar_icon: key-square
+zuplo: false
 ---
 
 ## Managing API Keys in UI
@@ -75,6 +76,9 @@ const config = {
 ```
 
 ## Using with any API Key Management System
+
+If you are not using Zuplo's API key management system, you can implement the `ApiKeyService`
+interface to connect to any API key management system.
 
 ```typescript
 interface ApiKeyService {

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -112,6 +112,7 @@ export const docs: Navigation = [
     icon: "cloud-upload",
     link: "docs/deployment",
     items: [
+      "docs/deploy/zuplo",
       "docs/deploy/cloudflare-pages",
       "docs/deploy/github-pages",
       "docs/deploy/vercel",


### PR DESCRIPTION
## Summary

- Add new documentation page for deploying Zudoku to Zuplo with managed hosting, API gateway integration, and developer portal features
- Update `auth-provider-api-identities.md` to simplify Zuplo frontmatter filtering
- Update `managing-api-keys-and-identities.md` to add context for non-Zuplo API key management
- Add Zuplo deployment option to the docs sidebar

## Test plan

- [ ] Verify the new Zuplo deployment page renders correctly
- [ ] Verify sidebar navigation includes the new page
- [ ] Verify Zuplo-specific content filtering works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)