### PR TITLE
fix(ui): resolve spacing issue between admonitions and stepper component

### DIFF
--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -340,6 +340,10 @@
 }
 
 @layer utilities {
+  .stepper {
+    @apply my-4;
+  }
+
   .stepper > ol {
     --bullet-size: 1.75rem;
     --line-spacing: 0.25rem;


### PR DESCRIPTION
## Problem

When a `<Stepper>` component is placed directly after an admonition (Callout), the spacing between them looks broken. The stepper appears too close to the admonition, creating a visually inconsistent layout.

Reported in #1559.

## Root Cause

The `.stepper` wrapper div had no vertical margin of its own. It relied entirely on the prose context for spacing. However, the Callout component uses `not-prose`, which breaks the prose margin flow for adjacent elements. Since the stepper's inner `ol` explicitly sets `m-0 p-0`, the spacing collapsed completely.

## Fix

Added `my-4` (`1rem` vertical margin) to the `.stepper` class in `main.css`. This matches the standard prose paragraph spacing and ensures consistent vertical rhythm regardless of the preceding element's prose context.

### Changes

- `packages/zudoku/src/app/main.css`: Added `.stepper { @apply my-4; }`

## Testing

This fix addresses:
- ✅ Stepper after admonition (the reported issue)
- ✅ Stepper after regular prose content (no visual regression — margin matches prose rhythm)
- ✅ Stepper inside a list item with admonition (no impact — the `my-4` applies to the outer wrapper, not inner elements)

Fixes #1559