### PR TITLE
Remove generated shiki wrapper files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto
 packages/zudoku/src/config/validators/icon-types.ts linguist-generated
-packages/zudoku/src/shiki/** linguist-generated
 packages/zudoku/src/lib/plugins/openapi/graphql/** linguist-generated
 packages/zudoku/schema.graphql linguist-generated

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -63,7 +63,6 @@
     "./app/*": "./src/app/*",
     "./hooks": "./src/lib/hooks/index.ts",
     "./main.css": "./src/app/main.css",
-    "./shiki/*": "./src/shiki/*.js",
     "./processors/*": "./src/lib/plugins/openapi/processors/*.ts",
     "./with-zuplo": "./src/zuplo/with-zuplo.ts",
     "./testing": "./src/lib/testing/index.tsx"

--- a/packages/zudoku/scripts/generate-types.ts
+++ b/packages/zudoku/scripts/generate-types.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { format } from "oxfmt";
 
@@ -29,26 +29,3 @@ const outputPath = fileURLToPath(
   new URL("../src/config/validators/icon-types.ts", import.meta.url),
 );
 await writeFile(outputPath, code);
-
-// Generate shiki code
-const { languageNames } = await import("@shikijs/langs");
-const { themeNames } = await import("@shikijs/themes");
-
-const generateFiles = async (items: readonly string[], type: string) => {
-  const dir = fileURLToPath(new URL(`../src/shiki/${type}`, import.meta.url));
-  await mkdir(dir, { recursive: true });
-
-  for (const item of items) {
-    await writeFile(
-      fileURLToPath(
-        new URL(`../src/shiki/${type}/${item}.js`, import.meta.url),
-      ),
-      `import _default from "@shikijs/${type}/${item}";\nexport default _default;\n`,
-    );
-  }
-};
-
-await Promise.all([
-  generateFiles(languageNames, "langs"),
-  generateFiles(themeNames, "themes"),
-]);

--- a/packages/zudoku/src/shiki/langs/abap.js
+++ b/packages/zudoku/src/shiki/langs/abap.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/abap";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/actionscript-3.js
+++ b/packages/zudoku/src/shiki/langs/actionscript-3.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/actionscript-3";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ada.js
+++ b/packages/zudoku/src/shiki/langs/ada.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ada";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-expression.js
+++ b/packages/zudoku/src/shiki/langs/angular-expression.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-expression";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-html.js
+++ b/packages/zudoku/src/shiki/langs/angular-html.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-html";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-inline-style.js
+++ b/packages/zudoku/src/shiki/langs/angular-inline-style.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-inline-style";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-inline-template.js
+++ b/packages/zudoku/src/shiki/langs/angular-inline-template.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-inline-template";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-let-declaration.js
+++ b/packages/zudoku/src/shiki/langs/angular-let-declaration.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-let-declaration";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-template-blocks.js
+++ b/packages/zudoku/src/shiki/langs/angular-template-blocks.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-template-blocks";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-template.js
+++ b/packages/zudoku/src/shiki/langs/angular-template.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-template";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/angular-ts.js
+++ b/packages/zudoku/src/shiki/langs/angular-ts.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/angular-ts";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/apache.js
+++ b/packages/zudoku/src/shiki/langs/apache.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/apache";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/apex.js
+++ b/packages/zudoku/src/shiki/langs/apex.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/apex";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/apl.js
+++ b/packages/zudoku/src/shiki/langs/apl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/apl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/applescript.js
+++ b/packages/zudoku/src/shiki/langs/applescript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/applescript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ara.js
+++ b/packages/zudoku/src/shiki/langs/ara.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ara";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/asciidoc.js
+++ b/packages/zudoku/src/shiki/langs/asciidoc.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/asciidoc";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/asm.js
+++ b/packages/zudoku/src/shiki/langs/asm.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/asm";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/astro.js
+++ b/packages/zudoku/src/shiki/langs/astro.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/astro";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/awk.js
+++ b/packages/zudoku/src/shiki/langs/awk.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/awk";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ballerina.js
+++ b/packages/zudoku/src/shiki/langs/ballerina.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ballerina";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/bat.js
+++ b/packages/zudoku/src/shiki/langs/bat.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/bat";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/beancount.js
+++ b/packages/zudoku/src/shiki/langs/beancount.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/beancount";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/berry.js
+++ b/packages/zudoku/src/shiki/langs/berry.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/berry";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/bibtex.js
+++ b/packages/zudoku/src/shiki/langs/bibtex.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/bibtex";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/bicep.js
+++ b/packages/zudoku/src/shiki/langs/bicep.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/bicep";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/blade.js
+++ b/packages/zudoku/src/shiki/langs/blade.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/blade";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/bsl.js
+++ b/packages/zudoku/src/shiki/langs/bsl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/bsl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/c.js
+++ b/packages/zudoku/src/shiki/langs/c.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/c";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/c3.js
+++ b/packages/zudoku/src/shiki/langs/c3.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/c3";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cadence.js
+++ b/packages/zudoku/src/shiki/langs/cadence.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cadence";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cairo.js
+++ b/packages/zudoku/src/shiki/langs/cairo.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cairo";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/clarity.js
+++ b/packages/zudoku/src/shiki/langs/clarity.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/clarity";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/clojure.js
+++ b/packages/zudoku/src/shiki/langs/clojure.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/clojure";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cmake.js
+++ b/packages/zudoku/src/shiki/langs/cmake.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cmake";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cobol.js
+++ b/packages/zudoku/src/shiki/langs/cobol.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cobol";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/codeowners.js
+++ b/packages/zudoku/src/shiki/langs/codeowners.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/codeowners";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/codeql.js
+++ b/packages/zudoku/src/shiki/langs/codeql.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/codeql";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/coffee.js
+++ b/packages/zudoku/src/shiki/langs/coffee.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/coffee";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/common-lisp.js
+++ b/packages/zudoku/src/shiki/langs/common-lisp.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/common-lisp";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/coq.js
+++ b/packages/zudoku/src/shiki/langs/coq.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/coq";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cpp-macro.js
+++ b/packages/zudoku/src/shiki/langs/cpp-macro.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cpp-macro";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cpp.js
+++ b/packages/zudoku/src/shiki/langs/cpp.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cpp";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/crystal.js
+++ b/packages/zudoku/src/shiki/langs/crystal.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/crystal";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/csharp.js
+++ b/packages/zudoku/src/shiki/langs/csharp.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/csharp";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/css.js
+++ b/packages/zudoku/src/shiki/langs/css.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/css";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/csv.js
+++ b/packages/zudoku/src/shiki/langs/csv.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/csv";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cue.js
+++ b/packages/zudoku/src/shiki/langs/cue.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cue";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/cypher.js
+++ b/packages/zudoku/src/shiki/langs/cypher.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/cypher";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/d.js
+++ b/packages/zudoku/src/shiki/langs/d.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/d";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/dart.js
+++ b/packages/zudoku/src/shiki/langs/dart.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/dart";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/dax.js
+++ b/packages/zudoku/src/shiki/langs/dax.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/dax";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/desktop.js
+++ b/packages/zudoku/src/shiki/langs/desktop.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/desktop";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/diff.js
+++ b/packages/zudoku/src/shiki/langs/diff.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/diff";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/docker.js
+++ b/packages/zudoku/src/shiki/langs/docker.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/docker";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/dotenv.js
+++ b/packages/zudoku/src/shiki/langs/dotenv.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/dotenv";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/dream-maker.js
+++ b/packages/zudoku/src/shiki/langs/dream-maker.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/dream-maker";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/edge.js
+++ b/packages/zudoku/src/shiki/langs/edge.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/edge";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/elixir.js
+++ b/packages/zudoku/src/shiki/langs/elixir.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/elixir";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/elm.js
+++ b/packages/zudoku/src/shiki/langs/elm.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/elm";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/emacs-lisp.js
+++ b/packages/zudoku/src/shiki/langs/emacs-lisp.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/emacs-lisp";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/erb.js
+++ b/packages/zudoku/src/shiki/langs/erb.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/erb";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/erlang.js
+++ b/packages/zudoku/src/shiki/langs/erlang.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/erlang";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/es-tag-css.js
+++ b/packages/zudoku/src/shiki/langs/es-tag-css.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/es-tag-css";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/es-tag-glsl.js
+++ b/packages/zudoku/src/shiki/langs/es-tag-glsl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/es-tag-glsl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/es-tag-html.js
+++ b/packages/zudoku/src/shiki/langs/es-tag-html.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/es-tag-html";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/es-tag-sql.js
+++ b/packages/zudoku/src/shiki/langs/es-tag-sql.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/es-tag-sql";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/es-tag-xml.js
+++ b/packages/zudoku/src/shiki/langs/es-tag-xml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/es-tag-xml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/fennel.js
+++ b/packages/zudoku/src/shiki/langs/fennel.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/fennel";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/fish.js
+++ b/packages/zudoku/src/shiki/langs/fish.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/fish";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/fluent.js
+++ b/packages/zudoku/src/shiki/langs/fluent.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/fluent";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/fortran-fixed-form.js
+++ b/packages/zudoku/src/shiki/langs/fortran-fixed-form.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/fortran-fixed-form";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/fortran-free-form.js
+++ b/packages/zudoku/src/shiki/langs/fortran-free-form.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/fortran-free-form";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/fsharp.js
+++ b/packages/zudoku/src/shiki/langs/fsharp.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/fsharp";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/gdresource.js
+++ b/packages/zudoku/src/shiki/langs/gdresource.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/gdresource";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/gdscript.js
+++ b/packages/zudoku/src/shiki/langs/gdscript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/gdscript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/gdshader.js
+++ b/packages/zudoku/src/shiki/langs/gdshader.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/gdshader";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/genie.js
+++ b/packages/zudoku/src/shiki/langs/genie.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/genie";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/gherkin.js
+++ b/packages/zudoku/src/shiki/langs/gherkin.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/gherkin";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/git-commit.js
+++ b/packages/zudoku/src/shiki/langs/git-commit.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/git-commit";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/git-rebase.js
+++ b/packages/zudoku/src/shiki/langs/git-rebase.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/git-rebase";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/gleam.js
+++ b/packages/zudoku/src/shiki/langs/gleam.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/gleam";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/glimmer-js.js
+++ b/packages/zudoku/src/shiki/langs/glimmer-js.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/glimmer-js";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/glimmer-ts.js
+++ b/packages/zudoku/src/shiki/langs/glimmer-ts.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/glimmer-ts";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/glsl.js
+++ b/packages/zudoku/src/shiki/langs/glsl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/glsl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/gn.js
+++ b/packages/zudoku/src/shiki/langs/gn.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/gn";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/gnuplot.js
+++ b/packages/zudoku/src/shiki/langs/gnuplot.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/gnuplot";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/go.js
+++ b/packages/zudoku/src/shiki/langs/go.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/go";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/graphql.js
+++ b/packages/zudoku/src/shiki/langs/graphql.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/graphql";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/groovy.js
+++ b/packages/zudoku/src/shiki/langs/groovy.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/groovy";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/hack.js
+++ b/packages/zudoku/src/shiki/langs/hack.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/hack";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/haml.js
+++ b/packages/zudoku/src/shiki/langs/haml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/haml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/handlebars.js
+++ b/packages/zudoku/src/shiki/langs/handlebars.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/handlebars";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/haskell.js
+++ b/packages/zudoku/src/shiki/langs/haskell.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/haskell";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/haxe.js
+++ b/packages/zudoku/src/shiki/langs/haxe.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/haxe";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/hcl.js
+++ b/packages/zudoku/src/shiki/langs/hcl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/hcl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/hjson.js
+++ b/packages/zudoku/src/shiki/langs/hjson.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/hjson";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/hlsl.js
+++ b/packages/zudoku/src/shiki/langs/hlsl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/hlsl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/html-derivative.js
+++ b/packages/zudoku/src/shiki/langs/html-derivative.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/html-derivative";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/html.js
+++ b/packages/zudoku/src/shiki/langs/html.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/html";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/http.js
+++ b/packages/zudoku/src/shiki/langs/http.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/http";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/hurl.js
+++ b/packages/zudoku/src/shiki/langs/hurl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/hurl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/hxml.js
+++ b/packages/zudoku/src/shiki/langs/hxml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/hxml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/hy.js
+++ b/packages/zudoku/src/shiki/langs/hy.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/hy";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/imba.js
+++ b/packages/zudoku/src/shiki/langs/imba.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/imba";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ini.js
+++ b/packages/zudoku/src/shiki/langs/ini.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ini";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/java.js
+++ b/packages/zudoku/src/shiki/langs/java.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/java";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/javascript.js
+++ b/packages/zudoku/src/shiki/langs/javascript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/javascript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jinja-html.js
+++ b/packages/zudoku/src/shiki/langs/jinja-html.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jinja-html";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jinja.js
+++ b/packages/zudoku/src/shiki/langs/jinja.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jinja";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jison.js
+++ b/packages/zudoku/src/shiki/langs/jison.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jison";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/json.js
+++ b/packages/zudoku/src/shiki/langs/json.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/json";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/json5.js
+++ b/packages/zudoku/src/shiki/langs/json5.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/json5";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jsonc.js
+++ b/packages/zudoku/src/shiki/langs/jsonc.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jsonc";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jsonl.js
+++ b/packages/zudoku/src/shiki/langs/jsonl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jsonl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jsonnet.js
+++ b/packages/zudoku/src/shiki/langs/jsonnet.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jsonnet";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jssm.js
+++ b/packages/zudoku/src/shiki/langs/jssm.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jssm";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/jsx.js
+++ b/packages/zudoku/src/shiki/langs/jsx.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/jsx";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/julia.js
+++ b/packages/zudoku/src/shiki/langs/julia.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/julia";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/kdl.js
+++ b/packages/zudoku/src/shiki/langs/kdl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/kdl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/kotlin.js
+++ b/packages/zudoku/src/shiki/langs/kotlin.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/kotlin";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/kusto.js
+++ b/packages/zudoku/src/shiki/langs/kusto.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/kusto";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/latex.js
+++ b/packages/zudoku/src/shiki/langs/latex.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/latex";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/lean.js
+++ b/packages/zudoku/src/shiki/langs/lean.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/lean";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/less.js
+++ b/packages/zudoku/src/shiki/langs/less.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/less";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/liquid.js
+++ b/packages/zudoku/src/shiki/langs/liquid.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/liquid";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/llvm.js
+++ b/packages/zudoku/src/shiki/langs/llvm.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/llvm";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/log.js
+++ b/packages/zudoku/src/shiki/langs/log.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/log";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/logo.js
+++ b/packages/zudoku/src/shiki/langs/logo.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/logo";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/lua.js
+++ b/packages/zudoku/src/shiki/langs/lua.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/lua";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/luau.js
+++ b/packages/zudoku/src/shiki/langs/luau.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/luau";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/make.js
+++ b/packages/zudoku/src/shiki/langs/make.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/make";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/markdown-nix.js
+++ b/packages/zudoku/src/shiki/langs/markdown-nix.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/markdown-nix";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/markdown-vue.js
+++ b/packages/zudoku/src/shiki/langs/markdown-vue.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/markdown-vue";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/markdown.js
+++ b/packages/zudoku/src/shiki/langs/markdown.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/markdown";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/marko.js
+++ b/packages/zudoku/src/shiki/langs/marko.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/marko";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/matlab.js
+++ b/packages/zudoku/src/shiki/langs/matlab.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/matlab";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/mdc.js
+++ b/packages/zudoku/src/shiki/langs/mdc.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/mdc";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/mdx.js
+++ b/packages/zudoku/src/shiki/langs/mdx.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/mdx";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/mermaid.js
+++ b/packages/zudoku/src/shiki/langs/mermaid.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/mermaid";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/mipsasm.js
+++ b/packages/zudoku/src/shiki/langs/mipsasm.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/mipsasm";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/mojo.js
+++ b/packages/zudoku/src/shiki/langs/mojo.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/mojo";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/moonbit.js
+++ b/packages/zudoku/src/shiki/langs/moonbit.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/moonbit";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/move.js
+++ b/packages/zudoku/src/shiki/langs/move.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/move";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/narrat.js
+++ b/packages/zudoku/src/shiki/langs/narrat.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/narrat";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/nextflow.js
+++ b/packages/zudoku/src/shiki/langs/nextflow.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/nextflow";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/nginx.js
+++ b/packages/zudoku/src/shiki/langs/nginx.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/nginx";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/nim.js
+++ b/packages/zudoku/src/shiki/langs/nim.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/nim";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/nix.js
+++ b/packages/zudoku/src/shiki/langs/nix.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/nix";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/nushell.js
+++ b/packages/zudoku/src/shiki/langs/nushell.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/nushell";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/objective-c.js
+++ b/packages/zudoku/src/shiki/langs/objective-c.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/objective-c";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/objective-cpp.js
+++ b/packages/zudoku/src/shiki/langs/objective-cpp.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/objective-cpp";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ocaml.js
+++ b/packages/zudoku/src/shiki/langs/ocaml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ocaml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/odin.js
+++ b/packages/zudoku/src/shiki/langs/odin.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/odin";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/openscad.js
+++ b/packages/zudoku/src/shiki/langs/openscad.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/openscad";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/pascal.js
+++ b/packages/zudoku/src/shiki/langs/pascal.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/pascal";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/perl.js
+++ b/packages/zudoku/src/shiki/langs/perl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/perl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/php.js
+++ b/packages/zudoku/src/shiki/langs/php.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/php";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/pkl.js
+++ b/packages/zudoku/src/shiki/langs/pkl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/pkl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/plsql.js
+++ b/packages/zudoku/src/shiki/langs/plsql.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/plsql";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/po.js
+++ b/packages/zudoku/src/shiki/langs/po.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/po";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/polar.js
+++ b/packages/zudoku/src/shiki/langs/polar.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/polar";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/postcss.js
+++ b/packages/zudoku/src/shiki/langs/postcss.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/postcss";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/powerquery.js
+++ b/packages/zudoku/src/shiki/langs/powerquery.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/powerquery";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/powershell.js
+++ b/packages/zudoku/src/shiki/langs/powershell.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/powershell";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/prisma.js
+++ b/packages/zudoku/src/shiki/langs/prisma.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/prisma";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/prolog.js
+++ b/packages/zudoku/src/shiki/langs/prolog.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/prolog";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/proto.js
+++ b/packages/zudoku/src/shiki/langs/proto.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/proto";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/pug.js
+++ b/packages/zudoku/src/shiki/langs/pug.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/pug";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/puppet.js
+++ b/packages/zudoku/src/shiki/langs/puppet.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/puppet";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/purescript.js
+++ b/packages/zudoku/src/shiki/langs/purescript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/purescript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/python.js
+++ b/packages/zudoku/src/shiki/langs/python.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/python";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/qml.js
+++ b/packages/zudoku/src/shiki/langs/qml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/qml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/qmldir.js
+++ b/packages/zudoku/src/shiki/langs/qmldir.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/qmldir";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/qss.js
+++ b/packages/zudoku/src/shiki/langs/qss.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/qss";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/r.js
+++ b/packages/zudoku/src/shiki/langs/r.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/r";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/racket.js
+++ b/packages/zudoku/src/shiki/langs/racket.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/racket";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/raku.js
+++ b/packages/zudoku/src/shiki/langs/raku.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/raku";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/razor.js
+++ b/packages/zudoku/src/shiki/langs/razor.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/razor";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/reg.js
+++ b/packages/zudoku/src/shiki/langs/reg.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/reg";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/regexp.js
+++ b/packages/zudoku/src/shiki/langs/regexp.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/regexp";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/rel.js
+++ b/packages/zudoku/src/shiki/langs/rel.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/rel";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/riscv.js
+++ b/packages/zudoku/src/shiki/langs/riscv.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/riscv";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ron.js
+++ b/packages/zudoku/src/shiki/langs/ron.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ron";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/rosmsg.js
+++ b/packages/zudoku/src/shiki/langs/rosmsg.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/rosmsg";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/rst.js
+++ b/packages/zudoku/src/shiki/langs/rst.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/rst";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ruby.js
+++ b/packages/zudoku/src/shiki/langs/ruby.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ruby";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/rust.js
+++ b/packages/zudoku/src/shiki/langs/rust.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/rust";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/sas.js
+++ b/packages/zudoku/src/shiki/langs/sas.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/sas";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/sass.js
+++ b/packages/zudoku/src/shiki/langs/sass.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/sass";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/scala.js
+++ b/packages/zudoku/src/shiki/langs/scala.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/scala";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/scheme.js
+++ b/packages/zudoku/src/shiki/langs/scheme.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/scheme";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/scss.js
+++ b/packages/zudoku/src/shiki/langs/scss.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/scss";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/sdbl.js
+++ b/packages/zudoku/src/shiki/langs/sdbl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/sdbl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/shaderlab.js
+++ b/packages/zudoku/src/shiki/langs/shaderlab.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/shaderlab";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/shellscript.js
+++ b/packages/zudoku/src/shiki/langs/shellscript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/shellscript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/shellsession.js
+++ b/packages/zudoku/src/shiki/langs/shellsession.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/shellsession";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/smalltalk.js
+++ b/packages/zudoku/src/shiki/langs/smalltalk.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/smalltalk";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/solidity.js
+++ b/packages/zudoku/src/shiki/langs/solidity.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/solidity";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/soy.js
+++ b/packages/zudoku/src/shiki/langs/soy.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/soy";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/sparql.js
+++ b/packages/zudoku/src/shiki/langs/sparql.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/sparql";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/splunk.js
+++ b/packages/zudoku/src/shiki/langs/splunk.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/splunk";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/sql.js
+++ b/packages/zudoku/src/shiki/langs/sql.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/sql";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ssh-config.js
+++ b/packages/zudoku/src/shiki/langs/ssh-config.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ssh-config";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/stata.js
+++ b/packages/zudoku/src/shiki/langs/stata.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/stata";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/stylus.js
+++ b/packages/zudoku/src/shiki/langs/stylus.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/stylus";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/surrealql.js
+++ b/packages/zudoku/src/shiki/langs/surrealql.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/surrealql";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/svelte.js
+++ b/packages/zudoku/src/shiki/langs/svelte.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/svelte";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/swift.js
+++ b/packages/zudoku/src/shiki/langs/swift.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/swift";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/system-verilog.js
+++ b/packages/zudoku/src/shiki/langs/system-verilog.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/system-verilog";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/systemd.js
+++ b/packages/zudoku/src/shiki/langs/systemd.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/systemd";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/talonscript.js
+++ b/packages/zudoku/src/shiki/langs/talonscript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/talonscript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/tasl.js
+++ b/packages/zudoku/src/shiki/langs/tasl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/tasl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/tcl.js
+++ b/packages/zudoku/src/shiki/langs/tcl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/tcl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/templ.js
+++ b/packages/zudoku/src/shiki/langs/templ.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/templ";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/terraform.js
+++ b/packages/zudoku/src/shiki/langs/terraform.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/terraform";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/tex.js
+++ b/packages/zudoku/src/shiki/langs/tex.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/tex";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/toml.js
+++ b/packages/zudoku/src/shiki/langs/toml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/toml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/ts-tags.js
+++ b/packages/zudoku/src/shiki/langs/ts-tags.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/ts-tags";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/tsv.js
+++ b/packages/zudoku/src/shiki/langs/tsv.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/tsv";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/tsx.js
+++ b/packages/zudoku/src/shiki/langs/tsx.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/tsx";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/turtle.js
+++ b/packages/zudoku/src/shiki/langs/turtle.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/turtle";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/twig.js
+++ b/packages/zudoku/src/shiki/langs/twig.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/twig";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/typescript.js
+++ b/packages/zudoku/src/shiki/langs/typescript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/typescript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/typespec.js
+++ b/packages/zudoku/src/shiki/langs/typespec.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/typespec";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/typst.js
+++ b/packages/zudoku/src/shiki/langs/typst.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/typst";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/v.js
+++ b/packages/zudoku/src/shiki/langs/v.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/v";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vala.js
+++ b/packages/zudoku/src/shiki/langs/vala.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vala";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vb.js
+++ b/packages/zudoku/src/shiki/langs/vb.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vb";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/verilog.js
+++ b/packages/zudoku/src/shiki/langs/verilog.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/verilog";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vhdl.js
+++ b/packages/zudoku/src/shiki/langs/vhdl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vhdl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/viml.js
+++ b/packages/zudoku/src/shiki/langs/viml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/viml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vue-directives.js
+++ b/packages/zudoku/src/shiki/langs/vue-directives.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vue-directives";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vue-html.js
+++ b/packages/zudoku/src/shiki/langs/vue-html.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vue-html";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vue-interpolations.js
+++ b/packages/zudoku/src/shiki/langs/vue-interpolations.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vue-interpolations";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vue-sfc-style-variable-injection.js
+++ b/packages/zudoku/src/shiki/langs/vue-sfc-style-variable-injection.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vue-sfc-style-variable-injection";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vue-vine.js
+++ b/packages/zudoku/src/shiki/langs/vue-vine.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vue-vine";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vue.js
+++ b/packages/zudoku/src/shiki/langs/vue.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vue";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/vyper.js
+++ b/packages/zudoku/src/shiki/langs/vyper.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/vyper";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/wasm.js
+++ b/packages/zudoku/src/shiki/langs/wasm.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/wasm";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/wenyan.js
+++ b/packages/zudoku/src/shiki/langs/wenyan.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/wenyan";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/wgsl.js
+++ b/packages/zudoku/src/shiki/langs/wgsl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/wgsl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/wikitext.js
+++ b/packages/zudoku/src/shiki/langs/wikitext.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/wikitext";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/wit.js
+++ b/packages/zudoku/src/shiki/langs/wit.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/wit";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/wolfram.js
+++ b/packages/zudoku/src/shiki/langs/wolfram.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/wolfram";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/xml.js
+++ b/packages/zudoku/src/shiki/langs/xml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/xml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/xsl.js
+++ b/packages/zudoku/src/shiki/langs/xsl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/xsl";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/yaml.js
+++ b/packages/zudoku/src/shiki/langs/yaml.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/yaml";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/zenscript.js
+++ b/packages/zudoku/src/shiki/langs/zenscript.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/zenscript";
-export default _default;

--- a/packages/zudoku/src/shiki/langs/zig.js
+++ b/packages/zudoku/src/shiki/langs/zig.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/langs/zig";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/andromeeda.js
+++ b/packages/zudoku/src/shiki/themes/andromeeda.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/andromeeda";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/aurora-x.js
+++ b/packages/zudoku/src/shiki/themes/aurora-x.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/aurora-x";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/ayu-dark.js
+++ b/packages/zudoku/src/shiki/themes/ayu-dark.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/ayu-dark";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/ayu-light.js
+++ b/packages/zudoku/src/shiki/themes/ayu-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/ayu-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/ayu-mirage.js
+++ b/packages/zudoku/src/shiki/themes/ayu-mirage.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/ayu-mirage";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/catppuccin-frappe.js
+++ b/packages/zudoku/src/shiki/themes/catppuccin-frappe.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/catppuccin-frappe";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/catppuccin-latte.js
+++ b/packages/zudoku/src/shiki/themes/catppuccin-latte.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/catppuccin-latte";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/catppuccin-macchiato.js
+++ b/packages/zudoku/src/shiki/themes/catppuccin-macchiato.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/catppuccin-macchiato";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/catppuccin-mocha.js
+++ b/packages/zudoku/src/shiki/themes/catppuccin-mocha.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/catppuccin-mocha";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/dark-plus.js
+++ b/packages/zudoku/src/shiki/themes/dark-plus.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/dark-plus";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/dracula-soft.js
+++ b/packages/zudoku/src/shiki/themes/dracula-soft.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/dracula-soft";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/dracula.js
+++ b/packages/zudoku/src/shiki/themes/dracula.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/dracula";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/everforest-dark.js
+++ b/packages/zudoku/src/shiki/themes/everforest-dark.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/everforest-dark";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/everforest-light.js
+++ b/packages/zudoku/src/shiki/themes/everforest-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/everforest-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/github-dark-default.js
+++ b/packages/zudoku/src/shiki/themes/github-dark-default.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/github-dark-default";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/github-dark-dimmed.js
+++ b/packages/zudoku/src/shiki/themes/github-dark-dimmed.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/github-dark-dimmed";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/github-dark-high-contrast.js
+++ b/packages/zudoku/src/shiki/themes/github-dark-high-contrast.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/github-dark-high-contrast";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/github-dark.js
+++ b/packages/zudoku/src/shiki/themes/github-dark.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/github-dark";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/github-light-default.js
+++ b/packages/zudoku/src/shiki/themes/github-light-default.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/github-light-default";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/github-light-high-contrast.js
+++ b/packages/zudoku/src/shiki/themes/github-light-high-contrast.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/github-light-high-contrast";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/github-light.js
+++ b/packages/zudoku/src/shiki/themes/github-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/github-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/gruvbox-dark-hard.js
+++ b/packages/zudoku/src/shiki/themes/gruvbox-dark-hard.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/gruvbox-dark-hard";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/gruvbox-dark-medium.js
+++ b/packages/zudoku/src/shiki/themes/gruvbox-dark-medium.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/gruvbox-dark-medium";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/gruvbox-dark-soft.js
+++ b/packages/zudoku/src/shiki/themes/gruvbox-dark-soft.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/gruvbox-dark-soft";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/gruvbox-light-hard.js
+++ b/packages/zudoku/src/shiki/themes/gruvbox-light-hard.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/gruvbox-light-hard";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/gruvbox-light-medium.js
+++ b/packages/zudoku/src/shiki/themes/gruvbox-light-medium.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/gruvbox-light-medium";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/gruvbox-light-soft.js
+++ b/packages/zudoku/src/shiki/themes/gruvbox-light-soft.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/gruvbox-light-soft";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/horizon.js
+++ b/packages/zudoku/src/shiki/themes/horizon.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/horizon";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/houston.js
+++ b/packages/zudoku/src/shiki/themes/houston.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/houston";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/kanagawa-dragon.js
+++ b/packages/zudoku/src/shiki/themes/kanagawa-dragon.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/kanagawa-dragon";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/kanagawa-lotus.js
+++ b/packages/zudoku/src/shiki/themes/kanagawa-lotus.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/kanagawa-lotus";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/kanagawa-wave.js
+++ b/packages/zudoku/src/shiki/themes/kanagawa-wave.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/kanagawa-wave";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/laserwave.js
+++ b/packages/zudoku/src/shiki/themes/laserwave.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/laserwave";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/light-plus.js
+++ b/packages/zudoku/src/shiki/themes/light-plus.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/light-plus";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/material-theme-darker.js
+++ b/packages/zudoku/src/shiki/themes/material-theme-darker.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/material-theme-darker";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/material-theme-lighter.js
+++ b/packages/zudoku/src/shiki/themes/material-theme-lighter.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/material-theme-lighter";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/material-theme-ocean.js
+++ b/packages/zudoku/src/shiki/themes/material-theme-ocean.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/material-theme-ocean";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/material-theme-palenight.js
+++ b/packages/zudoku/src/shiki/themes/material-theme-palenight.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/material-theme-palenight";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/material-theme.js
+++ b/packages/zudoku/src/shiki/themes/material-theme.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/material-theme";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/min-dark.js
+++ b/packages/zudoku/src/shiki/themes/min-dark.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/min-dark";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/min-light.js
+++ b/packages/zudoku/src/shiki/themes/min-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/min-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/monokai.js
+++ b/packages/zudoku/src/shiki/themes/monokai.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/monokai";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/night-owl-light.js
+++ b/packages/zudoku/src/shiki/themes/night-owl-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/night-owl-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/night-owl.js
+++ b/packages/zudoku/src/shiki/themes/night-owl.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/night-owl";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/nord.js
+++ b/packages/zudoku/src/shiki/themes/nord.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/nord";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/one-dark-pro.js
+++ b/packages/zudoku/src/shiki/themes/one-dark-pro.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/one-dark-pro";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/one-light.js
+++ b/packages/zudoku/src/shiki/themes/one-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/one-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/plastic.js
+++ b/packages/zudoku/src/shiki/themes/plastic.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/plastic";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/poimandres.js
+++ b/packages/zudoku/src/shiki/themes/poimandres.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/poimandres";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/red.js
+++ b/packages/zudoku/src/shiki/themes/red.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/red";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/rose-pine-dawn.js
+++ b/packages/zudoku/src/shiki/themes/rose-pine-dawn.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/rose-pine-dawn";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/rose-pine-moon.js
+++ b/packages/zudoku/src/shiki/themes/rose-pine-moon.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/rose-pine-moon";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/rose-pine.js
+++ b/packages/zudoku/src/shiki/themes/rose-pine.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/rose-pine";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/slack-dark.js
+++ b/packages/zudoku/src/shiki/themes/slack-dark.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/slack-dark";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/slack-ochin.js
+++ b/packages/zudoku/src/shiki/themes/slack-ochin.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/slack-ochin";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/snazzy-light.js
+++ b/packages/zudoku/src/shiki/themes/snazzy-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/snazzy-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/solarized-dark.js
+++ b/packages/zudoku/src/shiki/themes/solarized-dark.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/solarized-dark";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/solarized-light.js
+++ b/packages/zudoku/src/shiki/themes/solarized-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/solarized-light";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/synthwave-84.js
+++ b/packages/zudoku/src/shiki/themes/synthwave-84.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/synthwave-84";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/tokyo-night.js
+++ b/packages/zudoku/src/shiki/themes/tokyo-night.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/tokyo-night";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/vesper.js
+++ b/packages/zudoku/src/shiki/themes/vesper.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/vesper";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/vitesse-black.js
+++ b/packages/zudoku/src/shiki/themes/vitesse-black.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/vitesse-black";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/vitesse-dark.js
+++ b/packages/zudoku/src/shiki/themes/vitesse-dark.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/vitesse-dark";
-export default _default;

--- a/packages/zudoku/src/shiki/themes/vitesse-light.js
+++ b/packages/zudoku/src/shiki/themes/vitesse-light.js
@@ -1,2 +1,0 @@
-import _default from "@shikijs/themes/vitesse-light";
-export default _default;

--- a/packages/zudoku/src/vite/plugin-shiki-register.ts
+++ b/packages/zudoku/src/vite/plugin-shiki-register.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { bundledLanguagesInfo, type BundledLanguage } from "shiki";
 import type { Plugin } from "vite";
 import { getCurrentConfig } from "../config/loader.js";
@@ -29,10 +30,19 @@ export const viteShikiRegisterPlugin = (): Plugin => {
       );
 
       return {
+        resolve: {
+          alias: [
+            {
+              find: /^@shikijs\/(langs|themes)\/.+$/,
+              replacement: "$&",
+              customResolver: (id) => fileURLToPath(import.meta.resolve(id)),
+            },
+          ],
+        },
         optimizeDeps: {
           include: [
-            ...languages.map((l) => `zudoku/shiki/langs/${resolveLang(l)}`),
-            ...themes.map((t) => `zudoku/shiki/themes/${t}`),
+            ...languages.map((lang) => `@shikijs/langs/${resolveLang(lang)}`),
+            ...themes.map((theme) => `@shikijs/themes/${theme}`),
           ],
         },
       };
@@ -70,11 +80,11 @@ export const viteShikiRegisterPlugin = (): Plugin => {
         "export const registerShiki = async (highlighter) => {",
         "  await Promise.all([",
         "    highlighter.loadTheme(",
-        themes.map((t) => `import('zudoku/shiki/themes/${t}')`).join(","),
+        themes.map((theme) => `import('@shikijs/themes/${theme}')`).join(","),
         "    ),",
         "    highlighter.loadLanguage(",
         languages
-          .map((l) => `import('zudoku/shiki/langs/${resolveLang(l)}')`)
+          .map((lang) => `import('@shikijs/langs/${resolveLang(lang)}')`)
           .join(","),
         "    ),",
         "  ]);",


### PR DESCRIPTION
The generated `.js` wrapper files in `src/shiki/` existed because the pre-bundle step needed physical files behind the package exports map. Now that we ship raw source, the Vite plugin can resolve `@shikijs/*` imports directly via `import.meta.resolve`.

- Deleted `src/shiki/` directory and `./shiki/*` package export
- Removed shiki generation code from `scripts/generate-types.ts`
- Added `resolve.alias` with `customResolver` in `plugin-shiki-register.ts` for pnpm strict mode