### PR TITLE
fix: use OIDC auth for monetization plugin publish

### DIFF
--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -62,8 +62,6 @@ jobs:
 
       - name: Publish
         run: pnpm publish --provenance --filter @zuplo/zudoku-plugin-monetization --no-git-checks --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit and tag
         run: |


### PR DESCRIPTION
Remove unused `NODE_AUTH_TOKEN` env var from monetization release workflow. OIDC trusted publisher handles auth automatically, matching how the main zudoku release workflow works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal publishing workflow configuration.

---

**Note:** This release contains no user-facing changes. The update addresses internal build and deployment processes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->