### PR TITLE
fix: preserve $ref sibling properties in nested schemas

### DIFF
--- a/packages/zudoku/src/lib/oas/parser/dereference/dereference.test.ts
+++ b/packages/zudoku/src/lib/oas/parser/dereference/dereference.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import { dereference } from "./index.js";
+
+describe("dereference", () => {
+  it("should resolve basic $ref", async () => {
+    const schema = {
+      components: {
+        schemas: {
+          Pet: { type: "object", properties: { name: { type: "string" } } },
+        },
+      },
+      paths: {
+        "/pets": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Pet" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = await dereference(schema);
+    const responseSchema =
+      result.paths["/pets"].get.responses["200"].content["application/json"]
+        .schema;
+
+    expect(responseSchema.type).toBe("object");
+    expect(responseSchema.properties.name.type).toBe("string");
+  });
+
+  it("should preserve OAS 3.1 sibling properties alongside $ref", async () => {
+    const schema = {
+      components: {
+        schemas: {
+          Child: { type: "string" },
+        },
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        field: {
+                          $ref: "#/components/schemas/Child",
+                          description: "Overridden description",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = await dereference(schema);
+    const field =
+      result.paths["/test"].get.responses["200"].content["application/json"]
+        .schema.properties.field;
+
+    expect(field.type).toBe("string");
+    expect(field.description).toBe("Overridden description");
+  });
+
+  it("should preserve sibling descriptions in nested $ref'd schemas", async () => {
+    // Reproduces https://github.com/zuplo/zudoku/issues/2191
+    const schema = {
+      components: {
+        schemas: {
+          Child: { type: "string" },
+          ObjectContainingRef: {
+            type: "object",
+            properties: {
+              child: {
+                $ref: "#/components/schemas/Child",
+                description: "Description for ObjectContainingRef.child",
+              },
+            },
+          },
+          Parent: {
+            type: "object",
+            properties: {
+              childObject: {
+                type: "object",
+                properties: {
+                  child: {
+                    $ref: "#/components/schemas/Child",
+                    description: "Inline description for childObject.child",
+                  },
+                },
+              },
+              childObjectRef: {
+                $ref: "#/components/schemas/ObjectContainingRef",
+              },
+              childObjectArray: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    child: {
+                      $ref: "#/components/schemas/Child",
+                      description:
+                        "Inline description for childObjectArray.[].child",
+                    },
+                  },
+                },
+              },
+              childObjectArrayRef: {
+                type: "array",
+                items: {
+                  $ref: "#/components/schemas/ObjectContainingRef",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = await dereference(schema);
+    const parent = result.components.schemas.Parent;
+
+    // Inline object: description preserved
+    expect(parent.properties.childObject.properties.child.description).toBe(
+      "Inline description for childObject.child",
+    );
+
+    // $ref'd object: description preserved (the reported bug)
+    expect(parent.properties.childObjectRef.properties.child.description).toBe(
+      "Description for ObjectContainingRef.child",
+    );
+
+    // Inline array items: description preserved
+    expect(
+      parent.properties.childObjectArray.items.properties.child.description,
+    ).toBe("Inline description for childObjectArray.[].child");
+
+    // $ref'd array items: description preserved (the reported bug)
+    expect(
+      parent.properties.childObjectArrayRef.items.properties.child.description,
+    ).toBe("Description for ObjectContainingRef.child");
+  });
+
+  it("should let sibling properties override referenced properties", async () => {
+    const schema = {
+      components: {
+        schemas: {
+          Base: {
+            type: "object",
+            description: "Base description",
+            properties: { id: { type: "string" } },
+          },
+        },
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/Base",
+                      description: "Overridden description",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = await dereference(schema);
+    const responseSchema =
+      result.paths["/test"].get.responses["200"].content["application/json"]
+        .schema;
+
+    // Sibling description overrides the referenced schema's description
+    expect(responseSchema.description).toBe("Overridden description");
+    expect(responseSchema.properties.id.type).toBe("string");
+  });
+});

--- a/packages/zudoku/src/lib/oas/parser/dereference/index.ts
+++ b/packages/zudoku/src/lib/oas/parser/dereference/index.ts
@@ -41,12 +41,27 @@ export const dereference = async (
         if ("$ref" in current && typeof current.$ref === "string") {
           // Store the ref path before resolving
           current.__$ref = current.$ref;
+
+          // Collect OAS 3.1 sibling properties to merge after resolution
+          const { $ref: _, __$ref: __, ...siblings } = current;
+          const hasSiblings = Object.keys(siblings).length > 0;
+
           for (const resolver of resolvers) {
             const resolved = await resolver(current.$ref);
-            if (resolved) return await resolve(resolved, path);
+            if (resolved) {
+              const result = await resolve(resolved, path);
+              if (hasSiblings && isIndexableObject(result)) {
+                return { ...result, ...siblings };
+              }
+              return result;
+            }
           }
           const resolved = await resolveLocalRef(cloned, current.$ref);
-          return await resolve(resolved, path);
+          const result = await resolve(resolved, path);
+          if (hasSiblings && isIndexableObject(result)) {
+            return { ...result, ...siblings };
+          }
+          return result;
         }
 
         for (const key in current) {

--- a/packages/zudoku/src/vite/api/schema-codegen.test.ts
+++ b/packages/zudoku/src/vite/api/schema-codegen.test.ts
@@ -433,9 +433,10 @@ describe("Generate OpenAPI schema module", () => {
 
     const code = await generateCode(input);
 
-    // Ref with siblings uses a merged variable and preserves __$ref
+    // Merged placeholders are declared empty, then populated after base refs
+    expect(code).toContain("const __merged_0 = {};");
     expect(code).toContain(
-      'const __merged_0 = Object.assign({}, __refMap["#/components/schemas/Pet"], {\n  "description": "The pet data"\n});',
+      'Object.assign(__merged_0, __refMap["#/components/schemas/Pet"], {\n  "description": "The pet data"\n});',
     );
     expect(code).toContain(
       'Object.defineProperty(__merged_0, "__$ref", { value: __refMapPaths[0], enumerable: false });',
@@ -443,6 +444,94 @@ describe("Generate OpenAPI schema module", () => {
 
     // Plain ref uses direct reference
     expect(code).toContain('"error": __refMap["#/components/schemas/Pet"]');
+  });
+
+  it("should preserve $ref sibling descriptions in nested referenced schemas", async () => {
+    // Reproduces https://github.com/zuplo/zudoku/issues/2191
+    const input = {
+      components: {
+        schemas: {
+          Child: { type: "string" },
+          ObjectContainingRef: {
+            type: "object",
+            properties: {
+              child: {
+                $ref: "#/components/schemas/Child",
+                description: "Description for ObjectContainingRef.child",
+              },
+            },
+          },
+          Parent: {
+            type: "object",
+            properties: {
+              childObject: {
+                type: "object",
+                properties: {
+                  child: {
+                    $ref: "#/components/schemas/Child",
+                    description: "Inline description for childObject.child",
+                  },
+                },
+              },
+              childObjectRef: {
+                $ref: "#/components/schemas/ObjectContainingRef",
+              },
+              childObjectArray: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    child: {
+                      $ref: "#/components/schemas/Child",
+                      description:
+                        "Inline description for childObjectArray.[].child",
+                    },
+                  },
+                },
+              },
+              childObjectArrayRef: {
+                type: "array",
+                items: {
+                  $ref: "#/components/schemas/ObjectContainingRef",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { schema } = await executeCode(await generateCode(input));
+
+    // Top-level component view — should always work
+    expect(
+      schema.components.schemas.ObjectContainingRef.properties.child
+        .description,
+    ).toBe("Description for ObjectContainingRef.child");
+
+    // Inline object — should work
+    expect(
+      schema.components.schemas.Parent.properties.childObject.properties.child
+        .description,
+    ).toBe("Inline description for childObject.child");
+
+    // $ref'd object nested inside Parent — this is the reported bug
+    expect(
+      schema.components.schemas.Parent.properties.childObjectRef.properties
+        .child.description,
+    ).toBe("Description for ObjectContainingRef.child");
+
+    // Inline array items — should work
+    expect(
+      schema.components.schemas.Parent.properties.childObjectArray.items
+        .properties.child.description,
+    ).toBe("Inline description for childObjectArray.[].child");
+
+    // $ref'd array items — same bug
+    expect(
+      schema.components.schemas.Parent.properties.childObjectArrayRef.items
+        .properties.child.description,
+    ).toBe("Description for ObjectContainingRef.child");
   });
 
   it("should handle OpenAPI v3.1 refs alongside description and summary", async () => {

--- a/packages/zudoku/src/vite/api/schema-codegen.ts
+++ b/packages/zudoku/src/vite/api/schema-codegen.ts
@@ -130,63 +130,71 @@ export const generateCode = (schema: RecordAny, filePath?: string) => {
    * Problem: When we have { $ref: "#/path", description: "text" }, we need to merge
    * the referenced schema with siblings using Object.assign(). But if we do this
    * before the referenced schema is populated, we merge with an empty object.
-
-   * Solution:
-   *   - Pass 1: Populate all base schemas in __refMap (ignoring siblings)
-   *   - Pass 2: Create merged objects that combine refs with their siblings
    *
-   * This ensures Object.assign() merges with populated schemas, not empty objects.
+   * Solution:
+   *   1. Declare empty placeholder objects for each merged ref upfront
+   *   2. Pass 1: Populate all base schemas in __refMap, referencing the placeholders
+   *      for any nested $ref nodes that have sibling properties
+   *   3. Pass 2: Populate the merged placeholders now that base refs are filled
+   *
+   * Because the placeholders are mutated in-place via Object.assign, any base ref
+   * that already holds a reference to a placeholder automatically sees the final
+   * merged content — including when the base ref is reached through another $ref.
    */
 
-  // Pass 1: Populate all base refs (ignoring siblings temporarily)
-  // This ensures all refs have their base properties before merging
-  const assignBaseRefs = () => {
-    for (const [refPath, index] of refMap) {
-      const value = lookup(schema, refPath, filePath);
-
-      if (!value) {
-        // biome-ignore lint/suspicious/noConsole: Logging allowed here
-        console.warn(`Could not find value for refPath: ${refPath}`);
-        continue;
-      }
-
-      const transformedValue = setRefMarkers(value, refMap, true);
-
-      lines.push(
-        `Object.assign(__refs[${index}], ${replaceRefMarkers(str(transformedValue))});`,
-        `Object.defineProperty(__refs[${index}], "__$ref", { value: __refMapPaths[${index}], enumerable: false });`,
-      );
-    }
-  };
-
-  // Pass 2: Create merged objects for refs with siblings
-  const createMergedRefs = () => {
-    if (siblingsMap.size === 0) return;
-
-    const mergedRefs = new Map<string, string>();
+  // Build merged variable name map and declare empty placeholders
+  const mergedRefs = new Map<string, string>();
+  if (siblingsMap.size > 0) {
     let mergedCounter = 0;
+    for (const [uniqueKey] of siblingsMap) {
+      mergedRefs.set(uniqueKey, `__merged_${mergedCounter++}`);
+    }
+    for (const varName of mergedRefs.values()) {
+      lines.push(`const ${varName} = {};`);
+    }
+  }
 
-    for (const [uniqueKey, { refPath, siblings }] of siblingsMap) {
-      const varName = `__merged_${mergedCounter++}`;
-      mergedRefs.set(uniqueKey, varName);
+  // Pass 1: Populate all base schemas in __refMap.
+  // Uses sibling-aware markers so nested $ref+sibling nodes reference the
+  // merged placeholders declared above.
+  for (const [refPath, index] of refMap) {
+    const value = lookup(schema, refPath, filePath);
 
-      // Create merged object and preserve __$ref
-      const refIndex = refMap.get(refPath);
-      lines.push(
-        `const ${varName} = Object.assign({}, __refMap["${refPath}"], ${str(siblings)});`,
-        `Object.defineProperty(${varName}, "__$ref", { value: __refMapPaths[${refIndex}], enumerable: false });`,
-      );
+    if (!value) {
+      // biome-ignore lint/suspicious/noConsole: Logging allowed here
+      console.warn(`Could not find value for refPath: ${refPath}`);
+      continue;
     }
 
-    return mergedRefs;
-  };
+    const transformedValue = setRefMarkers(value, refMap);
+    let code = replaceRefMarkers(str(transformedValue));
+    if (mergedRefs.size > 0) {
+      code = replaceSiblingRefMarkers(code, mergedRefs);
+    }
 
-  assignBaseRefs();
-  const mergedRefs = createMergedRefs();
+    lines.push(
+      `Object.assign(__refs[${index}], ${code});`,
+      `Object.defineProperty(__refs[${index}], "__$ref", { value: __refMapPaths[${index}], enumerable: false });`,
+    );
+  }
+
+  // Pass 2: Populate merged placeholders (base refs are now filled, so
+  // Object.assign copies the full referenced schema into the placeholder)
+  for (const [uniqueKey, { refPath, siblings }] of siblingsMap) {
+    const varName = mergedRefs.get(uniqueKey);
+    const refIndex = refMap.get(refPath);
+    lines.push(
+      `Object.assign(${varName}, __refMap["${refPath}"], ${str(siblings)});`,
+      `Object.defineProperty(${varName}, "__$ref", { value: __refMapPaths[${refIndex}], enumerable: false });`,
+    );
+  }
+
   const transformed = setRefMarkers(schema, refMap);
 
   let finalCode = replaceRefMarkers(str(transformed));
-  if (mergedRefs) finalCode = replaceSiblingRefMarkers(finalCode, mergedRefs);
+  if (mergedRefs.size > 0) {
+    finalCode = replaceSiblingRefMarkers(finalCode, mergedRefs);
+  }
 
   lines.push(`export const schema = ${finalCode};`);
 


### PR DESCRIPTION
## Summary

- Fixes #2191 — fields with `$ref` and OAS 3.1 `description` overrides lost their description when the containing schema was itself referenced via `$ref`
- **File pipeline** (`schema-codegen.ts`): Pass 1 populated `__refMap` entries with `ignoreSiblings=true`, stripping sibling properties from nested `$ref` nodes. Fixed by declaring merged placeholders upfront and using sibling-aware markers in Pass 1.
- **URL pipeline** (`dereference/index.ts`): `$ref` resolution replaced the entire node with the resolved value, losing all sibling properties. Fixed by collecting siblings before resolution and merging them into the result.

## Test plan

- [x] Added `dereference.test.ts` — 4 tests covering basic resolution, sibling preservation, nested `$ref`'d schemas, and sibling override behavior
- [x] Added test in `schema-codegen.test.ts` reproducing the exact scenario from the issue (inline object, `$ref`'d object, inline array items, `$ref`'d array items)
- [x] All 566 existing tests pass