### PR TITLE
[codex] Add temporary npm publish monitor

### DIFF
--- a/.github/npm-publish-monitor.json
+++ b/.github/npm-publish-monitor.json
@@ -1,0 +1,17 @@
+{
+  "capturedAt": "2026-04-03T22:11:01Z",
+  "expiresAt": "2026-04-06T22:11:01Z",
+  "packages": [
+    "@zudoku/plugin-api-key",
+    "@zudoku/plugin-markdown",
+    "@zudoku/plugin-openapi",
+    "@zudoku/zudoku",
+    "zudoku",
+    "create-zudoku",
+    "@zudoku/httpsnippet",
+    "@zudoku/react-helmet-async",
+    "@zudoku/config",
+    "@zudoku/plugin-search-algolia",
+    "@zuplo/zudoku-plugin-monetization"
+  ]
+}

--- a/.github/workflows/publish-monitor.yaml
+++ b/.github/workflows/publish-monitor.yaml
@@ -1,0 +1,174 @@
+name: npm publish monitor
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "7,22,37,52 * * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: npm-publish-monitor
+  cancel-in-progress: true
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    env:
+      INCIDENT_IO_ALERT_URL: https://api.incident.io/v2/alert_events/http/01J85NBDXG21QA8DK915TYMVVW
+      PUBLISH_MONITOR_REPORT_PATH: ${{ runner.temp }}/publish-monitor-report.json
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".tool-versions"
+
+      - name: Check npm publishes
+        id: check
+        run: node scripts/check-npm-publishes.mjs
+
+      - name: Open or update alert issue
+        if: ${{ failure() }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require("node:fs");
+            const reportPath = process.env.PUBLISH_MONITOR_REPORT_PATH;
+
+            if (!reportPath || !fs.existsSync(reportPath)) {
+              core.warning("No publish monitor report found; skipping issue creation.");
+              return;
+            }
+
+            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+
+            if (report.status !== "detected") {
+              core.notice(`Monitor failed without a publish detection (status: ${report.status ?? "unknown"}).`);
+              return;
+            }
+
+            const title = "Urgent: unexpected npm publish detected";
+            const rows = report.detections.flatMap(({ packageName, unexpectedPublishes }) =>
+              unexpectedPublishes.map(
+                ({ version, publishedAt }) => `| \`${packageName}\` | \`${version}\` | ${publishedAt} |`,
+              ),
+            );
+            const body = [
+              "Unexpected npm publishes were detected by the temporary Zudoku publish monitor.",
+              "",
+              `- Baseline: ${report.capturedAt}`,
+              `- Checked at: ${report.checkedAt}`,
+              `- Monitor expires: ${report.expiresAt}`,
+              "",
+              "| Package | Version | Published at |",
+              "| --- | --- | --- |",
+              ...rows,
+              "",
+              `Workflow run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            ].join("\n");
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const existing = issues.find((issue) => issue.title === title);
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.notice(`Updated alert issue #${existing.number}.`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+
+            core.notice(`Created alert issue #${created.data.number}.`);
+
+      - name: Create Incident
+        if: ${{ failure() }}
+        shell: bash
+        env:
+          INCIDENT_IO_WEBHOOK_KEY: ${{ secrets.INCIDENT_IO_WEBHOOK_KEY }}
+        run: |
+          if [ ! -f "$PUBLISH_MONITOR_REPORT_PATH" ]; then
+            echo "No publish monitor report found; skipping incident.io alert."
+            exit 0
+          fi
+
+          if [ -z "$INCIDENT_IO_WEBHOOK_KEY" ]; then
+            echo "INCIDENT_IO_WEBHOOK_KEY is not configured for this repository; skipping incident.io alert."
+            exit 0
+          fi
+
+          INCIDENT_PAYLOAD=$(node <<'NODE'
+          const fs = require("node:fs");
+          const reportPath = process.env.PUBLISH_MONITOR_REPORT_PATH;
+          const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+          const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+
+          if (report.status !== "detected") {
+            process.exit(0);
+          }
+
+          const lines = report.detections.flatMap(({ packageName, unexpectedPublishes }) =>
+            unexpectedPublishes.map(
+              ({ version, publishedAt }) => `- ${packageName}@${version} at ${publishedAt}`,
+            ),
+          );
+
+          const payload = {
+            title: "Unexpected Zudoku npm publish detected",
+            description: [
+              "The temporary Zudoku npm publish monitor detected a new publish after the baseline window.",
+              "",
+              `Baseline: ${report.capturedAt}`,
+              `Checked at: ${report.checkedAt}`,
+              "",
+              ...lines,
+            ].join("\n"),
+            status: "firing",
+            source_url: runUrl,
+            metadata: {
+              service: "zudoku-publish-monitor",
+              priority: "urgent",
+              repository: process.env.GITHUB_REPOSITORY,
+            },
+          };
+
+          process.stdout.write(JSON.stringify(payload));
+          NODE
+          )
+
+          if [ -z "$INCIDENT_PAYLOAD" ]; then
+            echo "Monitor did not detect a publish; skipping incident.io alert."
+            exit 0
+          fi
+
+          curl --request POST \
+            --url "$INCIDENT_IO_ALERT_URL" \
+            --header "Authorization: Bearer $INCIDENT_IO_WEBHOOK_KEY" \
+            --header 'Content-Type: application/json' \
+            --data "$INCIDENT_PAYLOAD"
+
+      - name: Upload monitor report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: publish-monitor-report
+          path: ${{ env.PUBLISH_MONITOR_REPORT_PATH }}

--- a/scripts/check-npm-publishes.mjs
+++ b/scripts/check-npm-publishes.mjs
@@ -1,0 +1,150 @@
+import { readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+
+const configPath = new URL("../.github/npm-publish-monitor.json", import.meta.url);
+const reportPath = process.env.PUBLISH_MONITOR_REPORT_PATH ?? "publish-monitor-report.json";
+
+async function loadConfig() {
+  const raw = await readFile(configPath, "utf8");
+  const config = JSON.parse(raw);
+
+  if (!config.capturedAt || !config.expiresAt || !Array.isArray(config.packages)) {
+    throw new Error("Monitor config must include capturedAt, expiresAt, and packages.");
+  }
+
+  return config;
+}
+
+async function fetchMetadata(packageName) {
+  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${packageName}: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+function findUnexpectedPublishes(metadata, capturedAt) {
+  return Object.entries(metadata.time ?? {})
+    .filter(([version]) => version !== "created" && version !== "modified")
+    .map(([version, publishedAt]) => ({ version, publishedAt }))
+    .filter(({ publishedAt }) => new Date(publishedAt).getTime() > capturedAt.getTime())
+    .sort((a, b) => new Date(a.publishedAt) - new Date(b.publishedAt));
+}
+
+function appendSummary(lines) {
+  if (!process.env.GITHUB_STEP_SUMMARY) {
+    return Promise.resolve();
+  }
+
+  return writeFile(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`, { flag: "a" });
+}
+
+async function writeReport(report) {
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+const config = await loadConfig();
+const capturedAt = new Date(config.capturedAt);
+const expiresAt = new Date(config.expiresAt);
+const now = new Date();
+
+if (Number.isNaN(capturedAt.getTime()) || Number.isNaN(expiresAt.getTime())) {
+  throw new Error("capturedAt and expiresAt must be valid ISO timestamps.");
+}
+
+if (now.getTime() > expiresAt.getTime()) {
+  const report = {
+    status: "expired",
+    capturedAt: config.capturedAt,
+    expiresAt: config.expiresAt,
+    checkedAt: now.toISOString(),
+    packages: config.packages,
+  };
+
+  await writeReport(report);
+  await appendSummary([
+    "## npm publish monitor",
+    "",
+    `Monitor expired at ${config.expiresAt}; skipping checks.`,
+  ]);
+  process.exit(0);
+}
+
+const detections = [];
+const inspected = [];
+
+for (const packageName of config.packages) {
+  const metadata = await fetchMetadata(packageName);
+  const unexpectedPublishes = findUnexpectedPublishes(metadata, capturedAt);
+  const distTags = metadata["dist-tags"] ?? {};
+
+  inspected.push({
+    packageName,
+    latest: distTags.latest ?? null,
+    dev: distTags.dev ?? null,
+    modified: metadata.time?.modified ?? null,
+  });
+
+  if (unexpectedPublishes.length > 0) {
+    detections.push({
+      packageName,
+      unexpectedPublishes,
+      distTags,
+    });
+  }
+}
+
+const report = {
+  status: detections.length > 0 ? "detected" : "ok",
+  capturedAt: config.capturedAt,
+  expiresAt: config.expiresAt,
+  checkedAt: now.toISOString(),
+  inspected,
+  detections,
+};
+
+await writeReport(report);
+
+if (detections.length === 0) {
+  await appendSummary([
+    "## npm publish monitor",
+    "",
+    `No new publishes detected since ${config.capturedAt}.`,
+    "",
+    "| Package | latest | dev |",
+    "| --- | --- | --- |",
+    ...inspected.map(
+      ({ packageName, latest, dev }) => `| \`${packageName}\` | \`${latest ?? "-"}\` | \`${dev ?? "-"}\` |`,
+    ),
+  ]);
+  console.log(`No new publishes detected since ${config.capturedAt}.`);
+  process.exit(0);
+}
+
+await appendSummary([
+  "## npm publish monitor",
+  "",
+  `Unexpected publishes detected after ${config.capturedAt}.`,
+  "",
+  "| Package | Version | Published at |",
+  "| --- | --- | --- |",
+  ...detections.flatMap(({ packageName, unexpectedPublishes }) =>
+    unexpectedPublishes.map(
+      ({ version, publishedAt }) => `| \`${packageName}\` | \`${version}\` | ${publishedAt} |`,
+    ),
+  ),
+]);
+
+for (const { packageName, unexpectedPublishes } of detections) {
+  for (const { version, publishedAt } of unexpectedPublishes) {
+    console.error(`Unexpected publish detected: ${packageName}@${version} at ${publishedAt}`);
+  }
+}
+
+process.exit(1);


### PR DESCRIPTION
## What changed

Adds a temporary npm publish monitor for the Zudoku packages during the next 72 hours.

- checks the npm registry every 15 minutes plus manual dispatch
- watches the Zudoku npm org packages and `@zuplo/zudoku-plugin-monetization`
- fails the workflow if any package is published after the captured baseline timestamp
- opens or updates a GitHub issue with the detected publish details
- sends an incident.io alert when `INCIDENT_IO_WEBHOOK_KEY` is available to the repo
- automatically stops alerting after the configured expiry window

## Why

The immediate concern is unauthorized package publication while team access and token validity are being verified.

## Validation

- `node scripts/check-npm-publishes.mjs`
- YAML parsed successfully with Ruby `YAML.load_file`

## Follow-up

- Ensure the `zudoku` repo has access to `INCIDENT_IO_WEBHOOK_KEY`, otherwise the incident.io step will skip cleanly.
