### PR TITLE
fix: add color-scheme to native select dropdowns for dark mode

### DIFF
--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -247,6 +247,11 @@
     @apply focus-visible:ring-primary focus-visible:ring-[1.5px] focus:outline-hidden scheme-light dark:scheme-dark;
   }
 
+  select option {
+    color: CanvasText;
+    background-color: Canvas;
+  }
+
   .CollapsibleContent {
     --easing: cubic-bezier(0.4, 0, 0.2, 1);
     --slide-offset: -0.75rem;

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -244,7 +244,7 @@
   }
 
   select {
-    @apply focus-visible:ring-primary focus-visible:ring-[1.5px] focus:outline-hidden;
+    @apply focus-visible:ring-primary focus-visible:ring-[1.5px] focus:outline-hidden scheme-light dark:scheme-dark;
   }
 
   .CollapsibleContent {

--- a/packages/zudoku/src/lib/ui/NativeSelect.tsx
+++ b/packages/zudoku/src/lib/ui/NativeSelect.tsx
@@ -14,7 +14,6 @@ function NativeSelect({ className, ...props }: React.ComponentProps<"select">) {
           "border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed",
           "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
           "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-          "scheme-light dark:scheme-dark",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary

- Fixes dark mode dropdown text being the same color as the background in Chrome and Edge (#2270)
- Adds `scheme-light dark:scheme-dark` to the global `select` CSS rule so browsers correctly render native dropdown option colors in both themes

## How to test in cosmo-cargo

Run `nx run cosmo-cargo:dev`, switch to dark mode, and open dropdowns on the following pages using **Chrome or Edge**:

**Server selector dropdown (`SimpleSelect`):**
- `/api-shipments/shipment-management` — has 4 server environments (Production, Staging, Dev, MockBin)

**Sidecar dropdowns (`NativeSelect`) — visible on any API endpoint page:**
- **Language selector** (top-right of "Example Requests") — cURL, JavaScript, Python, etc.
- **Response status code selector** (e.g. POST `/shipments` has 201, 400, 500)
- **Response media type selector** — when a response has multiple content types

Before this fix, the dropdown option text was invisible in Chrome/Edge dark mode. After the fix, options should have proper contrast in all browsers.

https://claude.ai/code/session_01TVNHEgXtRoNKLed877oUgo