### PR TITLE
Improve generateSchemaExample with missing schema features

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.test.ts
@@ -306,7 +306,23 @@ describe("generateSchemaExample", () => {
     it("respects exclusiveMaximum", () => {
       expect(
         generateSchemaExample({ type: "number", exclusiveMaximum: 0 }),
-      ).toBe(-1);
+      ).toBe(-0.1);
+    });
+
+    it("uses integer offset for exclusiveMinimum on integer types", () => {
+      expect(
+        generateSchemaExample({ type: "integer", exclusiveMinimum: 5 }),
+      ).toBe(6);
+    });
+
+    it("uses float offset for exclusiveMinimum on number types", () => {
+      expect(
+        generateSchemaExample({
+          type: "number",
+          format: "float",
+          exclusiveMinimum: 0,
+        }),
+      ).toBe(0.1);
     });
 
     it("returns 0 when it satisfies constraints", () => {

--- a/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/generateSchemaExample.ts
@@ -1,6 +1,11 @@
 import type { SchemaObject } from "../../../oas/graphql/index.js";
 import { isCircularRef } from "../schema/utils.js";
 
+const isIntegerSchema = (schema: SchemaObject): boolean =>
+  schema.type === "integer" ||
+  schema.format === "int32" ||
+  schema.format === "int64";
+
 const getNumberExample = (schema: SchemaObject): number => {
   const min =
     typeof schema.exclusiveMinimum === "number"
@@ -15,8 +20,9 @@ const getNumberExample = (schema: SchemaObject): number => {
         ? schema.maximum
         : undefined;
 
-  const minOffset = typeof schema.exclusiveMinimum === "number" ? 1 : 0;
-  const maxOffset = typeof schema.exclusiveMaximum === "number" ? 1 : 0;
+  const offset = isIntegerSchema(schema) ? 1 : 0.1;
+  const minOffset = typeof schema.exclusiveMinimum === "number" ? offset : 0;
+  const maxOffset = typeof schema.exclusiveMaximum === "number" ? offset : 0;
 
   if (min !== undefined && min >= 0) return min + minOffset;
   if (max !== undefined && max <= 0) return max - maxOffset;


### PR DESCRIPTION
## Summary
- Add `schema.default` support in the value precedence chain
- Handle `additionalProperties` for objects without explicit `properties`
- Add missing format examples: `hostname`, `password`, `byte`, `binary`, `duration`, `int32`/`int64`/`float`/`double`
- Respect number constraints (`minimum`, `exclusiveMinimum`, `maximum`, `exclusiveMaximum`)
- Respect string `minLength` by padding when generated value is too short
- Add tests

Closes #1027