### PR TITLE
Support x-code-samples extension in OpenAPI operations

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -730,7 +730,7 @@
             "source": "curl -X POST https://api.cosmocargo.com/v1/shipments \\\n  -H 'Content-Type: application/json' \\\n  -H 'X-API-Key: YOUR_API_KEY' \\\n  -d '{\n    \"recipientAddress\": {\n      \"name\": \"Zara Nebula\",\n      \"planet\": \"Mars\",\n      \"station\": \"Olympus Mons Hub\"\n    },\n    \"packages\": [{ \"weight\": 2.5, \"dimensions\": \"30x20x15\" }]\n  }'"
           },
           {
-            "lang": "javascript",
+            "lang": "js",
             "label": "JavaScript",
             "source": "const response = await fetch(\n  'https://api.cosmocargo.com/v1/shipments',\n  {\n    method: 'POST',\n    headers: {\n      'Content-Type': 'application/json',\n      'X-API-Key': 'YOUR_API_KEY',\n    },\n    body: JSON.stringify({\n      recipientAddress: {\n        name: 'Zara Nebula',\n        planet: 'Mars',\n        station: 'Olympus Mons Hub',\n      },\n      packages: [{ weight: 2.5, dimensions: '30x20x15' }],\n    }),\n  },\n);\n\nconst shipment = await response.json();"
           },

--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -723,6 +723,23 @@
         "summary": "Create a new shipment",
         "description": "Creates a new shipment with the provided details.\n\nThis endpoint allows you to **create and register** a new shipment in the Cosmo Cargo platform. The shipment will be assigned a unique `trackingNumber` and will enter the `CREATED` status.\n\n### How to use with SDK\n\nHere's how to create a shipment using `@cosmo-cargo/sdk{:sh}`:\n\n```ts\nimport { CosmoCargoClient } from '@cosmo-cargo/sdk';\n\nconst client = new CosmoCargoClient({ key: process.env.COSMO_API_KEY });\n\nconst shipment = await client.shipments.create(config);\nconsole.log(`Shipment created: ${shipment.trackingNumber}`);\n```\n\n**Note:** Use the `X-Request-Priority` header to expedite processing for urgent shipments.",
         "operationId": "createShipment",
