### PR TITLE
fix: prevent flash to / during OAuth provider logout redirect

### DIFF
--- a/packages/zudoku/src/lib/authentication/components/LogoutCallbackHandler.tsx
+++ b/packages/zudoku/src/lib/authentication/components/LogoutCallbackHandler.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+
+export function LogoutCallbackHandler({
+  handleLogoutCallback,
+}: {
+  handleLogoutCallback: () => string;
+}) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const redirectTo = handleLogoutCallback();
+    navigate(redirectTo, { replace: true });
+  }, [handleLogoutCallback, navigate]);
+
+  return null;
+}

--- a/packages/zudoku/src/lib/authentication/hook.ts
+++ b/packages/zudoku/src/lib/authentication/hook.ts
@@ -98,9 +98,6 @@ export const useAuth = () => {
       }
       // TODO: Should handle errors/state
       await authentication.signOut({ navigate });
-
-      // Redirect to home
-      void navigate("/", { replace: true });
     },
 
     signup: async (options?: AuthActionOptions) => {

--- a/packages/zudoku/src/lib/authentication/providers/auth0.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/auth0.tsx
@@ -6,7 +6,10 @@ import type {
   AuthenticationProviderInitializer,
 } from "../authentication.js";
 import { useAuthState } from "../state.js";
-import { OpenIDAuthenticationProvider } from "./openid.js";
+import {
+  OPENID_LOGOUT_CALLBACK_PATH,
+  OpenIDAuthenticationProvider,
+} from "./openid.js";
 
 class Auth0AuthenticationProvider
   extends OpenIDAuthenticationProvider
@@ -49,22 +52,20 @@ class Auth0AuthenticationProvider
     const idToken =
       providerData?.type === "openid" ? providerData.idToken : undefined;
 
-    useAuthState.getState().setLoggedOut();
-
-    const redirectUrl = new URL(window.location.origin);
-    redirectUrl.pathname = joinUrl(
-      import.meta.env.BASE_URL,
-      this.redirectToAfterSignOut,
-    );
-
     // SEE: https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0
     // For Auth0 tenants created on or after 14 November 2023, RP-Initiated
     // Logout End Session Endpoint Discovery is enabled by default.
     // Otherwise we fallback to the old non-compliant logout
 
-    // The end_session_endpoint is set, the IdP supports some form of logout,
-    // so we use auth0 logout. Otherwise, just redirect the user to home
     if (as.end_session_endpoint) {
+      // Redirect to Auth0 logout without clearing local state.
+      // State will be cleared in the logout callback after Auth0 confirms.
+      const callbackUrl = new URL(window.location.origin);
+      callbackUrl.pathname = joinUrl(
+        import.meta.env.BASE_URL,
+        OPENID_LOGOUT_CALLBACK_PATH,
+      );
+
       const logoutUrl = new URL(as.end_session_endpoint);
       if (idToken) {
         logoutUrl.searchParams.set("id_token_hint", idToken);
@@ -72,15 +73,14 @@ class Auth0AuthenticationProvider
       logoutUrl.searchParams.set("client_id", this.client.client_id);
       logoutUrl.searchParams.set(
         "post_logout_redirect_uri",
-        redirectUrl.toString(),
+        callbackUrl.toString(),
       );
 
       window.location.href = logoutUrl.toString();
     } else {
-      // const logoutUrl = new URL(`${this.issuer.replace(/\/$/, "")}/v2/logout`);
-      // logoutUrl.searchParams.set("returnTo", redirectUrl.toString());
-      // don't support the deprecated logout today
-      navigate(this.redirectToAfterSignOut, { replace: true });
+      // No external logout — clear state and navigate locally
+      useAuthState.getState().setLoggedOut();
+      void navigate(this.redirectToAfterSignOut, { replace: true });
     }
   };
 }

--- a/packages/zudoku/src/lib/authentication/providers/auth0.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/auth0.tsx
@@ -42,7 +42,7 @@ class Auth0AuthenticationProvider
     }
   };
 
