### PR TITLE
fix(env): Add `ZUPLO_PUBLIC_DISABLE_INJECT_ENDPOINT` to stop overwriting server URL

### DIFF
--- a/packages/zudoku/src/app/env.ts
+++ b/packages/zudoku/src/app/env.ts
@@ -36,7 +36,7 @@ export const ZuploEnv = {
   },
 
   get serverUrl(): string | undefined {
-    return process.env.ZUDOKU_SERVER_URL ?? process.env.ZUPLO_SERVER_URL;
+    return process.env.ZUPLO_SERVER_URL;
   },
 
   buildConfig: getZuploBuildConfig(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Server configuration now prioritizes a new environment variable while remaining backward compatible with the previous setting.
* **Bug Fixes**
  * Public API documentation generation no longer injects a server endpoint when injection has been explicitly disabled, preventing unintended URL exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->