### PR TITLE
fix: prevent nested <a> in tag description links causing CLS

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/SchemaInfo.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SchemaInfo.tsx
@@ -260,7 +260,11 @@ export const SchemaInfo = () => {
                           {tag.description && (
                             <ItemDescription asChild>
                               <Markdown
-                                components={{ p: ({ children }) => children }}
+                                components={{
+                                  // Because the description is wrapped in a <p> and a <Link> already
+                                  p: ({ children }) => children,
+                                  a: (props) => <span {...props} />,
+                                }}
                                 content={tag.description}
                                 className="prose-sm text-pretty"
                               />


### PR DESCRIPTION
Tag descriptions containing markdown links (e.g. "learn more [here](...)") were rendering `<a>` elements inside the card's `<Link>` component (also an `<a>`). The browser breaks nested anchors out of their parent, producing an empty bordered box alongside floating content — causing a large CLS on the API info page.

Fix mirrors the same pattern in `api-catalog/Catalog.tsx`: override `a` in `Markdown` components to render as `<span>` instead.