### PR TITLE
fix: standardize meter name to "requests" across monetization templates

### DIFF
--- a/examples/zuplo-monetization/config/policies.json
+++ b/examples/zuplo-monetization/config/policies.json
@@ -8,7 +8,7 @@
         "export": "MonetizationInboundPolicy",
         "options": {
           "meters": {
-            "api": 1
+            "requests": 1
           }
         }
       }

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
@@ -191,7 +191,7 @@ describe("PricingPage", () => {
             rateCards: [
               {
                 type: "usage_based",
-                key: "api-requests",
+                key: "requests",
                 name: "API Requests",
                 billingCadence: "P1M",
                 price: {
@@ -218,7 +218,7 @@ describe("PricingPage", () => {
     ];
     mockSubscriptionData.items = [];
 
-    render(<PricingPage units={{ "api-requests": "request" }} />);
+    render(<PricingPage units={{ requests: "request" }} />);
 
     expect(screen.getByText(/\/request after quota/)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Standardized the meter/feature key to `"requests"` across all monetization templates and test fixtures
- Example policy config used `"api"`, PricingPage test used `"api-requests"`, while Usage tests already used `"requests"` — these must all match for the monetization pipeline to work end-to-end (policy meter → event type → entitlement key → subscription featureKey)
- See how `zuplo/core` policy.ts [sends the meter name as the CloudEvent `type`](https://github.com/zuplo/core/blob/main/packages/runtime/src/policies/monetization-inbound/policy.ts#L503) and [validates it against `subscription.entitlements`](https://github.com/zuplo/core/blob/main/packages/runtime/src/policies/monetization-inbound/policy.ts#L548-L567)

## Test plan
- [x] All 88 monetization plugin tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)