### PR TITLE
:bug: Fix the wcag2 accessibilty issue for callout

### DIFF
--- a/packages/zudoku/src/lib/ui/Callout.tsx
+++ b/packages/zudoku/src/lib/ui/Callout.tsx
@@ -5,7 +5,7 @@ import {
   type LucideIcon,
   ShieldAlertIcon,
 } from "lucide-react";
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import { cn } from "../util/cn.js";
 
 const stylesMap = {
@@ -39,10 +39,10 @@ const stylesMap = {
   caution: {
     border: "border-yellow-400 dark:border-yellow-400/25",
     bg: "bg-yellow-100/60 dark:bg-yellow-400/10",
-    iconColor: "text-yellow-500 dark:text-yellow-300",
-    titleColor: "text-yellow-600 dark:text-yellow-300",
+    iconColor: "text-yellow-900 dark:text-yellow-200",
+    titleColor: "text-yellow-950 dark:text-yellow-100",
     textColor:
-      "text-yellow-700 dark:text-yellow-200 [&_a]:hover:text-yellow-800 [&_a]:dark:hover:text-yellow-300",
+      "text-yellow-950 dark:text-yellow-100 [&_a]:hover:text-yellow-950 [&_a]:dark:hover:text-yellow-50",
     Icon: AlertTriangleIcon as LucideIcon,
   },
   danger: {
@@ -73,9 +73,12 @@ export const Callout = ({
 }: CalloutProps) => {
   const { border, bg, iconColor, titleColor, textColor, Icon } =
     stylesMap[type];
+  const titleId = useId();
 
   return (
     <div
+      role={title ? "note" : undefined}
+      aria-labelledby={title ? titleId : undefined}
       className={cn(
         "not-prose rounded-md border p-4 text-md my-2",
         icon &&
@@ -97,7 +100,11 @@ export const Callout = ({
           aria-hidden="true"
         />
       )}
-      {title && <h3 className={cn("font-medium", titleColor)}>{title}</h3>}
+      {title && (
+        <div id={titleId} className={cn("font-medium", titleColor)}>
+          {title}
+        </div>
+      )}
       <div
         className={cn(
           icon && "col-start-2",


### PR DESCRIPTION
Fixes https://github.com/zuplo/zudoku/issues/2281
## Summary
- **Heading order:** Replaced titled callout `<h3>` with a labeled `<div>`. The callout root uses `role="note"` and `aria-labelledby` when a title is present so callouts stay discoverable without breaking the document heading outline when authors place a callout before the first `h1`/`h2`.
- **Color contrast:** Darkened default **caution** (MDX `warning`) icon, title, and body text so combinations meet **WCAG 2 AA** on the existing light/dark yellow callout backgrounds.
## Files
- `packages/zudoku/src/lib/ui/Callout.tsx`
## Testing
- Manual: axe / a11y scan on pages with leading `:::warning` / `:::note` callouts.