### PR TITLE
Show empty state on pricing page when no plans returned

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
@@ -83,6 +83,20 @@ const renderWithConfig = (config: MonetizationConfig = {}) =>
   );
 
 describe("PricingPage", () => {
+  it("Shows a helpful message when no plans are available", () => {
+    mockPricingData.items = [];
+    mockSubscriptionData.items = [];
+
+    renderWithConfig();
+
+    expect(
+      screen.getByText("No plans are currently available."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Make sure your plans are set up and published."),
+    ).toBeInTheDocument();
+  });
+
   it("Shows 'Manage Subscriptions' if the user has any active subscriptions", () => {
     mockPricingData.items = [
       makePlan("1", "starter", "Starter"),

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
@@ -46,18 +46,27 @@ const PricingPage = () => {
             "See our pricing options and choose the one that best suits your needs."}
         </p>
       </div>
-      <div className="w-full grid grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(300px,max-content))] justify-center gap-6">
-        {pricingTable.items.map((plan) => (
-          <PricingCard
-            key={plan.id}
-            plan={plan}
-            isPopular={plan.metadata?.zuplo_most_popular === "true"}
-            isSubscribed={subscriptions.items.some((subscription) =>
-              ["active", "canceled"].includes(subscription.status),
-            )}
-          />
-        ))}
-      </div>
+      {pricingTable.items.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <p>No plans are currently available.</p>
+          <p className="text-sm mt-2">
+            Make sure your plans are set up and published.
+          </p>
+        </div>
+      ) : (
+        <div className="w-full grid grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(300px,max-content))] justify-center gap-6">
+          {pricingTable.items.map((plan) => (
+            <PricingCard
+              key={plan.id}
+              plan={plan}
+              isPopular={plan.metadata?.zuplo_most_popular === "true"}
+              isSubscribed={subscriptions.items.some((subscription) =>
+                ["active", "canceled"].includes(subscription.status),
+              )}
+            />
+          ))}
+        </div>
+      )}
       <Slot.Target name="pricing-page-after" />
     </div>
   );


### PR DESCRIPTION
## Summary

- When the monetization pricing page API returns zero plan items, the page now displays a helpful message ("No plans are currently available. Make sure your plans are set up and published.") instead of rendering an empty grid.
- Added test coverage for the empty state.

## Test plan

- [ ] Verify the empty state message appears when the pricing API returns `{ items: [] }`
- [ ] Verify existing pricing card rendering is unaffected when plans are present
- [ ] All existing tests pass (`pnpm vitest run packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx`)