### PR TITLE
feat: MCP server security schemes and app-aware configuration UI

### DIFF
--- a/examples/cosmo-cargo/schema/ai-cargo.json
+++ b/examples/cosmo-cargo/schema/ai-cargo.json
@@ -283,7 +283,19 @@
         "operationId": "mcpUniversal",
         "x-mcp-server": {
           "name": "Cosmo Cargo AI",
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "security": [
+            {
+              "ApiKeyAuth": []
+            }
+          ],
+          "securitySchemes": {
+            "ApiKeyAuth": {
+              "type": "apiKey",
+              "in": "header",
+              "name": "X-API-Key"
+            }
+          }
         },
         "requestBody": {
           "required": true,

--- a/examples/cosmo-cargo/schema/docs.json
+++ b/examples/cosmo-cargo/schema/docs.json
@@ -1,0 +1,252 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Cosmo Cargo Documentation API",
+    "description": "Public documentation endpoints for the Cosmo Cargo platform. Provides searchable access to shipping guides, regulatory information, and interstellar logistics knowledge base.\n\n## MCP Integration\nThis API includes an MCP endpoint that allows AI tools to search and retrieve Cosmo Cargo documentation for context-aware assistance.\n",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Cosmo Cargo Docs",
+      "email": "docs@cosmocargo.space",
+      "url": "https://docs.cosmocargo.space"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://docs.cosmocargo.space/api/v1",
+      "description": "Documentation API"
+    }
+  ],
+  "paths": {
+    "/mcp": {
+      "post": {
+        "tags": ["Documentation"],
+        "summary": "Documentation MCP Server",
+        "description": "MCP endpoint for AI tools to search and retrieve Cosmo Cargo documentation. No authentication required — all documentation is publicly available.",
+        "operationId": "mcpDocs",
+        "x-mcp-server": {
+          "name": "Cosmo Cargo Docs",
+          "version": "1.0.0"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["action"],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "search_docs",
+                      "get_article",
+                      "list_categories",
+                      "get_shipping_guide"
+                    ],
+                    "description": "The documentation action to perform"
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Action-specific parameters"
+                  }
+                }
+              },
+              "example": {
+                "action": "search_docs",
+                "parameters": {
+                  "query": "hazardous materials shipping requirements",
+                  "limit": 5
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Documentation response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocsResponse"
+                },
+                "example": {
+                  "results": [
+                    {
+                      "title": "Hazardous Materials Shipping Guide",
+                      "slug": "hazmat-shipping-guide",
+                      "excerpt": "Regulations and procedures for shipping hazardous materials across interstellar routes...",
+                      "category": "Compliance"
+                    }
+                  ],
+                  "totalResults": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search": {
+      "get": {
+        "tags": ["Documentation"],
+        "summary": "Search documentation",
+        "description": "Full-text search across all Cosmo Cargo documentation including shipping guides, regulatory information, and FAQ.",
+        "operationId": "searchDocs",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search query"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Shipping Guides",
+                "Compliance",
+                "FAQ",
+                "Route Information",
+                "Vessel Specifications"
+              ]
+            },
+            "description": "Filter by documentation category"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 50
+            },
+            "description": "Maximum results to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/articles/{slug}": {
+      "get": {
+        "tags": ["Documentation"],
+        "summary": "Get article by slug",
+        "description": "Retrieve a specific documentation article by its URL slug.",
+        "operationId": "getArticle",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Article URL slug",
+            "example": "hazmat-shipping-guide"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Article content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Article"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Article not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DocsResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            }
+          },
+          "totalResults": {
+            "type": "integer"
+          }
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "excerpt": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          }
+        }
+      },
+      "Article": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "description": "Article content in Markdown format"
+          },
+          "category": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "relatedArticles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Slugs of related articles"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Documentation",
+      "description": "Public documentation search and retrieval endpoints"
+    }
+  ]
+}

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -459,6 +459,17 @@ const config: ZudokuConfig = {
     },
     {
       type: "file",
+      input: "./schema/docs.json",
+      path: "/catalog/api-docs",
+      categories: [
+        {
+          label: "Documentation",
+          tags: ["Documentation"],
+        },
+      ],
+    },
+    {
+      type: "file",
       input: "./schema/cargo-containers.json",
       path: "/catalog/api-cargo-containers",
       categories: [{ label: "General", tags: ["Containers", "Booking"] }],

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -52,44 +52,6 @@ export const MCPEndpoint = ({
     <Card className="p-6 mb-6 max-w-screen-md">
       <div className="space-y-4">
         <div>
-          <h3 className="text-lg font-semibold mb-2">MCP Endpoint</h3>
-          <p className="text-sm text-muted-foreground mb-3">
-            Copy the url to connect any{" "}
-            <a
-              href="https://modelcontextprotocol.io/"
-              target="_blank"
-              rel="noopener"
-              className="text-primary hover:underline"
-            >
-              MCP
-            </a>
-            -compatible app
-          </p>
-
-          <div
-            className={cn(
-              "relative flex items-center gap-2 p-3 rounded-md border border-primary/50",
-            )}
-          >
-            <InlineCode className="bg-primary/20 px-4 py-2 flex-1 border-none">
-              {mcpUrl}
-            </InlineCode>
-            <Button
-              onClick={handleCopy}
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-            >
-              {isCopied ? (
-                <CheckIcon className="h-4 w-4 text-green-600" />
-              ) : (
-                <CopyIcon className="h-4 w-4" />
-              )}
-            </Button>
-          </div>
-        </div>
-
-        <div>
           <h3 className="text-lg font-semibold mb-2">App Configuration</h3>
           <p className="text-sm text-muted-foreground mb-3">
             Choose your app and copy the configuration to get started.
@@ -268,6 +230,44 @@ export const MCPEndpoint = ({
               </TabsContent>
             </Typography>
           </Tabs>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold mb-2">MCP Endpoint</h3>
+          <p className="text-sm text-muted-foreground mb-3">
+            Copy the url to connect any{" "}
+            <a
+              href="https://modelcontextprotocol.io/"
+              target="_blank"
+              rel="noopener"
+              className="text-primary hover:underline"
+            >
+              MCP
+            </a>
+            -compatible app
+          </p>
+
+          <div
+            className={cn(
+              "relative flex items-center gap-2 p-3 rounded-md border border-primary/50",
+            )}
+          >
+            <InlineCode className="bg-primary/20 px-4 py-2 flex-1 border-none">
+              {mcpUrl}
+            </InlineCode>
+            <Button
+              onClick={handleCopy}
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+            >
+              {isCopied ? (
+                <CheckIcon className="h-4 w-4 text-green-600" />
+              ) : (
+                <CopyIcon className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
         </div>
       </div>
     </Card>

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -8,6 +8,16 @@ import { Card } from "../../ui/Card.js";
 import { SyntaxHighlight } from "../../ui/SyntaxHighlight.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/Tabs.js";
 import { cn } from "../../util/cn.js";
+import {
+  type McpServerData,
+  getAuthHeader,
+  getClaudeCodeCommand,
+  getCursorConfig,
+  getGenericConfig,
+  getMcpServerName,
+  getMcpUrl,
+  getVscodeConfig,
+} from "./mcp-configs.js";
 
 export const MCPEndpoint = ({
   serverUrl,
@@ -17,45 +27,19 @@ export const MCPEndpoint = ({
 }: {
   serverUrl?: string;
   operationPath?: string;
-  data?: boolean | Record<string, unknown>;
+  data?: McpServerData;
   summary?: string;
 }) => {
   const [isCopied, setIsCopied] = useState(false);
-  const mcpUrl = `${(serverUrl ?? "").replace(/\/+$/, "")}${operationPath ?? "/mcp"}`;
+  const mcpUrl = getMcpUrl(serverUrl, operationPath);
+  const name = getMcpServerName(data, summary);
+  const auth = getAuthHeader(data);
 
-  const name =
-    typeof data === "boolean"
-      ? (summary ?? "mcp-server")
-      : (data?.name ?? summary ?? "mcp-server");
-
-  const claudeCodeCommand = `claude mcp add --transport http '${name}' '${mcpUrl}'`;
-
-  const cursorConfig = `{
-  "mcpServers": {
-    "${name}": {
-      "url": "${mcpUrl}"
-    }
-  }
-}`;
-
+  const claudeCodeCommand = getClaudeCodeCommand(name, mcpUrl, auth);
+  const cursorConfig = getCursorConfig(name, mcpUrl, auth);
   const chatgptConfig = mcpUrl;
-
-  const genericConfig = `{
-  "mcpServers": {
-    "${name}": {
-      "url": "${mcpUrl}"
-    }
-  }
-}`;
-
-  const vscodeConfig = `{
-  "servers": {
-    "${name}": {
-      "type": "http",
-      "url": "${mcpUrl}"
-    }
-  }
-}`;
+  const genericConfig = getGenericConfig(name, mcpUrl, auth);
+  const vscodeConfig = getVscodeConfig(name, mcpUrl, auth);
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(mcpUrl).then(() => {

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -9,15 +9,38 @@ import { SyntaxHighlight } from "../../ui/SyntaxHighlight.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/Tabs.js";
 import { cn } from "../../util/cn.js";
 import {
+  type McpApp,
   type McpServerData,
   getAuthHeader,
+  getAuthType,
   getClaudeCodeCommand,
+  getCodexCliCommand,
+  getCodexConfig,
   getCursorConfig,
   getGenericConfig,
   getMcpServerName,
   getMcpUrl,
+  getVisibleApps,
   getVscodeConfig,
 } from "./mcp-configs.js";
+
+const SubAppSection = ({
+  label,
+  showLabel,
+  children,
+}: {
+  label: string;
+  showLabel: boolean;
+  children: React.ReactNode;
+}) =>
+  showLabel ? (
+    <div className="space-y-3">
+      <h4 className="text-sm font-semibold">{label}</h4>
+      {children}
+    </div>
+  ) : (
+    <div className="space-y-3">{children}</div>
+  );
 
 export const MCPEndpoint = ({
   serverUrl,
@@ -34,18 +57,267 @@ export const MCPEndpoint = ({
   const mcpUrl = getMcpUrl(serverUrl, operationPath);
   const name = getMcpServerName(data, summary);
   const auth = getAuthHeader(data);
+  const authType = getAuthType(data);
+  const visibleApps = getVisibleApps(authType);
 
   const claudeCodeCommand = getClaudeCodeCommand(name, mcpUrl, auth);
+  const codexCliCommand = getCodexCliCommand(name, mcpUrl, auth);
   const cursorConfig = getCursorConfig(name, mcpUrl, auth);
-  const chatgptConfig = mcpUrl;
+  const codexConfig = getCodexConfig(name, mcpUrl, auth);
   const genericConfig = getGenericConfig(name, mcpUrl, auth);
   const vscodeConfig = getVscodeConfig(name, mcpUrl, auth);
+
+  const defaultTab = visibleApps[0]?.id ?? "generic";
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(mcpUrl).then(() => {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000);
     });
+  };
+
+  const hasSubApp = (app: McpApp, subAppId: string) =>
+    app.subApps.some((s) => s.id === subAppId);
+
+  const renderAppContent = (app: McpApp) => {
+    const multiSub = app.subApps.length > 1;
+
+    switch (app.id) {
+      case "claude":
+        return (
+          <div className="space-y-4">
+            {hasSubApp(app, "claude-desktop") && (
+              <SubAppSection label="Claude Desktop" showLabel={multiSub}>
+                <ol>
+                  <li>
+                    Open Claude Desktop and navigate to{" "}
+                    <strong>Settings</strong>
+                  </li>
+                  <li>
+                    Go to <strong>Connectors</strong> →{" "}
+                    <strong>Add custom connector</strong> and paste the MCP URL
+                  </li>
+                  <li>Save and the server will appear in your conversations</li>
+                </ol>
+                <a
+                  href="https://modelcontextprotocol.io/quickstart/user"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  View official docs
+                  <ExternalLinkIcon className="h-3 w-3" />
+                </a>
+              </SubAppSection>
+            )}
+            {hasSubApp(app, "claude-code") && (
+              <SubAppSection label="Claude Code CLI" showLabel={multiSub}>
+                <p className="text-xs text-muted-foreground">
+                  Add it to Claude Code CLI by running:
+                </p>
+                <SyntaxHighlight
+                  showLanguageIndicator
+                  title="Terminal"
+                  language="bash"
+                  code={claudeCodeCommand}
+                  className="mt-2"
+                />
+              </SubAppSection>
+            )}
+          </div>
+        );
+
+      case "chatgpt":
+        return (
+          <>
+            <Callout type="note" title="Requirements">
+              ChatGPT Plus, Team, Enterprise, or Edu subscription.
+            </Callout>
+            <ol>
+              <li>
+                Go to <strong>Settings</strong> → <strong>Apps</strong> →{" "}
+                <strong>Advanced Settings</strong>
+              </li>
+              <li>
+                Click <strong>Create app</strong> and fill out the form
+              </li>
+              <li>
+                Enter the MCP server URL:
+                <InlineCode className="ml-2">{mcpUrl}</InlineCode>
+              </li>
+              <li>Save and the app will be available in your conversations</li>
+            </ol>
+            <a
+              href="https://developers.openai.com/apps-sdk/deploy/connect-chatgpt#create-a-connector"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              View official docs
+              <ExternalLinkIcon className="h-3 w-3" />
+            </a>
+          </>
+        );
+
+      case "codex":
+        return (
+          <div className="space-y-4">
+            {hasSubApp(app, "codex-gui") && (
+              <SubAppSection label="Codex" showLabel={multiSub}>
+                <ol>
+                  <li>
+                    Open Codex and go to <strong>Settings</strong> →{" "}
+                    <strong>MCP Servers</strong>
+                  </li>
+                  <li>Add a new server and paste the MCP URL</li>
+                  <li>
+                    Save and the server will be available in your sessions
+                  </li>
+                </ol>
+                <a
+                  href="https://openai.com/index/introducing-codex/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  View official docs
+                  <ExternalLinkIcon className="h-3 w-3" />
+                </a>
+              </SubAppSection>
+            )}
+            {hasSubApp(app, "codex-cli") && (
+              <SubAppSection label="Codex CLI" showLabel={multiSub}>
+                <p className="text-xs text-muted-foreground">
+                  Add it to Codex CLI by running:
+                </p>
+                <SyntaxHighlight
+                  showLanguageIndicator
+                  title="Terminal"
+                  language="bash"
+                  code={codexCliCommand}
+                  className="mt-2"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Or add to <InlineCode>~/.codex/config.json</InlineCode>:
+                </p>
+                <SyntaxHighlight
+                  showLanguageIndicator
+                  title="config.json"
+                  language="json"
+                  code={codexConfig}
+                  className="mt-2"
+                />
+              </SubAppSection>
+            )}
+          </div>
+        );
+
+      case "cursor":
+        return (
+          <>
+            <ol>
+              <li>
+                <span>
+                  Go to <strong>Settings</strong> →{" "}
+                  <strong>Tools & MCPs</strong> →{" "}
+                  <strong>New MCP Server</strong>, or edit:{" "}
+                </span>
+                <InlineCode>~/.cursor/mcp.json</InlineCode>
+                <span> (global) or </span>
+                <InlineCode>.cursor/mcp.json</InlineCode>
+                <span> (project)</span>
+                <SyntaxHighlight
+                  showLanguageIndicator
+                  title="mcp.json"
+                  language="json"
+                  code={cursorConfig}
+                  className="mt-2"
+                />
+              </li>
+              <li>Restart Cursor to apply the configuration</li>
+            </ol>
+            <a
+              href="https://cursor.com/docs/context/mcp"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              View official docs
+              <ExternalLinkIcon className="h-3 w-3" />
+            </a>
+          </>
+        );
+
+      case "vscode":
+        return (
+          <>
+            <Callout type="note" title="Requirements">
+              VS Code with GitHub Copilot extension
+            </Callout>
+            <ol>
+              <li>
+                <span>Create </span>
+                <InlineCode>.vscode/mcp.json</InlineCode>
+                <span> in your workspace (or user-level mcp.json):</span>
+                <SyntaxHighlight
+                  showLanguageIndicator
+                  title="mcp.json"
+                  language="json"
+                  code={vscodeConfig}
+                  className="mt-2"
+                />
+              </li>
+              <li>Restart VS Code to apply the configuration</li>
+              <li>
+                Use MCP tools in GitHub Copilot Chat by selecting Agent mode
+              </li>
+            </ol>
+            <a
+              href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              View official docs
+              <ExternalLinkIcon className="h-3 w-3" />
+            </a>
+          </>
+        );
+
+      case "generic":
+        return (
+          <>
+            <p>
+              Generic <InlineCode>.mcp.json</InlineCode> configuration format
+              that works with most MCP-compatible apps.
+            </p>
+            <SyntaxHighlight
+              showLanguageIndicator
+              title=".mcp.json"
+              language="json"
+              code={genericConfig}
+              className="mt-2"
+            />
+            <p className="text-sm text-muted-foreground">
+              Place this file in your project root or the appropriate
+              configuration directory for your app. The exact location depends
+              on your specific tool.
+            </p>
+            <a
+              href="https://modelcontextprotocol.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              Learn more about MCP
+              <ExternalLinkIcon className="h-3 w-3" />
+            </a>
+          </>
+        );
+
+      default:
+        return null;
+    }
   };
 
   return (
@@ -59,175 +331,26 @@ export const MCPEndpoint = ({
 
           <hr className="my-4" />
 
-          <Tabs defaultValue="claude" className="w-full">
-            <TabsList className="grid w-full grid-cols-5">
-              <TabsTrigger value="claude">Claude</TabsTrigger>
-              <TabsTrigger value="chatgpt">ChatGPT</TabsTrigger>
-              <TabsTrigger value="cursor">Cursor</TabsTrigger>
-              <TabsTrigger value="vscode">VS Code</TabsTrigger>
-              <TabsTrigger value="generic">Generic</TabsTrigger>
+          <Tabs defaultValue={defaultTab} className="w-full">
+            <TabsList
+              className="grid w-full"
+              style={{
+                gridTemplateColumns: `repeat(${visibleApps.length}, minmax(0, 1fr))`,
+              }}
+            >
+              {visibleApps.map((app) => (
+                <TabsTrigger key={app.id} value={app.id}>
+                  {app.label}
+                </TabsTrigger>
+              ))}
             </TabsList>
 
             <Typography className="text-sm max-w-full">
-              <TabsContent value="claude" className="space-y-3">
-                <ol>
-                  <li>
-                    Open Claude Desktop and navigate to{" "}
-                    <strong>Settings</strong>
-                  </li>
-                  <li>
-                    Go to <strong>Connectors</strong> →{" "}
-                    <strong>Add custom connector</strong> and paste the MCP URL
-                  </li>
-                  <li>Save and the server will appear in your conversations</li>
-                </ol>
-                <p className="text-xs text-muted-foreground mt-2">
-                  Alternatively, add it to Claude Code CLI by running:
-                </p>
-                <SyntaxHighlight
-                  showLanguageIndicator
-                  title="Terminal"
-                  language="bash"
-                  code={claudeCodeCommand}
-                  className="mt-2"
-                />
-                <a
-                  href="https://modelcontextprotocol.io/quickstart/user"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  View official docs
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              </TabsContent>
-
-              <TabsContent value="chatgpt" className="space-y-3">
-                <Callout type="note" title="Requirements">
-                  ChatGPT Plus, Team, Enterprise, or Edu subscription.
-                </Callout>
-                <ol>
-                  <li>
-                    Go to <strong>Settings</strong> → <strong>Apps</strong> →{" "}
-                    <strong>Advanced Settings</strong>
-                  </li>
-                  <li>
-                    Click <strong>Create app</strong> and fill out the form
-                  </li>
-                  <li>
-                    Enter the MCP server URL:
-                    <InlineCode className="ml-2">{chatgptConfig}</InlineCode>
-                  </li>
-                  <li>
-                    Save and the app will be available in your conversations
-                  </li>
-                </ol>
-
-                <a
-                  href="https://developers.openai.com/apps-sdk/deploy/connect-chatgpt#create-a-connector"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  View official docs
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              </TabsContent>
-
-              <TabsContent value="cursor" className="space-y-3">
-                <ol>
-                  <li>
-                    <span>
-                      Go to <strong>Settings</strong> →{" "}
-                      <strong>Tools & MCPs</strong> →{" "}
-                      <strong>New MCP Server</strong>, or edit:{" "}
-                    </span>
-                    <InlineCode>~/.cursor/mcp.json</InlineCode>
-                    <span> (global) or </span>
-                    <InlineCode>.cursor/mcp.json</InlineCode>
-                    <span> (project)</span>
-                    <SyntaxHighlight
-                      showLanguageIndicator
-                      title="mcp.json"
-                      language="json"
-                      code={cursorConfig}
-                      className="mt-2"
-                    />
-                  </li>
-                  <li>Restart Cursor to apply the configuration</li>
-                </ol>
-                <a
-                  href="https://cursor.com/docs/context/mcp"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  View official docs
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              </TabsContent>
-
-              <TabsContent value="vscode" className="space-y-3">
-                <Callout type="note" title="Requirements">
-                  VS Code with GitHub Copilot extension
-                </Callout>
-
-                <ol>
-                  <li>
-                    <span>Create </span>
-                    <InlineCode>.vscode/mcp.json</InlineCode>
-                    <span> in your workspace (or user-level mcp.json):</span>
-                    <SyntaxHighlight
-                      showLanguageIndicator
-                      title="mcp.json"
-                      language="json"
-                      code={vscodeConfig}
-                      className="mt-2"
-                    />
-                  </li>
-                  <li>Restart VS Code to apply the configuration</li>
-                  <li>
-                    Use MCP tools in GitHub Copilot Chat by selecting Agent mode
-                  </li>
-                </ol>
-                <a
-                  href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  View official docs
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              </TabsContent>
-
-              <TabsContent value="generic" className="space-y-3">
-                <p>
-                  Generic <InlineCode>.mcp.json</InlineCode> configuration
-                  format that works with most MCP-compatible apps.
-                </p>
-                <SyntaxHighlight
-                  showLanguageIndicator
-                  title=".mcp.json"
-                  language="json"
-                  code={genericConfig}
-                  className="mt-2"
-                />
-                <p className="text-sm text-muted-foreground">
-                  Place this file in your project root or the appropriate
-                  configuration directory for your app. The exact location
-                  depends on your specific tool.
-                </p>
-                <a
-                  href="https://modelcontextprotocol.io/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  Learn more about MCP
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              </TabsContent>
+              {visibleApps.map((app) => (
+                <TabsContent key={app.id} value={app.id} className="space-y-3">
+                  {renderAppContent(app)}
+                </TabsContent>
+              ))}
             </Typography>
           </Tabs>
         </div>

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -7,7 +7,6 @@ import { Callout } from "../../ui/Callout.js";
 import { Card } from "../../ui/Card.js";
 import { SyntaxHighlight } from "../../ui/SyntaxHighlight.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/Tabs.js";
-import { cn } from "../../util/cn.js";
 import {
   type McpApp,
   type McpServerData,
@@ -324,7 +323,22 @@ export const MCPEndpoint = ({
     <Card className="p-6 mb-6 max-w-screen-md">
       <div className="space-y-4">
         <div>
-          <h3 className="text-lg font-semibold mb-2">App Configuration</h3>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-lg font-semibold">App Configuration</h3>
+            <Button
+              onClick={handleCopy}
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+            >
+              {isCopied ? (
+                <CheckIcon className="h-3.5 w-3.5 text-green-600" />
+              ) : (
+                <CopyIcon className="h-3.5 w-3.5" />
+              )}
+              {isCopied ? "Copied!" : "Copy URL"}
+            </Button>
+          </div>
           <p className="text-sm text-muted-foreground mb-3">
             Choose your app and copy the configuration to get started.
           </p>
@@ -353,44 +367,6 @@ export const MCPEndpoint = ({
               ))}
             </Typography>
           </Tabs>
-        </div>
-
-        <div>
-          <h3 className="text-lg font-semibold mb-2">MCP Endpoint</h3>
-          <p className="text-sm text-muted-foreground mb-3">
-            Copy the url to connect any{" "}
-            <a
-              href="https://modelcontextprotocol.io/"
-              target="_blank"
-              rel="noopener"
-              className="text-primary hover:underline"
-            >
-              MCP
-            </a>
-            -compatible app
-          </p>
-
-          <div
-            className={cn(
-              "relative flex items-center gap-2 p-3 rounded-md border border-primary/50",
-            )}
-          >
-            <InlineCode className="bg-primary/20 px-4 py-2 flex-1 border-none">
-              {mcpUrl}
-            </InlineCode>
-            <Button
-              onClick={handleCopy}
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-            >
-              {isCopied ? (
-                <CheckIcon className="h-4 w-4 text-green-600" />
-              ) : (
-                <CopyIcon className="h-4 w-4" />
-              )}
-            </Button>
-          </div>
         </div>
       </div>
     </Card>

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -63,7 +63,7 @@ export const MCPEndpoint = ({
             >
               MCP
             </a>
-            -compatible AI tool
+            -compatible app
           </p>
 
           <div
@@ -90,9 +90,9 @@ export const MCPEndpoint = ({
         </div>
 
         <div>
-          <h3 className="text-lg font-semibold mb-2">AI Tool Configuration</h3>
+          <h3 className="text-lg font-semibold mb-2">App Configuration</h3>
           <p className="text-sm text-muted-foreground mb-3">
-            Choose your AI tool and copy the configuration to get started.
+            Choose your app and copy the configuration to get started.
           </p>
 
           <hr className="my-4" />
@@ -242,7 +242,7 @@ export const MCPEndpoint = ({
               <TabsContent value="generic" className="space-y-3">
                 <p>
                   Generic <InlineCode>.mcp.json</InlineCode> configuration
-                  format that works with most MCP-compatible AI tools.
+                  format that works with most MCP-compatible apps.
                 </p>
                 <SyntaxHighlight
                   showLanguageIndicator
@@ -253,7 +253,7 @@ export const MCPEndpoint = ({
                 />
                 <p className="text-sm text-muted-foreground">
                   Place this file in your project root or the appropriate
-                  configuration directory for your AI tool. The exact location
+                  configuration directory for your app. The exact location
                   depends on your specific tool.
                 </p>
                 <a

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
@@ -90,20 +90,23 @@ describe("getVisibleApps", () => {
     ]);
   });
 
-  it("hides chatgpt for apiKey auth", () => {
+  it("hides chatgpt and claude-desktop for apiKey auth", () => {
     const apps = getVisibleApps("apiKey");
     const ids = apps.map((a) => a.id);
     expect(ids).not.toContain("chatgpt");
     expect(ids).toContain("claude");
     expect(ids).toContain("codex");
-  });
 
-  it("filters claude-desktop for oauth auth", () => {
-    const apps = getVisibleApps("oauth");
     const claude = apps.find((a) => a.id === "claude");
     const subIds = claude?.subApps.map((s) => s.id);
     expect(subIds).toEqual(["claude-code"]);
-    expect(subIds).not.toContain("claude-desktop");
+  });
+
+  it("shows claude-desktop and claude-code for oauth auth", () => {
+    const apps = getVisibleApps("oauth");
+    const claude = apps.find((a) => a.id === "claude");
+    const subIds = claude?.subApps.map((s) => s.id);
+    expect(subIds).toEqual(["claude-desktop", "claude-code"]);
   });
 
   it("shows chatgpt for oauth auth", () => {

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   type AuthHeader,
   getAuthHeader,
+  getAuthType,
   getClaudeCodeCommand,
+  getCodexCliCommand,
+  getCodexConfig,
   getCursorConfig,
   getGenericConfig,
   getMcpServerName,
   getMcpUrl,
+  getVisibleApps,
   getVscodeConfig,
 } from "./mcp-configs.js";
 
@@ -23,6 +27,103 @@ const apiKeyAuth: AuthHeader = {
   headerName: "X-API-Key",
   placeholder: "YOUR_API_KEY",
 };
+
+describe("getAuthType", () => {
+  it("returns none for boolean data", () => {
+    expect(getAuthType(true)).toBe("none");
+  });
+
+  it("returns none when no security", () => {
+    expect(getAuthType({ name: "test" })).toBe("none");
+  });
+
+  it("returns apiKey for http/bearer scheme", () => {
+    expect(
+      getAuthType({
+        security: [{ api_key: [] }],
+        securitySchemes: { api_key: { type: "http", scheme: "bearer" } },
+      }),
+    ).toBe("apiKey");
+  });
+
+  it("returns apiKey for apiKey scheme", () => {
+    expect(
+      getAuthType({
+        security: [{ key: [] }],
+        securitySchemes: {
+          key: { type: "apiKey", in: "header", name: "X-API-Key" },
+        },
+      }),
+    ).toBe("apiKey");
+  });
+
+  it("returns oauth for oauth2 scheme", () => {
+    expect(
+      getAuthType({
+        security: [{ oauth: [] }],
+        securitySchemes: { oauth: { type: "oauth2" } },
+      }),
+    ).toBe("oauth");
+  });
+
+  it("returns oauth for openIdConnect scheme", () => {
+    expect(
+      getAuthType({
+        security: [{ oidc: [] }],
+        securitySchemes: { oidc: { type: "openIdConnect" } },
+      }),
+    ).toBe("oauth");
+  });
+});
+
+describe("getVisibleApps", () => {
+  it("shows all apps for none auth", () => {
+    const apps = getVisibleApps("none");
+    const ids = apps.map((a) => a.id);
+    expect(ids).toEqual([
+      "claude",
+      "chatgpt",
+      "codex",
+      "cursor",
+      "vscode",
+      "generic",
+    ]);
+  });
+
+  it("hides chatgpt for apiKey auth", () => {
+    const apps = getVisibleApps("apiKey");
+    const ids = apps.map((a) => a.id);
+    expect(ids).not.toContain("chatgpt");
+    expect(ids).toContain("claude");
+    expect(ids).toContain("codex");
+  });
+
+  it("filters claude-desktop for oauth auth", () => {
+    const apps = getVisibleApps("oauth");
+    const claude = apps.find((a) => a.id === "claude");
+    const subIds = claude?.subApps.map((s) => s.id);
+    expect(subIds).toEqual(["claude-code"]);
+    expect(subIds).not.toContain("claude-desktop");
+  });
+
+  it("shows chatgpt for oauth auth", () => {
+    const apps = getVisibleApps("oauth");
+    const ids = apps.map((a) => a.id);
+    expect(ids).toContain("chatgpt");
+  });
+
+  it("shows both claude sub-apps for none auth", () => {
+    const apps = getVisibleApps("none");
+    const claude = apps.find((a) => a.id === "claude");
+    expect(claude?.subApps).toHaveLength(2);
+  });
+
+  it("shows both codex sub-apps for apiKey auth", () => {
+    const apps = getVisibleApps("apiKey");
+    const codex = apps.find((a) => a.id === "codex");
+    expect(codex?.subApps).toHaveLength(2);
+  });
+});
 
 describe("getAuthHeader", () => {
   it("returns undefined for boolean data", () => {
@@ -138,6 +239,14 @@ describe("config snapshots - no auth", () => {
     );
   });
 
+  it("codex cli command", () => {
+    expect(
+      getCodexCliCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`),
+    ).toMatchInlineSnapshot(
+      `"codex mcp add --transport http 'my-api' 'https://api.example.com/mcp'"`,
+    );
+  });
+
   it("cursor config", () => {
     expect(getCursorConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`))
       .toMatchInlineSnapshot(`
@@ -165,6 +274,19 @@ describe("config snapshots - no auth", () => {
     `);
   });
 
+  it("codex config", () => {
+    expect(getCodexConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`))
+      .toMatchInlineSnapshot(`
+      "{
+        "mcpServers": {
+          "my-api": {
+            "url": "https://api.example.com/mcp"
+          }
+        }
+      }"
+    `);
+  });
+
   it("generic config", () => {
     expect(getGenericConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`))
       .toMatchInlineSnapshot(`
@@ -185,6 +307,14 @@ describe("config snapshots - bearer auth", () => {
       getClaudeCodeCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth),
     ).toMatchInlineSnapshot(
       `"claude mcp add --transport http --header 'Authorization: Bearer YOUR_API_KEY' 'my-api' 'https://api.example.com/mcp'"`,
+    );
+  });
+
+  it("codex cli command", () => {
+    expect(
+      getCodexCliCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth),
+    ).toMatchInlineSnapshot(
+      `"codex mcp add --transport http --header 'Authorization: Bearer YOUR_API_KEY' 'my-api' 'https://api.example.com/mcp'"`,
     );
   });
 
@@ -221,6 +351,22 @@ describe("config snapshots - bearer auth", () => {
     `);
   });
 
+  it("codex config", () => {
+    expect(getCodexConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth))
+      .toMatchInlineSnapshot(`
+      "{
+        "mcpServers": {
+          "my-api": {
+            "url": "https://api.example.com/mcp",
+            "headers": {
+              "Authorization": "Bearer YOUR_API_KEY"
+            }
+          }
+        }
+      }"
+    `);
+  });
+
   it("generic config", () => {
     expect(
       getGenericConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth),
@@ -245,6 +391,14 @@ describe("config snapshots - apiKey auth", () => {
       getClaudeCodeCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, apiKeyAuth),
     ).toMatchInlineSnapshot(
       `"claude mcp add --transport http --header 'X-API-Key: YOUR_API_KEY' 'my-api' 'https://api.example.com/mcp'"`,
+    );
+  });
+
+  it("codex cli command", () => {
+    expect(
+      getCodexCliCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, apiKeyAuth),
+    ).toMatchInlineSnapshot(
+      `"codex mcp add --transport http --header 'X-API-Key: YOUR_API_KEY' 'my-api' 'https://api.example.com/mcp'"`,
     );
   });
 

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AuthHeader,
+  getAuthHeader,
+  getClaudeCodeCommand,
+  getCursorConfig,
+  getGenericConfig,
+  getMcpServerName,
+  getMcpUrl,
+  getVscodeConfig,
+} from "./mcp-configs.js";
+
+const SERVER_URL = "https://api.example.com";
+const MCP_PATH = "/mcp";
+const SERVER_NAME = "my-api";
+
+const bearerAuth: AuthHeader = {
+  headerName: "Authorization",
+  placeholder: "Bearer YOUR_API_KEY",
+};
+
+const apiKeyAuth: AuthHeader = {
+  headerName: "X-API-Key",
+  placeholder: "YOUR_API_KEY",
+};
+
+describe("getAuthHeader", () => {
+  it("returns undefined for boolean data", () => {
+    expect(getAuthHeader(true)).toBeUndefined();
+  });
+
+  it("returns undefined when no security", () => {
+    expect(getAuthHeader({ name: "test" })).toBeUndefined();
+  });
+
+  it("returns bearer auth for http/bearer scheme", () => {
+    expect(
+      getAuthHeader({
+        security: [{ api_key: [] }],
+        securitySchemes: { api_key: { type: "http", scheme: "bearer" } },
+      }),
+    ).toEqual({
+      headerName: "Authorization",
+      placeholder: "Bearer YOUR_API_KEY",
+    });
+  });
+
+  it("returns basic auth for http/basic scheme", () => {
+    expect(
+      getAuthHeader({
+        security: [{ basic: [] }],
+        securitySchemes: { basic: { type: "http", scheme: "basic" } },
+      }),
+    ).toEqual({
+      headerName: "Authorization",
+      placeholder: "Basic YOUR_API_KEY",
+    });
+  });
+
+  it("defaults to bearer when http scheme is unspecified", () => {
+    expect(
+      getAuthHeader({
+        security: [{ auth: [] }],
+        securitySchemes: { auth: { type: "http" } },
+      }),
+    ).toEqual({
+      headerName: "Authorization",
+      placeholder: "Bearer YOUR_API_KEY",
+    });
+  });
+
+  it("returns apiKey header for apiKey scheme", () => {
+    expect(
+      getAuthHeader({
+        security: [{ key: [] }],
+        securitySchemes: {
+          key: { type: "apiKey", in: "header", name: "X-API-Key" },
+        },
+      }),
+    ).toEqual({ headerName: "X-API-Key", placeholder: "YOUR_API_KEY" });
+  });
+
+  it("returns undefined for apiKey in query (not header)", () => {
+    expect(
+      getAuthHeader({
+        security: [{ key: [] }],
+        securitySchemes: {
+          key: { type: "apiKey", in: "query", name: "api_key" },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for oauth2 scheme", () => {
+    expect(
+      getAuthHeader({
+        security: [{ oauth: [] }],
+        securitySchemes: { oauth: { type: "oauth2" } },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("getMcpUrl", () => {
+  it("strips trailing slash from server URL", () => {
+    expect(getMcpUrl("https://api.example.com/", "/mcp")).toBe(
+      "https://api.example.com/mcp",
+    );
+  });
+
+  it("defaults operation path to /mcp", () => {
+    expect(getMcpUrl("https://api.example.com")).toBe(
+      "https://api.example.com/mcp",
+    );
+  });
+});
+
+describe("getMcpServerName", () => {
+  it("uses data.name when available", () => {
+    expect(getMcpServerName({ name: "my-server" })).toBe("my-server");
+  });
+
+  it("falls back to summary", () => {
+    expect(getMcpServerName({}, "My API")).toBe("My API");
+  });
+
+  it("falls back to mcp-server", () => {
+    expect(getMcpServerName(true)).toBe("mcp-server");
+  });
+});
+
+describe("config snapshots - no auth", () => {
+  it("claude code command", () => {
+    expect(
+      getClaudeCodeCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`),
+    ).toMatchInlineSnapshot(
+      `"claude mcp add --transport http 'my-api' 'https://api.example.com/mcp'"`,
+    );
+  });
+
+  it("cursor config", () => {
+    expect(getCursorConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`))
+      .toMatchInlineSnapshot(`
+      "{
+        "mcpServers": {
+          "my-api": {
+            "url": "https://api.example.com/mcp"
+          }
+        }
+      }"
+    `);
+  });
+
+  it("vscode config", () => {
+    expect(getVscodeConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`))
+      .toMatchInlineSnapshot(`
+      "{
+        "servers": {
+          "my-api": {
+            "type": "http",
+            "url": "https://api.example.com/mcp"
+          }
+        }
+      }"
+    `);
+  });
+
+  it("generic config", () => {
+    expect(getGenericConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`))
+      .toMatchInlineSnapshot(`
+      "{
+        "mcpServers": {
+          "my-api": {
+            "url": "https://api.example.com/mcp"
+          }
+        }
+      }"
+    `);
+  });
+});
+
+describe("config snapshots - bearer auth", () => {
+  it("claude code command", () => {
+    expect(
+      getClaudeCodeCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth),
+    ).toMatchInlineSnapshot(
+      `"claude mcp add --transport http --header 'Authorization: Bearer YOUR_API_KEY' 'my-api' 'https://api.example.com/mcp'"`,
+    );
+  });
+
+  it("cursor config", () => {
+    expect(getCursorConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth))
+      .toMatchInlineSnapshot(`
+      "{
+        "mcpServers": {
+          "my-api": {
+            "url": "https://api.example.com/mcp",
+            "headers": {
+              "Authorization": "Bearer YOUR_API_KEY"
+            }
+          }
+        }
+      }"
+    `);
+  });
+
+  it("vscode config", () => {
+    expect(getVscodeConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth))
+      .toMatchInlineSnapshot(`
+      "{
+        "servers": {
+          "my-api": {
+            "type": "http",
+            "url": "https://api.example.com/mcp",
+            "headers": {
+              "Authorization": "Bearer YOUR_API_KEY"
+            }
+          }
+        }
+      }"
+    `);
+  });
+
+  it("generic config", () => {
+    expect(
+      getGenericConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, bearerAuth),
+    ).toMatchInlineSnapshot(`
+      "{
+        "mcpServers": {
+          "my-api": {
+            "url": "https://api.example.com/mcp",
+            "headers": {
+              "Authorization": "Bearer YOUR_API_KEY"
+            }
+          }
+        }
+      }"
+    `);
+  });
+});
+
+describe("config snapshots - apiKey auth", () => {
+  it("claude code command", () => {
+    expect(
+      getClaudeCodeCommand(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, apiKeyAuth),
+    ).toMatchInlineSnapshot(
+      `"claude mcp add --transport http --header 'X-API-Key: YOUR_API_KEY' 'my-api' 'https://api.example.com/mcp'"`,
+    );
+  });
+
+  it("cursor config", () => {
+    expect(getCursorConfig(SERVER_NAME, `${SERVER_URL}${MCP_PATH}`, apiKeyAuth))
+      .toMatchInlineSnapshot(`
+      "{
+        "mcpServers": {
+          "my-api": {
+            "url": "https://api.example.com/mcp",
+            "headers": {
+              "X-API-Key": "YOUR_API_KEY"
+            }
+          }
+        }
+      }"
+    `);
+  });
+});

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
@@ -12,6 +12,35 @@ export interface AuthHeader {
   placeholder: string;
 }
 
+export type AuthType = "none" | "apiKey" | "oauth";
+
+// Detects auth type from x-mcp-server security data
+export const getAuthType = (data?: McpServerData): AuthType => {
+  if (typeof data === "boolean" || !data?.security || !data?.securitySchemes) {
+    return "none";
+  }
+
+  const schemes = data.securitySchemes as Record<string, SecurityScheme>;
+  const security = data.security as Array<Record<string, string[]>>;
+  const firstReq = security[0];
+  if (!firstReq) return "none";
+
+  const schemeName = Object.keys(firstReq)[0];
+  if (!schemeName) return "none";
+
+  const scheme = schemes[schemeName];
+  if (!scheme) return "none";
+
+  if (scheme.type === "oauth2" || scheme.type === "openIdConnect") {
+    return "oauth";
+  }
+  if (scheme.type === "http" || scheme.type === "apiKey") {
+    return "apiKey";
+  }
+
+  return "none";
+};
+
 // Derives auth header name and placeholder from the first security scheme
 export const getAuthHeader = (data?: McpServerData): AuthHeader | undefined => {
   if (typeof data === "boolean" || !data?.security || !data?.securitySchemes) {
@@ -48,6 +77,108 @@ export const getAuthHeader = (data?: McpServerData): AuthHeader | undefined => {
   return undefined;
 };
 
+// -- App compatibility matrix --
+
+export interface McpSubApp {
+  id: string;
+  label: string;
+  supportedAuth: AuthType[];
+}
+
+export interface McpApp {
+  id: string;
+  label: string;
+  subApps: McpSubApp[];
+}
+
+export const MCP_APPS: McpApp[] = [
+  {
+    id: "claude",
+    label: "Claude",
+    subApps: [
+      {
+        id: "claude-desktop",
+        label: "Claude Desktop",
+        supportedAuth: ["none", "apiKey"],
+      },
+      {
+        id: "claude-code",
+        label: "Claude Code CLI",
+        supportedAuth: ["none", "apiKey", "oauth"],
+      },
+    ],
+  },
+  {
+    id: "chatgpt",
+    label: "ChatGPT",
+    subApps: [
+      {
+        id: "chatgpt-desktop",
+        label: "ChatGPT",
+        supportedAuth: ["none", "oauth"],
+      },
+    ],
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    subApps: [
+      {
+        id: "codex-gui",
+        label: "Codex",
+        supportedAuth: ["none", "apiKey", "oauth"],
+      },
+      {
+        id: "codex-cli",
+        label: "Codex CLI",
+        supportedAuth: ["none", "apiKey", "oauth"],
+      },
+    ],
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    subApps: [
+      {
+        id: "cursor",
+        label: "Cursor",
+        supportedAuth: ["none", "apiKey", "oauth"],
+      },
+    ],
+  },
+  {
+    id: "vscode",
+    label: "VS Code",
+    subApps: [
+      {
+        id: "vscode",
+        label: "VS Code",
+        supportedAuth: ["none", "apiKey", "oauth"],
+      },
+    ],
+  },
+  {
+    id: "generic",
+    label: "Generic",
+    subApps: [
+      {
+        id: "generic",
+        label: "Generic",
+        supportedAuth: ["none", "apiKey", "oauth"],
+      },
+    ],
+  },
+];
+
+// Filters apps and sub-apps to those supporting the given auth type
+export const getVisibleApps = (authType: AuthType): McpApp[] =>
+  MCP_APPS.map((app) => ({
+    ...app,
+    subApps: app.subApps.filter((sub) => sub.supportedAuth.includes(authType)),
+  })).filter((app) => app.subApps.length > 0);
+
+// -- Config generators --
+
 export const getMcpServerName = (
   data?: McpServerData,
   summary?: string,
@@ -68,6 +199,17 @@ export const getClaudeCodeCommand = (
     ? ` --header '${auth.headerName}: ${auth.placeholder}'`
     : "";
   return `claude mcp add --transport http${headerFlag} '${name}' '${mcpUrl}'`;
+};
+
+export const getCodexCliCommand = (
+  name: string,
+  mcpUrl: string,
+  auth?: AuthHeader,
+) => {
+  const headerFlag = auth
+    ? ` --header '${auth.headerName}: ${auth.placeholder}'`
+    : "";
+  return `codex mcp add --transport http${headerFlag} '${name}' '${mcpUrl}'`;
 };
 
 const jsonHeaders = (auth: AuthHeader) =>
@@ -93,6 +235,18 @@ export const getVscodeConfig = (
   "servers": {
     "${name}": {
       "type": "http",
+      "url": "${mcpUrl}"${auth ? jsonHeaders(auth) : ""}
+    }
+  }
+}`;
+
+export const getCodexConfig = (
+  name: string,
+  mcpUrl: string,
+  auth?: AuthHeader,
+) => `{
+  "mcpServers": {
+    "${name}": {
       "url": "${mcpUrl}"${auth ? jsonHeaders(auth) : ""}
     }
   }

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
@@ -99,7 +99,7 @@ export const MCP_APPS: McpApp[] = [
       {
         id: "claude-desktop",
         label: "Claude Desktop",
-        supportedAuth: ["none", "apiKey"],
+        supportedAuth: ["none", "oauth"],
       },
       {
         id: "claude-code",

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
@@ -1,0 +1,111 @@
+interface SecurityScheme {
+  type: string;
+  scheme?: string;
+  name?: string;
+  in?: string;
+}
+
+export type McpServerData = boolean | Record<string, unknown>;
+
+export interface AuthHeader {
+  headerName: string;
+  placeholder: string;
+}
+
+// Derives auth header name and placeholder from the first security scheme
+export const getAuthHeader = (data?: McpServerData): AuthHeader | undefined => {
+  if (typeof data === "boolean" || !data?.security || !data?.securitySchemes) {
+    return undefined;
+  }
+
+  const schemes = data.securitySchemes as Record<string, SecurityScheme>;
+  const security = data.security as Array<Record<string, string[]>>;
+  const firstReq = security[0];
+  if (!firstReq) return undefined;
+
+  const schemeName = Object.keys(firstReq)[0];
+  if (!schemeName) return undefined;
+
+  const scheme = schemes[schemeName];
+  if (!scheme) return undefined;
+
+  if (scheme.type === "http") {
+    const authScheme = scheme.scheme ?? "bearer";
+    const label = authScheme.charAt(0).toUpperCase() + authScheme.slice(1);
+    return {
+      headerName: "Authorization",
+      placeholder: `${label} YOUR_API_KEY`,
+    };
+  }
+
+  if (scheme.type === "apiKey" && scheme.in === "header" && scheme.name) {
+    return {
+      headerName: scheme.name,
+      placeholder: "YOUR_API_KEY",
+    };
+  }
+
+  return undefined;
+};
+
+export const getMcpServerName = (
+  data?: McpServerData,
+  summary?: string,
+): string => {
+  if (typeof data === "boolean") return summary ?? "mcp-server";
+  return (data?.name as string) ?? summary ?? "mcp-server";
+};
+
+export const getMcpUrl = (serverUrl?: string, operationPath?: string) =>
+  `${(serverUrl ?? "").replace(/\/+$/, "")}${operationPath ?? "/mcp"}`;
+
+export const getClaudeCodeCommand = (
+  name: string,
+  mcpUrl: string,
+  auth?: AuthHeader,
+) => {
+  const headerFlag = auth
+    ? ` --header '${auth.headerName}: ${auth.placeholder}'`
+    : "";
+  return `claude mcp add --transport http${headerFlag} '${name}' '${mcpUrl}'`;
+};
+
+const jsonHeaders = (auth: AuthHeader) =>
+  `,\n      "headers": {\n        "${auth.headerName}": "${auth.placeholder}"\n      }`;
+
+export const getCursorConfig = (
+  name: string,
+  mcpUrl: string,
+  auth?: AuthHeader,
+) => `{
+  "mcpServers": {
+    "${name}": {
+      "url": "${mcpUrl}"${auth ? jsonHeaders(auth) : ""}
+    }
+  }
+}`;
+
+export const getVscodeConfig = (
+  name: string,
+  mcpUrl: string,
+  auth?: AuthHeader,
+) => `{
+  "servers": {
+    "${name}": {
+      "type": "http",
+      "url": "${mcpUrl}"${auth ? jsonHeaders(auth) : ""}
+    }
+  }
+}`;
+
+export const getGenericConfig = (
+  name: string,
+  mcpUrl: string,
+  auth?: AuthHeader,
+) => `{
+  "mcpServers": {
+    "${name}": {
+      "url": "${mcpUrl}"${auth ? jsonHeaders(auth) : ""}
+    }
+  }
+}`;

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
@@ -6,8 +6,12 @@ import type { OpenAPIDocument } from "../lib/oas/parser/index.js";
 import { removeExtensions } from "../lib/plugins/openapi/processors/removeExtensions.js";
 import { removePaths } from "../lib/plugins/openapi/processors/removePaths.js";
 import { enrichWithZuploMcpServerData } from "./enrich-with-zuplo-mcp.js";
+import type { PoliciesConfigFile } from "./policy-types.js";
 
-const mcpRouteHandler = (operations: Array<{ file: string; id: string }>) => ({
+const mcpRouteHandler = (
+  operations: Array<{ file: string; id: string }>,
+  inboundPolicies: string[] = [],
+) => ({
   "x-zuplo-route": {
     corsPolicy: "none",
     handler: {
@@ -15,9 +19,11 @@ const mcpRouteHandler = (operations: Array<{ file: string; id: string }>) => ({
       module: "$import(@zuplo/runtime)",
       options: { operations },
     },
-    policies: { inbound: [] },
+    policies: { inbound: inboundPolicies },
   },
 });
+
+const emptyPoliciesConfig: PoliciesConfigFile = { policies: [] };
 
 describe("enrichWithZuploMcpServerData", () => {
   let tempDir: string;
@@ -77,9 +83,10 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({ rootDir })(
-      processorArg(schema),
-    );
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: emptyPoliciesConfig,
+    })(processorArg(schema));
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
@@ -135,9 +142,10 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({ rootDir })(
-      processorArg(schema),
-    );
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: emptyPoliciesConfig,
+    })(processorArg(schema));
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
@@ -196,9 +204,10 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(result.paths?.["/mcp"]).toBeDefined();
 
     // 2. enrichWithZuploMcpServerData
-    result = await enrichWithZuploMcpServerData({ rootDir })(
-      processorArg(result),
-    );
+    result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: emptyPoliciesConfig,
+    })(processorArg(result));
 
     // 3. removeExtensions (strip x-zuplo-*)
     result = removeExtensions({
@@ -211,5 +220,272 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(op["x-mcp-server"].name).toBe("MCP Server");
     expect(op["x-mcp-server"].tools).toHaveLength(1);
     expect(op["x-zuplo-route"]).toBeUndefined();
+  });
+
+  it("should add security to x-mcp-server when API key inbound policy is present", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const policiesConfig: PoliciesConfigFile = {
+      policies: [
+        {
+          name: "my-api-key-policy",
+          policyType: "api-key-inbound",
+          handler: {
+            module: "$import(@zuplo/runtime)",
+            export: "ApiKeyInboundPolicy",
+            options: {},
+          },
+        },
+      ],
+    };
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            ...mcpRouteHandler(
+              [{ file: "./config/routes.oas.json", id: "get-users" }],
+              ["my-api-key-policy"],
+            ),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig,
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].security).toEqual([{ api_key: [] }]);
+
+    // Should also add security scheme to components
+    expect(result.components?.securitySchemes?.api_key).toEqual({
+      type: "http",
+      scheme: "bearer",
+    });
+  });
+
+  it("should not add security to x-mcp-server when no API key policy is present", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            ...mcpRouteHandler([
+              { file: "./config/routes.oas.json", id: "get-users" },
+            ]),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: emptyPoliciesConfig,
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].security).toBeUndefined();
+    expect(result.components?.securitySchemes).toBeUndefined();
+  });
+
+  it("should add security when API key policy is inside composite policy", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const policiesConfig: PoliciesConfigFile = {
+      policies: [
+        {
+          name: "composite-auth",
+          policyType: "composite-inbound",
+          handler: {
+            module: "$import(@zuplo/runtime)",
+            export: "CompositeInboundPolicy",
+            options: { policies: ["inner-api-key-policy"] },
+          },
+        },
+        {
+          name: "inner-api-key-policy",
+          policyType: "api-key-inbound",
+          handler: {
+            module: "$import(@zuplo/runtime)",
+            export: "ApiAuthKeyInboundPolicy",
+            options: {},
+          },
+        },
+      ],
+    };
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            ...mcpRouteHandler(
+              [{ file: "./config/routes.oas.json", id: "get-users" }],
+              ["composite-auth"],
+            ),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig,
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].security).toEqual([{ api_key: [] }]);
+  });
+
+  it("should add default MCP tag when operation has no tags", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            ...mcpRouteHandler([
+              { file: "./config/routes.oas.json", id: "get-users" },
+            ]),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: emptyPoliciesConfig,
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op.tags).toEqual(["MCP"]);
+
+    // Top-level tags should include MCP definition
+    expect(result.tags).toContainEqual({
+      name: "MCP",
+      description:
+        "Model Context Protocol (MCP) server endpoints for AI tool integration",
+    });
+  });
+
+  it("should not override existing tags on MCP operation", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            tags: ["AI"],
+            ...mcpRouteHandler([
+              { file: "./config/routes.oas.json", id: "get-users" },
+            ]),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: emptyPoliciesConfig,
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op.tags).toEqual(["AI"]);
+
+    // Should not add MCP tag definition since it wasn't assigned
+    expect(result.tags).toBeUndefined();
   });
 });

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
@@ -6,12 +6,8 @@ import type { OpenAPIDocument } from "../lib/oas/parser/index.js";
 import { removeExtensions } from "../lib/plugins/openapi/processors/removeExtensions.js";
 import { removePaths } from "../lib/plugins/openapi/processors/removePaths.js";
 import { enrichWithZuploMcpServerData } from "./enrich-with-zuplo-mcp.js";
-import type { PoliciesConfigFile } from "./policy-types.js";
 
-const mcpRouteHandler = (
-  operations: Array<{ file: string; id: string }>,
-  inboundPolicies: string[] = [],
-) => ({
+const mcpRouteHandler = (operations: Array<{ file: string; id: string }>) => ({
   "x-zuplo-route": {
     corsPolicy: "none",
     handler: {
@@ -19,11 +15,9 @@ const mcpRouteHandler = (
       module: "$import(@zuplo/runtime)",
       options: { operations },
     },
-    policies: { inbound: inboundPolicies },
+    policies: { inbound: [] },
   },
 });
-
-const emptyPoliciesConfig: PoliciesConfigFile = { policies: [] };
 
 describe("enrichWithZuploMcpServerData", () => {
   let tempDir: string;
@@ -83,10 +77,9 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig: emptyPoliciesConfig,
-    })(processorArg(schema));
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
@@ -142,10 +135,9 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig: emptyPoliciesConfig,
-    })(processorArg(schema));
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
@@ -204,10 +196,9 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(result.paths?.["/mcp"]).toBeDefined();
 
     // 2. enrichWithZuploMcpServerData
-    result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig: emptyPoliciesConfig,
-    })(processorArg(result));
+    result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(result),
+    );
 
     // 3. removeExtensions (strip x-zuplo-*)
     result = removeExtensions({
@@ -222,10 +213,69 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(op["x-zuplo-route"]).toBeUndefined();
   });
 
-  it("should add security to x-mcp-server when API key inbound policy is present", async () => {
+  it("should add security to x-mcp-server when referenced operations have security", async () => {
     await writeApiFile("config/routes.oas.json", {
       openapi: "3.1.0",
       info: { title: "Routes API", version: "1.0.0" },
+      components: {
+        securitySchemes: {
+          api_key: { type: "http", scheme: "bearer" },
+        },
+      },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            security: [{ api_key: [] }],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            ...mcpRouteHandler([
+              { file: "./config/routes.oas.json", id: "get-users" },
+            ]),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].security).toEqual([{ api_key: [] }]);
+
+    // Security scheme should be copied to main schema
+    expect(result.components?.securitySchemes?.api_key).toEqual({
+      type: "http",
+      scheme: "bearer",
+    });
+  });
+
+  it("should inherit doc-level security when operations have none", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      security: [{ bearer_auth: [] }],
+      components: {
+        securitySchemes: {
+          bearer_auth: { type: "http", scheme: "bearer" },
+        },
+      },
       paths: {
         "/users": {
           get: {
@@ -237,20 +287,6 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     });
 
-    const policiesConfig: PoliciesConfigFile = {
-      policies: [
-        {
-          name: "my-api-key-policy",
-          policyType: "api-key-inbound",
-          handler: {
-            module: "$import(@zuplo/runtime)",
-            export: "ApiKeyInboundPolicy",
-            options: {},
-          },
-        },
-      ],
-    };
-
     const schema = {
       openapi: "3.1.0",
       info: { title: "Test MCP API", version: "1.0.0" },
@@ -259,33 +295,29 @@ describe("enrichWithZuploMcpServerData", () => {
           post: {
             summary: "MCP Server",
             operationId: "mcp-endpoint",
-            ...mcpRouteHandler(
-              [{ file: "./config/routes.oas.json", id: "get-users" }],
-              ["my-api-key-policy"],
-            ),
+            ...mcpRouteHandler([
+              { file: "./config/routes.oas.json", id: "get-users" },
+            ]),
             responses: { "200": { description: "MCP response" } },
           },
         },
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig,
-    })(processorArg(schema));
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
-    expect(op["x-mcp-server"].security).toEqual([{ api_key: [] }]);
-
-    // Should also add security scheme to components
-    expect(result.components?.securitySchemes?.api_key).toEqual({
+    expect(op["x-mcp-server"].security).toEqual([{ bearer_auth: [] }]);
+    expect(result.components?.securitySchemes?.bearer_auth).toEqual({
       type: "http",
       scheme: "bearer",
     });
   });
 
-  it("should not add security to x-mcp-server when no API key policy is present", async () => {
+  it("should not add security when no operations have security", async () => {
     await writeApiFile("config/routes.oas.json", {
       openapi: "3.1.0",
       info: { title: "Routes API", version: "1.0.0" },
@@ -317,10 +349,9 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig: emptyPoliciesConfig,
-    })(processorArg(schema));
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
@@ -328,43 +359,32 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(result.components?.securitySchemes).toBeUndefined();
   });
 
-  it("should add security when API key policy is inside composite policy", async () => {
+  it("should deduplicate security requirements across operations", async () => {
     await writeApiFile("config/routes.oas.json", {
       openapi: "3.1.0",
       info: { title: "Routes API", version: "1.0.0" },
+      components: {
+        securitySchemes: {
+          api_key: { type: "http", scheme: "bearer" },
+        },
+      },
       paths: {
         "/users": {
           get: {
             operationId: "get-users",
             summary: "Get all users",
+            security: [{ api_key: [] }],
             responses: { "200": { description: "OK" } },
+          },
+          post: {
+            operationId: "create-user",
+            summary: "Create a user",
+            security: [{ api_key: [] }],
+            responses: { "201": { description: "Created" } },
           },
         },
       },
     });
-
-    const policiesConfig: PoliciesConfigFile = {
-      policies: [
-        {
-          name: "composite-auth",
-          policyType: "composite-inbound",
-          handler: {
-            module: "$import(@zuplo/runtime)",
-            export: "CompositeInboundPolicy",
-            options: { policies: ["inner-api-key-policy"] },
-          },
-        },
-        {
-          name: "inner-api-key-policy",
-          policyType: "api-key-inbound",
-          handler: {
-            module: "$import(@zuplo/runtime)",
-            export: "ApiAuthKeyInboundPolicy",
-            options: {},
-          },
-        },
-      ],
-    };
 
     const schema = {
       openapi: "3.1.0",
@@ -374,23 +394,23 @@ describe("enrichWithZuploMcpServerData", () => {
           post: {
             summary: "MCP Server",
             operationId: "mcp-endpoint",
-            ...mcpRouteHandler(
-              [{ file: "./config/routes.oas.json", id: "get-users" }],
-              ["composite-auth"],
-            ),
+            ...mcpRouteHandler([
+              { file: "./config/routes.oas.json", id: "get-users" },
+              { file: "./config/routes.oas.json", id: "create-user" },
+            ]),
             responses: { "200": { description: "MCP response" } },
           },
         },
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig,
-    })(processorArg(schema));
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    // Should be deduplicated to a single entry
     expect(op["x-mcp-server"].security).toEqual([{ api_key: [] }]);
   });
 
@@ -426,10 +446,9 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig: emptyPoliciesConfig,
-    })(processorArg(schema));
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
@@ -476,10 +495,9 @@ describe("enrichWithZuploMcpServerData", () => {
       },
     } as unknown as OpenAPIDocument;
 
-    const result = await enrichWithZuploMcpServerData({
-      rootDir,
-      policiesConfig: emptyPoliciesConfig,
-    })(processorArg(schema));
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
@@ -259,6 +259,11 @@ describe("enrichWithZuploMcpServerData", () => {
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
     expect(op["x-mcp-server"].security).toEqual([{ api_key: [] }]);
 
+    // Security scheme definitions should be included in extension for UI rendering
+    expect(op["x-mcp-server"].securitySchemes).toEqual({
+      api_key: { type: "http", scheme: "bearer" },
+    });
+
     // Security scheme should be copied to main schema
     expect(result.components?.securitySchemes?.api_key).toEqual({
       type: "http",

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -226,7 +226,10 @@ export const enrichWithZuploMcpServerData = ({
       // Add security from referenced operations to x-mcp-server
       const dedupedSecurity = deduplicateSecurity(allSecurity);
       if (dedupedSecurity.length > 0) {
-        (node["x-mcp-server"] as RecordAny).security = dedupedSecurity;
+        const ext = node["x-mcp-server"] as RecordAny;
+        ext.security = dedupedSecurity;
+        // Include scheme definitions so the UI can generate auth headers
+        ext.securitySchemes = { ...collectedSecuritySchemes };
       }
 
       // Assign default MCP tag if the operation has no tags

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -162,7 +162,7 @@ export const enrichWithZuploMcpServerData = ({
     const modifiedSchema = { ...schema };
     if (!modifiedSchema?.paths) return modifiedSchema;
 
-    let hasMcpEndpoints = false;
+    let assignedDefaultMcpTag = false;
     const collectedSecuritySchemes: Record<
       string,
       OpenAPIV3_1.SecuritySchemeObject
@@ -234,7 +234,7 @@ export const enrichWithZuploMcpServerData = ({
 
       // Assign default MCP tag if the operation has no tags
       if (!operation.tags || operation.tags.length === 0) {
-        hasMcpEndpoints = true;
+        assignedDefaultMcpTag = true;
         operation.tags = [MCP_TAG_NAME];
       }
 
@@ -242,7 +242,7 @@ export const enrichWithZuploMcpServerData = ({
     });
 
     // Add MCP tag definition to top-level tags if we assigned it
-    if (hasMcpEndpoints) {
+    if (assignedDefaultMcpTag) {
       if (!modifiedSchema.tags) modifiedSchema.tags = [];
       if (!modifiedSchema.tags.some((tag) => tag.name === MCP_TAG_NAME)) {
         modifiedSchema.tags.push({

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -13,57 +13,10 @@ import type { ProcessorArg } from "../config/validators/BuildSchema.js";
 import { traverse, traverseAsync } from "../lib/util/traverse.js";
 import type { RecordAny } from "../lib/util/types.js";
 import { operations } from "./enrich-with-zuplo.js";
-import type { PoliciesConfigFile } from "./policy-types.js";
 
 const MCP_TAG_NAME = "MCP";
 const MCP_TAG_DESCRIPTION =
   "Model Context Protocol (MCP) server endpoints for AI tool integration";
-
-const API_KEY_POLICY_EXPORTS = [
-  "ApiAuthKeyInboundPolicy",
-  "ApiKeyInboundPolicy",
-  "MonetizationInboundPolicy",
-];
-
-// Resolves inbound policy names from x-zuplo-route, expanding composite policies
-const resolveInboundPolicies = (
-  operation: RecordAny,
-  policiesConfig: PoliciesConfigFile,
-): string[] => {
-  const inbound = operation["x-zuplo-route"]?.policies?.inbound;
-  if (!Array.isArray(inbound)) return [];
-
-  return inbound.reduce((acc: string[], policyName: string) => {
-    const policy = policiesConfig.policies?.find(
-      ({ name }) => name === policyName,
-    );
-    if (!policy) return acc;
-
-    if (policy.handler.export === "CompositeInboundPolicy") {
-      const childPolicies = policy.handler.options?.policies as
-        | string[]
-        | undefined;
-      return childPolicies ? [...acc, ...childPolicies] : acc;
-    }
-
-    return [...acc, policyName];
-  }, []);
-};
-
-// Finds API key policies from resolved inbound policy names
-const findApiKeyPolicies = (
-  inboundPolicyNames: string[],
-  policiesConfig: PoliciesConfigFile,
-) => {
-  return (
-    policiesConfig.policies?.filter(
-      (policy) =>
-        inboundPolicyNames.includes(policy.name) &&
-        API_KEY_POLICY_EXPORTS.includes(policy.handler.export) &&
-        !policy.handler.options?.disableAutomaticallyAddingKeyHeaderToOpenApi,
-    ) ?? []
-  );
-};
 
 // extracts x-mcp-server metadata from the operation using x-zuplo-mcp-tool
 // as a first class citizen.
@@ -135,29 +88,74 @@ const buildOperationLookup = (
   return operationMap;
 };
 
-// Takes an OpenAPI document and extracts tool metadata for the given operation IDs
-const findOperationsInDocument = (
+interface DocumentExtractionResult {
+  tools: ExtensionMcpServerTool[];
+  security: OpenAPIV3_1.SecurityRequirementObject[];
+  securitySchemes: Record<string, OpenAPIV3_1.SecuritySchemeObject>;
+}
+
+// Extracts tools, security requirements, and security schemes from referenced operations
+const extractFromDocument = (
   document: OpenAPIV3_1.Document,
   operationIds: string[],
-): ExtensionMcpServerTool[] => {
+): DocumentExtractionResult => {
   const operationLookup = buildOperationLookup(document);
+  const tools: ExtensionMcpServerTool[] = [];
+  const securityReqs: OpenAPIV3_1.SecurityRequirementObject[] = [];
+  const referencedSchemeNames = new Set<string>();
 
-  return operationIds.flatMap((operationId) => {
+  for (const operationId of operationIds) {
     const operation = operationLookup.get(operationId);
-    if (!operation) return [];
+    if (!operation) continue;
 
     const tool = extractOperationSchema(operation);
-    return tool ? [tool] : [];
+    if (tool) tools.push(tool);
+
+    // Collect security: operation-level takes precedence, fall back to doc-level
+    const opSecurity = operation.security ?? document.security;
+    if (opSecurity) {
+      for (const req of opSecurity) {
+        securityReqs.push(req);
+        for (const name of Object.keys(req)) {
+          referencedSchemeNames.add(name);
+        }
+      }
+    }
+  }
+
+  // Grab referenced security scheme definitions from the document
+  const securitySchemes: Record<string, OpenAPIV3_1.SecuritySchemeObject> = {};
+  const docSchemes = document.components?.securitySchemes;
+  if (docSchemes) {
+    for (const name of referencedSchemeNames) {
+      const scheme = docSchemes[name];
+      if (scheme && !("$ref" in scheme)) {
+        securitySchemes[name] = scheme;
+      }
+    }
+  }
+
+  return { tools, security: securityReqs, securitySchemes };
+};
+
+// Deduplicates security requirements by stringified key
+const deduplicateSecurity = (
+  reqs: OpenAPIV3_1.SecurityRequirementObject[],
+): OpenAPIV3_1.SecurityRequirementObject[] => {
+  const seen = new Set<string>();
+  return reqs.filter((req) => {
+    const key = JSON.stringify(req);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
   });
 };
 
 // Enriches an OpenAPI schema with x-mcp-server data based on the Zuplo MCP server handler
 export const enrichWithZuploMcpServerData = ({
   rootDir,
-  policiesConfig,
 }: {
   rootDir: string;
-  policiesConfig: PoliciesConfigFile;
 }) => {
   return async ({ schema }: ProcessorArg) => {
     if (!schema.paths) return schema;
@@ -165,7 +163,10 @@ export const enrichWithZuploMcpServerData = ({
     if (!modifiedSchema?.paths) return modifiedSchema;
 
     let hasMcpEndpoints = false;
-    let hasApiKeySecurity = false;
+    const collectedSecuritySchemes: Record<
+      string,
+      OpenAPIV3_1.SecuritySchemeObject
+    > = {};
 
     await traverseAsync(modifiedSchema, async (node, nodePath) => {
       // Check if we're at a "post" operation (paths -> /some/path -> "post").
@@ -195,7 +196,8 @@ export const enrichWithZuploMcpServerData = ({
 
       if (operationsByFile.size === 0) return node;
 
-      const tools: ExtensionMcpServerTool[] = [];
+      const allTools: ExtensionMcpServerTool[] = [];
+      const allSecurity: OpenAPIV3_1.SecurityRequirementObject[] = [];
 
       for (const [filePath, operationIds] of operationsByFile) {
         const resolvedPath = path.resolve(rootDir, "../", filePath);
@@ -203,7 +205,10 @@ export const enrichWithZuploMcpServerData = ({
         const document = JSON.parse(fileContent);
 
         if (document) {
-          tools.push(...findOperationsInDocument(document, operationIds));
+          const result = extractFromDocument(document, operationIds);
+          allTools.push(...result.tools);
+          allSecurity.push(...result.security);
+          Object.assign(collectedSecuritySchemes, result.securitySchemes);
         }
       }
 
@@ -212,25 +217,16 @@ export const enrichWithZuploMcpServerData = ({
         version: DEFAULT_MCP_SERVER_VERSION,
       };
 
-      if (tools.length > 0) {
-        mcpExtension.tools = tools;
+      if (allTools.length > 0) {
+        mcpExtension.tools = allTools;
       }
-
-      // Check if any inbound policies on this MCP route are API key policies
-      const inboundPolicyNames = resolveInboundPolicies(
-        operation,
-        policiesConfig,
-      );
-      const apiKeyPolicies = findApiKeyPolicies(
-        inboundPolicyNames,
-        policiesConfig,
-      );
 
       node["x-mcp-server"] = mcpExtension;
 
-      if (apiKeyPolicies.length > 0) {
-        hasApiKeySecurity = true;
-        (node["x-mcp-server"] as RecordAny).security = [{ api_key: [] }];
+      // Add security from referenced operations to x-mcp-server
+      const dedupedSecurity = deduplicateSecurity(allSecurity);
+      if (dedupedSecurity.length > 0) {
+        (node["x-mcp-server"] as RecordAny).security = dedupedSecurity;
       }
 
       // Assign default MCP tag if the operation has no tags
@@ -253,17 +249,16 @@ export const enrichWithZuploMcpServerData = ({
       }
     }
 
-    // Ensure api_key security scheme exists if any MCP endpoint needs it
-    if (hasApiKeySecurity) {
+    // Merge collected security schemes into the main schema
+    if (Object.keys(collectedSecuritySchemes).length > 0) {
       if (!modifiedSchema.components) modifiedSchema.components = {};
       if (!modifiedSchema.components.securitySchemes) {
         modifiedSchema.components.securitySchemes = {};
       }
-      if (!modifiedSchema.components.securitySchemes.api_key) {
-        modifiedSchema.components.securitySchemes.api_key = {
-          type: "http",
-          scheme: "bearer",
-        };
+      for (const [name, scheme] of Object.entries(collectedSecuritySchemes)) {
+        if (!modifiedSchema.components.securitySchemes[name]) {
+          modifiedSchema.components.securitySchemes[name] = scheme;
+        }
       }
     }
 

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -13,6 +13,57 @@ import type { ProcessorArg } from "../config/validators/BuildSchema.js";
 import { traverse, traverseAsync } from "../lib/util/traverse.js";
 import type { RecordAny } from "../lib/util/types.js";
 import { operations } from "./enrich-with-zuplo.js";
+import type { PoliciesConfigFile } from "./policy-types.js";
+
+const MCP_TAG_NAME = "MCP";
+const MCP_TAG_DESCRIPTION =
+  "Model Context Protocol (MCP) server endpoints for AI tool integration";
+
+const API_KEY_POLICY_EXPORTS = [
+  "ApiAuthKeyInboundPolicy",
+  "ApiKeyInboundPolicy",
+  "MonetizationInboundPolicy",
+];
+
+// Resolves inbound policy names from x-zuplo-route, expanding composite policies
+const resolveInboundPolicies = (
+  operation: RecordAny,
+  policiesConfig: PoliciesConfigFile,
+): string[] => {
+  const inbound = operation["x-zuplo-route"]?.policies?.inbound;
+  if (!Array.isArray(inbound)) return [];
+
+  return inbound.reduce((acc: string[], policyName: string) => {
+    const policy = policiesConfig.policies?.find(
+      ({ name }) => name === policyName,
+    );
+    if (!policy) return acc;
+
+    if (policy.handler.export === "CompositeInboundPolicy") {
+      const childPolicies = policy.handler.options?.policies as
+        | string[]
+        | undefined;
+      return childPolicies ? [...acc, ...childPolicies] : acc;
+    }
+
+    return [...acc, policyName];
+  }, []);
+};
+
+// Finds API key policies from resolved inbound policy names
+const findApiKeyPolicies = (
+  inboundPolicyNames: string[],
+  policiesConfig: PoliciesConfigFile,
+) => {
+  return (
+    policiesConfig.policies?.filter(
+      (policy) =>
+        inboundPolicyNames.includes(policy.name) &&
+        API_KEY_POLICY_EXPORTS.includes(policy.handler.export) &&
+        !policy.handler.options?.disableAutomaticallyAddingKeyHeaderToOpenApi,
+    ) ?? []
+  );
+};
 
 // extracts x-mcp-server metadata from the operation using x-zuplo-mcp-tool
 // as a first class citizen.
@@ -103,13 +154,18 @@ const findOperationsInDocument = (
 // Enriches an OpenAPI schema with x-mcp-server data based on the Zuplo MCP server handler
 export const enrichWithZuploMcpServerData = ({
   rootDir,
+  policiesConfig,
 }: {
   rootDir: string;
+  policiesConfig: PoliciesConfigFile;
 }) => {
   return async ({ schema }: ProcessorArg) => {
     if (!schema.paths) return schema;
     const modifiedSchema = { ...schema };
     if (!modifiedSchema?.paths) return modifiedSchema;
+
+    let hasMcpEndpoints = false;
+    let hasApiKeySecurity = false;
 
     await traverseAsync(modifiedSchema, async (node, nodePath) => {
       // Check if we're at a "post" operation (paths -> /some/path -> "post").
@@ -160,9 +216,56 @@ export const enrichWithZuploMcpServerData = ({
         mcpExtension.tools = tools;
       }
 
+      // Check if any inbound policies on this MCP route are API key policies
+      const inboundPolicyNames = resolveInboundPolicies(
+        operation,
+        policiesConfig,
+      );
+      const apiKeyPolicies = findApiKeyPolicies(
+        inboundPolicyNames,
+        policiesConfig,
+      );
+
       node["x-mcp-server"] = mcpExtension;
+
+      if (apiKeyPolicies.length > 0) {
+        hasApiKeySecurity = true;
+        (node["x-mcp-server"] as RecordAny).security = [{ api_key: [] }];
+      }
+
+      // Assign default MCP tag if the operation has no tags
+      if (!operation.tags || operation.tags.length === 0) {
+        hasMcpEndpoints = true;
+        operation.tags = [MCP_TAG_NAME];
+      }
+
       return node;
     });
+
+    // Add MCP tag definition to top-level tags if we assigned it
+    if (hasMcpEndpoints) {
+      if (!modifiedSchema.tags) modifiedSchema.tags = [];
+      if (!modifiedSchema.tags.some((tag) => tag.name === MCP_TAG_NAME)) {
+        modifiedSchema.tags.push({
+          name: MCP_TAG_NAME,
+          description: MCP_TAG_DESCRIPTION,
+        });
+      }
+    }
+
+    // Ensure api_key security scheme exists if any MCP endpoint needs it
+    if (hasApiKeySecurity) {
+      if (!modifiedSchema.components) modifiedSchema.components = {};
+      if (!modifiedSchema.components.securitySchemes) {
+        modifiedSchema.components.securitySchemes = {};
+      }
+      if (!modifiedSchema.components.securitySchemes.api_key) {
+        modifiedSchema.components.securitySchemes.api_key = {
+          type: "http",
+          scheme: "bearer",
+        };
+      }
+    }
 
     return modifiedSchema;
   };

--- a/packages/zudoku/src/zuplo/with-zuplo-processors.ts
+++ b/packages/zudoku/src/zuplo/with-zuplo-processors.ts
@@ -22,7 +22,7 @@ export const getProcessors = async (rootDir: string): Promise<Processor[]> => {
       shouldRemove: ({ parameter }) => parameter["x-internal"],
     }),
     enrichWithZuploData({ policiesConfig }),
-    enrichWithZuploMcpServerData({ rootDir, policiesConfig }),
+    enrichWithZuploMcpServerData({ rootDir }),
     ({ schema }: ProcessorArg) => {
       const url = ZuploEnv.serverUrl;
       if (!url || process.env.ZUPLO_PUBLIC_DISABLE_INJECT_ENDPOINT)

--- a/packages/zudoku/src/zuplo/with-zuplo-processors.ts
+++ b/packages/zudoku/src/zuplo/with-zuplo-processors.ts
@@ -22,7 +22,7 @@ export const getProcessors = async (rootDir: string): Promise<Processor[]> => {
       shouldRemove: ({ parameter }) => parameter["x-internal"],
     }),
     enrichWithZuploData({ policiesConfig }),
-    enrichWithZuploMcpServerData({ rootDir }),
+    enrichWithZuploMcpServerData({ rootDir, policiesConfig }),
     ({ schema }: ProcessorArg) => {
       const url = ZuploEnv.serverUrl;
       if (!url || process.env.ZUPLO_PUBLIC_DISABLE_INJECT_ENDPOINT)


### PR DESCRIPTION
## Summary

- **MCP security from OpenAPI spec**: When referenced operations have OpenAPI security requirements, the `x-mcp-server` extension now includes `security` and `securitySchemes` fields. Security schemes are also copied to `components.securitySchemes` in the main schema.
- **Auth-aware client configs**: MCP client configurations (Claude Code, Cursor, VS Code, Codex, Generic) include appropriate auth headers (`--header` for CLI, `"headers"` for JSON configs) when security is defined.
- **App compatibility matrix**: Apps and sub-apps are filtered based on auth type (none/apiKey/oauth). E.g., ChatGPT hidden for apiKey auth, Claude Desktop hidden for apiKey auth. Matrix is easy to extend in `mcp-configs.ts`.
- **Codex support**: Added Codex GUI and Codex CLI as new MCP client options.
- **Default MCP tag**: MCP server operations with no tags get a default "MCP" tag with description.
- **UI improvements**: Replaced MCP Endpoint section with compact "Copy URL" button, renamed "AI Tool" to "App" throughout.
- **Cosmo Cargo examples**: Added security to existing AI MCP server, added new public docs MCP server (no auth) for contrast.

## Auth compatibility matrix

| App | Sub-app | none | apiKey | oauth |
|-----|---------|:----:|:------:|:-----:|
| Claude | Desktop | ✓ | | ✓ |
| Claude | Code CLI | ✓ | ✓ | ✓ |
| ChatGPT | Desktop | ✓ | | ✓ |
| Codex | GUI | ✓ | ✓ | ✓ |
| Codex | CLI | ✓ | ✓ | ✓ |
| Cursor | | ✓ | ✓ | ✓ |
| VS Code | | ✓ | ✓ | ✓ |
| Generic | | ✓ | ✓ | ✓ |

## Test plan

- [x] 9 enrichment tests (security from OpenAPI spec, doc-level inheritance, deduplication, default tags)
- [x] 40 config tests (auth type detection, visibility matrix, inline snapshots for all generators × auth variants)
- [x] Typecheck passes
- [x] Lint passes

https://claude.ai/code/session_01XNSWhhk2EUiBmyzBUtekL4