### PR TITLE
Add `requestIdleCallback` polyfill

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -78,6 +78,12 @@ responses/request bodies is passed as `JSONSchemaScalar`, which serializes the r
 through `handleCircularRefs()`. Media-type level `example`/`examples` are resolved into
 `ExampleItem` arrays by the GraphQL resolvers before reaching the client.
 
+## Polyfills
+
+`polyfills.ts` is a side-effect module imported in `main.tsx` and listed in `package.json`
+`sideEffects`. All browser polyfills must go in this file or be added as a separate entry in the
+`sideEffects` array, otherwise they will be tree-shaken in production builds.
+
 ## Bundle Size
 
 Heavy modules must never be statically imported from entry-path code (modules reachable from

--- a/packages/zudoku/src/app/polyfills.ts
+++ b/packages/zudoku/src/app/polyfills.ts
@@ -15,3 +15,11 @@ if (typeof Object.groupBy === "undefined") {
     return result;
   };
 }
+
+if (typeof window !== "undefined" && !window.requestIdleCallback) {
+  window.requestIdleCallback = (cb: IdleRequestCallback) =>
+    Number(
+      setTimeout(() => cb({ didTimeout: false, timeRemaining: () => 50 }), 1),
+    );
+  window.cancelIdleCallback = (id: number) => clearTimeout(id);
+}

--- a/packages/zudoku/src/lib/components/Zudoku.tsx
+++ b/packages/zudoku/src/lib/components/Zudoku.tsx
@@ -17,7 +17,6 @@ import {
 } from "../core/ZudokuContext.js";
 import { TopLevelError } from "../errors/TopLevelError.js";
 import { MdxComponents } from "../util/MdxComponents.js";
-import "../util/requestIdleCallbackPolyfill.js";
 import { RouterEventsEmitter } from "./context/RouterEventsEmitter.js";
 import { SlotProvider } from "./context/SlotProvider.js";
 import { ViewportAnchorProvider } from "./context/ViewportAnchorContext.js";

--- a/packages/zudoku/src/lib/util/requestIdleCallbackPolyfill.ts
+++ b/packages/zudoku/src/lib/util/requestIdleCallbackPolyfill.ts
@@ -1,6 +1,0 @@
-const root = globalThis;
-
-if (!root.requestIdleCallback || !root.cancelIdleCallback) {
-  root.requestIdleCallback = (cb: IdleRequestCallback) => setTimeout(cb, 1);
-  root.cancelIdleCallback = clearTimeout;
-}


### PR DESCRIPTION
- Move `requestIdleCallback` polyfill to `polyfills.ts` for Safari which doesn't support it
- The previous polyfill was in a separate file that got tree-shaken in production because it wasn't in the `sideEffects` array of `package.json`
