### PR TITLE
Fix monetization publish failing on unclean working tree

### DIFF
--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish
         working-directory: packages/plugin-zuplo-monetization
-        run: pnpm publish --provenance --access public --tag latest
+        run: pnpm publish --provenance --access public --tag latest --no-git-checks
 
       - name: Commit and tag
         run: |


### PR DESCRIPTION
Add `--no-git-checks` to `pnpm publish` since the version bump makes the tree unclean before the post-publish commit.