### PR TITLE
fix: use undefined instead of empty string for missing name

### DIFF
--- a/packages/zudoku/src/lib/authentication/providers/clerk.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.tsx
@@ -101,9 +101,9 @@ const clerkAuth: AuthenticationProviderInitializer<
         verifiedEmail?.emailAddress ??
         user.emailAddresses[0]?.emailAddress ??
         "",
-      name: user.fullName ?? "",
+      name: user.fullName ?? undefined,
       emailVerified: !!verifiedEmail?.emailAddress,
-      pictureUrl: user.imageUrl ?? "",
+      pictureUrl: user.imageUrl ?? undefined,
     };
   }
 


### PR DESCRIPTION
When a Clerk user is missing name (by default in Clerk), the provider falls back to "", but this leads to the header button rendering with no visible text (`profile?.name ?? "My Account"`) so it's in effect invisible. This change aligns with how the other auth providers in Zudoku handle missing fields, so that the header correctly shows "My Account".

Changes:
* For unset Clerk user.fullName fallback to undefined
* for unset Clerk user.imageUrl fallback to undefined

To test:
Pre PR: Create a user in Clerk with no name field set -> user menu should show empty in the header. After PR: user menu shows "My Account". The pictureUrl doesn't seem to be used anywhere, but I changed it still to make it match the other providers (like firebase.tsx)