+        "x-code-samples": [
+          {
+            "lang": "shell",
+            "label": "cURL",
+            "source": "curl -X POST https://api.cosmocargo.com/v1/shipments \\\n  -H 'Content-Type: application/json' \\\n  -H 'X-API-Key: YOUR_API_KEY' \\\n  -d '{\n    \"recipientAddress\": {\n      \"name\": \"Zara Nebula\",\n      \"planet\": \"Mars\",\n      \"station\": \"Olympus Mons Hub\"\n    },\n    \"packages\": [{ \"weight\": 2.5, \"dimensions\": \"30x20x15\" }]\n  }'"
+          },
+          {
+            "lang": "javascript",
+            "label": "JavaScript",
+            "source": "const response = await fetch(\n  'https://api.cosmocargo.com/v1/shipments',\n  {\n    method: 'POST',\n    headers: {\n      'Content-Type': 'application/json',\n      'X-API-Key': 'YOUR_API_KEY',\n    },\n    body: JSON.stringify({\n      recipientAddress: {\n        name: 'Zara Nebula',\n        planet: 'Mars',\n        station: 'Olympus Mons Hub',\n      },\n      packages: [{ weight: 2.5, dimensions: '30x20x15' }],\n    }),\n  },\n);\n\nconst shipment = await response.json();"
+          },
+          {
+            "lang": "python",
+            "label": "Python",
+            "source": "import requests\n\nresponse = requests.post(\n    'https://api.cosmocargo.com/v1/shipments',\n    headers={\n        'Content-Type': 'application/json',\n        'X-API-Key': 'YOUR_API_KEY',\n    },\n    json={\n        'recipientAddress': {\n            'name': 'Zara Nebula',\n            'planet': 'Mars',\n            'station': 'Olympus Mons Hub',\n        },\n        'packages': [{'weight': 2.5, 'dimensions': '30x20x15'}],\n    },\n)\n\nshipment = response.json()"
+          }
+        ],
         "security": [{ "ApiKeyAuth": [] }, { "BearerAuth": [] }],
         "parameters": [
           {

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -47,6 +47,21 @@ const EXAMPLE_LANGUAGES = [
   { value: "swift", label: "Swift" },
 ];
 
+type CodeSample = {
+  lang: string;
+  label?: string;
+  source: string;
+};
+
+const getCodeSamples = (
+  extensions: Record<string, unknown> | null | undefined,
+): CodeSample[] | undefined => {
+  const samples =
+    extensions?.["x-code-samples"] ?? extensions?.["x-codeSamples"];
+  if (!Array.isArray(samples) || samples.length === 0) return undefined;
+  return samples;
+};
+
 export const Sidecar = ({
   operation,
   selectedResponse,
@@ -67,7 +82,14 @@ export const Sidecar = ({
   const [searchParams, setSearchParams] = useSearchParams();
   const [, startTransition] = useTransition();
 
-  const supportedLanguages = options?.supportedLanguages ?? EXAMPLE_LANGUAGES;
+  const codeSamples = getCodeSamples(operation.extensions);
+
+  const supportedLanguages = codeSamples
+    ? codeSamples.map((sample) => ({
+        value: sample.lang,
+        label: sample.label ?? sample.lang,
+      }))
+    : (options?.supportedLanguages ?? EXAMPLE_LANGUAGES);
 
   const preferredLang =
     searchParams.get("lang") ?? options?.examplesLanguage ?? "shell";
@@ -133,6 +155,11 @@ export const Sidecar = ({
     globalSelectedServer || operation.servers.at(0)?.url || "";
 
   const httpSnippetCode = useMemo<string | undefined>(() => {
+    if (codeSamples) {
+      const match = codeSamples.find((s) => s.lang === selectedLang);
+      return match?.source;
+    }
+
     const converted = options?.generateCodeSnippet?.({
       selectedLang,
       selectedServer,
@@ -157,6 +184,7 @@ export const Sidecar = ({
 
     return getConverted(snippet, selectedLang);
   }, [
+    codeSamples,
     currentExampleCode,
     operation,
     selectedServer,

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -53,13 +53,31 @@ type CodeSample = {
   source: string;
 };
 
+const isCodeSample = (sample: unknown): sample is CodeSample => {
+  if (typeof sample !== "object" || sample === null) return false;
+
+  const { lang, label, source } = sample as {
+    lang?: unknown;
+    label?: unknown;
+    source?: unknown;
+  };
+
+  return (
+    typeof lang === "string" &&
+    typeof source === "string" &&
+    (label === undefined || typeof label === "string")
+  );
+};
+
 const getCodeSamples = (
   extensions: Record<string, unknown> | null | undefined,
 ): CodeSample[] | undefined => {
   const samples =
     extensions?.["x-code-samples"] ?? extensions?.["x-codeSamples"];
   if (!Array.isArray(samples) || samples.length === 0) return undefined;
-  return samples;
+
+  const validSamples = samples.filter(isCodeSample);
+  return validSamples.length > 0 ? validSamples : undefined;
 };
 
 export const Sidecar = ({


### PR DESCRIPTION
## Summary
- Add support for `x-code-samples` and `x-codeSamples` OpenAPI extensions to display custom code examples in the Sidecar
- When custom samples exist on an operation, they replace auto-generated HTTP snippets
- Language selector dynamically shows only the languages defined in the extension

## Changes
- **`Sidecar.tsx`**: Added `getCodeSamples()` to extract samples from `operation.extensions`, updated language selector and snippet memo to use custom samples when available
- **`cosmo-cargo/schema/shipments.json`**: Added `x-code-samples` with cURL, JavaScript, Python examples on the "Create a new shipment" operation

## Test plan

### Testing in Cosmo Cargo

1. Start the dev server:
   ```sh
   nx run cosmo-cargo:dev
   ```
2. Navigate to **Shipment Management** → **Create a new shipment** (`POST /shipments`)
3. Verify the sidecar code block shows custom code samples instead of auto-generated ones
4. Use the language dropdown — should show **cURL**, **JavaScript**, **Python** (only these three, not the default list)
5. Switch between languages and confirm each displays the correct custom source code
6. Navigate to any other operation (e.g. **Filter shipments**) — should still show the default auto-generated snippets with the full language list

### Edge cases to verify
- [ ] Operations without `x-code-samples` behave exactly as before (generated snippets)
- [ ] Language selector persists via `?lang=` query param across operations with and without custom samples
- [ ] Playground button still appears when applicable on operations with custom samples

Closes #185

https://claude.ai/code/session_011p8MdD4YALQTtsfEHYYcKG