### PR TITLE
fix: prevent layout shift when dropdowns remove scrollbar

### DIFF
--- a/packages/zudoku/src/app/polyfills.ts
+++ b/packages/zudoku/src/app/polyfills.ts
@@ -16,6 +16,28 @@ if (typeof Object.groupBy === "undefined") {
   };
 }
 
+// Freeze --scrollbar-width when react-remove-scroll locks the body, preventing
+// the CSS calc(100vw - 100%) from recalculating to 0 and causing layout shift.
+if (typeof window !== "undefined") {
+  new MutationObserver(() => {
+    const locked = document.body.hasAttribute("data-scroll-locked");
+    const gap = locked
+      ? getComputedStyle(document.body).getPropertyValue(
+          "--removed-body-scroll-bar-size",
+        )
+      : "";
+
+    if (gap) {
+      document.documentElement.style.setProperty("--scrollbar-width", gap);
+    } else {
+      document.documentElement.style.removeProperty("--scrollbar-width");
+    }
+  }).observe(document.body, {
+    attributes: true,
+    attributeFilter: ["data-scroll-locked"],
+  });
+}
+
 if (typeof window !== "undefined" && !window.requestIdleCallback) {
   window.requestIdleCallback = (cb: IdleRequestCallback) =>
     Number(


### PR DESCRIPTION
Freezes `--scrollbar-width` CSS var when react-remove-scroll locks the body for dropdowns/dialogs, preventing the `calc(100vw - 100%)` from recalculating to 0 and causing CLS on macOS with classic scrollbars.