### PR TITLE
fix: use separate slug counters for operations and tags

### DIFF
--- a/packages/zudoku/src/lib/oas/graphql/index.ts
+++ b/packages/zudoku/src/lib/oas/graphql/index.ts
@@ -153,7 +153,8 @@ export const getAllSlugs = (
   ops: GraphQLOperationObject[],
   schemaTags: TagObject[] = [],
 ): Slugs => {
-  const slugify = slugifyWithCounter();
+  const operationSlugify = slugifyWithCounter();
+  const tagSlugify = slugifyWithCounter();
 
   const tags = Array.from(
     new Set([
@@ -166,10 +167,10 @@ export const getAllSlugs = (
     operations: Object.fromEntries(
       ops.map((op) => [
         getOperationSlugKey(op),
-        createOperationSlug(slugify, op),
+        createOperationSlug(operationSlugify, op),
       ]),
     ),
-    tags: Object.fromEntries(tags.map((tag) => [tag, slugify(tag)])),
+    tags: Object.fromEntries(tags.map((tag) => [tag, tagSlugify(tag)])),
   };
 };
 

--- a/packages/zudoku/src/vite/api/schema-codegen.test.ts
+++ b/packages/zudoku/src/vite/api/schema-codegen.test.ts
@@ -230,6 +230,40 @@ describe("Generate OpenAPI schema module", () => {
     `);
   });
 
+  it("should not add suffix to tag slugs when operation summaries match tag names", () => {
+    const operations = getAllOperations({
+      "/agreements": {
+        get: {
+          tags: ["Agreements"],
+          summary: "Agreements",
+          responses: { "200": { description: "OK" } },
+        },
+        post: {
+          tags: ["Agreements"],
+          summary: "Create Agreement",
+          responses: { "201": { description: "Created" } },
+        },
+      },
+      "/assets": {
+        get: {
+          tags: ["Assets"],
+          summary: "Assets",
+          responses: { "200": { description: "OK" } },
+        },
+      },
+    });
+
+    const slugs = getAllSlugs(operations, [
+      { name: "Agreements" },
+      { name: "Assets" },
+    ]);
+
+    expect(slugs.tags).toStrictEqual({
+      Agreements: "agreements",
+      Assets: "assets",
+    });
+  });
+
   it("should generate correct code for circular refs", async () => {
     const input = {
       definitions: {


### PR DESCRIPTION
Operations and tags shared the same incremental slugifier, so when both had the same name (e.g. "Agreements") the tag slug got a `-2` suffix.

## Summary
- `getAllSlugs` used a single `slugifyWithCounter()` for both operations and tags, so when operation summaries matched tag names the tags got `-2` suffixed slugs
- Split into separate counters so operation and tag slugs don't collide