### PR TITLE
docs: improve navigation configuration documentation

### DIFF
--- a/docs/pages/docs/configuration/navigation.mdx
+++ b/docs/pages/docs/configuration/navigation.mdx
@@ -95,6 +95,7 @@ type NavigationLink = {
   badge?: {
     label: string;
     color: "green" | "blue" | "yellow" | "red" | "purple" | "indigo" | "gray" | "outline";
+    invert?: boolean;
   };
   display?:
     | "auth"
@@ -222,6 +223,7 @@ type NavigationDoc = {
   badge?: {
     label: string;
     color: "green" | "blue" | "yellow" | "red" | "purple" | "indigo" | "gray" | "outline";
+    invert?: boolean;
   };
   display?:
     | "auth"
@@ -557,6 +559,9 @@ sidebar_label: Short Title
 
 In this example, the document's title remains "My Long Title," but the sidebar displays "Short
 Title."
+
+For the complete list of supported frontmatter properties, see
+[Frontmatter](/docs/markdown/frontmatter).
 
 ## Common Patterns
 


### PR DESCRIPTION
## Summary

- **Document missing navigation types**: Add docs for `separator`, `section`, and `filter` types that exist in the schema and are used in examples (cosmo-cargo) but were completely undocumented
- **Document category `link` property**: Add "Category links" subsection with examples for both string shorthand and object form with custom `path` — the exact edge case that tripped up users trying to serve docs at `/` (see internal Slack discussion)
- **Add "Common Patterns" section**: Root-level docs, hidden landing pages with `layout: "none"`, and organized sidebars combining sections/separators/filters
- **Fix TypeScript type declarations**: Add missing `path` on category link object, add missing `layout` on custom-page, remove non-existent `description` on link type
- **Add `index.md` hosting provider warning**: Note about Vercel (and similar hosts) stripping `/index` from URLs, recommending descriptive filenames + `path` property instead

## Test plan

- [ ] Verify the docs site builds successfully
- [ ] Review the navigation page at `/docs/configuration/navigation` renders correctly
- [ ] Check that all code examples are syntactically valid
- [ ] Confirm the new types match the actual Zod schemas in `InputNavigationSchema.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)