### PR TITLE
docs: add generic OIDC auth guide with Okta/Keycloak examples

### DIFF
--- a/docs/pages/docs/configuration/authentication-openid.md
+++ b/docs/pages/docs/configuration/authentication-openid.md
@@ -28,11 +28,11 @@ Add the `authentication` property to your [Zudoku configuration](./overview.md):
 }
 ```
 
-| Option     | Required | Description                                                                                                                                 |
-| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clientId` | Yes      | The OAuth client ID issued by your provider.                                                                                                |
-| `issuer`   | Yes      | The issuer URL. Zudoku discovers endpoints from `<issuer>/.well-known/openid-configuration`.                                                |
-| `scopes`   | No       | Scopes to request. Defaults to `["openid", "profile", "email"]`.                                                                            |
+| Option     | Required | Description                                                                                  |
+| ---------- | -------- | -------------------------------------------------------------------------------------------- |
+| `clientId` | Yes      | The OAuth client ID issued by your provider.                                                 |
+| `issuer`   | Yes      | The issuer URL. Zudoku discovers endpoints from `<issuer>/.well-known/openid-configuration`. |
+| `scopes`   | No       | Scopes to request. Defaults to `["openid", "profile", "email"]`.                             |
 
 ## Provider Setup
 
@@ -47,8 +47,7 @@ Register Zudoku as a public SPA / single page application client in your identit
 
 ### Okta
 
-1. In the Okta admin console go to **Applications** → **Applications** → **Create App
-   Integration**.
+1. In the Okta admin console go to **Applications** → **Applications** → **Create App Integration**.
 2. Select **OIDC - OpenID Connect** and **Single Page Application**.
 3. Set **Sign-in redirect URIs** to `https://your-site.com/oauth/callback` (add
    `http://localhost:3000/oauth/callback` for local development).
@@ -89,9 +88,9 @@ enable **Standard Flow** (Authorization Code).
 
 ## Verifying the Issuer
 
