### PR TITLE
fix: include redirect source paths in prerender URL list

### DIFF
--- a/packages/zudoku/src/vite/prerender/prerender.ts
+++ b/packages/zudoku/src/vite/prerender/prerender.ts
@@ -12,6 +12,7 @@ import { getBuildConfig } from "../../config/validators/BuildSchema.js";
 import type { ZudokuConfig } from "../../config/validators/validate.js";
 import { runPluginTransformConfig } from "../../lib/core/transform-config.js";
 import invariant from "../../lib/util/invariant.js";
+import { joinUrl } from "../../lib/util/joinUrl.js";
 import type { MarkdownFileInfo } from "../plugin-markdown-export.js";
 import { isTTY, throttle, writeLine } from "../reporter.js";
 import { generateSitemap } from "../sitemap.js";
@@ -76,6 +77,13 @@ export const prerender = async ({
   const routes = getRoutes(config);
   const paths = routesToPaths(routes);
   const rewrites = routesToRewrites(routes);
+
+  // Add redirect source paths so they get prerendered as redirects
+  if (config.redirects) {
+    for (const r of config.redirects) {
+      paths.push(joinUrl(r.from));
+    }
+  }
   const maxThreads =
     buildConfig?.prerender?.workers ?? Math.floor(os.cpus().length * 0.8);
 


### PR DESCRIPTION
In v0.71.2, redirects were refactored from plugin-based routes to a root
route loader. This meant `routesToPaths` no longer included redirect
`from` paths, so the prerender worker never visited them. No redirect
HTML files or Vercel redirect rules were generated, causing all redirect
URLs to 404.

Add redirect `from` paths to the prerender paths array so the worker
visits them and correctly generates redirect artifacts.