### PR TITLE
fix: include id_token_hint in OpenID logout request

### DIFF
--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -327,7 +327,9 @@ export class OpenIDAuthenticationProvider
   signOut = async (_: AuthActionContext) => {
     const { providerData } = useAuthState.getState();
     const idToken =
-      providerData?.type === "openid" ? providerData.idToken : undefined;
+      providerData?.type === "openid" || providerData?.type === undefined
+        ? providerData?.idToken
+        : undefined;
 
     useAuthState.getState().setLoggedOut();
 


### PR DESCRIPTION
Fixes #2115

Reads the stored `id_token` before clearing state and appends it as `id_token_hint` on the end-session endpoint URL. Required by Okta (and other strict OIDC providers) to avoid a 400 on logout.