-You can confirm your issuer URL is correct by opening
-`<issuer>/.well-known/openid-configuration` in a browser. It should return a JSON document listing
-`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, and `jwks_uri`.
+You can confirm your issuer URL is correct by opening `<issuer>/.well-known/openid-configuration` in
+a browser. It should return a JSON document listing `authorization_endpoint`, `token_endpoint`,
+`userinfo_endpoint`, and `jwks_uri`.
 
 ## User Profile
 

--- a/docs/pages/docs/configuration/authentication-openid.md
+++ b/docs/pages/docs/configuration/authentication-openid.md
@@ -1,0 +1,111 @@
+---
+title: OpenID Connect (OIDC)
+sidebar_label: OpenID Connect
+description:
+  Configure any OpenID Connect compliant identity provider (Okta, Keycloak, Authentik, etc.) as the
+  authentication provider for Zudoku.
+---
+
+Zudoku supports any identity provider that implements the
+[OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) protocol via the generic
+`openid` provider type. This includes Okta, Keycloak, Authentik, Ory, ZITADEL, AWS Cognito, Google
+Identity, and most enterprise IdPs.
+
+## Configuration
+
+Add the `authentication` property to your [Zudoku configuration](./overview.md):
+
+```typescript title="zudoku.config.ts"
+{
+  // ...
+  authentication: {
+    type: "openid",
+    clientId: "<your-client-id>",
+    issuer: "<the-issuer-url>",
+    scopes: ["openid", "profile", "email"], // Optional
+  },
+  // ...
+}
+```
+
+| Option     | Required | Description                                                                                                                                 |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clientId` | Yes      | The OAuth client ID issued by your provider.                                                                                                |
+| `issuer`   | Yes      | The issuer URL. Zudoku discovers endpoints from `<issuer>/.well-known/openid-configuration`.                                                |
+| `scopes`   | No       | Scopes to request. Defaults to `["openid", "profile", "email"]`.                                                                            |
+
+## Provider Setup
+
+Register Zudoku as a public SPA / single page application client in your identity provider and set:
+
+- Callback / Redirect URI to `https://your-site.com/oauth/callback`
+- For local development, add `http://localhost:3000/oauth/callback`
+- If your provider supports wildcards, add `https://*.your-domain.com/oauth/callback` for preview
+  environments
+- Add your site origin to the list of allowed CORS origins
+- Enable the `Authorization Code` grant with PKCE and the `Refresh Token` grant
+
+### Okta
+
+1. In the Okta admin console go to **Applications** → **Applications** → **Create App
+   Integration**.
+2. Select **OIDC - OpenID Connect** and **Single Page Application**.
+3. Set **Sign-in redirect URIs** to `https://your-site.com/oauth/callback` (add
+   `http://localhost:3000/oauth/callback` for local development).
+4. Under **Assignments**, assign the users or groups that should have access.
+5. After creating the app, copy the **Client ID**. Your issuer is your Okta domain, for example
+   `https://your-tenant.okta.com` or a custom authorization server like
+   `https://your-tenant.okta.com/oauth2/default`.
+6. Under **Security** → **API** → **Trusted Origins**, add your site origin for both CORS and
+   Redirect.
+
+```typescript title="zudoku.config.ts"
+{
+  authentication: {
+    type: "openid",
+    clientId: "<your-okta-client-id>",
+    issuer: "https://your-tenant.okta.com/oauth2/default",
+    scopes: ["openid", "profile", "email"],
+  },
+}
+```
+
+### Keycloak
+
+Use the realm issuer URL:
+
+```typescript title="zudoku.config.ts"
+{
+  authentication: {
+    type: "openid",
+    clientId: "zudoku",
+    issuer: "https://keycloak.example.com/realms/<your-realm>",
+  },
+}
+```
+
+In the realm, create a client with **Client type** `OpenID Connect`, **Access type** `public`, and
+enable **Standard Flow** (Authorization Code).
+
+## Verifying the Issuer
+
+You can confirm your issuer URL is correct by opening
+`<issuer>/.well-known/openid-configuration` in a browser. It should return a JSON document listing
+`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, and `jwks_uri`.
+
+## User Profile
+
+After sign-in Zudoku calls the provider's
+[UserInfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) and reads
+`name`, `email`, `picture`, and `email_verified` from the response. Map these claims in your
+provider if they are not emitted by default.
+
+## Troubleshooting
+
+- **Discovery fails**: verify `<issuer>/.well-known/openid-configuration` resolves and matches the
+  `issuer` value in the document.
+- **CORS errors on token / userinfo**: add your site origin to the provider's allowed origins.
+- **Redirect URI mismatch**: the URI registered with the provider must match the Zudoku origin
+  exactly, including protocol and port.
+- **Missing profile fields**: ensure `profile` and `email` scopes are granted and that the provider
+  includes `name`, `email`, and `picture` claims in the UserInfo response.

--- a/docs/pages/docs/configuration/authentication.md
+++ b/docs/pages/docs/configuration/authentication.md
@@ -15,8 +15,8 @@ authentication provider you use.
 
 ## Authentication Providers
 
-Zudoku supports Clerk, Auth0, Supabase, Firebase, Azure B2C, and any OpenID provider that supports
-the OpenID Connect protocol (including PingFederate).
+Zudoku supports Clerk, Auth0, Supabase, Firebase, Azure B2C, and any OpenID Connect provider
+(including Okta, Keycloak, Authentik, and PingFederate).
 
 Not seeing your authentication provider? [Let us know](https://github.com/zuplo/zudoku/issues)
 
@@ -95,6 +95,9 @@ When configuring your OpenID provider, you will need to set the following:
 
 By default, the scopes "openid", "profile", and "email" are requested. You can customize these by
 providing your own array of scopes.
+
+For provider-specific guides (Okta, Keycloak, etc.), see the
+[OpenID Connect setup page](./authentication-openid.md).
 
 ### Firebase
 

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -95,6 +95,7 @@ export const docs: Navigation = [
           "docs/configuration/authentication-auth0",
           "docs/configuration/authentication-clerk",
           "docs/configuration/authentication-azure-ad",
+          "docs/configuration/authentication-openid",
           "docs/configuration/authentication-pingfederate",
           "docs/configuration/authentication-supabase",
           "docs/configuration/authentication-firebase",


### PR DESCRIPTION
Adds a dedicated OpenID Connect setup page covering generic OIDC config plus Okta and Keycloak walkthroughs. Links it from the auth overview and sidebar so users searching for Okta/OIDC actually find it.