### PR TITLE
Fix header CLS during auth hydration

### DIFF
--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from "@zudoku/react-helmet-async";
 import { LogOutIcon } from "lucide-react";
 import { memo } from "react";
 import { Link } from "react-router";
@@ -167,6 +168,10 @@ export const Header = memo(function HeaderInner() {
               <div className="flex items-center gap-3.5">
                 {site?.logo ? (
                   <>
+                    <Helmet>
+                      <link rel="preload" as="image" href={logoLightSrc} />
+                      <link rel="preload" as="image" href={logoDarkSrc} />
+                    </Helmet>
                     <img
                       src={logoLightSrc}
                       alt={site.logo.alt ?? site.title}

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -1,5 +1,5 @@
 import { LogOutIcon } from "lucide-react";
-import { lazy, memo, Suspense } from "react";
+import { memo } from "react";
 import { Link } from "react-router";
 import { Button } from "zudoku/ui/Button.js";
 import { Skeleton } from "zudoku/ui/Skeleton.js";
@@ -22,24 +22,13 @@ import { joinUrl } from "../util/joinUrl.js";
 import { Banner } from "./Banner.js";
 import { ClientOnly } from "./ClientOnly.js";
 import { useZudoku } from "./context/ZudokuContext.js";
+import { HeaderNavigation } from "./HeaderNavigation.js";
 import { MobileTopNavigation } from "./MobileTopNavigation.js";
 import { PageProgress } from "./PageProgress.js";
 import { Search } from "./Search.js";
 import { Slot } from "./Slot.js";
 import { ThemeSwitch } from "./ThemeSwitch.js";
 import { TopNavigation } from "./TopNavigation.js";
-
-const HeaderNavigation = lazy(() =>
-  import("./HeaderNavigation.js").then((m) => ({
-    default: m.HeaderNavigation,
-  })),
-);
-
-const SuspendedHeaderNavigation = () => (
-  <Suspense>
-    <HeaderNavigation />
-  </Suspense>
-);
 
 const RecursiveMenu = ({ item }: { item: ProfileNavigationItem }) => {
   return item.children ? (
@@ -209,7 +198,7 @@ export const Header = memo(function HeaderInner() {
             )}
             {navPosition === "start" && (
               <div className="hidden lg:block min-w-0">
-                <SuspendedHeaderNavigation />
+                <HeaderNavigation />
               </div>
             )}
           </div>
@@ -222,7 +211,7 @@ export const Header = memo(function HeaderInner() {
             />
             {navPosition === "center" && (
               <div className="hidden lg:block min-w-0">
-                <SuspendedHeaderNavigation />
+                <HeaderNavigation />
               </div>
             )}
             {authPosition === "center" && (
@@ -237,7 +226,7 @@ export const Header = memo(function HeaderInner() {
             <div className="hidden lg:flex items-center text-sm gap-2">
               {navPosition === "end" && (
                 <div className="min-w-0">
-                  <SuspendedHeaderNavigation />
+                  <HeaderNavigation />
                 </div>
               )}
               {authPosition === "end" && <ProfileMenu />}

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -172,14 +172,12 @@ export const Header = memo(function HeaderInner() {
                       alt={site.logo.alt ?? site.title}
                       style={{ width: site.logo.width }}
                       className="max-h-(--top-header-height) dark:hidden"
-                      loading="lazy"
                     />
                     <img
                       src={logoDarkSrc}
                       alt={site.logo.alt ?? site.title}
                       style={{ width: site.logo.width }}
                       className="max-h-(--top-header-height) hidden dark:block"
-                      loading="lazy"
                     />
                   </>
                 ) : (

--- a/packages/zudoku/src/lib/components/Layout.tsx
+++ b/packages/zudoku/src/lib/components/Layout.tsx
@@ -31,9 +31,7 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
   return (
     <TooltipProvider>
       <Slot.Target name="layout-before-head" />
-      <Suspense>
-        <Header />
-      </Suspense>
+      <Header />
       <Slot.Target name="layout-after-head" />
 
       <div

--- a/packages/zudoku/src/lib/components/TopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/TopNavigation.tsx
@@ -1,6 +1,5 @@
 import { cx } from "class-variance-authority";
 import { deepEqual } from "fast-equals";
-import { Suspense } from "react";
 import { NavLink, type NavLinkProps } from "react-router";
 import { Separator } from "zudoku/ui/Separator.js";
 import type { NavigationItem } from "../../config/validators/NavigationSchema.js";
@@ -22,27 +21,24 @@ export const TopNavigation = () => {
   }
 
   return (
-    <Suspense>
-      <div className="items-center justify-between px-8 h-(--top-nav-height) hidden lg:flex text-sm relative">
-        <nav className="text-sm">
-          <ul className="flex flex-row items-center gap-8">
-            {filteredItems.map((item) =>
-              item.type === "separator" ? (
-                <li key={item.label} className="-mx-4 h-7">
-                  <Separator orientation="vertical" />
-                </li>
-              ) : item.type !== "section" && item.type !== "filter" ? (
-                <li key={item.label + item.type}>
-                  <TopNavItem {...item} />
-                </li>
-              ) : null,
-            )}
-          </ul>
-        </nav>
-        <Slot.Target name="top-navigation-side" />
-      </div>
-      {/* <PageProgress /> */}
-    </Suspense>
+    <div className="items-center justify-between px-8 h-(--top-nav-height) hidden lg:flex text-sm relative">
+      <nav className="text-sm">
+        <ul className="flex flex-row items-center gap-8">
+          {filteredItems.map((item) =>
+            item.type === "separator" ? (
+              <li key={item.label} className="-mx-4 h-7">
+                <Separator orientation="vertical" />
+              </li>
+            ) : item.type !== "section" && item.type !== "filter" ? (
+              <li key={item.label + item.type}>
+                <TopNavItem {...item} />
+              </li>
+            ) : null,
+          )}
+        </ul>
+      </nav>
+      <Slot.Target name="top-navigation-side" />
+    </div>
   );
 };
 

--- a/packages/zudoku/src/lib/testing/index.tsx
+++ b/packages/zudoku/src/lib/testing/index.tsx
@@ -4,6 +4,7 @@ import {
   type QueryKey,
 } from "@tanstack/react-query";
 import { HelmetProvider } from "@zudoku/react-helmet-async";
+import { Suspense } from "react";
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
 import { createRedirectRoutes } from "../../app/utils/createRedirectRoutes.js";
 import type { ZudokuRedirect } from "../../config/validators/ZudokuConfig.js";
@@ -39,7 +40,11 @@ const getRoutesByOptions = (options: ZudokuContextOptions) => {
 };
 
 const wrapWithLayout = (route: RouteObject) => ({
-  element: <Layout />,
+  element: (
+    <Suspense>
+      <Layout />
+    </Suspense>
+  ),
   children: [route],
 });
 


### PR DESCRIPTION
## Summary
- Remove `<Suspense>` with no fallback wrapping `<Header />` in Layout — this caused the entire header to vanish when any child re-rendered during hydration
- Replace lazy-loaded `HeaderNavigation` with direct import since it's above-the-fold content
- Remove bare `<Suspense>` wrapper in `TopNavigation`

The three empty-fallback Suspense boundaries were cascading during auth hydration: any state change triggered them all to render null simultaneously, causing the full header to disappear and reappear.