### PR TITLE
feat: spread userinfo response into UserProfile for custom OIDC claims

### DIFF
--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -62,9 +62,11 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
     const setupCallback = ({
       claimsEmailVerified,
       userInfoEmailVerified,
+      customClaims,
     }: {
       claimsEmailVerified?: boolean;
       userInfoEmailVerified?: boolean;
+      customClaims?: Record<string, unknown>;
     }) => {
       Object.defineProperty(window, "location", {
         configurable: true,
@@ -108,6 +110,7 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
         email: "user@example.com",
         name: "Test User",
         picture: "https://example.com/pic.jpg",
+        ...customClaims,
       };
       if (userInfoEmailVerified !== undefined) {
         userInfo.email_verified = userInfoEmailVerified;
@@ -188,6 +191,25 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
 
       expect(useAuthState.getState().profile?.emailVerified).toBe(false);
     });
+
+    test("preserves custom claims from userInfo in claims field", async () => {
+      const provider = createProvider();
+      setupCallback({
+        userInfoEmailVerified: true,
+        customClaims: {
+          resource_access: { api: { roles: ["admin"] } },
+          custom_role: "editor",
+        },
+      });
+
+      await provider.handleCallback();
+
+      const profile = useAuthState.getState().profile;
+      expect(profile?.claims).toEqual({
+        resource_access: { api: { roles: ["admin"] } },
+        custom_role: "editor",
+      });
+    });
   });
 
   describe("refreshUserProfile", () => {
@@ -244,6 +266,25 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       await provider.refreshUserProfile();
 
       expect(useAuthState.getState().profile?.emailVerified).toBe(false);
+    });
+
+    test("preserves custom claims from userInfo in claims field", async () => {
+      const provider = setupRefresh({
+        sub: "user-1",
+        email: "user@example.com",
+        name: "Test",
+        email_verified: true,
+        resource_access: { api: { roles: ["admin"] } },
+        custom_role: "editor",
+      });
+
+      await provider.refreshUserProfile();
+
+      const profile = useAuthState.getState().profile;
+      expect(profile?.claims).toEqual({
+        resource_access: { api: { roles: ["admin"] } },
+        custom_role: "editor",
+      });
     });
   });
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -19,6 +19,30 @@ import { type UserProfile, useAuthState } from "../state.js";
 const CODE_VERIFIER_KEY = "code-verifier";
 const STATE_KEY = "oauth-state";
 
+// Standard OIDC userinfo fields that are mapped to named UserProfile properties.
+// Everything else is treated as a custom claim.
+const KNOWN_USERINFO_FIELDS = new Set([
+  "sub",
+  "email",
+  "email_verified",
+  "name",
+  "picture",
+]);
+
+const extractCustomClaims = (
+  userInfo: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+  const custom: Record<string, unknown> = {};
+  let hasCustom = false;
+  for (const [key, value] of Object.entries(userInfo)) {
+    if (!KNOWN_USERINFO_FIELDS.has(key)) {
+      custom[key] = value;
+      hasCustom = true;
+    }
+  }
+  return hasCustom ? custom : undefined;
+};
+
 export interface OpenIdProviderData {
   // just for easy migration we also allow for undefined type. can be removed in the future.
   type: "openid" | undefined;
@@ -204,6 +228,7 @@ export class OpenIDAuthenticationProvider
       name: userInfo.name,
       emailVerified: userInfo.email_verified ?? emailVerified ?? false,
       pictureUrl: userInfo.picture,
+      claims: extractCustomClaims(userInfo),
     };
 
     useAuthState.setState({
@@ -483,12 +508,12 @@ export class OpenIDAuthenticationProvider
     const userInfo = await userInfoResponse.json();
 
     const profile: UserProfile = {
-      ...userInfo,
       sub: userInfo.sub,
       email: userInfo.email,
       name: userInfo.name,
       emailVerified: userInfo.email_verified ?? claims?.email_verified ?? false,
       pictureUrl: userInfo.picture,
+      claims: extractCustomClaims(userInfo),
     };
 
     useAuthState.setState({

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -87,5 +87,6 @@ export interface UserProfile {
   emailVerified: boolean;
   name: string | undefined;
   pictureUrl: string | undefined;
-  [key: string]: string | boolean | undefined;
+  claims?: Record<string, unknown>;
+  [key: string]: string | boolean | Record<string, unknown> | undefined;
 }


### PR DESCRIPTION
The refreshUserProfile method only mapped 5 hardcoded fields from the userinfo response, discarding custom OIDC claims like Keycloak's resource_access or Auth0 custom claims. This made role-based route protection impossible without manually decoding the JWT access token.

Changes:
- Spread full userinfo response into profile in refreshUserProfile to match existing handleCallback behavior
- Widen UserProfile index signature to accept unknown values so nested objects like resource_access are representable
- Add tests verifying custom claims survive in both handleCallback and refreshUserProfile