### PR TITLE
fix(auth): improve OpenID token error handling

### DIFF
--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -218,8 +218,10 @@ export class OpenIDAuthenticationProvider
 
   async getAccessToken(): Promise<string> {
     const as = await this.getAuthServer();
-    const { providerData } = useAuthState.getState();
+    const { providerData, setLoggedOut } = useAuthState.getState();
+
     if (!providerData) {
+      setLoggedOut();
       throw new AuthorizationError("User is not authenticated");
     }
     const tokenState = providerData as OpenIdProviderData;
@@ -232,7 +234,7 @@ export class OpenIDAuthenticationProvider
           profile: null,
           providerData: null,
         });
-        return "";
+        throw new AuthorizationError("No refresh token found");
       }
 
       const request = await oauth.refreshTokenGrantRequest(
@@ -247,6 +249,7 @@ export class OpenIDAuthenticationProvider
       );
 
       if (!response.access_token) {
+        setLoggedOut();
         throw new AuthorizationError("No access token in response");
       }
 


### PR DESCRIPTION
In packages/zudoku/src/lib/authentication/providers/openid.tsx destructure setLoggedOut and call it to mark the user logged out when provider data is missing or when token exchange fails. Replace the previous silent return of an empty string with an AuthorizationError when no refresh token is present. Also call setLoggedOut and throw an AuthorizationError when the token refresh response lacks an access token.

These changes keep the authentication state consistent and surface explicit errors to callers instead of returning empty tokens that could lead to incorrect downstream behavior.