### PR TITLE
feat: add `playgroundPrefillWith` option to control playground pre-fill values

### DIFF
--- a/docs/pages/docs/configuration/api-reference.md
+++ b/docs/pages/docs/configuration/api-reference.md
@@ -214,6 +214,7 @@ const config = {
         enabled: true, // Enable schema download button
         fileName: "schema", // Set name of the schema file when downloaded
       },
+      playgroundPrefillWith: "default", // Which values pre-fill the playground
     },
   },
 };
@@ -241,6 +242,15 @@ Available options:
   - `enabled`: Enable or disable the schema download button
   - `fileName`: Set name of the schema file when downloaded (default: `schema`). Note: Do not
     include a file extension, as that is added automatically based on the input file type.
+- `playgroundPrefillWith`: Control which values are used to pre-fill the API playground fields
+  (headers, query, and path parameters). Both `"default"` and `"example"` fall back to the other
+  source so as many fields as possible are pre-filled — they only differ in which value wins when a
+  parameter has both.
+  - `"default"`: Prefer `schema.default`, then parameter-level examples, then `schema.example` /
+    `schema.examples` (default)
+  - `"example"`: Prefer `schema.example` / `schema.examples`, then parameter-level examples, then
+    `schema.default`. Useful when you maintain realistic example values for one-click testing
+  - `"none"`: Leave all fields empty
 - `transformExamples`: Function to transform request/response examples before rendering. See
   [Transforming Examples](../guides/transforming-examples.md) for detailed usage
 - `generateCodeSnippet`: Function to generate custom code snippets for the API playground. See

--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -1000,13 +1000,14 @@
             "name": "status",
             "in": "query",
             "required": true,
-            "description": "Filter by shipment status",
+            "description": "Filter by shipment status. Array example demonstrates JSON-encoded pre-fill with `playgroundPrefillWith: \"example\"`.",
             "schema": {
               "type": "array",
               "items": {
                 "type": "string",
                 "enum": ["CREATED", "IN_TRANSIT", "DELIVERED", "EXCEPTION"]
-              }
+              },
+              "example": ["IN_TRANSIT", "EXCEPTION"]
             },
             "style": "form",
             "explode": true
@@ -1025,6 +1026,12 @@
                   "INTERNATIONAL",
                   "CUSTOMS_REQUIRED"
                 ]
+              }
+            },
+            "examples": {
+              "priority": {
+                "summary": "High-priority international cargo",
+                "value": ["EXPRESS", "INTERNATIONAL"]
               }
             }
           },
