### PR TITLE
fix: name playground response types from the response schema

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -140,7 +140,6 @@
     },
     "schemas": {
       "Shipment": {
-        "title": "Shipment",
         "type": "object",
         "required": ["recipientAddress", "senderAddress", "packages"],
         "properties": {
@@ -367,7 +366,6 @@
         }
       },
       "Error": {
-        "title": "Error",
         "type": "object",
         "required": ["code", "message"],
         "example": {

--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -140,6 +140,7 @@
     },
     "schemas": {
       "Shipment": {
+        "title": "Shipment",
         "type": "object",
         "required": ["recipientAddress", "senderAddress", "packages"],
         "properties": {
@@ -366,6 +367,7 @@
         }
       },
       "Error": {
+        "title": "Error",
         "type": "object",
         "required": ["code", "message"],
         "example": {

--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -66,7 +66,7 @@
   ],
   "servers": [
     {
-      "url": "https://8f9618f3bc0f4eec989627ceaafd5e4d_oas.api.mockbin.io/",
+      "url": "https://c1cf69108515455da09b5a33ff336111-oas.api.mockbin.io/",
       "description": "Production environment"
     },
     {
@@ -1120,6 +1120,20 @@
                       "type": "integer"
                     }
                   }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error retrieving shipments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "code": "QUANTUM_FLUX_ERROR",
+                  "message": "Shipment manifest lost in a warp-field anomaly"
                 }
               }
             }

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -259,7 +259,8 @@
     background-color: var(--shiki-dark-bg) !important;
   }
   .code-block .shiki {
-    @apply grid grid-rows-1 whitespace-pre;
+    @apply grid whitespace-pre;
+    align-content: start;
     grid-auto-rows: 1lh;
   }
 

--- a/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
@@ -4,6 +4,11 @@ import type { Content } from "./interfaces.js";
 import { PlaygroundDialog } from "./playground/PlaygroundDialog.js";
 import { extractOperationSecuritySchemes } from "./util/extractOperationSecuritySchemes.js";
 
