### PR TITLE
fix: security scheme tooltip styling and duplicated title

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/SecurityRequirements.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SecurityRequirements.tsx
@@ -2,11 +2,10 @@ import { KeyRoundIcon, LockIcon, ShieldCheckIcon } from "lucide-react";
 import { type ReactNode, Suspense, lazy } from "react";
 import { Badge } from "zudoku/ui/Badge.js";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "zudoku/ui/Tooltip.js";
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "zudoku/ui/HoverCard.js";
 import type {
   SecuritySchemeIn,
   SecuritySchemeType,
@@ -63,7 +62,7 @@ const schemeLabel = (scheme: SecurityScheme): string => {
   }
 };
 
-const SchemeTooltipContent = ({
+const SchemeHoverContent = ({
   scheme,
   scopes,
 }: {
@@ -73,7 +72,7 @@ const SchemeTooltipContent = ({
   if (!scheme.description && scopes.length === 0) return null;
 
   return (
-    <div className="flex flex-col gap-1 max-w-xs">
+    <div className="flex flex-col gap-2">
       {scheme.description && (
         <Suspense
           fallback={<div className="text-xs">{scheme.description}</div>}
@@ -85,7 +84,7 @@ const SchemeTooltipContent = ({
         </Suspense>
       )}
       {scopes.length > 0 && (
-        <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col gap-1">
           <span className="text-xs text-muted-foreground">
             Required scopes:
           </span>
@@ -118,61 +117,57 @@ export const SecurityRequirements = ({
   if (requirements.length === 0) return null;
 
   return (
-    <TooltipProvider delayDuration={150}>
-      <div className="flex items-center gap-1.5 flex-wrap">
-        {requirements.map((req, reqIdx) => {
-          const reqKey = `${reqIdx}-${req.schemes.map((s) => s.scheme.name).join("+")}`;
-          return (
-            <div key={reqKey} className="contents">
-              {reqIdx > 0 && (
-                <span className="text-[10px] text-muted-foreground font-medium uppercase">
-                  or
-                </span>
-              )}
-              {req.schemes.map((reqScheme, schemeIdx) => {
-                const hasTooltip =
-                  !!reqScheme.scheme.description || reqScheme.scopes.length > 0;
-                const badge = (
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] gap-1 py-0 h-5 font-normal cursor-default"
-                  >
-                    {schemeIcon[reqScheme.scheme.type]}
-                    {schemeLabel(reqScheme.scheme)}
-                  </Badge>
-                );
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {requirements.map((req, reqIdx) => {
+        const reqKey = `${reqIdx}-${req.schemes.map((s) => s.scheme.name).join("+")}`;
+        return (
+          <div key={reqKey} className="contents">
+            {reqIdx > 0 && (
+              <span className="text-[10px] text-muted-foreground font-medium uppercase">
+                or
+              </span>
+            )}
+            {req.schemes.map((reqScheme, schemeIdx) => {
+              const hasHoverContent =
+                !!reqScheme.scheme.description || reqScheme.scopes.length > 0;
+              const badge = (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] gap-1 py-0 h-5 font-normal cursor-default"
+                >
+                  {schemeIcon[reqScheme.scheme.type]}
+                  {schemeLabel(reqScheme.scheme)}
+                </Badge>
+              );
 
-                return (
-                  <div key={reqScheme.scheme.name} className="contents">
-                    {schemeIdx > 0 && (
-                      <span className="text-[10px] text-muted-foreground">
-                        +
-                      </span>
-                    )}
-                    {hasTooltip ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>{badge}</TooltipTrigger>
-                        <TooltipContent
-                          side="bottom"
-                          align="start"
-                          className="bg-popover text-popover-foreground border shadow-md [&>svg]:!hidden"
-                        >
-                          <SchemeTooltipContent
-                            scheme={reqScheme.scheme}
-                            scopes={reqScheme.scopes}
-                          />
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : (
-                      badge
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          );
-        })}
-      </div>
-    </TooltipProvider>
+              return (
+                <div key={reqScheme.scheme.name} className="contents">
+                  {schemeIdx > 0 && (
+                    <span className="text-[10px] text-muted-foreground">+</span>
+                  )}
+                  {hasHoverContent ? (
+                    <HoverCard openDelay={150} closeDelay={100}>
+                      <HoverCardTrigger asChild>{badge}</HoverCardTrigger>
+                      <HoverCardContent
+                        side="bottom"
+                        align="start"
+                        className="w-auto max-w-xs p-3"
+                      >
+                        <SchemeHoverContent
+                          scheme={reqScheme.scheme}
+                          scopes={reqScheme.scopes}
+                        />
+                      </HoverCardContent>
+                    </HoverCard>
+                  ) : (
+                    badge
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
   );
 };

--- a/packages/zudoku/src/lib/plugins/openapi/SecurityRequirements.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SecurityRequirements.tsx
@@ -155,7 +155,7 @@ export const SecurityRequirements = ({
                         <TooltipContent
                           side="bottom"
                           align="start"
-                          className="bg-popover text-popover-foreground border shadow-md [&>svg]:!fill-popover [&>svg]:!bg-popover"
+                          className="bg-popover text-popover-foreground border shadow-md [&>svg]:!hidden"
                         >
                           <SchemeTooltipContent
                             scheme={reqScheme.scheme}

--- a/packages/zudoku/src/lib/plugins/openapi/SecurityRequirements.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SecurityRequirements.tsx
@@ -69,35 +69,42 @@ const SchemeTooltipContent = ({
 }: {
   scheme: SecurityScheme;
   scopes: string[];
-}) => (
-  <div className="flex flex-col gap-1 max-w-xs">
-    <div className="text-xs capitalize">{schemeLabel(scheme)}</div>
-    {scheme.description && (
-      <Suspense fallback={<div className="text-xs">{scheme.description}</div>}>
-        <Markdown
-          content={scheme.description}
-          className="prose-xs text-xs max-w-full"
-        />
-      </Suspense>
-    )}
-    {scopes.length > 0 && (
-      <div className="flex flex-col gap-0.5">
-        <span className="text-xs text-muted-foreground">Required scopes:</span>
-        <div className="flex flex-wrap gap-1">
-          {scopes.map((scope) => (
-            <Badge
-              key={scope}
-              variant="muted"
-              className="text-[10px] px-1 py-0 h-auto font-mono"
-            >
-              {scope}
-            </Badge>
-          ))}
+}) => {
+  if (!scheme.description && scopes.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1 max-w-xs">
+      {scheme.description && (
+        <Suspense
+          fallback={<div className="text-xs">{scheme.description}</div>}
+        >
+          <Markdown
+            content={scheme.description}
+            className="prose-xs text-xs max-w-full"
+          />
+        </Suspense>
+      )}
+      {scopes.length > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">
+            Required scopes:
+          </span>
+          <div className="flex flex-wrap gap-1">
+            {scopes.map((scope) => (
+              <Badge
+                key={scope}
+                variant="muted"
+                className="text-[10px] px-1 py-0 h-auto font-mono"
+              >
+                {scope}
+              </Badge>
+            ))}
+          </div>
         </div>
-      </div>
-    )}
-  </div>
-);
+      )}
+    </div>
+  );
+};
 
 export const SecurityRequirements = ({
   security,
@@ -122,30 +129,46 @@ export const SecurityRequirements = ({
                   or
                 </span>
               )}
-              {req.schemes.map((reqScheme, schemeIdx) => (
-                <div key={reqScheme.scheme.name} className="contents">
-                  {schemeIdx > 0 && (
-                    <span className="text-[10px] text-muted-foreground">+</span>
-                  )}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Badge
-                        variant="outline"
-                        className="text-[10px] gap-1 py-0 h-5 font-normal cursor-default"
-                      >
-                        {schemeIcon[reqScheme.scheme.type]}
-                        {schemeLabel(reqScheme.scheme)}
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" align="start">
-                      <SchemeTooltipContent
-                        scheme={reqScheme.scheme}
-                        scopes={reqScheme.scopes}
-                      />
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              ))}
+              {req.schemes.map((reqScheme, schemeIdx) => {
+                const hasTooltip =
+                  !!reqScheme.scheme.description || reqScheme.scopes.length > 0;
+                const badge = (
+                  <Badge
+                    variant="outline"
+                    className="text-[10px] gap-1 py-0 h-5 font-normal cursor-default"
+                  >
+                    {schemeIcon[reqScheme.scheme.type]}
+                    {schemeLabel(reqScheme.scheme)}
+                  </Badge>
+                );
+
+                return (
+                  <div key={reqScheme.scheme.name} className="contents">
+                    {schemeIdx > 0 && (
+                      <span className="text-[10px] text-muted-foreground">
+                        +
+                      </span>
+                    )}
+                    {hasTooltip ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>{badge}</TooltipTrigger>
+                        <TooltipContent
+                          side="bottom"
+                          align="start"
+                          className="bg-popover text-popover-foreground border shadow-md [&>svg]:!fill-popover [&>svg]:!bg-popover"
+                        >
+                          <SchemeTooltipContent
+                            scheme={reqScheme.scheme}
+                            scopes={reqScheme.scopes}
+                          />
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      badge
+                    )}
+                  </div>
+                );
+              })}
             </div>
           );
         })}

--- a/packages/zudoku/src/lib/ui/HoverCard.tsx
+++ b/packages/zudoku/src/lib/ui/HoverCard.tsx
@@ -1,26 +1,40 @@
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "../util/cn.js";
 
-const HoverCard = HoverCardPrimitive.Root;
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
 
-const HoverCardTrigger = HoverCardPrimitive.Trigger;
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  );
+}
 
-const HoverCardContent = React.forwardRef<
-  React.ElementRef<typeof HoverCardPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
-));
-HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
-
-export { HoverCard, HoverCardContent, HoverCardTrigger };
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  );
+}
+export { HoverCard, HoverCardTrigger, HoverCardContent };


### PR DESCRIPTION
Tooltip used inverted colors (bg-foreground) which clashed with inner components using normal theme colors (text-muted-foreground, Badge variant="muted"). Switch to popover-style colors for proper contrast in both light and dark mode.

Remove duplicated scheme label from tooltip content since badge already displays it. Only show tooltip when description or scopes exist.

Closes #2314
<!--
https://claude.ai/code/session_01CsLSjFA5NYTvbASjuWKTaK
-->