### PR TITLE
Hardcode en-US locale for price formatting

### DIFF
--- a/packages/plugin-zuplo-monetization/src/utils/formatPrice.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatPrice.ts
@@ -1,5 +1,5 @@
 export const formatPrice = (amount: number, currency?: string) =>
-  new Intl.NumberFormat(undefined, {
+  new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: currency ?? "USD",
     minimumFractionDigits: 2,


### PR DESCRIPTION
Ensure price formatting uses a consistent "en-US" locale instead of
passing undefined. This avoids relying on the runtime's default locale
and produces predictable currency formatting across environments; it
also provides a sensible default when currency is omitted.