### PR TITLE
fix: use float layout for mdx page copy buttons to prevent mobile overflow

### DIFF
--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -152,17 +152,13 @@ export const MdxPage = ({
       </Helmet>
 
       <Typography className="max-w-full xl:w-full xl:max-w-3xl flex-1 shrink pt-(--padding-content-top)">
-        {(category || title) && (
-          <header className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              {category && <CategoryHeading>{category}</CategoryHeading>}
-              {title && (
-                <Heading level={1} id={slugify(title)}>
-                  {title}
-                </Heading>
-              )}
-            </div>
-            {copyMarkdownConfig && (
+        <header className="flow-root">
+          {copyMarkdownConfig && (
+            <div
+              className="float-end ms-4 mt-1"
+              role="group"
+              aria-label="Page actions"
+            >
               <ButtonGroup>
                 <Button
                   variant="outline"
@@ -235,9 +231,15 @@ export const MdxPage = ({
                   </DropdownMenuContent>
                 </DropdownMenu>
               </ButtonGroup>
-            )}
-          </header>
-        )}
+            </div>
+          )}
+          {category && <CategoryHeading>{category}</CategoryHeading>}
+          {title && (
+            <Heading level={1} id={slugify(title)}>
+              {title}
+            </Heading>
+          )}
+        </header>
 
         {frontmatter.draft && (
           <DeveloperHint>


### PR DESCRIPTION
## Summary
- Replaces flex row layout with float for the copy/share button group in mdx page headers
- On iOS Safari, the flex row with title + buttons overflowed the viewport on narrow screens because `overflow-x: clip` on body isn't fully supported
- Float layout lets the title render as full-width block content (same as markdown `# heading`) so it never causes horizontal overflow

<img width="280" src="https://github.com/user-attachments/assets/2bc5ea36-6e1d-4e31-84c4-e31a6a4ed529" />