### PR TITLE
fix: validate config schema and show clear error messages

### DIFF
--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -66,27 +66,44 @@ async function loadZudokuConfigWithMeta(
 ): Promise<ConfigWithMeta> {
   const configPath = await getConfigFilePath(rootDir);
 
-  const { module, dependencies } = await runnerImport<{
-    default: ZudokuConfig;
-  }>(configPath, {
-    plugins: [virtualModuleStubPlugin],
-    environments: {
-      inline: {
-        resolve: {
-          // Prevent Node.js from trying to load zudoku's raw .ts source
-          // directly, which fails with ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING
-          // when --experimental-strip-types is enabled. Uses regex to also
-          // catch plugins that re-export from zudoku (e.g. @zuplo/zudoku-plugin-*).
-          noExternal: [/zudoku/],
+  let module: { default: ZudokuConfig };
+  let dependencies: string[];
+
+  try {
+    ({ module, dependencies } = await runnerImport<{
+      default: ZudokuConfig;
+    }>(configPath, {
+      plugins: [virtualModuleStubPlugin],
+      environments: {
+        inline: {
+          resolve: {
+            // Prevent Node.js from trying to load zudoku's raw .ts source
+            // directly, which fails with ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING
+            // when --experimental-strip-types is enabled. Uses regex to also
+            // catch plugins that re-export from zudoku (e.g. @zuplo/zudoku-plugin-*).
+            noExternal: [/zudoku/],
+          },
         },
       },
-    },
-    server: {
-      // this allows us to 'load' CSS files in the config
-      // see https://github.com/vitejs/vite/pull/19577
-      perEnvironmentStartEndDuringDev: true,
-    },
-  });
+      server: {
+        // this allows us to 'load' CSS files in the config
+        // see https://github.com/vitejs/vite/pull/19577
+        perEnvironmentStartEndDuringDev: true,
+      },
+    }));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid Zudoku configuration at ${colors.dim(configPath)}.\n\n${detail}\n\nCheck the logs above for more details.`,
+      { cause: error },
+    );
+  }
+
+  if (!module.default) {
+    throw new Error(
+      `Invalid Zudoku configuration at ${colors.dim(configPath)}.\n\nConfig file must have a default export.`,
+    );
+  }
 
   const config = module.default;
 
@@ -209,14 +226,17 @@ export async function loadZudokuConfig(
 
     return { config, envPrefix, publicEnv };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
     if (config) {
-      // return the last valid config if it exists
+      // Log the error but return the last valid config
+      logger.error(
+        colors.red("Failed to reload config, using last valid config."),
+        { timestamp: true },
+      );
+      logger.error(error instanceof Error ? error.message : String(error));
       return { config, envPrefix, publicEnv };
     }
 
-    throw new Error(errorMessage, { cause: error });
+    throw error;
   } finally {
     await updateModifiedTimes();
   }

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -41,7 +41,7 @@ describe("validateConfig", () => {
 
     expect(() => validateConfig(configWithValidAuth0))
       .toThrowErrorMatchingInlineSnapshot(`
-      [Error: Whoops, looks like there's an issue with your config:
+      [Error: Invalid Zudoku configuration:
       ✖ Clerk public key invalid, must start with pk_test or pk_live
         → at authentication.clerkPubKey]
     `);
@@ -142,7 +142,7 @@ describe("validateConfig", () => {
       validateConfig(configWithInvalidAuth0Domain),
     ).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: Whoops, looks like there's an issue with your config:
+      [Error: Invalid Zudoku configuration:
       ✖ Domain must be a host only (e.g., 'example.com') without protocol or slashes
         → at authentication.domain]
     `,
@@ -164,7 +164,7 @@ describe("validateConfig", () => {
       validateConfig(configWithInvalidAuth0Domain),
     ).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: Whoops, looks like there's an issue with your config:
+      [Error: Invalid Zudoku configuration:
       ✖ Domain must be a host only (e.g., 'example.com') without protocol or slashes
         → at authentication.domain]
     `,

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -719,17 +719,20 @@ export function validateConfig(config: unknown, configPath?: string) {
   const validationResult = ZudokuConfig.safeParse(config);
 
   if (!validationResult.success) {
+    const prettyErrors = z.prettifyError(validationResult.error);
+    const location = configPath ? ` at ${configPath}` : "";
+
     // In production (build mode), throw an error to fail the build
     if (process.env.NODE_ENV === "production") {
       throw new Error(
-        `Whoops, looks like there's an issue with your ${configPath ?? "config"}:\n${z.prettifyError(validationResult.error)}`,
+        `Invalid Zudoku configuration${location}:\n${prettyErrors}`,
       );
     }
 
     // In development mode, log warnings but don't fail
     // biome-ignore lint/suspicious/noConsole: Logging allowed here
-    console.log(colors.yellow("Validation errors:"));
+    console.log(colors.yellow(`Invalid Zudoku configuration${location}:`));
     // biome-ignore lint/suspicious/noConsole: Logging allowed here
-    console.log(colors.yellow(z.prettifyError(validationResult.error)));
+    console.log(colors.yellow(prettyErrors));
   }
 }


### PR DESCRIPTION
When config loading fails (bad imports, syntax errors), show "Invalid Zudoku configuration at <path>" with the underlying error details instead of the misleading "no config file found" message. Also check for missing default export. When falling back to cached config in dev mode, log the error instead of silently swallowing it.

Closes #894
<!--
https://claude.ai/code/session_01SAP2ELSqQZ12BWKP2Z7Cik
-->