### PR TITLE
fix: prioritize examples array in schema example generation

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -342,17 +342,23 @@
       "Error": {
         "type": "object",
         "required": ["code", "message"],
+        "example": {
+          "code": "SHIPMENT_NOT_FOUND",
+          "message": "The requested shipment could not be found"
+        },
         "properties": {
           "code": {
             "type": "string",
             "pattern": "^[A-Z_]+$",
             "minLength": 1,
-            "maxLength": 50
+            "maxLength": 50,
+            "example": "SHIPMENT_NOT_FOUND"
           },
           "message": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 500
+            "maxLength": 500,
+            "example": "The requested shipment could not be found"
           }
         }
       },

--- a/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.ts
@@ -29,9 +29,17 @@ export const generateSchemaExample = (
     }
   }
 
-  // No example needed for const values
+  // const is a strict constraint and takes precedence over examples
   if (schema.const !== undefined) {
     return schema.const;
+  }
+
+  if (
+    schema.examples &&
+    Array.isArray(schema.examples) &&
+    schema.examples.length > 0
+  ) {
+    return schema.examples[0];
   }
 
   // For object schemas with properties
@@ -93,15 +101,6 @@ export const generateSchemaExample = (
     // Should likely be expanded to return a partial set of values, but it would require
     // detection if being used within an array or a string type.
     return generateSchemaExample(schema.anyOf[0]);
-  }
-
-  // Check for property-level examples
-  if (
-    schema.examples &&
-    Array.isArray(schema.examples) &&
-    schema.examples.length > 0
-  ) {
-    return schema.examples[0];
   }
 
   switch (schema.type) {


### PR DESCRIPTION
Closes #1024

The OAS 3.0→3.1 upgrade converts `example` to `examples: [value]` and deletes `example`. The `examples` array check in `generateSchemaExample` was after the object-properties loop and format handlers so it was never reached for those cases. Moved the check earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OpenAPI processing pipeline docs, including schema loading paths, upgrade steps, GraphQL exposure/serialization, and plugin architecture notes.

* **Updates**
  * Added example data to error schemas (codes and messages).
  * Updated example resolution to prioritize top-level examples for more consistent sample output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->