### PR TITLE
fix: normalize trailing slashes in navigation path matching

### DIFF
--- a/packages/zudoku/src/lib/components/context/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/components/context/ZudokuContext.ts
@@ -4,6 +4,7 @@ import { matchPath, useLocation } from "react-router";
 import type { NavigationItem } from "../../../config/validators/NavigationSchema.js";
 import { useAuthState } from "../../authentication/state.js";
 import { applyRules } from "../../navigation/applyRules.js";
+import { joinUrl } from "../../util/joinUrl.js";
 import { CACHE_KEYS, useCache } from "../cache.js";
 import { getItemPath, traverseNavigation } from "../navigation/utils.js";
 import { ZudokuReactContext } from "./ZudokuReactContext.js";
@@ -59,16 +60,18 @@ export const useCurrentNavigation = () => {
   const location = useLocation();
   const loggedWarnings = useRef(new Set<string>());
 
+  const pathname = joinUrl(location.pathname);
+
   const navItem = traverseNavigation(navigation, (item, parentCategories) => {
     if (item.type === "link") return;
-    if (getItemPath(item) === location.pathname) {
+    if (getItemPath(item) === pathname) {
       return parentCategories.at(0) ?? item;
     }
   });
 
   const { data } = useSuspenseQuery({
-    queryFn: () => getPluginNavigation(location.pathname),
-    queryKey: ["plugin-navigation", location.pathname],
+    queryFn: () => getPluginNavigation(pathname),
+    queryKey: ["plugin-navigation", pathname],
   });
 
   let topNavItem = navItem;

--- a/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
@@ -135,8 +135,10 @@ export const NavigationItem = ({
             isActive:
               href ===
               (hasAnchor
-                ? [location.pathname, activeAnchor].filter(Boolean).join("#")
-                : location.pathname),
+                ? [joinUrl(location.pathname), activeAnchor]
+                    .filter(Boolean)
+                    .join("#")
+                : joinUrl(location.pathname)),
           })}
           onClick={onRequestClose}
         >

--- a/packages/zudoku/src/lib/components/navigation/utils.ts
+++ b/packages/zudoku/src/lib/components/navigation/utils.ts
@@ -87,18 +87,18 @@ export const getFirstMatchingPath = (item: NavigationItem): string => {
 };
 
 export const useCurrentItem = () => {
-  const location = useLocation();
+  const pathname = joinUrl(useLocation().pathname);
   const { navigation } = useCurrentNavigation();
 
   return traverseNavigation(navigation, (item) => {
-    if (item.type === "doc" && joinUrl(item.path) === location.pathname) {
+    if (item.type === "doc" && joinUrl(item.path) === pathname) {
       return item;
     }
   });
 };
 
 export const useIsCategoryOpen = (category: NavigationCategory) => {
-  const location = useLocation();
+  const pathname = joinUrl(useLocation().pathname);
 
   return traverseNavigationItem(category, (item) => {
     switch (item.type) {
@@ -106,10 +106,10 @@ export const useIsCategoryOpen = (category: NavigationCategory) => {
         if (!item.link) {
           return undefined;
         }
-        return joinUrl(item.link.path) === location.pathname ? true : undefined;
+        return joinUrl(item.link.path) === pathname ? true : undefined;
       case "custom-page":
       case "doc":
-        return joinUrl(item.path) === location.pathname ? true : undefined;
+        return joinUrl(item.path) === pathname ? true : undefined;
       default:
         return undefined;
     }
@@ -120,7 +120,7 @@ export const usePrevNext = (): {
   prev?: { label?: string; id: string };
   next?: { label?: string; id: string };
 } => {
-  const currentId = useLocation().pathname;
+  const currentId = joinUrl(useLocation().pathname);
   const { navigation } = useCurrentNavigation();
 
   let prev: { label?: string; id: string } | undefined;


### PR DESCRIPTION
## Summary
- Sidebar navigation disappears when URLs have a trailing slash (e.g. `/docs/` vs `/docs`)
- `joinUrl()` strips trailing slashes from config paths but `location.pathname` preserves them, causing strict equality comparisons to fail
- Normalize `location.pathname` through `joinUrl()` at all comparison points in `ZudokuContext.ts`, `utils.ts`, and `NavigationItem.tsx`