### PR TITLE
Fix "Generate Key" button not submitting form

### DIFF
--- a/packages/zudoku/src/lib/plugins/api-keys/CreateApiKey.tsx
+++ b/packages/zudoku/src/lib/plugins/api-keys/CreateApiKey.tsx
@@ -108,7 +108,7 @@ export const CreateApiKey = ({
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <ActionButton isPending={createKeyMutation.isPending}>
+          <ActionButton type="submit" isPending={createKeyMutation.isPending}>
             Generate Key
           </ActionButton>
         </DialogFooter>


### PR DESCRIPTION
The "Generate Key" button in the API keys dialog stopped working when #1808 added `type="button"` as the default on all `Button` components. Since the HTML default button type is `submit`, this was likely a defensive change to prevent accidental form submissions, but it broke this button. Added explicit `type="submit"` to restore functionality.