### PR TITLE
feat: Only deploy docs to production on release tags

### DIFF
--- a/docs/scripts/check-release-tag.sh
+++ b/docs/scripts/check-release-tag.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Vercel Ignored Build Step script
+# Exit 0 = Skip build
+# Exit 1 = Proceed with build
+
+# Always build preview deployments
+if [ "$VERCEL_ENV" != "production" ]; then
+  echo "Preview deployment - proceeding with build"
+  exit 1
+fi
+
+# For production: only build if the commit is tagged with a release
+echo "Production deployment - checking for release tag..."
+
+# Fetch tags from remote (Vercel does shallow clones)
+git fetch --tags --quiet 2>/dev/null || true
+
+# Check if current commit has a version tag (e.g., v1.0.0, 1.0.0)
+TAGS=$(git tag --points-at HEAD 2>/dev/null)
+
+if [ -z "$TAGS" ]; then
+  echo "No tags found on this commit - skipping production build"
+  echo "Production deployments only occur on tagged releases"
+  exit 0
+fi
+
+# Check if any tag matches a version pattern
+for TAG in $TAGS; do
+  if echo "$TAG" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "Found release tag: $TAG - proceeding with production build"
+    exit 1
+  fi
+done
+
+echo "No release tags found (tags: $TAGS) - skipping production build"
+exit 0


### PR DESCRIPTION
## Summary
- Add Vercel Ignored Build Step script to control production deployments
- Preview deployments proceed normally
- Production deployments only proceed when the commit has a release tag (e.g., `v1.0.0`)
- Ensures the docs site version matches the published release

## Setup Required
After merging, configure in Vercel dashboard:
1. Go to project → **Settings** → **Git**
2. Find **Ignored Build Step**
3. Enter: `bash scripts/check-release-tag.sh`
4. Save

## Test plan
- [ ] Verify preview deployments still work on PRs
- [ ] Verify production builds are skipped on non-tagged main commits
- [ ] Verify production builds proceed when a release tag is present

🤖 Generated with [Claude Code](https://claude.ai/code)