### PR TITLE
claude/fix-markdown-preview-tag-DusuU

### DIFF
--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -62,6 +62,7 @@ export const MdxPage = ({
   basePath,
   frontmatter = {},
   defaultOptions,
+  publishMarkdown,
   __filepath,
   tableOfContents,
   excerpt,
@@ -70,6 +71,7 @@ export const MdxPage = ({
     basePath: string;
     mdxComponent: MDXImport["default"];
     defaultOptions?: MarkdownPluginDefaultOptions;
+    publishMarkdown?: boolean;
   }
 >) => {
   const categoryTitle = useCurrentItem()?.categoryLabel;
@@ -154,6 +156,9 @@ export const MdxPage = ({
       <Helmet>
         <title>{pageTitle}</title>
         {description && <meta name="description" content={description} />}
+        {publishMarkdown && (
+          <link rel="alternate" type="text/markdown" href={markdownUrl} />
+        )}
       </Helmet>
 
       <Typography className="max-w-full xl:w-full xl:max-w-3xl flex-1 shrink pt-(--padding-content-top)">

--- a/packages/zudoku/src/lib/plugins/markdown/index.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/index.tsx
@@ -52,6 +52,7 @@ export const markdownPlugin = (
                 mdxComponent={Component}
                 {...props}
                 defaultOptions={options.defaultOptions}
+                publishMarkdown={options.publishMarkdown}
               />
             ),
           };

--- a/packages/zudoku/src/vite/plugin-docs.ts
+++ b/packages/zudoku/src/vite/plugin-docs.ts
@@ -189,6 +189,7 @@ const viteDocsPlugin = (): Plugin => {
         `  basePath: "${config.basePath ?? ""}",`,
         `  fileImports,`,
         `  defaultOptions: ${JSON.stringify(docsConfig.defaultOptions)},`,
+        `  publishMarkdown: ${JSON.stringify(docsConfig.publishMarkdown)},`,
         `});`,
       );
 


### PR DESCRIPTION
Adds a `<link rel="alternate" type="text/markdown">` tag to the HTML
head on markdown pages when `publishMarkdown` is configured. This helps
LLMs discover the raw markdown version of documentation pages.

Closes #2322

https://claude.ai/code/session_01K242HE1DrV5Tw8PHUGwQy2