### PR TITLE
Fix link rewriting to skip external and mailto URLs

### DIFF
--- a/packages/zudoku/src/vite/mdx/remark-link-rewrite.ts
+++ b/packages/zudoku/src/vite/mdx/remark-link-rewrite.ts
@@ -7,18 +7,14 @@ export const remarkLinkRewrite =
   (tree: Root) => {
     visit(tree, "link", (node) => {
       if (!node.url) return;
+      if (node.url.startsWith("http") || node.url.startsWith("mailto:")) return;
 
       node.url = node.url.replace(/\\/g, "/");
 
       const base = path.posix.join(basePath);
       if (basePath && node.url.startsWith(base)) {
         node.url = node.url.slice(base.length);
-      } else if (
-        !node.url.startsWith("http") &&
-        !node.url.startsWith("mailto:") &&
-        !node.url.startsWith("/") &&
-        !node.url.startsWith("#")
-      ) {
+      } else if (!node.url.startsWith("/") && !node.url.startsWith("#")) {
         node.url = path.posix.join("..", node.url);
       }
 


### PR DESCRIPTION
Fix #1952

## Summary
Updated the MDX link rewriting logic to prevent modification of external URLs and mailto links, which should be preserved as-is.

## Key Changes
- Added a conditional check to only apply the `.mdx?` extension stripping to relative URLs
- External URLs (starting with `http`) and mailto links are now skipped from the rewrite transformation
- This prevents unintended modifications to absolute URLs and email links during the MDX processing pipeline

https://claude.ai/code/session_01HdKesEvtWLzr7nT5o4wCGX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling to properly preserve external links (HTTP and mailto URLs) and relative links, ensuring they are not incorrectly rewritten during content processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->