### PR TITLE
fix: read package.json version at runtime instead of bundle time

### DIFF
--- a/packages/zudoku/src/cli/build/handler.ts
+++ b/packages/zudoku/src/cli/build/handler.ts
@@ -1,12 +1,16 @@
 import path from "node:path";
-import packageJson from "../../../package.json" with { type: "json" };
+import { fileURLToPath } from "node:url";
 import { runBuild } from "../../vite/build.js";
 import type { Arguments } from "../cmds/build.js";
 import { logger } from "../common/logger.js";
 import { printDiagnosticsToConsole } from "../common/output.js";
+import { getPackageJson } from "../common/package-json.js";
 import { preview as runPreview } from "../preview/handler.js";
 
 export async function build(argv: Arguments) {
+  const packageJson = getPackageJson(
+    fileURLToPath(import.meta.resolve("zudoku/package.json")),
+  );
   printDiagnosticsToConsole(`Starting Zudoku build v${packageJson.version}`);
   printDiagnosticsToConsole("");
   printDiagnosticsToConsole("");

--- a/packages/zudoku/src/cli/cli.ts
+++ b/packages/zudoku/src/cli/cli.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as Sentry from "@sentry/node";
 import { hideBin } from "yargs/helpers";
@@ -10,24 +9,12 @@ import { shutdownAnalytics } from "./common/analytics/lib.js";
 import { MAX_WAIT_PENDING_TIME_MS, SENTRY_DSN } from "./common/constants.js";
 import { warnIfOutdatedVersion } from "./common/outdated.js";
 import { printDiagnosticsToConsole } from "./common/output.js";
+import { getPackageJson } from "./common/package-json.js";
 import { warnPackageVersionMismatch } from "./common/version-check.js";
 
 process.env.ZUDOKU_ENV = process.env.ZUDOKU_INTERNAL_DEV
   ? "internal"
   : "module";
-
-// Minimal representation of a package.json file
-type PackageJson = {
-  name: string;
-  version: string;
-  type: string;
-  dependencies: Record<string, string>;
-  devDependencies: Record<string, string>;
-  peerDependencies: Record<string, string>;
-};
-
-export const getPackageJson = (path: string): PackageJson =>
-  JSON.parse(readFileSync(path, "utf-8")) as PackageJson;
 
 const packageJson = getPackageJson(
   fileURLToPath(import.meta.resolve("zudoku/package.json")),

--- a/packages/zudoku/src/cli/common/package-json.ts
+++ b/packages/zudoku/src/cli/common/package-json.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+
+// Minimal representation of a package.json file
+type PackageJson = {
+  name: string;
+  version: string;
+  type: string;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+};
+
+export const getPackageJson = (path: string): PackageJson =>
+  JSON.parse(readFileSync(path, "utf-8")) as PackageJson;

--- a/packages/zudoku/src/cli/common/version-check.ts
+++ b/packages/zudoku/src/cli/common/version-check.ts
@@ -1,8 +1,8 @@
 import { fileURLToPath } from "node:url";
 import colors from "picocolors";
 import { minVersion, satisfies } from "semver";
-import { getPackageJson } from "../cli.js";
 import { printWarningToConsole } from "./output.js";
+import { getPackageJson } from "./package-json.js";
 import box from "./utils/box.js";
 
 export const getPkgManager = () => {

--- a/packages/zudoku/src/cli/dev/handler.ts
+++ b/packages/zudoku/src/cli/dev/handler.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
-import packageJson from "../../../package.json" with { type: "json" };
+import { fileURLToPath } from "node:url";
 import { joinUrl } from "../../lib/util/joinUrl.js";
 import { DevServer } from "../../vite/dev-server.js";
 import { printDiagnosticsToConsole } from "../common/output.js";
+import { getPackageJson } from "../common/package-json.js";
 
 export interface Arguments {
   dir: string;
@@ -12,6 +13,9 @@ export interface Arguments {
 }
 
 export async function dev(argv: Arguments) {
+  const packageJson = getPackageJson(
+    fileURLToPath(import.meta.resolve("zudoku/package.json")),
+  );
   process.env.NODE_ENV = "development";
   const dir = path.resolve(process.cwd(), argv.dir);
   const server = new DevServer({


### PR DESCRIPTION
## Summary
- CLI build/dev handlers imported `package.json` statically which got inlined by tsdown at bundle time, causing the version to be stale after release bumps
- Extracted `getPackageJson` to `cli/common/package-json.ts` and read version at runtime via `readFileSync` + `import.meta.resolve`