### PR TITLE
Document `protectedRoutes` improvements

### DIFF
--- a/docs/pages/docs/configuration/authentication.md
+++ b/docs/pages/docs/configuration/authentication.md
@@ -168,19 +168,32 @@ If the provider does not return a field, it will be left blank.
 ## Protected Routes
 
 Once authentication is configured, you can protect specific routes in your documentation to require
-users to be authenticated or meet custom authorization requirements.
+users to be authenticated or meet custom authorization requirements. Routes can be protected with a
+simple array of patterns, or with custom callback functions that support reason codes for
+distinguishing between unauthorized and forbidden access.
 
 ```typescript title="zudoku.config.ts"
 {
   // ...
+  // Simple array format: requires authentication
   protectedRoutes: [
-    "/admin/*",     // Protect all routes under /admin
-    "/settings",    // Protect the settings page
-    "/api/*",       // Protect all API-related routes
+    "/admin/*",
+    "/settings",
+    "/api/*",
   ],
+
+  // Or object format: custom authorization with reason codes
+  protectedRoutes: {
+    "/admin/*": ({ auth, reasonCode }) =>
+      !auth.isAuthenticated
+        ? reasonCode.UNAUTHORIZED
+        : auth.profile?.email?.endsWith("@example.com")
+          ? true
+          : reasonCode.FORBIDDEN,
+  },
   // ...
 }
 ```
 
 See the [Protected Routes](./protected-routes.md) documentation for detailed information on
-configuring route protection with simple patterns or advanced authorization logic.
+configuring route protection, reason codes, and navigation behavior.

--- a/docs/pages/docs/configuration/protected-routes.md
+++ b/docs/pages/docs/configuration/protected-routes.md
@@ -3,12 +3,13 @@ title: Protected Routes
 sidebar_icon: squares-subtract
 description:
   Learn how to protect specific routes in your documentation using authentication, including simple
-  array patterns and advanced authorization logic with custom callback functions.
+  array patterns, advanced authorization with reason codes, and custom callback functions.
 ---
 
 You can protect specific routes in your documentation by adding the `protectedRoutes` property to
-your [Zudoku configuration](./overview.md). This property supports two formats: a simple array of
-path patterns, or an advanced object format with custom authorization logic.
+your [Zudoku configuration](./overview.md). This requires [authentication](./authentication.md) to
+be configured. The property supports two formats: a simple array of path patterns, or an advanced
+object format with custom authorization logic.
 
 ## Array Format
 
@@ -28,7 +29,11 @@ authenticated to access these routes.
 }
 ```
 
-## Advanced Object Format
+When a user tries to access a protected route, a login dialog will appear prompting them to sign in
+or register. After logging in, they are automatically redirected back to the route they were trying
+to access.
+
+## Object Format
 
 For more complex authorization logic, you can provide a record mapping route patterns to custom
 callback functions:
@@ -38,27 +43,82 @@ callback functions:
   // ...
   protectedRoutes: {
     // Only allow authenticated users with admin role
-    "/admin/*": ({ auth, context }) =>
+    "/admin/*": ({ auth }) =>
       auth.isAuthenticated && auth.user?.role === "admin",
 
     // Check if user has enterprise access
-    "/api/enterprise/*": ({ auth, context }) =>
+    "/api/enterprise/*": ({ auth }) =>
       auth.isAuthenticated && auth.user?.subscription === "enterprise",
 
     // Allow access to beta features based on user attributes
-    "/beta/*": ({ auth, context }) =>
+    "/beta/*": ({ auth }) =>
       auth.isAuthenticated && auth.user?.betaAccess === true,
   },
   // ...
 }
 ```
 
+### Callback Parameters
+
 The callback function receives an object with:
 
-- `auth`: The current authentication state including `isAuthenticated`, `user` data, and more
-- `context`: The Zudoku context providing access to configuration and utilities
+- `auth` - The current authentication state, including `isAuthenticated`, `isPending`, `profile`,
+  and more
+- `context` - The Zudoku context providing access to configuration and utilities
+- `reasonCode` - An object containing the reason code constants `UNAUTHORIZED` and `FORBIDDEN` (see
+  [Reason Codes](#reason-codes))
 
-The callback must return a boolean indicating whether the user should have access to the route.
+### Return Values
+
+The callback can return a `boolean` or a reason code string:
+
+| Return value              | Behavior                                          |
+| ------------------------- | ------------------------------------------------- |
+| `true`                    | Allow access to the route                         |
+| `false`                   | Treated as `UNAUTHORIZED` - prompts login         |
+| `reasonCode.UNAUTHORIZED` | Show a login dialog prompting the user to sign in |
+| `reasonCode.FORBIDDEN`    | Show a 403 "Access Denied" page                   |
+
+## Reason Codes
+
+Reason codes allow you to distinguish between users who need to sign in and users who are signed in
+but lack permission. This is useful for building role-based or attribute-based access control.
+
+- **`UNAUTHORIZED`** - The user is not authenticated. A login dialog is shown, and navigation to the
+  route is blocked until the user signs in.
+- **`FORBIDDEN`** - The user is authenticated but does not have permission. A 403 "Access Denied"
+  page is displayed instead of the route content.
+
+```typescript title="zudoku.config.ts"
+{
+  // ...
+  protectedRoutes: {
+    // Members-only page: unauthenticated users see a login prompt
+    "/only-members": ({ auth, reasonCode }) =>
+      auth.isAuthenticated ? true : reasonCode.UNAUTHORIZED,
+
+    // VIP page: unauthenticated users see a login prompt,
+    // authenticated users without permission see "Access Denied"
+    "/vip-lounge": ({ auth, reasonCode }) =>
+      !auth.isAuthenticated
+        ? reasonCode.UNAUTHORIZED
+        : auth.profile?.email?.endsWith("@example.com")
+          ? true
+          : reasonCode.FORBIDDEN,
+  },
+  // ...
+}
+```
+
+## Navigation Blocking
+
+When a user navigates to a route that returns `false` or `UNAUTHORIZED`, navigation is intercepted
+before the page changes. The user stays on the current page while a login dialog is displayed. If
+the user cancels, they remain on the current page. If they log in successfully, navigation
+automatically proceeds to the protected route.
+
+Routes that return `FORBIDDEN` do not block navigation — the user navigates to the route and sees
+the "Access Denied" page.
 
 ## Path Patterns
 
@@ -73,9 +133,6 @@ For example:
 - `/users/:id` matches `/users/123` or `/users/abc`
 - `/docs/*` matches `/docs/getting-started` or `/docs/api/reference`
 - `/settings` matches only the exact path `/settings`
-
-After logging in, users will be automatically redirected back to the protected route they were
-trying to access.
 
 ## Next Steps
 


### PR DESCRIPTION
Document the updated protectedRoutes feature including:
- Reason codes (UNAUTHORIZED vs FORBIDDEN) and their distinct behaviors
- Callback return values table (boolean and reason code strings)
- reasonCode parameter in callback context
- Navigation blocking behavior for unauthorized routes
- Forbidden (403) page behavior for authenticated but unpermitted users
- Updated examples showing reason code usage patterns

https://claude.ai/code/session_01EkPYn7ZvpYcpKBgLXXe6AN