### PR TITLE
Pass auth context to pricing page query for private plans

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
@@ -19,6 +19,7 @@ const PricingPage = ({
 
   const { data: pricingTable } = useSuspenseQuery<{ items: Plan[] }>({
     queryKey: [`/v3/zudoku-metering/${deploymentName}/pricing-page`],
+    meta: { context: auth.isAuthenticated ? zudoku : undefined },
   });
   const { data: subscriptions = { items: [] } } =
     useQuery<SubscriptionsResponse>({


### PR DESCRIPTION
When authenticated, passes the zudoku context to the pricing page query so the API returns private plans visible only to logged-in users.