### PR TITLE
Fix release app token not bypassing branch protection

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -121,8 +121,8 @@ jobs:
         env:
           ZUDOKU_RELEASE_TOKEN: ${{ steps.zudoku-release-token.outputs.token }}
         run: |
-          git remote set-url origin "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git"
-          git push origin main --follow-tags
+          echo "::add-mask::${ZUDOKU_RELEASE_TOKEN}"
+          git push "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git" main --follow-tags
 
       - uses: actions/github-script@v8
         name: ${{ env.IS_RELEASE == 'true' && 'Create Release' || 'Create Pre-release' }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -121,8 +121,8 @@ jobs:
         env:
           ZUDOKU_RELEASE_TOKEN: ${{ steps.zudoku-release-token.outputs.token }}
         run: |
-          auth_header=$(printf 'x-access-token:%s' "$ZUDOKU_RELEASE_TOKEN" | base64 -w0)
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $auth_header" push origin main --follow-tags
+          git remote set-url origin "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git"
+          git push origin main --follow-tags
 
       - uses: actions/github-script@v8
         name: ${{ env.IS_RELEASE == 'true' && 'Create Release' || 'Create Pre-release' }}

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -86,14 +86,14 @@ jobs:
           git config user.name "Zuplo Integrations"
           git add packages/plugin-zuplo-monetization/package.json
           git commit -m "chore(release): @zuplo/zudoku-plugin-monetization v${{ steps.version.outputs.version }} [skip ci]"
-          git tag "monetization-v${{ steps.version.outputs.version }}"
+          git tag -a "monetization-v${{ steps.version.outputs.version }}" -m "Release monetization v${{ steps.version.outputs.version }}"
 
       - name: Push Git Changes
         env:
           ZUDOKU_RELEASE_TOKEN: ${{ steps.zudoku-release-token.outputs.token }}
         run: |
-          git remote set-url origin "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git"
-          git push origin main --follow-tags
+          echo "::add-mask::${ZUDOKU_RELEASE_TOKEN}"
+          git push "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git" main --follow-tags
 
       - name: Generate a token
         id: app-token

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -92,8 +92,8 @@ jobs:
         env:
           ZUDOKU_RELEASE_TOKEN: ${{ steps.zudoku-release-token.outputs.token }}
         run: |
-          auth_header=$(printf 'x-access-token:%s' "$ZUDOKU_RELEASE_TOKEN" | base64 -w0)
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $auth_header" push origin main --follow-tags
+          git remote set-url origin "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git"
+          git push origin main --follow-tags
 
       - name: Generate a token
         id: app-token


### PR DESCRIPTION
## Summary

Fixes the release workflow failing to push to `main` after #2267 replaced deploy keys with a GitHub App token.

### Problem

The release workflow push step was rejected by all three branch protection rulesets despite the Zudoku Release App being in every bypass list:

- **Prod Branch Protection** — "Require a pull request before merging" → Push blocked
- **Main** — "Require a pull request before merging" + "Require status checks to pass" → Push blocked  
- **PR Reviews** — "Require a pull request before merging" → Push blocked

Failed run: https://github.com/zuplo/zudoku/actions/runs/24158333694

### Root cause

The `extraheader` approach for authenticating git push:
```bash
auth_header=$(printf 'x-access-token:%s' "$TOKEN" | base64 -w0)
git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $auth_header" push
```
was **not being recognized by GitHub's ruleset bypass evaluation** as the GitHub App identity. GitHub was seeing the push as coming from the default workflow credentials rather than the Zudoku Release App installation, so the bypass rules didn't apply.

Reference: https://github.com/orgs/community/discussions/136531

### Fix

Switch to embedding the app token directly in the remote URL:
```bash
git remote set-url origin "https://x-access-token:${TOKEN}@github.com/zuplo/zudoku.git"
git push origin main --follow-tags
```
This properly identifies the push as coming from the GitHub App, allowing the ruleset bypass to work.

Applied to both `main.yaml` and `release-monetization.yaml`.

## Test plan

- [ ] Trigger a manual release workflow and verify the push to `main` succeeds
- [ ] Verify tags are pushed correctly
- [ ] Check rule insights to confirm rulesets show "bypassed" instead of "blocked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)