### PR TITLE
Keep undeclared optional peer deps out of the bundle

### DIFF
--- a/docs/pages/docs/components/mermaid.mdx
+++ b/docs/pages/docs/components/mermaid.mdx
@@ -25,6 +25,14 @@ Install the `mermaid` peer dependency:
 npm install mermaid
 ```
 
+:::warning{title="Mermaid must be declared in your project"}
+
+Mermaid is only bundled when it's listed in your project's `package.json`. Without it, the diagram
+renders an "install mermaid" message instead. In a monorepo, declare it in the package that builds
+your docs (the nearest `package.json`), not just the workspace root.
+
+:::
+
 ## Import
 
 ```tsx

--- a/packages/zudoku/src/cli/common/package-json.ts
+++ b/packages/zudoku/src/cli/common/package-json.ts
@@ -10,6 +10,8 @@ type PackageJson = {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
 };
 
 export const getPackageJsonPath = (pkg: string) =>

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -20,6 +20,7 @@ import { CdnUrlSchema } from "../config/validators/ZudokuConfig.js";
 import { PROTECTED_CHUNK_DIR } from "../lib/manifest.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import type { SSRAdapter } from "./build.js";
+import { getOptionalExternals } from "./optional-externals.js";
 import { findPackageRoot } from "./package-root.js";
 import vitePlugin from "./plugin.js";
 import { protectedAnnotatorPlugin } from "./protected/annotator.js";
