### PR TITLE
feat: support robots metadata config

### DIFF
--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -256,6 +256,18 @@ describe("validateConfig", () => {
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
+  it('should accept metadata robots values like "noindex, nofollow"', () => {
+    const config = {
+      metadata: {
+        robots: "noindex, nofollow",
+      },
+    };
+
+    validateConfig(config);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
   it("should accept aiAssistants with preset strings", () => {
     const config = {
       aiAssistants: ["claude", "chatgpt"],

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -506,6 +506,11 @@ const MetadataSchema = z
     authors: z.array(z.string()),
     creator: z.string(),
     publisher: z.string(),
+    robots: z
+      .string()
+      .describe(
+        'Sets the contents of the `meta[name="robots"]` tag. For example: `noindex, nofollow`.',
+      ),
   })
   .partial();
 

--- a/packages/zudoku/src/lib/components/Meta.tsx
+++ b/packages/zudoku/src/lib/components/Meta.tsx
@@ -39,6 +39,7 @@ export const Meta = ({ children }: PropsWithChildren) => {
         ))}
         {meta?.creator && <meta name="creator" content={meta.creator} />}
         {meta?.publisher && <meta name="publisher" content={meta.publisher} />}
+        {meta?.robots && <meta name="robots" content={meta.robots} />}
       </Helmet>
       {children}
     </>

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -65,6 +65,7 @@ type Metadata = Partial<{
   authors: string[];
   creator: string;
   publisher: string;
+  robots: string;
 }>;
 
 type Site = Partial<{


### PR DESCRIPTION
Hey ! 

We needed to prevent a specific version of our Zudoku app from being indexed, and I noticed the `metadata` config did not support a [robots directive](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots).

  This PR adds support for that, so users can control whether their app should be indexed.

## Summary

  Add support for `metadata.robots` in the Zudoku config so users can set robots directives like `noindex, nofollow`.

  ## Changes

  - add `metadata.robots` to the config schema and types
  - render `<meta name="robots" ...>` from metadata config
  - add test for config validation

  ## How to test

  - set `metadata.robots = "noindex, nofollow"` in config
  - verify the page head includes `<meta name="robots" content="noindex, nofollow">`
  - run:
    - `pnpm exec vitest run packages/zudoku/src/config/validators/ZudokuConfig.test.ts`