### PR TITLE
Fix code block text overlap

### DIFF
--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -185,7 +185,7 @@
     background-color: var(--shiki-dark-bg) !important;
   }
   .code-block .shiki {
-    @apply grid grid-rows-1;
+    @apply grid grid-rows-1 whitespace-pre;
     grid-auto-rows: 1lh;
   }
 


### PR DESCRIPTION
`highlight()` strips the `<pre>` wrapper from shiki output but doesn't add `white-space: pre` back. Without it, long lines wrap. The grid rows are fixed at one line height each, so wrapped text overflows into the line below.

Fix: add `whitespace-pre` to `.code-block .shiki`.

Screenshot of the issue:

<img width="475" src="https://github.com/user-attachments/assets/916dc15a-31ec-45a2-8b76-8c107937ef60" />