@@ -1143,27 +1150,34 @@
           {
             "name": "X-Cache-Control",
             "in": "header",
-            "description": "Caching behavior for the tracking response",
+            "description": "Caching behavior for the tracking response. Demonstrates `playgroundPrefillWith`: the schema default differs from the parameter example.",
             "schema": {
               "type": "string",
               "enum": ["no-cache", "max-age=60"],
               "default": "max-age=60"
+            },
+            "examples": {
+              "realtime": {
+                "summary": "Bypass cache for live tracking",
+                "value": "no-cache"
+              }
             }
           },
           {
             "name": "trackingNumber",
             "in": "path",
             "required": true,
+            "description": "Tracking number. The schema default is a placeholder while the schema example is a realistic value, so `playgroundPrefillWith: \"example\"` pre-fills a usable id.",
             "schema": {
-              "default": "SH123456789",
-              "type": "string"
-            },
-            "example": "SH123456789"
+              "type": "string",
+              "default": "SH000000000",
+              "example": "SH48291046-QX"
+            }
           },
           {
             "name": "includeHistory",
             "in": "query",
-            "description": "Include detailed tracking history and events in the response",
+            "description": "Include detailed tracking history and events in the response. The schema default is `false` while the example is `true`.",
             "schema": {
               "type": "boolean",
               "default": false

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -395,6 +395,11 @@ const config: ZudokuConfig = {
       ],
       options: {
         disableSecurity: false,
+        // Pre-fill the playground with schema/parameter examples instead of
+        // just `schema.default`. Try "default" or "none" to compare behavior.
+        // See the `trackShipment` and `filterShipments` operations for params
+        // where the default and example values intentionally differ.
+        playgroundPrefillWith: "example",
         transformExamples: ({ content, auth }) => {
           if (!auth.isAuthenticated) {
             return content;

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -103,6 +103,7 @@ const ApiOptionsSchema = z
           .optional(),
       })
       .partial(),
+    playgroundPrefillWith: z.enum(["example", "default", "none"]),
     transformExamples: z.custom<TransformExamplesFn>(
       (val) => typeof val === "function",
     ),

--- a/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
@@ -5,54 +5,69 @@ import type {
 } from "./graphql/graphql.js";
 import { PlaygroundDialog } from "./playground/PlaygroundDialog.js";
 import { extractOperationSecuritySchemes } from "./util/extractOperationSecuritySchemes.js";
+import {
+  type PrefillMode,
+  resolveParamValue,
+  stringifyParamValue,
+} from "./util/resolveParamValue.js";
 
 export const PlaygroundDialogWrapper = ({
   server,
   servers,
   operation,
   examples,
+  prefillWith = "default",
 }: {
   server?: string;
   servers?: string[];
   operation: OperationsFragmentFragment;
   examples?: MediaTypeObject[];
+  prefillWith?: PrefillMode;
 }) => {
   const headers = operation.parameters
     ?.filter((p) => p.in === "header")
     .sort((a, b) => Number(b.required ?? false) - Number(a.required ?? false))
-    .map((p) => ({
-      name: p.name,
-      defaultValue:
-        p.schema?.default ?? p.examples?.find((x) => x.value)?.value ?? "",
-      defaultActive: p.required ?? false,
-      isRequired: p.required ?? false,
-      enum: p.schema?.type === "array" ? p.schema?.items?.enum : p.schema?.enum,
-      type: p.schema?.type ?? "string",
-    }));
+    .map((p) => {
+      const raw = resolveParamValue(p, prefillWith);
+      return {
+        name: p.name,
+        defaultValue: stringifyParamValue(raw) ?? "",
+        defaultActive: p.required ?? false,
+        isRequired: p.required ?? false,
+        enum:
+          p.schema?.type === "array" ? p.schema?.items?.enum : p.schema?.enum,
+        type: p.schema?.type ?? "string",
+      };
+    });
 
   const queryParams = operation.parameters
     ?.filter((p) => p.in === "query")
     .sort((a, b) => Number(b.required ?? false) - Number(a.required ?? false))
-    .map((p) => ({
-      name: p.name,
-      defaultActive: p.required ?? false,
-      isRequired: p.required ?? false,
-      enum: p.schema?.type === "array" ? p.schema?.items?.enum : p.schema?.enum,
-      type: p.schema?.type ?? "string",
-      defaultValue: Array.isArray(p.schema?.default)
-        ? JSON.stringify(p.schema.default)
-        : p.schema?.default,
-      style: p.style ?? undefined,
-      explode: p.explode ?? undefined,
-      allowReserved: p.allowReserved ?? undefined,
-    }));
+    .map((p) => {
+      const raw = resolveParamValue(p, prefillWith);
+      return {
+        name: p.name,
+        defaultActive: p.required ?? false,
+        isRequired: p.required ?? false,
+        enum:
+          p.schema?.type === "array" ? p.schema?.items?.enum : p.schema?.enum,
+        type: p.schema?.type ?? "string",
+        defaultValue: stringifyParamValue(raw),
+        style: p.style ?? undefined,
+        explode: p.explode ?? undefined,
+        allowReserved: p.allowReserved ?? undefined,
+      };
+    });
 
   const pathParams = operation.parameters
     ?.filter((p) => p.in === "path")
-    .map((p) => ({
-      name: p.name,
-      defaultValue: p.schema?.default,
-    }));
+    .map((p) => {
+      const raw = resolveParamValue(p, prefillWith);
+      return {
+        name: p.name,
+        defaultValue: stringifyParamValue(raw),
+      };
+    });
 
   const { options } = useOasConfig();
 

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -389,6 +389,7 @@ export const Sidecar = ({
                   servers={operation.servers.map((server) => server.url)}
                   operation={operation}
                   examples={requestBodyContent ?? undefined}
+                  prefillWith={options?.playgroundPrefillWith}
                 />
               ))}
           </div>

--- a/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/interfaces.ts
@@ -82,6 +82,22 @@ type BaseOasConfig = {
     schemaDownload?: {
       enabled: boolean;
     };
+    /**
+     * Controls which values are used to pre-fill the API playground fields.
+     *
+     * Both `"default"` and `"example"` fall back to the other source so as many
+     * fields as possible are pre-filled; they only differ in which value wins
+     * when both are present.
+     *
+     * - `"default"` – prefer `schema.default`, fall back to parameter examples
+     *   and `schema.example` / `schema.examples` (default)
+     * - `"example"` – prefer `schema.example` / `schema.examples`, fall back to
+     *   parameter examples and `schema.default`
+     * - `"none"` – leave all fields empty
+     *
+     * @default "default"
+     */
+    playgroundPrefillWith?: "example" | "default" | "none";
     transformExamples?: TransformExamplesFn;
     generateCodeSnippet?: GenerateCodeSnippetFn;
   };

--- a/packages/zudoku/src/lib/plugins/openapi/util/resolveParamValue.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/resolveParamValue.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSchemaExample,
+  resolveParamValue,
+  stringifyParamValue,
+} from "./resolveParamValue.js";
+
+describe("getSchemaExample", () => {
+  it("returns undefined for null/undefined schema", () => {
+    expect(getSchemaExample(null)).toBeUndefined();
+    expect(getSchemaExample(undefined)).toBeUndefined();
+  });
+
+  it("returns schema.example when present", () => {
+    expect(getSchemaExample({ example: "foo" })).toBe("foo");
+  });
+
+  it("returns first element of schema.examples array", () => {
+    expect(getSchemaExample({ examples: ["a", "b"] })).toBe("a");
+  });
+
+  it("prefers schema.example over schema.examples", () => {
+    expect(getSchemaExample({ example: "ex", examples: ["arr"] })).toBe("ex");
+  });
+
+  it("returns undefined when schema has no example or examples", () => {
+    expect(getSchemaExample({ type: "string" })).toBeUndefined();
+  });
+
+  it("handles falsy example values correctly", () => {
+    expect(getSchemaExample({ example: 0 })).toBe(0);
+    expect(getSchemaExample({ example: "" })).toBe("");
+    expect(getSchemaExample({ example: false })).toBe(false);
+  });
+
+  it("ignores non-array examples", () => {
+    expect(
+      getSchemaExample({ examples: { default: { value: "x" } } }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveParamValue", () => {
+  const param = (overrides: {
+    schemaDefault?: unknown;
+    schemaExample?: unknown;
+    schemaExamples?: unknown[];
+    paramExamples?: Array<{ name: string; value?: unknown }>;
+  }) => ({
+    schema: {
+      ...(overrides.schemaDefault !== undefined && {
+        default: overrides.schemaDefault,
+      }),
+      ...(overrides.schemaExample !== undefined && {
+        example: overrides.schemaExample,
+      }),
+      ...(overrides.schemaExamples !== undefined && {
+        examples: overrides.schemaExamples,
+      }),
+    },
+    examples: overrides.paramExamples ?? null,
+  });
+
+  describe('mode = "none"', () => {
+    it("always returns undefined", () => {
+      expect(
+        resolveParamValue(
+          param({ schemaDefault: "d", schemaExample: "e" }),
+          "none",
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('mode = "example"', () => {
+    it("returns schema.example when available", () => {
+      expect(
+        resolveParamValue(
+          param({ schemaExample: "ex", schemaDefault: "def" }),
+          "example",
+        ),
+      ).toBe("ex");
+    });
+
+    it("falls back to parameter-level example", () => {
+      expect(
+        resolveParamValue(
+          param({
+            schemaDefault: "def",
+            paramExamples: [{ name: "e1", value: "pex" }],
+          }),
+          "example",
+        ),
+      ).toBe("pex");
+    });
+
+    it("falls back to schema.default when no examples exist", () => {
+      expect(
+        resolveParamValue(param({ schemaDefault: "def" }), "example"),
+      ).toBe("def");
+    });
+
+    it("returns schema.examples[0] from OAS 3.1 array", () => {
+      expect(
+        resolveParamValue(
+          param({ schemaExamples: ["arr1", "arr2"], schemaDefault: "def" }),
+          "example",
+        ),
+      ).toBe("arr1");
+    });
+
+    it("returns undefined when nothing is set", () => {
+      expect(resolveParamValue(param({}), "example")).toBeUndefined();
+    });
+
+    it("uses parameter-level examples with falsy values", () => {
+      expect(
+        resolveParamValue(
+          param({ paramExamples: [{ name: "e1", value: 0 }] }),
+          "example",
+        ),
+      ).toBe(0);
+    });
+  });
+
+  describe('mode = "default"', () => {
+    it("returns schema.default when available", () => {
+      expect(
+        resolveParamValue(
+          param({ schemaDefault: "def", schemaExample: "ex" }),
+          "default",
+        ),
+      ).toBe("def");
+    });
+
+    it("falls back to parameter-level example", () => {
+      expect(
+        resolveParamValue(
+          param({
+            schemaExample: "ex",
+            paramExamples: [{ name: "e1", value: "pex" }],
+          }),
+          "default",
+        ),
+      ).toBe("pex");
+    });
+
+    it("falls back to schema.example when no default or param examples", () => {
+      expect(resolveParamValue(param({ schemaExample: "ex" }), "default")).toBe(
+        "ex",
+      );
+    });
+
+    it("returns undefined when nothing is set", () => {
+      expect(resolveParamValue(param({}), "default")).toBeUndefined();
+    });
+  });
+});
+
+describe("stringifyParamValue", () => {
+  it("returns undefined for null/undefined", () => {
+    expect(stringifyParamValue(null)).toBeUndefined();
+    expect(stringifyParamValue(undefined)).toBeUndefined();
+  });
+
+  it("stringifies primitives", () => {
+    expect(stringifyParamValue("foo")).toBe("foo");
+    expect(stringifyParamValue(42)).toBe("42");
+    expect(stringifyParamValue(false)).toBe("false");
+    expect(stringifyParamValue(0)).toBe("0");
+  });
+
+  it("JSON-encodes arrays and objects", () => {
+    expect(stringifyParamValue(["a", "b"])).toBe('["a","b"]');
+    expect(stringifyParamValue({ a: 1 })).toBe('{"a":1}');
+  });
+});

--- a/packages/zudoku/src/lib/plugins/openapi/util/resolveParamValue.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/resolveParamValue.ts
@@ -1,0 +1,52 @@
+import type { ParameterItem } from "../graphql/graphql.js";
+
+export type PrefillMode = "example" | "default" | "none";
+
+export const getSchemaExample = (schema: ParameterItem["schema"]): unknown => {
+  if (!schema) return undefined;
+  if (schema.example !== undefined) return schema.example;
+  if (Array.isArray(schema.examples) && schema.examples.length > 0) {
+    return schema.examples[0];
+  }
+  return undefined;
+};
+
+/**
+ * Resolves the value used to pre-fill a single playground parameter field,
+ * based on the configured {@link PrefillMode}.
+ *
+ * Both `"example"` and `"default"` fall back to the other source so as many
+ * fields as possible get pre-filled — they only differ in which value wins
+ * when both are present:
+ *
+ * - `"example"` – `schema.example`/`examples` → parameter example → `schema.default`
+ * - `"default"` – `schema.default` → parameter example → `schema.example`/`examples`
+ * - `"none"` – nothing
+ */
+export const resolveParamValue = (
+  param: Pick<ParameterItem, "schema" | "examples">,
+  mode: PrefillMode,
+): unknown => {
+  if (mode === "none") return undefined;
+
+  const schemaExample = getSchemaExample(param.schema);
+  const paramExample = param.examples?.find((x) => x.value != null)?.value;
+  const schemaDefault = param.schema?.default;
+
+  if (mode === "example") {
+    return schemaExample ?? paramExample ?? schemaDefault;
+  }
+
+  // "default" — prefer schema.default, fall back to examples
+  return schemaDefault ?? paramExample ?? schemaExample;
+};
+
+/**
+ * Serializes a resolved parameter value into the string the playground input
+ * expects. Arrays and objects are JSON-encoded; primitives are stringified.
+ */
+export const stringifyParamValue = (value: unknown): string | undefined => {
+  if (value == null) return undefined;
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+};


### PR DESCRIPTION
Adds a new `playgroundPrefillWith` configuration option to the OpenAPI plugin that lets users choose which values pre-fill the API playground parameter fields (headers, query, and path):

- **`"default"`** (default) — prefer `schema.default`, fall back to parameter-level examples then `schema.example` / `schema.examples`
- **`"example"`** — prefer `schema.example` / `schema.examples`, fall back to parameter-level examples then `schema.default` (for one-click testing with realistic data)
- **`"none"`** — leave all fields empty

Both fallback modes pre-fill as many fields as possible and differ only in which value wins when a parameter has both a default and an example. This also unifies the previously **inconsistent** pre-fill logic — on `main`, header params fell back to parameter examples while query/path params did not.

This addresses #1807, where users wanted to use `schema.example` values for realistic one-click API testing instead of `schema.default` values.

### Implementation notes
- Value resolution lives in `resolveParamValue`; `stringifyParamValue` JSON-encodes arrays/objects and stringifies primitives uniformly across all parameter types.
- Both helpers are covered by unit tests.

https://claude.ai/code/session_01L2TxP7qVmf9WhRwwVjBrvp