### PR TITLE
chore: align package.json versions with published v0.71.0

### DIFF
--- a/packages/create-zudoku/package.json
+++ b/packages/create-zudoku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-zudoku",
-  "version": "0.70.4",
+  "version": "0.71.0",
   "keywords": [
     "react",
     "zudoku"

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zudoku",
-  "version": "0.70.4",
+  "version": "0.71.0",
   "type": "module",
   "sideEffects": [
     "**/*.css",


### PR DESCRIPTION
Release workflow for v0.71.0 published to npm and pushed the tag but failed to push the version bump commit to main (race condition with concurrent merges). This aligns package.json with the published version.