### PR TITLE
Merge tags and tagGroups with the same name in sidebar

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/util/buildTagCategories.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/buildTagCategories.test.ts
@@ -104,29 +104,11 @@ describe("buildTagCategories", () => {
     expect(contacts?.type).toBe("category");
 
     if (contacts?.type === "category") {
-      // Operations from the "Contacts" tag come first, then "Notes" as a child
+      // Operations from the "Contacts" tag come first, then "Notes" as a child.
+      // "Contacts" must not appear as a nested child of itself.
       expect(contacts.items).toHaveLength(2);
       expect(contacts.items[0]?.label).toBe("Contacts op");
       expect(contacts.items[1]?.label).toBe("Notes");
-    }
-  });
-
-  it("excludes self-reference when tagGroup includes its own name in tags", () => {
-    const tagCategories = new Map<string, NavigationItem>([
-      ["Contacts", makeTag("Contacts")],
-      ["Notes", makeTag("Notes")],
-    ]);
-
-    const result = buildTagCategories({
-      tagCategories,
-      tagGroups: [{ name: "Contacts", tags: ["Contacts", "Notes"] }],
-    });
-
-    const contacts = result[0];
-    if (contacts?.type === "category") {
-      // "Contacts" tag should NOT appear as a nested child of itself
-      const childLabels = contacts.items.map((i) => i.label);
-      expect(childLabels).not.toContain("Contacts");
     }
   });
 


### PR DESCRIPTION
Mimic the more permissive "Enhanced tags" behaviour from OpenAPI 3.2.0, by allowing a tag to have both direct operations and nested child tags from tagGroups. When a tag and x-tagGroup share the same name, they are now combined into a single sidebar category instead of appearing twice.

However, this current implementation does not use `x-displayName` as, these could still be different tags. Only the actual `name` of a tag is considered when checking name equality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for tag categorization and grouping logic covering various merging scenarios.

* **Improvements**
  * Enhanced tag and category merging strategy for improved organization of OpenAPI documentation categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->