### PR TITLE
Fix optional query params staying inactive when filled

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/QueryParams.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/QueryParams.tsx
@@ -32,7 +32,9 @@ export const QueryParams = ({
     shouldSetActive: (item) => {
       const schemaParam = schemaQueryParams.find((p) => p.name === item.name);
       if (schemaParam) {
-        return schemaParam.isRequired ?? false;
+        const isRequired = schemaParam.isRequired ?? false;
+        const hasValue = Boolean(item.value);
+        return isRequired || hasValue;
       }
       return Boolean(item.name || item.value);
     },


### PR DESCRIPTION
Optional schema-defined query params in the playground stayed inactive even after the user entered a value, so they were never included in the request URL. Now params with a value are also set to active.