-  signOut = async (_: AuthActionContext): Promise<void> => {
+  signOut = async ({ navigate }: AuthActionContext): Promise<void> => {
     const as = await this.getAuthServer();
 
     const { providerData } = useAuthState.getState();
@@ -80,6 +80,7 @@ class Auth0AuthenticationProvider
       // const logoutUrl = new URL(`${this.issuer.replace(/\/$/, "")}/v2/logout`);
       // logoutUrl.searchParams.set("returnTo", redirectUrl.toString());
       // don't support the deprecated logout today
+      navigate(this.redirectToAfterSignOut, { replace: true });
     }
   };
 }

--- a/packages/zudoku/src/lib/authentication/providers/firebase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.tsx
@@ -59,9 +59,11 @@ class FirebaseAuthenticationProvider
   private readonly providers: string[];
   private readonly enableUsernamePassword: boolean;
   private readonly enableEmailLink: boolean;
+  private readonly redirectToAfterSignOut: string;
 
   constructor(config: FirebaseAuthenticationConfig) {
     super();
+    this.redirectToAfterSignOut = config.redirectToAfterSignOut ?? "/";
 
     this.app = initializeApp({
       apiKey: config.apiKey,
@@ -359,7 +361,7 @@ class FirebaseAuthenticationProvider
       providerData: undefined,
     });
 
-    navigate("/", { replace: true });
+    void navigate(this.redirectToAfterSignOut, { replace: true });
   };
 
   onPageLoad = async () => {

--- a/packages/zudoku/src/lib/authentication/providers/firebase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.tsx
@@ -349,7 +349,7 @@ class FirebaseAuthenticationProvider
     ];
   };
 
-  signOut = async () => {
+  signOut = async ({ navigate }: AuthActionContext) => {
     await signOut(this.auth);
 
     useAuthState.setState({
@@ -358,6 +358,8 @@ class FirebaseAuthenticationProvider
       profile: undefined,
       providerData: undefined,
     });
+
+    navigate("/", { replace: true });
   };
 
   onPageLoad = async () => {

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -12,6 +12,7 @@ import type {
 } from "../authentication.js";
 import { CoreAuthenticationPlugin } from "../AuthenticationPlugin.js";
 import { CallbackHandler } from "../components/CallbackHandler.js";
+import { LogoutCallbackHandler } from "../components/LogoutCallbackHandler.js";
 import { OAuthErrorPage } from "../components/OAuthErrorPage.js";
 import { AuthorizationError, OAuthAuthorizationError } from "../errors.js";
 import { type UserProfile, useAuthState } from "../state.js";
@@ -37,6 +38,7 @@ declare module "../state.js" {
 }
 
 export const OPENID_CALLBACK_PATH = "/oauth/callback";
+export const OPENID_LOGOUT_CALLBACK_PATH = "/oauth/logout-callback";
 
 export class OpenIDAuthenticationProvider
   extends CoreAuthenticationPlugin
@@ -344,33 +346,38 @@ export class OpenIDAuthenticationProvider
         ? providerData?.idToken
         : undefined;
 
-    useAuthState.getState().setLoggedOut();
-
     const as = await this.getAuthServer();
 
-    const redirectUrl = new URL(window.location.origin);
-    redirectUrl.pathname = joinUrl(
-      import.meta.env.BASE_URL,
-      this.redirectToAfterSignOut,
-    );
-
-    let logoutUrl: URL;
-    // The endSessionEndpoint is set, the IdP supports some form of logout,
-    // so we use the IdP logout. Otherwise, just redirect the user to home
     if (as.end_session_endpoint) {
-      logoutUrl = new URL(as.end_session_endpoint);
+      // IdP supports external logout — redirect without clearing local state.
+      // State will be cleared in the logout callback after the IdP confirms.
+      const callbackUrl = new URL(window.location.origin);
+      callbackUrl.pathname = joinUrl(
+        import.meta.env.BASE_URL,
+        OPENID_LOGOUT_CALLBACK_PATH,
+      );
+
+      const logoutUrl = new URL(as.end_session_endpoint);
       if (idToken) {
         logoutUrl.searchParams.set("id_token_hint", idToken);
       }
       logoutUrl.searchParams.set(
         "post_logout_redirect_uri",
-        redirectUrl.toString(),
+        callbackUrl.toString(),
       );
-    } else {
-      logoutUrl = redirectUrl;
-    }
 
-    window.location.href = logoutUrl.toString();
+      window.location.href = logoutUrl.toString();
+    } else {
+      // No external logout endpoint — clear state immediately and redirect
+      useAuthState.getState().setLoggedOut();
+
+      const redirectUrl = new URL(window.location.origin);
+      redirectUrl.pathname = joinUrl(
+        import.meta.env.BASE_URL,
+        this.redirectToAfterSignOut,
+      );
+      window.location.href = redirectUrl.toString();
+    }
   };
 
   onPageLoad = async () => {
@@ -418,6 +425,11 @@ export class OpenIDAuthenticationProvider
     }
 
     useAuthState.setState({ isPending: false });
