### PR TITLE
fix: Do not `wrap-anywhere` if code element belongs to a table

### DIFF
--- a/examples/cosmo-cargo/pages/ship-states.mdx
+++ b/examples/cosmo-cargo/pages/ship-states.mdx
@@ -1,0 +1,13 @@
+# Ship States Reference
+
+A vessel can be in one of the following states. You can query the current state using the
+`getShipStatus()` method from the `@cosmo-cargo/fleet-sdk` package.
+
+| State          | Description                                                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `docked`       | The ship is docked at a station and not consuming fuel. Cargo can be loaded or unloaded.                                      |
+| `launching`    | The ship is preparing for departure. This typically takes just a few milliseconds.                                            |
+| `cruising`     | The ship has reached warp velocity and is traveling to its destination.                                                       |
+| `decelerating` | The ship is slowing down before arrival. No new cargo transfers can be initiated.                                             |
+| `landing`      | The ship is performing docking procedures.                                                                                    |
+| `standby`      | The ship has been scaled-to-zero. It isn't consuming resources but will automatically launch when there are queued shipments. |

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -255,7 +255,12 @@ const config: ZudokuConfig = {
           icon: "telescope",
           collapsed: false,
           label: "Space Operations",
-          items: ["shipping-process", "tracking", "quantum-express"],
+          items: [
+            "shipping-process",
+            "tracking",
+            "quantum-express",
+            "ship-states",
+          ],
         },
         "global",
         { type: "separator" },

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -55,6 +55,10 @@
   a {
     @apply font-normal underline-offset-4 hover:text-primary;
   }
+  td code,
+  th code {
+    @apply whitespace-nowrap;
+  }
   blockquote {
     @apply not-italic text-neutral-500/75 dark:text-neutral-400;
     /* Disable adding quote marks to block-quotes: https://github.com/tailwindlabs/tailwindcss-typography/issues/66 */


### PR DESCRIPTION
If `code` belongs to a table, let's not wrap it:

<img width="841" height="635" alt="image" src="https://github.com/user-attachments/assets/32133338-6a38-451c-9aac-47f35653d84e" />

In normal text, it still wraps as expected: 
<img width="1157" height="711" alt="image" src="https://github.com/user-attachments/assets/0fa62ce2-9ebb-4898-bdfb-83a4ebf3ed6f" />

Aims to solve #2285 
