### PR TITLE
fix: "Other endpoints" navigation shown when it shouldn't

### DIFF
--- a/packages/zudoku/src/lib/oas/graphql/index.ts
+++ b/packages/zudoku/src/lib/oas/graphql/index.ts
@@ -99,16 +99,14 @@ export const getAllTags = (
   slugs: ReturnType<typeof getAllSlugs>["tags"],
 ): Array<Omit<TagObject, "name"> & { name?: string; slug?: string }> => {
   const rootTags = schema.tags ?? [];
-  const operationTags = new Set(
-    Object.values(schema.paths ?? {})
-      .flatMap((path) => Object.values(path ?? {}))
-      .flatMap((op) => (op as OperationObject).tags ?? []),
+  const operations = Object.values(schema.paths ?? {}).flatMap((path) =>
+    HttpMethods.map((k) => path?.[k]).filter((op) => op != null),
   );
 
-  const hasUntaggedOperations = Object.values(schema.paths ?? {}).some((path) =>
-    Object.values(path ?? {}).some(
-      (op) => !(op as OperationObject).tags?.length,
-    ),
+  const operationTags = new Set(operations.flatMap((op) => op.tags ?? []));
+
+  const hasUntaggedOperations = operations.some(
+    (op) => (op.tags?.length ?? 0) === 0,
   );
 
   const result = [


### PR DESCRIPTION
The value for "hasUntaggedOperations" was set to true when a path declared for example "parameters". Fixed by only looking at HttpMethods keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to operation tag computation logic in the GraphQL OpenAPI handling. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->