### PR TITLE
feat: Support custom JSX components in OpenAPI descriptions

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "International Shipping",
-      "description": "Operations for managing customs documentation, duties, and international shipment processes."
+      "description": "Operations for managing customs documentation, duties, and international shipment processes.\n\n<SpaceWarning sector=\"7G\">\nInterstellar customs regulations were updated in Stardate 2025.3. All shipments crossing the Outer Rim must include a Quantum Manifest.\n</SpaceWarning>"
     },
     {
       "name": "Documentation",

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type {
   ApiIdentity,
   ApiIdentityPlugin,
@@ -211,6 +212,20 @@ const config: ZudokuConfig = {
   mdx: {
     components: {
       Trademark: () => "™",
+      SpaceWarning: ({
+        children,
+        sector,
+      }: {
+        children: ReactNode;
+        sector?: string;
+      }) => (
+        <div className="my-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
+          <div className="flex items-center gap-2 font-semibold text-yellow-600 dark:text-yellow-400">
+            ⚠️ {sector ? `Sector ${sector} Advisory` : "Space Advisory"}
+          </div>
+          <div className="mt-1 text-sm">{children}</div>
+        </div>
+      ),
     },
   },
   navigationRules: [

--- a/packages/zudoku/src/lib/components/Markdown.test.tsx
+++ b/packages/zudoku/src/lib/components/Markdown.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+import { MDXProvider } from "@mdx-js/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render } from "@testing-library/react";
+import type { MDXComponents } from "mdx/types.js";
+import { Suspense } from "react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Markdown } from "./Markdown.js";
+
+vi.mock("../hooks/useHighlighter.js", () => ({
+  useHighlighter: () => ({
+    codeToHast: () => ({ type: "root", children: [] }),
+    getLoadedLanguages: () => [],
+  }),
+}));
+
+vi.mock("../shiki.js", () => ({
+  createConfiguredShikiRehypePlugins: () => [],
+}));
+
+const renderMarkdown = async (
+  content: string,
+  mdxComponents: MDXComponents = {},
+) => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext({}, queryClient, {});
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: "*",
+        element: (
+          <QueryClientProvider client={queryClient}>
+            <ZudokuProvider context={context}>
+              <MDXProvider components={mdxComponents}>
+                <Suspense>
+                  <Markdown content={content} />
+                </Suspense>
+              </MDXProvider>
+            </ZudokuProvider>
+          </QueryClientProvider>
+        ),
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+
+  const result = await act(async () =>
+    render(<RouterProvider router={router} />),
+  );
+  return result;
+};
+
+describe("Markdown", () => {
+  it("renders plain markdown", async () => {
+    const { container } = await renderMarkdown("Hello **world**");
+
+    expect(container.querySelector("strong")?.textContent).toBe("world");
+  });
+
+  it("renders custom PascalCase components from MDXProvider", async () => {
+    const SpaceWarning = ({ children }: { children: string }) => (
+      <div data-testid="space-warning">{children}</div>
+    );
+
+    const { container } = await renderMarkdown(
+      "<SpaceWarning>Danger ahead</SpaceWarning>",
+      { SpaceWarning },
+    );
+
+    const el = container.querySelector("[data-testid='space-warning']");
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe("Danger ahead");
+  });
+
+  it("renders custom components with props", async () => {
+    const Alert = ({ type, children }: { type: string; children: string }) => (
+      <div data-testid="alert" data-type={type}>
+        {children}
+      </div>
+    );
+
+    const { container } = await renderMarkdown(
+      '<Alert type="warning">Watch out</Alert>',
+      { Alert },
+    );
+
+    const el = container.querySelector("[data-testid='alert']");
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute("data-type")).toBe("warning");
+    expect(el?.textContent).toBe("Watch out");
+  });
+
+  it("keeps native HTML tags that have no PascalCase component counterpart", async () => {
+    const { container } = await renderMarkdown("<button>Native</button>", {});
+
+    expect(container.querySelector("button")?.textContent).toBe("Native");
+  });
+});

--- a/packages/zudoku/src/lib/components/Markdown.tsx
+++ b/packages/zudoku/src/lib/components/Markdown.tsx
@@ -1,14 +1,34 @@
+import { useMDXComponents } from "@mdx-js/react";
+import type { Root } from "hast";
 import { memo, useMemo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
 import { useHighlighter } from "../hooks/useHighlighter.js";
 import { createConfiguredShikiRehypePlugins } from "../shiki.js";
-import { MdxComponents } from "../util/MdxComponents.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 import { Typography } from "./Typography.js";
 
 const remarkPlugins = [remarkGfm];
+
+// rehype-raw parses HTML per the HTML spec which lowercases all tag names.
+// This plugin restores the original casing so react-markdown can match them
+// against the components map (e.g. <strictmode> -> <StrictMode>).
+const rehypeRestoreComponentCase: (
+  componentNames: string[],
+) => Plugin<[], Root> = (componentNames) => () => (tree) => {
+  const lowerToOriginal = new Map(
+    componentNames.map((name) => [name.toLowerCase(), name]),
+  );
+  visit(tree, "element", (node) => {
+    const original = lowerToOriginal.get(node.tagName);
+    if (!original) return;
+
+    node.tagName = original;
+  });
+};
 
 export const Markdown = memo(
   ({
@@ -22,20 +42,23 @@ export const Markdown = memo(
   }) => {
     const { syntaxHighlighting } = useZudoku().options;
     const highlighter = useHighlighter();
+
+    const mdxComponents = useMDXComponents();
+    const mdComponents = useMemo(
+      () => ({ ...mdxComponents, ...components }),
+      [mdxComponents, components],
+    );
+
     const rehypePlugins = useMemo(
       () => [
         rehypeRaw,
+        rehypeRestoreComponentCase(Object.keys(mdComponents)),
         ...createConfiguredShikiRehypePlugins(
           highlighter,
           syntaxHighlighting?.themes,
         ),
       ],
-      [syntaxHighlighting?.themes, highlighter],
-    );
-
-    const mdComponents = useMemo(
-      () => ({ ...MdxComponents, ...components }),
-      [components],
+      [syntaxHighlighting?.themes, highlighter, mdComponents],
     );
 
     return (

--- a/packages/zudoku/src/lib/components/Markdown.tsx
+++ b/packages/zudoku/src/lib/components/Markdown.tsx
@@ -15,12 +15,16 @@ const remarkPlugins = [remarkGfm];
 
 // rehype-raw parses HTML per the HTML spec which lowercases all tag names.
 // This plugin restores the original casing so react-markdown can match them
-// against the components map (e.g. <strictmode> -> <StrictMode>).
+// against the components map (e.g. <spacewarning> -> <SpaceWarning>).
+// Only remaps names that are PascalCase (contain an uppercase letter) to avoid
+// turning native HTML tags like <button> into their component overrides.
 const rehypeRestoreComponentCase: (
   componentNames: string[],
 ) => Plugin<[], Root> = (componentNames) => () => (tree) => {
   const lowerToOriginal = new Map(
-    componentNames.map((name) => [name.toLowerCase(), name]),
+    componentNames
+      .filter((name) => name !== name.toLowerCase())
+      .map((name) => [name.toLowerCase(), name]),
   );
   visit(tree, "element", (node) => {
     const original = lowerToOriginal.get(node.tagName);


### PR DESCRIPTION
Closes #2280

Wires up user-registered `mdx.components` to the Markdown renderer used for OpenAPI description fields. Custom components like `<SpaceWarning>` or `<Callout>` now render in API descriptions the same way they do in .mdx pages.

This does NOT add full MDX support (no JS expressions, imports, or dynamic logic). Only HTML-like JSX component tags work in descriptions.

**Limitation:** PascalCase component names that shadow native HTML tags (e.g. `Button` vs `button`) cannot be distinguished after the HTML parser lowercases them. In practice this is a non-issue since those components were already unreachable in descriptions before this change.