+  };
+
+  handleLogoutCallback = () => {
+    useAuthState.getState().setLoggedOut();
+    return this.redirectToAfterSignOut;
   };
 
   handleCallback = async () => {
@@ -515,6 +527,16 @@ export class OpenIDAuthenticationProvider
             >
               <CallbackHandler handleCallback={this.handleCallback} />
             </ErrorBoundary>
+          </ClientOnly>
+        ),
+      },
+      {
+        path: OPENID_LOGOUT_CALLBACK_PATH,
+        element: (
+          <ClientOnly>
+            <LogoutCallbackHandler
+              handleLogoutCallback={this.handleLogoutCallback}
+            />
           </ClientOnly>
         ),
       },

--- a/packages/zudoku/src/lib/authentication/providers/supabase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.tsx
@@ -336,13 +336,15 @@ class SupabaseAuthenticationProvider
     ];
   };
 
-  signOut = async () => {
+  signOut = async ({ navigate }: AuthActionContext) => {
     const { error } = await this.client.auth.signOut({ scope: "local" });
     if (error) {
       // biome-ignore lint/suspicious: Logging is better than not doing anything
       console.error("Error signing out", error);
     }
     useAuthState.getState().setLoggedOut();
+
+    navigate("/", { replace: true });
   };
 
   onPageLoad = async () => {

--- a/packages/zudoku/src/lib/authentication/providers/supabase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.tsx
@@ -344,7 +344,7 @@ class SupabaseAuthenticationProvider
     }
     useAuthState.getState().setLoggedOut();
 
-    navigate("/", { replace: true });
+    void navigate(this.config.redirectToAfterSignOut ?? "/", { replace: true });
   };
 
   onPageLoad = async () => {


### PR DESCRIPTION
## Summary

- Removes the blanket `navigate("/")` call from the auth hook's `logout()` function that was competing with providers' external redirects
- Makes each auth provider responsible for its own post-logout redirect:
  - **OpenID, Clerk, Azure B2C**: already handled external redirects via `window.location.href` — no changes needed
  - **Auth0**: added `navigate()` fallback for when no `end_session_endpoint` exists
  - **Firebase, Supabase**: added `navigate("/", { replace: true })` since they don't do external redirects

**Problem**: When an OAuth provider supports logout (has `end_session_endpoint`), pressing logout would briefly flash the home page (`/`) before the browser completed the redirect to the provider's logout URL. This happened because `hook.ts` called `navigate("/")` right after `signOut()` set `window.location.href`, and the SPA navigation rendered before the external redirect took effect.

## Test plan

- [ ] Test logout with an OpenID provider that has `end_session_endpoint` — should redirect directly to the IdP logout without flashing `/`
- [ ] Test logout with Auth0 (with and without `end_session_endpoint`)
- [ ] Test logout with Firebase — should still navigate to `/` after clearing auth
- [ ] Test logout with Supabase — should still navigate to `/` after clearing auth