### PR TITLE
fix: use originalUrl for basePath redirect in dev server

### DIFF
--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -116,7 +116,7 @@ export class DevServer {
     vite.middlewares.use((req, res, next) => {
       if (
         req.method === "GET" &&
-        req.url === "/" &&
+        req.originalUrl === "/" &&
         config.basePath &&
         config.basePath !== "/"
       ) {


### PR DESCRIPTION
## Problem

When `basePath` is configured (e.g. `/docs`), visiting `localhost:3000/docs` causes an infinite redirect loop (`ERR_TOO_MANY_REDIRECTS`).

The basePath redirect middleware checks `req.url === "/"` to decide whether to redirect from root to the basePath. However, when Vite is configured with a `base`, it strips the base prefix from `req.url` — so a request to `/docs` arrives at the middleware with `req.url === "/"`, triggering a redirect back to `/docs`, which loops forever.

## Fix

Use `req.originalUrl` instead of `req.url`. `originalUrl` preserves the full request path before Vite's base-stripping, so the redirect only fires when the user actually visits `/` (not when they're already at the basePath).