### PR TITLE
Fix JS fetch snippets for responses without body

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -155,7 +155,14 @@ export const Sidecar = ({
         : { mimeType: selectedContent?.mediaType ?? "application/json" },
     });
 
-    return getConverted(snippet, selectedLang);
+    // Check if any success response (2xx) has content — if none do, the
+    // response body is empty (e.g. 204 No Content) and code snippets should
+    // not attempt to parse JSON from the response.
+    const hasResponseBody = operation.responses.some(
+      (r) => r.statusCode.startsWith("2") && r.content && r.content.length > 0,
+    );
+
+    return getConverted(snippet, selectedLang, { hasResponseBody });
   }, [
     currentExampleCode,
     operation,

--- a/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { OperationsFragmentFragment } from "../graphql/graphql.js";
+import { createHttpSnippet, getConverted } from "./createHttpSnippet.js";
+
+const makeOperation = (
+  overrides: Partial<OperationsFragmentFragment> = {},
+): OperationsFragmentFragment =>
+  ({
+    slug: "delete-product",
+    method: "delete",
+    path: "/products/{productId}",
+    contentTypes: [],
+    servers: [{ url: "https://api.example.com" }],
+    parameters: [],
+    requestBody: null,
+    responses: [],
+    extensions: {},
+    ...overrides,
+  }) as OperationsFragmentFragment;
+
+const buildSnippet = (operation = makeOperation()) =>
+  createHttpSnippet({
+    operation,
+    selectedServer: "https://api.example.com",
+    exampleBody: { mimeType: "application/json" },
+  });
+
+describe("getConverted", () => {
+  describe("JS fetch snippet with no response body", () => {
+    it("removes .then(response => response.json()) when hasResponseBody is false", () => {
+      const snippet = buildSnippet();
+      const code = getConverted(snippet, "js", { hasResponseBody: false });
+
+      expect(code).not.toContain("response.json()");
+      expect(code).toContain("fetch(");
+      expect(code).toContain(".catch(");
+      expect(code).toContain("console.log(response)");
+    });
+
+    it("keeps .then(response => response.json()) when hasResponseBody is true", () => {
+      const snippet = buildSnippet();
+      const code = getConverted(snippet, "js", { hasResponseBody: true });
+
+      expect(code).toContain("response.json()");
+    });
+
+    it("keeps .then(response => response.json()) by default", () => {
+      const snippet = buildSnippet();
+      const code = getConverted(snippet, "js");
+
+      expect(code).toContain("response.json()");
+    });
+  });
+
+  describe("non-JS languages are unaffected by hasResponseBody", () => {
+    it("shell output is unchanged when hasResponseBody is false", () => {
+      const snippet = buildSnippet();
+      const withBody = getConverted(snippet, "shell", {
+        hasResponseBody: true,
+      });
+      const withoutBody = getConverted(snippet, "shell", {
+        hasResponseBody: false,
+      });
+
+      expect(withBody).toBe(withoutBody);
+    });
+
+    it("python output is unchanged when hasResponseBody is false", () => {
+      const snippet = buildSnippet();
+      const withBody = getConverted(snippet, "python", {
+        hasResponseBody: true,
+      });
+      const withoutBody = getConverted(snippet, "python", {
+        hasResponseBody: false,
+      });
+
+      expect(withBody).toBe(withoutBody);
+    });
+  });
+});

--- a/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.ts
@@ -89,7 +89,21 @@ export const createHttpSnippet = ({
   });
 };
 
-export const getConverted = (snippet: HTTPSnippet, option: string) => {
+/**
+ * Removes `.json()` parsing from generated JS fetch snippets when the response
+ * has no body (e.g. 204 No Content), since calling `response.json()` on an
+ * empty body throws a runtime error.
+ */
+const removeJsonParsing = (code: string): string =>
+  code
+    .replace(/\n\s*\.then\(response => response\.json\(\)\)/, "")
+    .replace(/\n\s*\.then\(res => res\.json\(\)\)/, "");
+
+export const getConverted = (
+  snippet: HTTPSnippet,
+  option: string,
+  { hasResponseBody = true }: { hasResponseBody?: boolean } = {},
+) => {
   // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   let converted: any;
   switch (option) {
@@ -131,5 +145,11 @@ export const getConverted = (snippet: HTTPSnippet, option: string) => {
       break;
   }
 
-  return converted ? converted[0] : "";
+  const result = converted ? (converted[0] as string) : "";
+
+  if (!hasResponseBody && (option === "js" || option === "node")) {
+    return removeJsonParsing(result);
+  }
+
+  return result;
 };


### PR DESCRIPTION
## Summary
This PR fixes code snippet generation for API endpoints that return no response body (e.g., 204 No Content). Previously, generated JavaScript fetch snippets would attempt to parse JSON from empty responses, causing runtime errors.

## Key Changes
- Added `hasResponseBody` parameter to `getConverted()` function to conditionally remove `.json()` parsing from JS/Node.js snippets
- Implemented `removeJsonParsing()` utility to strip `.then(response => response.json())` from generated code when appropriate
- Updated `Sidecar.tsx` to detect whether success responses (2xx) contain content and pass this information to the snippet converter
- Added comprehensive test suite covering the new functionality with various scenarios

## Implementation Details
- Detection logic checks if any 2xx status code response has content defined in the OpenAPI spec
- JSON parsing removal only applies to JavaScript and Node.js targets; other languages (shell, python, etc.) are unaffected
- The feature defaults to `hasResponseBody: true` to maintain backward compatibility
- Tests verify both the removal behavior and that non-JS languages remain unchanged regardless of the flag
