### PR TITLE
feat: Improve Zuplo integration on homepage to increase paired usage

### DIFF
--- a/docs/src/LandingPage.tsx
+++ b/docs/src/LandingPage.tsx
@@ -22,8 +22,10 @@ import { BentoAuthReady } from "./components/BentoAuthReady";
 import { BentoInstall } from "./components/BentoInstall";
 import BentoInternalTools from "./components/BentoInternalTools";
 import { BentoStaticSite } from "./components/BentoStaticSite";
+import { BetterTogether } from "./components/BetterTogether";
 import { Box } from "./components/Box";
 import { BoxLongshadow } from "./components/BoxLongshadow";
+import { HostingSection } from "./components/HostingSection";
 import PoweredByYou from "./components/PoweredByYou";
 import { Preview } from "./components/Preview";
 import { SparklesText } from "./components/Sparkles";
@@ -335,39 +337,8 @@ const LandingPage = () => {
           <BentoStaticSite />
         </div>
       </div>
-      <div className="mt-16 w-full max-w-screen-lg flex flex-col items-center gap-16">
-        <div className="text-center font-semibold text-5xl capitalize">
-          Host it{" "}
-          <span className=" bg-gradient-to-br from-[#B6A0FB] via-[#7362EF] to-[#D2C6FF] bg-clip-text text-transparent">
-            Anywhere
-          </span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 items-center justify-center lg:grid-cols-4  w-full gap-5">
-          <div className="flex items-center justify-center">
-            <img src="/host/vercel.svg" alt="Vercel" />
-          </div>
-          <div className="flex items-center justify-center">
-            <img src="/host/cloudflare.svg" alt="Cloudflare" />
-          </div>
-          <div className="flex items-center justify-center">
-            <img src="/host/netlify.svg" alt="Netlify" />
-          </div>
-          <div className="flex items-center justify-center">
-            <img src="/host/zuplo.svg" alt="Zuplo" />
-          </div>
-        </div>
-
-        <a
-          href="https://zudoku.dev/docs"
-          className="hover:drop-shadow transition-all duration-300 text-xl rounded-full bg-black text-white px-8 py-3 flex items-center gap-2 w-fit self-center group"
-        >
-          Learn More{" "}
-          <ArrowRightIcon
-            size={20}
-            className="group-hover:translate-x-1 transition-all duration-300"
-          />
-        </a>
-      </div>
+      <BetterTogether />
+      <HostingSection />
       <div
         className="px-10 w-full bg-black rounded-3xl p-10 text-white shadow-[0px_-2px_16px_-4px_rgba(0,_0,_0,_0.5)]"
         style={{

--- a/docs/src/components/BetterTogether.tsx
+++ b/docs/src/components/BetterTogether.tsx
@@ -1,0 +1,138 @@
+import {
+  ArrowRightIcon,
+  GaugeIcon,
+  KeyIcon,
+  RefreshCwIcon,
+  ShieldCheckIcon,
+  ZapIcon,
+} from "zudoku/icons";
+import { BoxLongshadow } from "./BoxLongshadow";
+
+const benefits = [
+  {
+    icon: RefreshCwIcon,
+    title: "Auto-Sync OpenAPI",
+    description: "Your docs update automatically when your API changes",
+  },
+  {
+    icon: KeyIcon,
+    title: "Built-in Auth",
+    description: "API keys and auth flow seamlessly integrated",
+  },
+  {
+    icon: GaugeIcon,
+    title: "Usage Analytics",
+    description: "See how developers use your APIs in real-time",
+  },
+  {
+    icon: ShieldCheckIcon,
+    title: "Rate Limiting",
+    description: "Display rate limits directly in your documentation",
+  },
+];
+
+export const BetterTogether = () => {
+  return (
+    <div className="w-full bg-gradient-to-br from-[#7362EF] via-[#8D83FF] to-[#B6A0FB] py-20 px-10">
+      <div className="max-w-screen-lg mx-auto">
+        <div className="flex flex-col items-center text-center mb-16">
+          <div className="bg-white/20 backdrop-blur-sm rounded-full px-4 py-2 mb-6 text-white font-medium">
+            The Complete API Platform
+          </div>
+          <h2 className="text-4xl md:text-5xl font-bold text-white mb-4">
+            Better Together
+          </h2>
+          <p className="text-xl text-white/90 max-w-2xl">
+            Zudoku powers the documentation for Zuplo — the programmable API
+            gateway. Together, they deliver the complete developer experience.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+          <div className="flex flex-col gap-6">
+            <div className="bg-white rounded-2xl p-8 shadow-xl">
+              <div className="flex items-center gap-4 mb-6">
+                <BoxLongshadow className="p-3 bg-[#F2F4FF]">
+                  <img
+                    src="/zuplo.svg"
+                    alt="Zuplo"
+                    className="h-8 w-8 object-contain"
+                  />
+                </BoxLongshadow>
+                <div className="h-[2px] w-8 bg-gradient-to-r from-[#7362EF] to-[#B6A0FB]" />
+                <div className="text-2xl">+</div>
+                <div className="h-[2px] w-8 bg-gradient-to-r from-[#B6A0FB] to-[#7362EF]" />
+                <BoxLongshadow className="p-3 bg-[#F2F4FF]">
+                  <img
+                    src="/zudoku-logo.svg"
+                    alt="Zudoku"
+                    className="h-8 w-8 object-contain"
+                  />
+                </BoxLongshadow>
+              </div>
+
+              <h3 className="text-2xl font-bold text-black mb-2">
+                API Management + Beautiful Docs
+              </h3>
+              <p className="text-muted-foreground mb-6">
+                Deploy your API gateway and developer portal together. One
+                platform, seamless integration, exceptional developer
+                experience.
+              </p>
+
+              <a
+                href="https://zuplo.com"
+                target="_blank"
+                rel="noreferrer"
+                className="group inline-flex items-center gap-2 bg-black text-white px-6 py-3 rounded-full font-medium hover:bg-black/90 transition-all"
+              >
+                Try Zuplo Free
+                <ArrowRightIcon
+                  size={18}
+                  className="group-hover:translate-x-1 transition-transform"
+                />
+              </a>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {benefits.map((benefit) => (
+              <div
+                key={benefit.title}
+                className="bg-white/10 backdrop-blur-sm rounded-xl p-5 border border-white/20 hover:bg-white/20 transition-all group"
+              >
+                <benefit.icon
+                  size={24}
+                  className="text-white mb-3 group-hover:scale-110 transition-transform"
+                />
+                <h4 className="text-white font-semibold mb-1">
+                  {benefit.title}
+                </h4>
+                <p className="text-white/80 text-sm">{benefit.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <div className="flex items-center gap-3 text-white/90">
+            <ZapIcon size={20} className="text-yellow-300" />
+            <span>Instant deployment</span>
+          </div>
+          <div className="hidden sm:block w-1 h-1 bg-white/50 rounded-full" />
+          <div className="flex items-center gap-3 text-white/90">
+            <ShieldCheckIcon size={20} className="text-green-300" />
+            <span>Enterprise ready</span>
+          </div>
+          <div className="hidden sm:block w-1 h-1 bg-white/50 rounded-full" />
+          <div className="flex items-center gap-3 text-white/90">
+            <KeyIcon size={20} className="text-blue-300" />
+            <span>Free tier available</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BetterTogether;

--- a/docs/src/components/HostingSection.tsx
+++ b/docs/src/components/HostingSection.tsx
@@ -1,0 +1,135 @@
+import { cn } from "zudoku";
+import { ArrowRightIcon, CheckIcon, StarIcon } from "zudoku/icons";
+import { BoxLongshadow } from "./BoxLongshadow";
+
+const hostingOptions = [
+  {
+    name: "Vercel",
+    logo: "/host/vercel.svg",
+    href: "https://vercel.com",
+  },
+  {
+    name: "Cloudflare",
+    logo: "/host/cloudflare.svg",
+    href: "https://cloudflare.com",
+  },
+  {
+    name: "Netlify",
+    logo: "/host/netlify.svg",
+    href: "https://netlify.com",
+  },
+];
+
+const zuploFeatures = [
+  "Auto-sync from your API gateway",
+  "Built-in authentication",
+  "API key management",
+  "Usage analytics dashboard",
+  "Custom domains included",
+];
+
+export const HostingSection = () => {
+  return (
+    <div className="w-full max-w-screen-lg mx-auto px-10 py-16">
+      <div className="text-center mb-12">
+        <h2 className="text-4xl md:text-5xl font-semibold capitalize mb-4">
+          Host it{" "}
+          <span className="bg-gradient-to-br from-[#B6A0FB] via-[#7362EF] to-[#D2C6FF] bg-clip-text text-transparent">
+            Anywhere
+          </span>
+        </h2>
+        <p className="text-muted-foreground text-xl">
+          Deploy to any static hosting platform, or get the complete experience
+          with Zuplo
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-8">
+        {/* Zuplo - Recommended Option */}
+        <div className="lg:col-span-3 relative">
+          <div className="absolute -top-3 left-6 z-10">
+            <div className="bg-gradient-to-r from-[#7362EF] to-[#B6A0FB] text-white text-sm font-medium px-4 py-1.5 rounded-full flex items-center gap-1.5 shadow-lg">
+              <StarIcon size={14} fill="currentColor" />
+              Recommended
+            </div>
+          </div>
+          <BoxLongshadow
+            shadowLength="large"
+            className="p-8 bg-gradient-to-br from-white to-[#F8F7FF] h-full border-2 border-[#7362EF]"
+          >
+            <div className="flex items-center gap-4 mb-6">
+              <img src="/host/zuplo.svg" alt="Zuplo" className="h-10" />
+              <div className="flex-1" />
+              <span className="text-sm text-muted-foreground bg-[#F2F4FF] px-3 py-1 rounded-full">
+                API Gateway + Docs
+              </span>
+            </div>
+
+            <h3 className="text-2xl font-bold mb-2">
+              The Complete API Platform
+            </h3>
+            <p className="text-muted-foreground mb-6">
+              Deploy your Zudoku documentation alongside your API gateway. Get
+              automatic OpenAPI sync, authentication, and analytics out of the
+              box.
+            </p>
+
+            <ul className="space-y-3 mb-8">
+              {zuploFeatures.map((feature) => (
+                <li key={feature} className="flex items-center gap-3">
+                  <div className="bg-[#7362EF] rounded-full p-1">
+                    <CheckIcon size={12} className="text-white" />
+                  </div>
+                  <span className="text-sm">{feature}</span>
+                </li>
+              ))}
+            </ul>
+
+            <a
+              href="https://zuplo.com"
+              target="_blank"
+              rel="noreferrer"
+              className="group inline-flex items-center gap-2 bg-black text-white px-6 py-3 rounded-full font-medium hover:bg-black/90 transition-all"
+            >
+              Get Started with Zuplo
+              <ArrowRightIcon
+                size={18}
+                className="group-hover:translate-x-1 transition-transform"
+              />
+            </a>
+          </BoxLongshadow>
+        </div>
+
+        {/* Other Hosting Options */}
+        <div className="lg:col-span-2 flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground uppercase tracking-wide font-medium mb-2">
+            Or deploy anywhere
+          </p>
+          {hostingOptions.map((host) => (
+            <a
+              key={host.name}
+              href={host.href}
+              target="_blank"
+              rel="noreferrer"
+              className={cn(
+                "group flex items-center gap-4 p-4 rounded-xl border border-black/10 hover:border-[#7362EF]/50 hover:bg-[#F8F7FF] transition-all",
+              )}
+            >
+              <img src={host.logo} alt={host.name} className="h-8" />
+              <div className="flex-1" />
+              <ArrowRightIcon
+                size={16}
+                className="text-muted-foreground group-hover:text-[#7362EF] group-hover:translate-x-1 transition-all"
+              />
+            </a>
+          ))}
+          <p className="text-sm text-muted-foreground mt-2">
+            Zudoku generates static files that work with any hosting provider.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HostingSection;

--- a/docs/src/components/Preview.tsx
+++ b/docs/src/components/Preview.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useReducer } from "react";
 import { cn } from "zudoku";
-import { MoonStarIcon, SunIcon } from "zudoku/icons";
+import { ArrowRightIcon, MoonStarIcon, SunIcon, ZapIcon } from "zudoku/icons";
 import PoweredByYou from "./PoweredByYou";
 
 const tags = [
@@ -30,6 +30,27 @@ const Hero = () => {
         Create clean, consistent API docs with Zudoku — open source, extensible,
         and developer-first
       </p>
+      <div className="flex flex-col sm:flex-row items-center gap-4 mt-4">
+        <a
+          href="/docs/quickstart"
+          className="group font-medium bg-black text-white px-6 py-3 rounded-full flex items-center gap-2 hover:bg-black/90 transition-all"
+        >
+          Get Started
+          <ArrowRightIcon
+            size={18}
+            className="group-hover:translate-x-1 transition-transform"
+          />
+        </a>
+        <a
+          href="https://zuplo.com"
+          target="_blank"
+          rel="noreferrer"
+          className="group font-medium border-2 border-[#7362EF] text-black px-6 py-3 rounded-full flex items-center gap-2 hover:bg-[#7362EF] hover:text-white transition-all"
+        >
+          <ZapIcon size={18} />
+          Try with Zuplo
+        </a>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- Add "Better Together" section showcasing Zuplo + Zudoku synergy with
  key benefits (Auto-Sync OpenAPI, Built-in Auth, Usage Analytics, Rate Limiting)
- Replace basic "Host it Anywhere" section with enhanced HostingSection
  that positions Zuplo as the recommended premium option
- Add hero CTAs with "Get Started" for docs and "Try with Zuplo" for the
  full platform experience
- Use consistent brand styling with purple gradient theme

https://claude.ai/code/session_017FiaDKg6rRHPTxfUQBewa3