### PR TITLE
fix: use npm publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -46,6 +46,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
+      - name: Update npm for OIDC trusted publishing support
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -61,7 +64,8 @@ jobs:
         run: echo "version=$(node --print 'require(`./packages/plugin-zuplo-monetization/package.json`).version')" >> $GITHUB_OUTPUT
 
       - name: Publish
-        run: pnpm publish --provenance --filter @zuplo/zudoku-plugin-monetization --no-git-checks --tag latest
+        working-directory: packages/plugin-zuplo-monetization
+        run: npm publish --provenance --access public --tag latest
 
       - name: Commit and tag
         run: |


### PR DESCRIPTION
Node 22 ships npm 10.x which doesn't support OIDC trusted publishing (requires >= 11.5.1). Update npm to latest and switch to `npm publish` directly until pnpm 11 ships native OIDC support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure to improve publishing reliability and security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->