### PR TITLE
Add test coverage reporting to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,8 @@ name: Build
 on:
   workflow_call:
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   build:
@@ -12,6 +14,7 @@ jobs:
       actions: read
       contents: read
       id-token: write
+      pull-requests: write
 
     env:
       COREPACK_ENABLE_STRICT: 0
@@ -41,7 +44,47 @@ jobs:
 
       - run: pnpm check
       - run: nx run-many -t build:ci
-      - run: pnpm test
+      - run: pnpm test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+
+      - name: Restore base coverage
+        if: github.event_name == 'pull_request'
+        id: base-coverage
+        uses: actions/cache/restore@v5
+        with:
+          path: coverage-base/coverage-summary.json
+          key: coverage-base-
+          restore-keys: coverage-base-
+
+      - name: Save base coverage
+        if: github.ref == 'refs/heads/main'
+        run: mkdir -p coverage-base && cp coverage/coverage-summary.json coverage-base/
+
+      - name: Save base coverage cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: coverage-base/coverage-summary.json
+          key: coverage-base-${{ github.sha }}
+
+      - name: Coverage report comment (with comparison)
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.base-coverage.outputs.cache-matched-key != ''
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          json-summary-compare-path: coverage-base/coverage-summary.json
+
+      - name: Coverage report comment
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.base-coverage.outputs.cache-matched-key == ''
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
 
       - name: Get Variables
         id: vars

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "reset": "nx reset && npm run build:clean",
     "clean": "git clean -Xfde !.env",
     "test": "vitest run --typecheck",
+    "test:coverage": "vitest run --typecheck --coverage",
     "size": "size-limit"
   },
   "engines": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: ["packages/*"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "json", "html"],
+      reportsDirectory: "./coverage",
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Configure vitest with v8 coverage provider (text, json-summary, html reporters)
- Run tests with `--coverage` in the CI build workflow
- Upload HTML coverage report as a downloadable artifact
- Post a coverage summary comment on pull requests via `davelosert/vitest-coverage-report-action`

## Test plan
- [ ] Verify CI runs tests with coverage enabled
- [ ] Check that coverage artifact is uploaded
- [ ] Confirm coverage summary comment appears on this PR