### PR TITLE
Fixes protected routes

### DIFF
--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -66,7 +66,10 @@ export const render = async ({
 
   const router = createStaticRouter(dataRoutes, context);
   const helmetContext = {} as HelmetData["context"];
-  const renderContext = { status: 200 };
+  const renderContext = {
+    status: 200,
+    bypassProtection: bypassProtection ?? false,
+  };
 
   const App = (
     <BootstrapStatic

--- a/packages/zudoku/src/lib/components/Bootstrap.tsx
+++ b/packages/zudoku/src/lib/components/Bootstrap.tsx
@@ -4,7 +4,7 @@ import {
   QueryClientProvider,
 } from "@tanstack/react-query";
 import { type HelmetData, HelmetProvider } from "@zudoku/react-helmet-async";
-import { StrictMode, useMemo } from "react";
+import { StrictMode } from "react";
 import {
   type createBrowserRouter,
   type createStaticRouter,
@@ -57,28 +57,21 @@ const BootstrapStatic = ({
   queryClient: QueryClient;
   router: ReturnType<typeof createStaticRouter>;
   bypassProtection?: boolean;
-  renderContext?: Partial<RenderContextValue>;
-}) => {
-  const value = useMemo(
-    () => ({
-      status: 200,
-      bypassProtection,
-      ...renderContext,
-    }),
-    [bypassProtection, renderContext],
-  );
-
-  return (
-    <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <HelmetProvider context={helmetContext}>
-          <RenderContext value={value}>
-            <StaticRouterProvider router={router} context={context} />
-          </RenderContext>
-        </HelmetProvider>
-      </QueryClientProvider>
-    </StrictMode>
-  );
-};
+  renderContext?: RenderContextValue;
+}) => (
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider context={helmetContext}>
+        <RenderContext
+          value={
+            renderContext ?? { status: 200, bypassProtection: bypassProtection }
+          }
+        >
+          <StaticRouterProvider router={router} context={context} />
+        </RenderContext>
+      </HelmetProvider>
+    </QueryClientProvider>
+  </StrictMode>
+);
 
 export { Bootstrap, BootstrapStatic };

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -138,7 +138,13 @@ export const RouteGuard = () => {
   useEffect(() => {
     if (!auth.isAuthenticated || !intendedPath) return;
     const check = getAuthCheck(intendedPath);
-    if (!check || check(authCheckContext) === true) {
+    if (!check) {
+      blocker.proceed?.();
+      return;
+    }
+    const result = check(authCheckContext);
+    // Proceed whenever the result is no longer UNAUTHORIZED (e.g. true or FORBIDDEN)
+    if (result !== false && result !== REASON_CODES.UNAUTHORIZED) {
       blocker.proceed?.();
     }
   }, [


### PR DESCRIPTION
- Fix post-login blocker getting stuck on UNAUTHORIZED→FORBIDDEN transition by proceeding whenever the auth result is no longer UNAUTHORIZED
- Fix renderContext spread in BootstrapStatic breaking SSR status propagation by passing the original object reference instead of copying via useMemo
- Add test coverage for FORBIDDEN reason code (ForbiddenPage rendering and navigation not being blocked with login dialog)

https://claude.ai/code/session_018fLTYgTiERmHWmTSVUV6GF