### PR TITLE
Fix code blocks rendering as full CodeBlock in ToC

### DIFF
--- a/packages/zudoku/src/lib/components/InlineCode.tsx
+++ b/packages/zudoku/src/lib/components/InlineCode.tsx
@@ -1,26 +1,15 @@
-import type { ReactNode } from "react";
-import { SelectOnClick } from "../plugins/openapi/components/SelectOnClick.js";
+import type { AllHTMLAttributes } from "react";
 import { cn } from "../util/cn.js";
 
 export const InlineCode = ({
   className,
-  children,
-  selectOnClick,
-  onClick,
-}: {
-  className?: string;
-  children: ReactNode;
-  selectOnClick?: boolean;
-  onClick?: () => void;
-}) => (
-  <SelectOnClick asChild enabled={selectOnClick} onClick={onClick}>
-    <code
-      className={cn(
-        "font-mono border p-1 py-0.5 rounded-sm bg-border/50 dark:bg-border/70 [overflow-wrap:anywhere]",
-        className,
-      )}
-    >
-      {children}
-    </code>
-  </SelectOnClick>
+  ...props
+}: AllHTMLAttributes<HTMLSpanElement>) => (
+  <code
+    className={cn(
+      "font-mono border p-1 py-0.5 rounded-sm bg-border/50 dark:bg-border/70 wrap-anywhere",
+      className,
+    )}
+    {...props}
+  />
 );

--- a/packages/zudoku/src/lib/components/navigation/Toc.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Toc.tsx
@@ -11,6 +11,7 @@ import { cn } from "../../util/cn.js";
 import { RichText } from "../../util/hastToJsx.js";
 import { AnchorLink } from "../AnchorLink.js";
 import { useViewportAnchor } from "../context/ViewportAnchorContext.js";
+import { InlineCode } from "../InlineCode.js";
 
 const DATA_ANCHOR_ATTR = "data-active";
 
@@ -34,7 +35,13 @@ const TocItem = ({
           : "hover:text-accent-foreground text-muted-foreground",
       )}
     >
-      {item.rich ? <RichText>{item.rich}</RichText> : item.text}
+      {item.rich ? (
+        <RichText overrides={{ code: InlineCode, pre: "pre" }}>
+          {item.rich}
+        </RichText>
+      ) : (
+        item.text
+      )}
     </AnchorLink>
     {children}
   </li>
@@ -88,7 +95,7 @@ export const Toc = ({ entries }: { entries: TocEntry[] }) => {
         <div className="absolute inset-0 end-auto bg-border w-[1.5px]" />
         <div
           className={cn(
-            "absolute start-0 -translate-y-1 h-6 w-[2.5px] bg-primary",
+            "absolute inset-s-0 -translate-y-1 h-6 w-[2.5px] bg-primary",
             paintedOnce.current &&
               "ease-out [transition:top_150ms,opacity_325ms]",
           )}

--- a/packages/zudoku/src/lib/plugins/openapi/Endpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Endpoint.tsx
@@ -74,7 +74,7 @@ export const Endpoint = () => {
           }))}
         />
       ) : (
-        <InlineCode className="text-xs px-2 py-1.5" selectOnClick>
+        <InlineCode className="text-xs px-2 py-1.5">
           {firstServer.url}
         </InlineCode>
       )}

--- a/packages/zudoku/src/lib/plugins/openapi/ParamInfos.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/ParamInfos.tsx
@@ -13,7 +13,6 @@ const Pattern = ({ pattern }: { pattern: string }) => {
     <InlineCode
       className={cn("text-xs", isExpandable && "cursor-pointer")}
       onClick={() => setIsExpanded(!isExpanded)}
-      selectOnClick={false}
     >
       {isExpanded ? pattern : shortPattern}
       {isExpandable && (

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaPropertyItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaPropertyItem.tsx
@@ -21,10 +21,7 @@ import {
 } from "./utils.js";
 
 const RecursiveIndicator = ({ circularProp }: { circularProp?: string }) => (
-  <InlineCode
-    className="inline-flex items-center gap-1.5 text-xs translate-y-0.5"
-    selectOnClick={false}
-  >
+  <InlineCode className="inline-flex items-center gap-1.5 text-xs translate-y-0.5">
     <RefreshCcwDotIcon size={13} />
     <span>{circularProp ? `${circularProp} (circular)` : "circular"}</span>
   </InlineCode>

--- a/packages/zudoku/src/lib/util/hastToJsx.tsx
+++ b/packages/zudoku/src/lib/util/hastToJsx.tsx
@@ -49,8 +49,14 @@ const convertNode = (
   return toJsxRuntime(node, { Fragment, jsx, jsxs, components });
 };
 
-export const RichText = ({ children }: { children: RootContent[] }) => {
-  const components = useMDXComponents();
+export const RichText = ({
+  children,
+  overrides,
+}: {
+  children: RootContent[];
+  overrides?: MDXComponents;
+}) => {
+  const components = useMDXComponents(overrides);
 
   return children.map((node, i) => (
     // biome-ignore lint/suspicious/noArrayIndexKey: Stable content from markdown AST


### PR DESCRIPTION
RichText in ToC was using MDX `code` component which renders a full CodeBlock with copy buttons. Override it with `InlineCode` via new `overrides` prop on `RichText` that passes through to `useMDXComponents()`.

Remove `selectOnClick` as it was more distracting/confusing