### PR TITLE
fix:add pricing slot to mobile nav

### DIFF
--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -62,6 +62,9 @@ export const MobileTopNavigation = () => {
             <Search className="flex p-4" />
             <ul className="flex flex-col items-center gap-4 p-4">
               <li className="empty:hidden">
+                <Slot.Target name="head-navigation-start" />
+              </li>
+              <li className="empty:hidden">
                 <Slot.Target name="top-navigation-side" />
               </li>
 


### PR DESCRIPTION
The `Pricing` navigation element shows up on a full mobile view but doesn't transition to the mobile view. This adds a slot there to ensure it shows up consistently across both views.