### PR TITLE
Fix SSG 404 for routes with optional dynamic params

### DIFF
--- a/packages/zudoku/src/vite/prerender/utils.ts
+++ b/packages/zudoku/src/vite/prerender/utils.ts
@@ -29,7 +29,7 @@ export const routesToPaths = (
       : parentPath;
 
     return [
-      ...(routePath ? [fullPath] : []),
+      ...(routePath && fullPath !== parentPath ? [fullPath] : []),
       ...routesToPaths(route.children ?? [], fullPath),
     ];
   });


### PR DESCRIPTION
Routes like `/subscriptions/:subscriptionId?` were skipped entirely during SSG prerendering because `routesToPaths` filtered out any path containing `:`. Now optional dynamic segments are stripped and the base path is prerendered.