@@ -102,6 +103,10 @@ export async function getViteConfig(
     getZuploSystemConfigurations(process.env.ZUPLO_SYSTEM_CONFIGURATIONS)
       ?.__ZUPLO_DEPLOYMENT_NAME;
 
+  // Externalize optional deps outside Workers so missing packages fail at runtime.
+  // Workers bundle them because they must be self-contained.
+  const optionalExternals = isWorker ? [] : await getOptionalExternals(dir);
+
   const viteConfig: InlineConfig = {
     root: dir,
     base,
@@ -161,7 +166,10 @@ export async function getViteConfig(
       outDir: path.resolve(path.join(dir, "dist", config.basePath ?? "")),
       emptyOutDir: false,
       rolldownOptions: {
-        external: [joinUrl(config.basePath, "/pagefind/pagefind.js")],
+        external: [
+          joinUrl(config.basePath, "/pagefind/pagefind.js"),
+          ...optionalExternals,
+        ],
         logLevel: process.env.ZUDOKU_ENV === "internal" ? "info" : "warn",
         checks: {
           pluginTimings: process.env.ZUDOKU_ENV === "internal",

--- a/packages/zudoku/src/vite/optional-externals.test.ts
+++ b/packages/zudoku/src/vite/optional-externals.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeOptionalExternals,
+  getOptionalPeerDeps,
+  optionalDepExternal,
+} from "./optional-externals.js";
+
+describe("optionalDepExternal", () => {
+  it("matches the package and its subpaths", () => {
+    const re = optionalDepExternal("firebase");
+    expect(re.test("firebase")).toBe(true);
+    expect(re.test("firebase/app")).toBe(true);
+    expect(re.test("firebase/auth")).toBe(true);
+  });
+
+  it("does not match unrelated packages with the same prefix", () => {
+    const re = optionalDepExternal("firebase");
+    expect(re.test("firebaseui")).toBe(false);
+    expect(re.test("not-firebase")).toBe(false);
+  });
+
+  it("escapes scoped package names", () => {
+    const re = optionalDepExternal("@supabase/supabase-js");
+    expect(re.test("@supabase/supabase-js")).toBe(true);
+    expect(re.test("@supabase/supabase-js/dist")).toBe(true);
+    expect(re.test("@supabase/other")).toBe(false);
+  });
+});
+
+describe("computeOptionalExternals", () => {
+  const optionalDeps = ["mermaid", "firebase"];
+
+  it("externalizes deps the project did not declare", () => {
+    const externals = computeOptionalExternals(optionalDeps, new Set());
+    expect(externals.map((re) => re.source)).toEqual([
+      optionalDepExternal("mermaid").source,
+      optionalDepExternal("firebase").source,
+    ]);
+  });
+
+  it("does not externalize declared deps", () => {
+    const externals = computeOptionalExternals(
+      optionalDeps,
+      new Set(["firebase"]),
+    );
+    expect(externals.map((re) => re.source)).toEqual([
+      optionalDepExternal("mermaid").source,
+    ]);
+  });
+
+  it("externalizes nothing when all deps are declared", () => {
+    expect(
+      computeOptionalExternals(optionalDeps, new Set(["mermaid", "firebase"])),
+    ).toEqual([]);
+  });
+});
+
+describe("getOptionalPeerDeps", () => {
+  it("derives optional peers from zudoku and excludes env-gated deps", () => {
+    const deps = getOptionalPeerDeps();
+    expect(deps).toContain("mermaid");
+    // Sentry is gated on SENTRY_DSN, not the project's package.json.
+    expect(deps).not.toContain("@sentry/react");
+  });
+});

--- a/packages/zudoku/src/vite/optional-externals.ts
+++ b/packages/zudoku/src/vite/optional-externals.ts
@@ -1,0 +1,58 @@
+import path from "node:path";
+import {
+  getPackageJson,
+  getZudokuPackageJson,
+} from "../cli/common/package-json.js";
+import { findPackageRoot } from "./package-root.js";
+
+// Optional peer deps whose enablement comes from the build env, not the
+// project's package.json (e.g. Sentry is gated on SENTRY_DSN). Externalizing
+// these based on package.json absence would break those env-driven builds.
+const ENV_GATED_DEPS = new Set(["@sentry/react"]);
+
+const DEP_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+] as const;
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Matches the package itself and any subpath (e.g. firebase, firebase/app).
+export const optionalDepExternal = (dep: string) =>
+  new RegExp(`^${escapeRegExp(dep)}(/.*)?$`);
+
+// Optional peer deps zudoku declares, minus the env-gated ones. This is the
+// source of truth so the list can't drift from package.json.
+export const getOptionalPeerDeps = (): string[] =>
+  Object.entries(getZudokuPackageJson().peerDependenciesMeta ?? {})
+    .filter(([name, meta]) => meta?.optional && !ENV_GATED_DEPS.has(name))
+    .map(([name]) => name);
+
+const getDeclaredDeps = (pkgRoot: string): Set<string> => {
+  try {
+    const pkg = getPackageJson(path.join(pkgRoot, "package.json"));
+    return new Set(
+      DEP_FIELDS.flatMap((field) => Object.keys(pkg[field] ?? {})),
+    );
+  } catch {
+    return new Set();
+  }
+};
+
+// Externalize optional peers the project did not declare. Undeclared means the
+// project doesn't use the feature, so its dynamic import fails gracefully at
+// runtime instead of bloating (or breaking) the build.
+export const computeOptionalExternals = (
+  optionalDeps: string[],
+  declared: ReadonlySet<string>,
+): RegExp[] =>
+  optionalDeps.filter((dep) => !declared.has(dep)).map(optionalDepExternal);
+
+export const getOptionalExternals = async (dir: string): Promise<RegExp[]> => {
+  const pkgRoot = await findPackageRoot(dir);
+  const declared = pkgRoot ? getDeclaredDeps(pkgRoot) : new Set<string>();
+  return computeOptionalExternals(getOptionalPeerDeps(), declared);
+};


### PR DESCRIPTION
#2113 fixed mermaid loading in user projects by dropping it from Vite externals, but that pulled the mermaid chunk (~500KB) into every build even when no docs use it.

Now the optional peer dependencies zudoku declares are externalized unless the project actually lists them in its `package.json`. Projects that use a feature install its dependency, so it gets bundled. Projects that don't keep it out of the build, and the dynamic import fails gracefully at runtime with an install message.

The list is derived from zudoku's own `peerDependenciesMeta` so it can't drift, and externals use a regex so subpaths like `firebase/app` match. Sentry is excluded since it's enabled by an env var rather than the project's `package.json`.
