### PR TITLE
fix: add upper bounds to security override ranges

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,11 +50,11 @@ overrides:
   '@supabase/auth-ui-react>react': 19.2.4
   '@supabase/auth-ui-react>react-dom': 19.2.4
   bs58: '>=6'
+  immutable: '>=3.8.3 <4'
   js-yaml: '>=4.1.1'
-  minimatch: '>=10.2.3'
-  immutable: '>=3.8.3'
+  minimatch: '>=10.2.3 <11'
   qs: '>=6.14.1'
-  tar: '>=7.5.11'
+  tar: '>=7.5.11 <8'
 
 patchedDependencies:
   decode-named-character-reference@1.2.0:
@@ -439,7 +439,7 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       tar:
-        specifier: '>=7.5.11'
+        specifier: '>=7.5.11 <8'
         version: 7.5.11
       update-check:
         specifier: 1.5.4
@@ -7244,8 +7244,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
-  immutable@5.1.5:
-    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
+  immutable@3.8.3:
+    resolution: {integrity: sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==}
+    engines: {node: '>=0.10.0'}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -10170,7 +10171,7 @@ snapshots:
       chalk: 4.1.2
       fb-watchman: 2.0.2
       graphql: 16.13.1
-      immutable: 5.1.5
+      immutable: 3.8.3
       invariant: 2.2.4
       nullthrows: 1.1.1
       relay-runtime: 12.0.0
@@ -14329,7 +14330,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.83.5
       semver: 7.7.4
     transitivePeerDependencies:
@@ -17751,7 +17752,7 @@ snapshots:
     dependencies:
       queue: 6.0.2
 
-  immutable@5.1.5: {}
+  immutable@3.8.3: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -18657,6 +18658,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.83.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-cache: 0.83.5
+      metro-core: 0.83.5
+      metro-runtime: 0.83.5
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -18808,7 +18824,7 @@ snapshots:
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
-      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.83.5
       metro-file-map: 0.83.5
       metro-resolver: 0.83.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,11 +41,11 @@ overrides:
   "@supabase/auth-ui-react>react": "catalog:"
   "@supabase/auth-ui-react>react-dom": "catalog:"
   bs58: ">=6"
-  immutable: ">=3.8.3"
+  immutable: ">=3.8.3 <4"
   js-yaml: ">=4.1.1"
-  minimatch: ">=10.2.3"
+  minimatch: ">=10.2.3 <11"
   qs: ">=6.14.1"
-  tar: ">=7.5.11"
+  tar: ">=7.5.11 <8"
 
 patchedDependencies:
   decode-named-character-reference@1.2.0: patches/decode-named-character-reference@1.2.0.patch


### PR DESCRIPTION
Constrain open-ended security overrides to avoid unintended major version jumps:
- `immutable: ">=3.8.3 <4"` — prevents v3→v5 jump that broke relay-compiler compatibility
- `minimatch: ">=10.2.3 <11"`
- `tar: ">=7.5.11 <8"` — v8/v9/v10 exist on npm

Addresses feedback in https://github.com/zuplo/zudoku/pull/2162