### PR TITLE
docs: add client-side only caveat to protectedRoutes

### DIFF
--- a/docs/pages/docs/configuration/protected-routes.md
+++ b/docs/pages/docs/configuration/protected-routes.md
@@ -11,15 +11,12 @@ your [Zudoku configuration](./overview.md). This requires [authentication](./aut
 be configured. The property supports two formats: a simple array of path patterns, or an advanced
 object format with custom authorization logic.
 
-:::caution[Client-side protection only]
+:::note{title="Client-side protection only"}
 
-Zudoku builds your documentation as static site generated (SSG) content. All page content, including
-API specifications, is bundled into the JavaScript files served to every visitor. Protected routes
-only prevent navigation on the client side — they do not prevent the underlying content from being
-downloaded and inspected in the browser's JavaScript bundles.
+`protectedRoutes` are client-side only. Do not rely on `protectedRoutes` to hide sensitive
+information.
 
-Do not rely on `protectedRoutes` to hide sensitive or confidential API specifications. Server-side
-rendering support with proper access control is currently being developed.
+We are working on an additional offering that secures this data server-side.
 
 :::
 


### PR DESCRIPTION
## Summary
- Adds note to `protectedRoutes` docs that protection is client-side only
- Mentions server-side offering is in development

Supersedes #1962