### PR TITLE
Show problem+json details on fetch failure

### DIFF
--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
@@ -60,6 +60,14 @@ export const queryClient = new QueryClient({
         );
 
         if (!response.ok) {
+          if (
+            response.headers
+              .get("content-type")
+              ?.includes("application/problem+json")
+          ) {
+            const data = await response.json();
+            throw new Error(data.detail ?? data.title);
+          }
           throw new Error("Failed to fetch request");
         }
 


### PR DESCRIPTION
When a fetch during the checkout flow fails and the response `content-type` is `application/problem+json`, surface the problem details instead of the generic "Failed to fetch request" message. 

This change reads the JSON body and throws an Error with the problem's detail or title so the UI can display the specific error returned by the server.