### PR TITLE
fix: resolve allOf $refs before flattening (oneOf/allOf crash)

### DIFF
--- a/packages/zudoku/src/lib/util/flattenAllOfProcessor.ts
+++ b/packages/zudoku/src/lib/util/flattenAllOfProcessor.ts
@@ -11,7 +11,42 @@ export const flattenAllOfProcessor: Processor = async ({ schema, file }) => {
     await parser.resolve(schema);
     const $refs = parser.$refs;
 
-    const flattened = traverse(schema, (spec) => {
+    // Pre-resolve all $refs inside allOf items throughout the schema before
+    // flattening. flattenAllOf recurses internally into oneOf/anyOf/properties
+    // without going through $ref resolution, so we must ensure all allOf items
+    // are resolved upfront. This prevents stale $ref keys from being merged
+    // into parent schemas when they point to paths removed during flattening.
+    const resolved = traverse(schema, (spec) => {
+      if (
+        !spec ||
+        typeof spec !== "object" ||
+        Array.isArray(spec) ||
+        !("allOf" in spec) ||
+        !Array.isArray(spec.allOf)
+      ) {
+        return spec;
+      }
+
+      const resolvedAllOf = spec.allOf.map((item) => {
+        if (
+          item &&
+          typeof item === "object" &&
+          "$ref" in item &&
+          typeof item.$ref === "string"
+        ) {
+          try {
+            return $refs.get(item.$ref) ?? item;
+          } catch {
+            return item;
+          }
+        }
+        return item;
+      });
+
+      return { ...spec, allOf: resolvedAllOf };
+    }) as OpenAPIDocument;
+
+    const flattened = traverse(resolved, (spec) => {
       if (!spec || typeof spec !== "object" || Array.isArray(spec)) {
         return spec;
       }
@@ -24,25 +59,6 @@ export const flattenAllOfProcessor: Processor = async ({ schema, file }) => {
         "oneOf" in spec;
 
       if (!isSchemaObject) return spec;
-
-      if ("allOf" in spec && Array.isArray(spec.allOf)) {
-        const resolvedAllOf = spec.allOf.map((item) => {
-          if (
-            item &&
-            typeof item === "object" &&
-            "$ref" in item &&
-            typeof item.$ref === "string"
-          ) {
-            try {
-              return $refs.get(item.$ref) ?? item;
-            } catch {
-              return item;
-            }
-          }
-          return item;
-        });
-        return flattenAllOf({ ...spec, allOf: resolvedAllOf }) as RecordAny;
-      }
 
       return flattenAllOf(spec) as RecordAny;
     }) as OpenAPIDocument;

--- a/packages/zudoku/src/vite/api/SchemaManager.test.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { OpenAPIV3_1 } from "openapi-types";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ConfigWithMeta } from "../../config/loader.js";
 import type { Processor } from "../../config/validators/BuildSchema.js";
@@ -190,7 +191,7 @@ describe("SchemaManager", () => {
           },
         },
       },
-    } as OpenAPIDocument;
+    } satisfies OpenAPIV3_1.Document;
 
     const schemaPath = path.join(tempDir, "openapi.json");
     await fs.writeFile(schemaPath, JSON.stringify(schemaWithRefs));
@@ -215,6 +216,57 @@ describe("SchemaManager", () => {
     expect(generatedCode).toContain("#/components/schemas/Base");
     expect(generatedCode).toContain("#/components/schemas/Item");
     expect(generatedCode).not.toContain('"allOf"');
+  });
+
+  it("should flatten allOf with $refs nested inside oneOf variants", async () => {
+    // Simulates bundle() output: shared base is inlined at oneOf/0/allOf/0 and
+    // referenced via $ref from oneOf/1/allOf/0. After flattening, allOf/0 is
+    // gone, so the $ref must be resolved before flattening or generateCode throws.
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test API", version: "1.0.0" },
+      components: {
+        schemas: {
+          Result: {
+            oneOf: [
+              {
+                allOf: [
+                  { type: "object", properties: { id: { type: "string" } } },
+                  { type: "object", properties: { a: { type: "string" } } },
+                ],
+              },
+              {
+                allOf: [
+                  { $ref: "#/components/schemas/Result/oneOf/0/allOf/0" },
+                  { type: "object", properties: { b: { type: "string" } } },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenAPIV3_1.Document;
+
+    const schemaPath = path.join(tempDir, "openapi.json");
+    await fs.writeFile(schemaPath, JSON.stringify(schema));
+
+    const manager = new SchemaManager({
+      storeDir,
+      config: {
+        __meta,
+        apis: [{ type: "file", path: "test-api", input: schemaPath }],
+      },
+      processors: [flattenAllOfProcessor],
+    });
+
+    await expect(manager.processAllSchemas()).resolves.not.toThrow();
+
+    const oneOf =
+      manager.getLatestSchema("test-api")?.schema.components?.schemas?.Result
+        ?.oneOf;
+    expect(oneOf?.[1]).not.toHaveProperty("allOf");
+    expect(oneOf?.[1]).not.toHaveProperty("$ref");
+    expect(oneOf?.[1]?.properties).toHaveProperty("id");
   });
 
   it("should split same file into multiple versions using query params", async () => {


### PR DESCRIPTION
Fixes #2171.

`bundle()` deduplicates shared schemas by inlining the first usage and pointing subsequent usages to that path via `$ref` (e.g. `#/.../oneOf/0/allOf/0`). The bug: `flattenAllOf` recurses into `oneOf` variants internally without resolving `$ref`s, so `shallowAllOfMerge` merges the raw `$ref` key into the parent. After flattening removes `allOf`, that path no longer exists and `generateCode` crashes.

Fix is a pre-pass that resolves all `$ref`s inside `allOf` items before flattening. Only direct `allOf` items are resolved (same scope as before), no added bloat.