### PR TITLE
feat: add `reloadDocument` option to logo config

### DIFF
--- a/docs/pages/docs/configuration/site.md
+++ b/docs/pages/docs/configuration/site.md
@@ -58,11 +58,17 @@ Configure the site's logo with different versions for light and dark themes:
         dark: "/dark-logo.png"
       },
       alt: "Company Logo",
-      width: "120px" // optional width
+      width: "120px", // optional width
+      href: "/", // optional link target (defaults to "/")
+      reloadDocument: true, // optional, defaults to true
     }
   }
 }
 ```
+
+The `reloadDocument` option controls whether clicking the logo triggers a full page reload (`true`,
+the default) or uses client-side SPA navigation (`false`). A full reload is useful when your landing
+page is served by a different system (e.g. a CMS) outside of Zudoku.
 
 #### Colors & Theme
 

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -191,6 +191,7 @@ const LogoSchema = z.object({
   alt: z.string().optional(),
   width: z.string().or(z.number()).optional(),
   href: z.string().optional(),
+  reloadDocument: z.boolean().optional(),
 });
 
 export const FooterSocialIcons = [

--- a/packages/zudoku/src/lib/components/Header.test.tsx
+++ b/packages/zudoku/src/lib/components/Header.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render as testRender } from "@testing-library/react";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import type { ZudokuContextOptions } from "../core/ZudokuContext.js";
+import { SlotProvider } from "./context/SlotProvider.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Header } from "./Header.js";
+
+vi.mock("react-router", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("react-router")>();
+  const LinkSpy = vi.fn(mod.Link);
+  return { ...mod, Link: LinkSpy };
+});
+
+const { Link } = await import("react-router");
+const LinkMock = vi.mocked(Link);
+
+const render = async (options: Partial<ZudokuContextOptions> = {}) => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(options, queryClient, {});
+
+  const router = createMemoryRouter(
+    [
+      {
+        element: (
+          <QueryClientProvider client={queryClient}>
+            <ZudokuProvider context={context}>
+              <SlotProvider slots={{}}>
+                <Header />
+                <Outlet />
+              </SlotProvider>
+            </ZudokuProvider>
+          </QueryClientProvider>
+        ),
+        children: [{ path: "*", element: null }],
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+
+  await act(async () => {
+    testRender(<RouterProvider router={router} />);
+  });
+};
+
+const getLogoLinkProps = () => {
+  const call = LinkMock.mock.calls.find(
+    ([props]) => props.className === "shrink-0",
+  );
+  return call?.[0];
+};
+
+describe("Header", () => {
+  describe("logo link", () => {
+    it("defaults reloadDocument to true", async () => {
+      await render({ site: { title: "Test Site" } });
+
+      const props = getLogoLinkProps();
+      expect(props?.reloadDocument).toBe(true);
+    });
+  });
+});

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -131,7 +131,6 @@ const ProfileMenu = () => {
     </ClientOnly>
   );
 };
-
 export const Header = memo(function HeaderInner() {
   const context = useZudoku();
   const {
@@ -167,7 +166,11 @@ export const Header = memo(function HeaderInner() {
         <PageProgress />
         <div className="max-w-screen-2xl mx-auto flex lg:grid lg:grid-cols-[1fr_auto_1fr] gap-2 items-center justify-between h-(--top-header-height) px-4 lg:px-8 border-transparent">
           <div className="flex items-center gap-4 min-w-0 justify-self-start">
-            <Link to={site?.logo?.href ?? "/"} className="shrink-0">
+            <Link
+              to={site?.logo?.href ?? "/"}
+              reloadDocument={site?.logo?.reloadDocument ?? true}
+              className="shrink-0"
+            >
               <div className="flex items-center gap-3.5">
                 {site?.logo ? (
                   <>

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -79,6 +79,7 @@ type Site = Partial<{
     width?: string | number;
     alt?: string;
     href?: string;
+    reloadDocument?: boolean;
   };
   banner?: {
     message: ReactNode;


### PR DESCRIPTION
## Summary
- Adds `reloadDocument` option to `site.logo` config, passed through to React Router's `<Link>` on the header logo
- **Defaults to `true`** — clicking the logo triggers a full browser reload by default
- Set to `false` to use client-side SPA navigation instead
- Useful for sites that serve their landing page from a separate CMS (e.g. Squarespace)
- Adds documentation for the new option

### Config usage
```ts
site: {
  logo: {
    src: { light: "/light.png", dark: "/dark.png" },
    href: "/",
    reloadDocument: true, // default — full page reload
  },
}
```

## Test plan
- [ ] Verify that clicking the logo triggers a full page reload by default
- [ ] Verify that `reloadDocument: false` uses SPA navigation
- [ ] Verify `logo.href` still works correctly