+const extractRefName = (ref: unknown): string | undefined => {
+  if (typeof ref !== "string") return undefined;
+  return ref.split("/").pop();
+};
+
 export const PlaygroundDialogWrapper = ({
   server,
   servers,
@@ -60,11 +65,14 @@ export const PlaygroundDialogWrapper = ({
 
   const responseSchemas = Object.fromEntries(
     operation.responses.flatMap((response) => {
-      const schema = response.content?.find(
-        (c) => c.mediaType === "application/json",
+      const schema = response.content?.find((c) =>
+        c.mediaType.includes("json"),
       )?.schema;
-      if (schema?.title) {
-        return [[response.statusCode, schema.title]];
+
+      const name = extractRefName(schema?.__$ref) ?? schema?.title;
+
+      if (name) {
+        return [[response.statusCode, name]];
       }
       return [];
     }),

--- a/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
@@ -63,18 +63,16 @@ export const PlaygroundDialogWrapper = ({
     ? []
     : extractOperationSecuritySchemes(operation);
 
+  // Keep unnamed statuses so `default` only applies to undefined status codes.
   const responseSchemas = Object.fromEntries(
-    operation.responses.flatMap((response) => {
+    operation.responses.map((response) => {
       const schema = response.content?.find((c) =>
         c.mediaType.includes("json"),
       )?.schema;
 
       const name = extractRefName(schema?.__$ref) ?? schema?.title;
 
-      if (name) {
-        return [[response.statusCode, name]];
-      }
-      return [];
+      return [response.statusCode, name];
     }),
   );
 

--- a/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
@@ -58,6 +58,18 @@ export const PlaygroundDialogWrapper = ({
     ? []
     : extractOperationSecuritySchemes(operation);
 
+  const responseSchemas = Object.fromEntries(
+    operation.responses.flatMap((response) => {
+      const schema = response.content?.find(
+        (c) => c.mediaType === "application/json",
+      )?.schema;
+      if (schema?.title) {
+        return [[response.statusCode, schema.title]];
+      }
+      return [];
+    }),
+  );
+
   return (
     <PlaygroundDialog
       server={server}
@@ -74,6 +86,7 @@ export const PlaygroundDialogWrapper = ({
           : undefined
       }
       securitySchemes={securitySchemes}
+      responseSchemas={responseSchemas}
     />
   );
 };

--- a/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
@@ -197,6 +197,7 @@ export type PlaygroundContentProps = {
   requiresLogin?: boolean;
   onLogin?: () => void;
   onSignUp?: () => void;
+  responseSchemas?: Record<string, string>;
 };
 
 export const Playground = ({
@@ -214,6 +215,7 @@ export const Playground = ({
   requiresLogin = false,
   onLogin,
   onSignUp,
+  responseSchemas,
 }: PlaygroundContentProps) => {
   const { selectedServer, setSelectedServer } = useSelectedServer(
     servers.map((url) => ({ url })),
@@ -704,6 +706,7 @@ export const Playground = ({
               showLongRunningWarning={showLongRunningWarning}
               isFinished={isFinished}
               progress={progress}
+              responseSchemas={responseSchemas}
               tip={
                 <div className="text-xs w-full">
                   <span className="text-muted-foreground">

--- a/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
@@ -197,7 +197,7 @@ export type PlaygroundContentProps = {
   requiresLogin?: boolean;
   onLogin?: () => void;
   onSignUp?: () => void;
-  responseSchemas?: Record<string, string>;
+  responseSchemas?: Record<string, string | undefined>;
 };
 
 export const Playground = ({

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResponseTab.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResponseTab.tsx
@@ -150,6 +150,7 @@ export const ResponseTab = ({
   isBinary = false,
   fileName,
   blob,
+  typeName,
 }: {
   body?: string;
   headers: Array<[string, string]>;
@@ -163,6 +164,7 @@ export const ResponseTab = ({
   isBinary?: boolean;
   fileName?: string;
   blob?: Blob;
+  typeName?: string;
 }) => {
   const detectedLanguage = detectLanguage(headers);
   const jsonContent = tryParseJson(body);
@@ -172,9 +174,9 @@ export const ResponseTab = ({
   );
 
   const types = useQuery({
-    queryKey: ["types", beautifiedBody],
+    queryKey: ["types", beautifiedBody, typeName],
     queryFn: async () => {
-      return convertToTypes(JSON.parse(beautifiedBody));
+      return convertToTypes(JSON.parse(beautifiedBody), typeName);
     },
     enabled: view === "types" && !isBinary,
   });

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResponseTab.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResponseTab.tsx
@@ -295,7 +295,7 @@ export const ResponseTab = ({
         </CollapsibleContent>
       </Collapsible>
 
-      <div className="flex gap-2 justify-between items-center border-b px-2 flex-0">
+      <div className="flex gap-2 justify-between items-center border-b px-4 flex-0">
         <CollapsibleHeader className="flex items-center gap-2">
           <SquareCodeIcon size={14} aria-hidden="true" />
           Response body
@@ -307,7 +307,7 @@ export const ResponseTab = ({
               setView(value as "formatted" | "raw" | "types")
             }
           >
-            <SelectTrigger className="max-w-32 border-0 bg-transparent">
+            <SelectTrigger className="max-w-32 border-0 shadow-none bg-transparent! px-0">
               <SelectValue placeholder="View" />
             </SelectTrigger>
             <SelectContent>
@@ -318,7 +318,7 @@ export const ResponseTab = ({
           </Select>
         )}
       </div>
-      <div className="flex-1">
+      <div className="flex-1 min-h-0">
         {isBinary ? (
           blob && isAudioContentType(getContentType(headers)) ? (
             <AudioPlayer

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
@@ -15,6 +15,7 @@ export const ResultPanel = ({
   tip,
   isFinished,
   progress,
+  responseSchemas,
 }: {
   // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   queryMutation: UseMutationResult<PlaygroundResult, Error, any>;
@@ -23,6 +24,7 @@ export const ResultPanel = ({
   isFinished: boolean;
   progress: number;
   tip?: React.ReactNode;
+  responseSchemas?: Record<string, string>;
 }) => {
   return (
     <div className="flex flex-col overflow-y-auto h-[80vh] bg-muted/50">
@@ -61,6 +63,7 @@ export const ResultPanel = ({
           isBinary={queryMutation.data.isBinary}
           fileName={queryMutation.data.fileName}
           blob={queryMutation.data.blob}
+          typeName={responseSchemas?.[String(queryMutation.data.status)]}
         />
       ) : queryMutation.isPending ? (
         <div className="grid place-items-center h-full">

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
@@ -63,7 +63,13 @@ export const ResultPanel = ({
           isBinary={queryMutation.data.isBinary}
           fileName={queryMutation.data.fileName}
           blob={queryMutation.data.blob}
-          typeName={responseSchemas?.[String(queryMutation.data.status)]}
+          typeName={
+            responseSchemas?.[String(queryMutation.data.status)] ??
+            responseSchemas?.[
+              `${Math.floor(queryMutation.data.status / 100)}XX`
+            ] ??
+            responseSchemas?.default
+          }
         />
       ) : queryMutation.isPending ? (
         <div className="grid place-items-center h-full">

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/ResultPanel.tsx
@@ -8,6 +8,21 @@ import type { PlaygroundResult } from "../Playground.js";
 import ResponseStatusBar from "./ResponseStatusBar.js";
 import { ResponseTab } from "./ResponseTab.js";
 
+// Match status code to schema name: exact, then NXX, then `default`.
+const resolveTypeName = (
+  responseSchemas: Record<string, string | undefined> | undefined,
+  status: number,
+): string | undefined => {
+  if (!responseSchemas) return undefined;
+
+  const exact = String(status);
+  const range = `${Math.floor(status / 100)}XX`;
+
+  if (exact in responseSchemas) return responseSchemas[exact];
+  if (range in responseSchemas) return responseSchemas[range];
+  return responseSchemas.default;
+};
+
 export const ResultPanel = ({
   queryMutation,
   showLongRunningWarning,
@@ -24,7 +39,7 @@ export const ResultPanel = ({
   isFinished: boolean;
   progress: number;
   tip?: React.ReactNode;
-  responseSchemas?: Record<string, string>;
+  responseSchemas?: Record<string, string | undefined>;
 }) => {
   return (
     <div className="flex flex-col overflow-y-auto h-[80vh] bg-muted/50">
@@ -63,13 +78,7 @@ export const ResultPanel = ({
           isBinary={queryMutation.data.isBinary}
           fileName={queryMutation.data.fileName}
           blob={queryMutation.data.blob}
-          typeName={
-            responseSchemas?.[String(queryMutation.data.status)] ??
-            responseSchemas?.[
-              `${Math.floor(queryMutation.data.status / 100)}XX`
-            ] ??
-            responseSchemas?.default
-          }
+          typeName={resolveTypeName(responseSchemas, queryMutation.data.status)}
         />
       ) : queryMutation.isPending ? (
         <div className="grid place-items-center h-full">

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.test.ts
@@ -30,6 +30,31 @@ describe("convertToTypes", () => {
     const result = convertToTypes(null, "NullType");
     expect(result.lines[0]).toBe("type NullType = null;");
   });
+
+  it("should sanitize type names with spaces into PascalCase", () => {
+    const result = convertToTypes({ id: 1 }, "Root Schema");
+    expect(result.lines[0]).toMatch(/^type RootSchema = /);
+  });
+
+  it("should sanitize type names with special characters", () => {
+    const result = convertToTypes({ id: 1 }, "my-error_type.v2");
+    expect(result.lines[0]).toMatch(/^type MyErrorTypeV2 = /);
+  });
+
+  it("should fall back to GeneratedType for names starting with digits", () => {
+    const result = convertToTypes({ id: 1 }, "123invalid");
+    expect(result.lines[0]).toMatch(/^type GeneratedType = /);
+  });
+
+  it("should fall back to GeneratedType for empty string", () => {
+    const result = convertToTypes({ id: 1 }, "");
+    expect(result.lines[0]).toMatch(/^type GeneratedType = /);
+  });
+
+  it("should fall back to GeneratedType for all-special-chars name", () => {
+    const result = convertToTypes({ id: 1 }, "---");
+    expect(result.lines[0]).toMatch(/^type GeneratedType = /);
+  });
 });
 
 describe("generateInterface", () => {

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { generateInterface } from "./convertToTypes.js";
+import { convertToTypes, generateInterface } from "./convertToTypes.js";
+
+describe("convertToTypes", () => {
+  it("should use GeneratedType as default type name", () => {
+    const result = convertToTypes({ id: 1, name: "test" });
+    expect(result.lines[0]).toBe(
+      "type GeneratedType = {\n  id: number;\n  name: string;\n};",
+    );
+  });
+
+  it("should use custom type name when provided", () => {
+    const result = convertToTypes({ id: 1, name: "test" }, "ErrorDetails");
+    expect(result.lines[0]).toBe(
+      "type ErrorDetails = {\n  id: number;\n  name: string;\n};",
+    );
+  });
+
+  it("should use custom type name for primitive values", () => {
+    const result = convertToTypes("hello", "MyString");
+    expect(result.lines[0]).toBe("type MyString = string;");
+  });
+
+  it("should use custom type name for arrays", () => {
+    const result = convertToTypes([1, 2, 3], "NumberList");
+    expect(result.lines[0]).toBe("type NumberList = number[];");
+  });
+
+  it("should use custom type name for null", () => {
+    const result = convertToTypes(null, "NullType");
+    expect(result.lines[0]).toBe("type NullType = null;");
+  });
+});
 
 describe("generateInterface", () => {
   it("should handle primitive types", () => {

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.test.ts
@@ -89,9 +89,9 @@ describe("generateInterface", () => {
     const expected = [
       "{",
       "  user: {",
-      "  name: string;",
-      "  age: number;",
-      "};",
+      "    name: string;",
+      "    age: number;",
+      "  };",
       "}",
     ].join("\n");
 
@@ -110,8 +110,8 @@ describe("generateInterface", () => {
       "  numbers: number[];",
       "  empty: any[];",
       "  objects: {",
-      "  id: number;",
-      "}[];",
+      "    id: number;",
+      "  }[];",
       "}",
     ].join("\n");
 

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.ts
@@ -29,8 +29,11 @@ export function generateInterface(obj: JsonObject, _indentation = ""): string {
   return lines.join("\n");
 }
 
-export function convertToTypes(json: JsonValue): { lines: string[] } {
+export function convertToTypes(
+  json: JsonValue,
+  typeName = "GeneratedType",
+): { lines: string[] } {
   const typeDefinition = inferType(json);
-  const lines = [`type GeneratedType = ${typeDefinition};`];
+  const lines = [`type ${typeName} = ${typeDefinition};`];
   return { lines };
 }

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.ts
@@ -29,11 +29,26 @@ export function generateInterface(obj: JsonObject, _indentation = ""): string {
   return lines.join("\n");
 }
 
+const toValidIdentifier = (name: string): string | undefined => {
+  // PascalCase: split on non-alphanumeric, capitalize each part
+  const sanitized = name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+
+  if (!sanitized || /^\d/.test(sanitized)) return undefined;
+
+  return sanitized;
+};
+
 export function convertToTypes(
   json: JsonValue,
-  typeName = "GeneratedType",
+  typeName?: string,
 ): { lines: string[] } {
+  const name =
+    (typeName ? toValidIdentifier(typeName) : undefined) ?? "GeneratedType";
   const typeDefinition = inferType(json);
-  const lines = [`type ${typeName} = ${typeDefinition};`];
+  const lines = [`type ${name} = ${typeDefinition};`];
   return { lines };
 }

--- a/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/result-panel/convertToTypes.ts
@@ -2,35 +2,36 @@ type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
 type JsonObject = { [key: string]: JsonValue };
 type JsonArray = JsonValue[];
 
-function inferType(value: JsonValue): string {
+function inferType(value: JsonValue, indentation = ""): string {
   if (value === null) return "null";
   if (Array.isArray(value)) {
     if (value.length === 0) return "any[]";
     const firstValue = value[0];
     if (firstValue === undefined) return "any[]";
-    const elementType = inferType(firstValue);
+    const elementType = inferType(firstValue, indentation);
     return `${elementType}[]`;
   }
   if (typeof value === "object") {
-    return generateInterface(value);
+    return generateInterface(value, indentation);
   }
   return typeof value;
 }
 
-export function generateInterface(obj: JsonObject, _indentation = ""): string {
+export function generateInterface(obj: JsonObject, indentation = ""): string {
+  const inner = `${indentation}  `;
   const lines: string[] = ["{"];
 
   for (const [key, value] of Object.entries(obj)) {
-    const propertyType = inferType(value);
-    lines.push(`  ${key}: ${propertyType};`);
+    const propertyType = inferType(value, inner);
+    lines.push(`${inner}${key}: ${propertyType};`);
   }
 
-  lines.push("}");
+  lines.push(`${indentation}}`);
   return lines.join("\n");
 }
 
 const toValidIdentifier = (name: string): string | undefined => {
-  // PascalCase: split on non-alphanumeric, capitalize each part
+  // PascalCase the name, dropping non-alphanumeric separators.
   const sanitized = name
     .split(/[^a-zA-Z0-9]+/)
     .filter(Boolean)

--- a/packages/zudoku/src/lib/shiki.ts
+++ b/packages/zudoku/src/lib/shiki.ts
@@ -172,7 +172,7 @@ export const highlight = (
     jsxs,
     components: {
       pre: (props) => props.children,
-      code: (props) =>
+      code: ({ inline: _inline, ...props }) =>
         createElement("code", {
           ...props,
           className: cn(props.className, HIGHLIGHT_CODE_BLOCK_CLASS),

--- a/packages/zudoku/src/lib/ui/EmbeddedCodeBlock.tsx
+++ b/packages/zudoku/src/lib/ui/EmbeddedCodeBlock.tsx
@@ -40,11 +40,11 @@ export const EmbeddedCodeBlock = ({
         fullHeight && "h-full",
       )}
     >
-      <div className="relative overflow-auto">
+      <div className={cn("relative overflow-auto", fullHeight && "h-full")}>
         <div
           className={cn(
             "code-block text-sm not-prose scrollbar [&>pre]:overflow-x-auto [&_code]:p-2",
-            fullHeight && "h-full [&>pre]:h-full",
+            fullHeight && "h-full [&>pre]:h-full [&>code]:min-h-full",
             props.className,
           )}
           ref={ref}


### PR DESCRIPTION
The playground's Types view hardcoded `type GeneratedType` for every response. It now names the type after the response schema, matched by status code: the schema's `$ref` name (so `Shipment`, `Error`, and friends), falling back to its `title`, then `GeneratedType` when there's nothing to go on.

A handful of related bugs turned up along the way. Generated types weren't indented at all, so nested objects rendered flush left. The `default` response was being used to name successful responses too, so a plain 200 could show up labelled `Error`; it's now reserved for status codes the spec doesn't actually document. An `inline` attribute was leaking onto the highlighted `<code>` element. And the response body now fills the panel and scrolls on its own instead of dragging the whole panel with it.

Closes #1021
