### PR TITLE
fix: update Claude MCP instructions from Integrations to Connectors

### DIFF
--- a/docs/pages/docs/guides/mcp-servers.md
+++ b/docs/pages/docs/guides/mcp-servers.md
@@ -174,7 +174,7 @@ When Zudoku detects the `x-mcp-server` extension on an operation, the page shows
 - **MCP Endpoint card** with the full URL and a copy button
 - **AI Tool Configuration** tabs with setup instructions for:
   - **Claude** — add via Connectors UI or `claude mcp add` CLI command
-  - **ChatGPT** — connector setup via Settings
+  - **ChatGPT** — app setup via Settings → Apps → Advanced Settings
   - **Cursor** — `mcp.json` configuration (global or project-level)
   - **VS Code** — `.vscode/mcp.json` with native HTTP transport for GitHub Copilot
   - **Generic** — standard `mcp.json` format compatible with most MCP clients

--- a/docs/pages/docs/guides/mcp-servers.md
+++ b/docs/pages/docs/guides/mcp-servers.md
@@ -173,7 +173,7 @@ When Zudoku detects the `x-mcp-server` extension on an operation, the page shows
 
 - **MCP Endpoint card** with the full URL and a copy button
 - **AI Tool Configuration** tabs with setup instructions for:
-  - **Claude** — add via Connectors UI or `claude_desktop_config.json` using `mcp-remote`
+  - **Claude** — add via Connectors UI or `claude mcp add` CLI command
   - **ChatGPT** — connector setup via Settings
   - **Cursor** — `mcp.json` configuration (global or project-level)
   - **VS Code** — `.vscode/mcp.json` with native HTTP transport for GitHub Copilot

--- a/docs/pages/docs/guides/mcp-servers.md
+++ b/docs/pages/docs/guides/mcp-servers.md
@@ -173,7 +173,7 @@ When Zudoku detects the `x-mcp-server` extension on an operation, the page shows
 
 - **MCP Endpoint card** with the full URL and a copy button
 - **AI Tool Configuration** tabs with setup instructions for:
-  - **Claude** — add via Integrations UI or `claude_desktop_config.json` using `mcp-remote`
+  - **Claude** — add via Connectors UI or `claude_desktop_config.json` using `mcp-remote`
   - **ChatGPT** — connector setup via Settings
   - **Cursor** — `mcp.json` configuration (global or project-level)
   - **VS Code** — `.vscode/mcp.json` with native HTTP transport for GitHub Copilot

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -28,14 +28,7 @@ export const MCPEndpoint = ({
       ? (summary ?? "mcp-server")
       : (data?.name ?? summary ?? "mcp-server");
 
-  const claudeConfig = `{
-  "mcpServers": {
-    "${name}": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "${mcpUrl}"]
-    }
-  }
-}`;
+  const claudeCodeCommand = `claude mcp add --transport http ${name} ${mcpUrl}`;
 
   const cursorConfig = `{
   "mcpServers": {
@@ -143,23 +136,15 @@ export const MCPEndpoint = ({
                   <li>Save and the server will appear in your conversations</li>
                 </ol>
                 <p className="text-xs text-muted-foreground mt-2">
-                  Alternatively, add to{" "}
-                  <InlineCode>claude_desktop_config.json</InlineCode> using{" "}
-                  <InlineCode>mcp-remote</InlineCode> (requires Node.js):
+                  Alternatively, add it to Claude Code CLI by running:
                 </p>
                 <SyntaxHighlight
                   showLanguageIndicator
-                  title="claude_desktop_config.json"
-                  language="json"
-                  code={claudeConfig}
+                  title="Terminal"
+                  language="bash"
+                  code={claudeCodeCommand}
                   className="mt-2"
                 />
-                <p className="text-xs text-muted-foreground mt-2">
-                  macOS: ~/Library/Application
-                  Support/Claude/claude_desktop_config.json
-                  <br />
-                  Windows: %APPDATA%\Claude\claude_desktop_config.json
-                </p>
                 <a
                   href="https://modelcontextprotocol.io/quickstart/user"
                   target="_blank"

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -172,7 +172,9 @@ export const MCPEndpoint = ({
                     Enter the MCP server URL:
                     <InlineCode className="ml-2">{chatgptConfig}</InlineCode>
                   </li>
-                  <li>Save and the app will be available in your conversations</li>
+                  <li>
+                    Save and the app will be available in your conversations
+                  </li>
                 </ol>
 
                 <a

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -28,7 +28,7 @@ export const MCPEndpoint = ({
       ? (summary ?? "mcp-server")
       : (data?.name ?? summary ?? "mcp-server");
 
-  const claudeCodeCommand = `claude mcp add --transport http ${name} ${mcpUrl}`;
+  const claudeCodeCommand = `claude mcp add --transport http '${name}' '${mcpUrl}'`;
 
   const cursorConfig = `{
   "mcpServers": {

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -162,22 +162,21 @@ export const MCPEndpoint = ({
                 </Callout>
                 <ol>
                   <li>
-                    Go to <strong>Settings</strong> →{" "}
-                    <strong>Apps & Connectors</strong>
+                    Go to <strong>Settings</strong> → <strong>Apps</strong> →{" "}
+                    <strong>Advanced Settings</strong>
                   </li>
                   <li>
-                    Click <strong>Add connector</strong> and enter your MCP URL:
+                    Click <strong>Create app</strong> and fill out the form
+                  </li>
+                  <li>
+                    Enter the MCP server URL:
                     <InlineCode className="ml-2">{chatgptConfig}</InlineCode>
                   </li>
-                  <li>Provide a name and description for your connector</li>
-                  <li>
-                    Save and enable the connector. Users must authenticate with
-                    the connector before first use.
-                  </li>
+                  <li>Save and the app will be available in your conversations</li>
                 </ol>
 
                 <a
-                  href="https://help.openai.com/en/articles/11487775-connectors-in-chatgpt"
+                  href="https://developers.openai.com/apps-sdk/deploy/connect-chatgpt#create-a-connector"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1 text-sm text-primary hover:underline"

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -191,7 +191,11 @@ export const MCPEndpoint = ({
               <TabsContent value="cursor" className="space-y-3">
                 <ol>
                   <li>
-                    <span>Create or edit: </span>
+                    <span>
+                      Go to <strong>Settings</strong> →{" "}
+                      <strong>Tools & MCPs</strong> →{" "}
+                      <strong>New MCP Server</strong>, or edit:{" "}
+                    </span>
                     <InlineCode>~/.cursor/mcp.json</InlineCode>
                     <span> (global) or </span>
                     <InlineCode>.cursor/mcp.json</InlineCode>

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -137,7 +137,7 @@ export const MCPEndpoint = ({
                     <strong>Settings</strong>
                   </li>
                   <li>
-                    Go to <strong>Integrations</strong> →{" "}
+                    Go to <strong>Connectors</strong> →{" "}
                     <strong>Add custom connector</strong> and paste the MCP URL
                   </li>
                   <li>Save and the server will appear in your conversations</li>


### PR DESCRIPTION
The Claude Desktop UI renamed "Integrations" to "Connectors". Updated the MCPEndpoint component and docs to match.

<!--
https://claude.ai/code/session_01AUZuLhrWuGgky4u5iFvTZM
-->