### PR TITLE
Fix cross-category and cross-phase plan comparison in `SwitchPlanModal`

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
@@ -367,7 +367,14 @@ const PlanComparisonItem = ({
               {feature.change === "same" ? (
                 <>
                   <CheckIcon className="w-4 h-4 text-green-600 shrink-0" />
-                  <span className="text-muted-foreground">{feature.name}</span>
+                  <span className="text-muted-foreground">
+                    {feature.name}
+                    {typeof feature.newValue === "string"
+                      ? `: ${feature.newValue}`
+                      : typeof feature.currentValue === "string"
+                        ? `: ${feature.currentValue}`
+                        : ""}
+                  </span>
                 </>
               ) : feature.change === "added" ? (
                 <>


### PR DESCRIPTION
## Summary
- Compare last phase (steady state) instead of aggregating all phases, which showed misleading temporary phase values
- Handle cross-category feature keys (e.g. boolean feature in one plan, metered quota in another) by showing the target plan's value type instead of confusing "added" + "removed" simultaneously
- Show unchanged features/quotas that exist in both plans so users know what they keep