### PR TITLE
Revert OpenAPI default tag sorting from #1947

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/util/buildTagCategories.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/buildTagCategories.test.ts
@@ -13,44 +13,6 @@ const makeTag = (label: string): NavigationItem => ({
 });
 
 describe("buildTagCategories", () => {
-  it("returns tags sorted alphabetically when no tag groups exist", () => {
-    const tagCategories = new Map<string, NavigationItem>([
-      ["Zebra", makeTag("Zebra")],
-      ["Alpha", makeTag("Alpha")],
-    ]);
-
-    const result = buildTagCategories({
-      tagCategories,
-      tagGroups: [],
-    });
-
-    expect(result).toHaveLength(2);
-    expect(result[0]?.label).toBe("Alpha");
-    expect(result[1]?.label).toBe("Zebra");
-  });
-
-  it("sorts groups and ungrouped tags alphabetically", () => {
-    const tagCategories = new Map<string, NavigationItem>([
-      ["Packages", makeTag("Packages")],
-      ["Tracking", makeTag("Tracking")],
-      ["Documentation", makeTag("Documentation")],
-      ["Invoices", makeTag("Invoices")],
-    ]);
-
-    const result = buildTagCategories({
-      tagCategories,
-      tagGroups: [
-        { name: "Shipment", tags: ["Packages", "Tracking"] },
-        { name: "Billing", tags: ["Invoices"] },
-      ],
-    });
-
-    expect(result).toHaveLength(3);
-    expect(result[0]?.label).toBe("Billing");
-    expect(result[1]?.label).toBe("Documentation");
-    expect(result[2]?.label).toBe("Shipment");
-  });
-
   it("preserves nested group structure", () => {
     const tagCategories = new Map<string, NavigationItem>([
       ["Packages", makeTag("Packages")],

--- a/packages/zudoku/src/lib/plugins/openapi/util/buildTagCategories.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/buildTagCategories.ts
@@ -42,7 +42,5 @@ export const buildTagCategories = ({
     .filter(([name]) => !groupedTags.has(name))
     .map(([, cat]) => cat);
 
-  return [...groupedCategories, ...ungroupedCategories].sort((a, b) =>
-    (a.label ?? "").localeCompare(b.label ?? ""),
-  );
+  return [...groupedCategories, ...ungroupedCategories];
 };


### PR DESCRIPTION
Reverts the default alphabetical sorting of tag categories introduced in #1947. Sorting by default changes the sidebar order for all APIs which is a breaking change.

The same behavior can be achieved using the upcoming `navigationRules` feature #1949.
