### PR TITLE
fix: use zuplo_most_popular metadata 

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
@@ -160,12 +160,12 @@ describe("PricingPage", () => {
     expect(screen.queryByText("No CC required")).not.toBeInTheDocument();
   });
 
-  it("Shows 'Most Popular' badge when plan.metadata.isMostPopular is true", () => {
+  it("Shows 'Most Popular' badge when plan.metadata.zuplo_most_popular is 'true'", () => {
     mockPricingData.items = [
       makePlan("1", "starter", "Starter"),
       {
         ...makePlan("2", "pro", "Pro"),
-        metadata: { isMostPopular: true },
+        metadata: { zuplo_most_popular: "true" },
       },
       makePlan("3", "business", "Business"),
     ];
@@ -176,12 +176,12 @@ describe("PricingPage", () => {
     expect(screen.getByText("Most Popular")).toBeInTheDocument();
   });
 
-  it("Does not show 'Most Popular' badge when plan.metadata.isMostPopular is false or missing", () => {
+  it("Does not show 'Most Popular' badge when plan.metadata.zuplo_most_popular is not 'true' or missing", () => {
     mockPricingData.items = [
       makePlan("1", "starter", "Starter"),
       {
         ...makePlan("2", "pro", "Pro"),
-        metadata: { isMostPopular: false },
+        metadata: { zuplo_most_popular: "false" },
       },
       makePlan("3", "business", "Business"),
     ];

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
@@ -48,7 +48,7 @@ const PricingPage = ({
           <PricingCard
             key={plan.id}
             plan={plan}
-            isPopular={plan.metadata?.isMostPopular === true}
+            isPopular={plan.metadata?.zuplo_most_popular === "true"}
             isSubscribed={subscriptions.items.some((subscription) =>
               ["active", "canceled"].includes(subscription.status),
             )}


### PR DESCRIPTION


The API only allows string values for metadata, so changed from checking `isMostPopular === true` to `zuplo_most_popular === "true"`.

https://zuplo.slack.com/archives/C05V43L5H1A/p1771929816810589?thread_ts=1771898891.258199&cid=C05V43L5H1A

https://claude.ai/code/session_014vFaMrRYLggDTiGcyt7JeS