### PR TITLE
Link named component refs in OpenAPI property lists

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -191,8 +191,7 @@
             "items": {
               "$ref": "#/components/schemas/Comment"
             },
-            "maxItems": 100,
-            "enum": ["PENDING", "APPROVED", "REJECTED"]
+            "maxItems": 100
           },
           "tags": {
             "type": "array",

--- a/nx.json
+++ b/nx.json
@@ -52,5 +52,6 @@
       }
     }
   },
-  "neverConnectToCloud": true
+  "neverConnectToCloud": true,
+  "analytics": false
 }

--- a/packages/zudoku/src/lib/oas/graphql/circular.test.ts
+++ b/packages/zudoku/src/lib/oas/graphql/circular.test.ts
@@ -185,6 +185,22 @@ describe("handleCircularRefs", () => {
     expect(result.properties.child.properties.back).toContain(CIRCULAR_REF);
   });
 
+  it("should preserve non-enumerable __$ref in the result", () => {
+    const obj = { type: "object", properties: { foo: { type: "string" } } };
+    Object.defineProperty(obj, "__$ref", {
+      value: "#/components/schemas/Pet",
+      enumerable: false,
+    });
+
+    const result = handleCircularRefs(obj);
+
+    expect(result.__$ref).toBe("#/components/schemas/Pet");
+    // Also survives JSON serialization (must be enumerable on result)
+    expect(JSON.parse(JSON.stringify(result)).__$ref).toBe(
+      "#/components/schemas/Pet",
+    );
+  });
+
   // Exact reproduction of #1869 - shared object instances with __$ref
   it("should NOT mark shared object instances with __$ref as circular (issue #1869)", () => {
     // When dereferencing, the SAME object instance is returned for all refs to the same schema

--- a/packages/zudoku/src/lib/oas/graphql/circular.ts
+++ b/packages/zudoku/src/lib/oas/graphql/circular.ts
@@ -53,6 +53,17 @@ export const handleCircularRefs = (
         Object.entries(obj).map(([k, v]) => [k, recurse(v, k)]),
       );
 
+  // __$ref is defined non-enumerable at build-time codegen (schema-codegen.ts)
+  // to keep it out of snapshots and deep equality. Copy it enumerably onto
+  // the serialized result so the client receives it.
+  if (
+    !Array.isArray(result) &&
+    typeof refPath === "string" &&
+    !("__$ref" in result)
+  ) {
+    (result as Record<string, unknown>).__$ref = refPath;
+  }
+
   refs.set(obj, result);
   currentPath.delete(obj);
   if (typeof refPath === "string") currentRefPaths.delete(refPath);

--- a/packages/zudoku/src/lib/plugins/openapi/ParamInfos.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/ParamInfos.tsx
@@ -3,6 +3,8 @@ import { isValidElement, useState } from "react";
 import { InlineCode } from "../../components/InlineCode.js";
 import type { SchemaObject } from "../../oas/parser/index.js";
 import { cn } from "../../util/cn.js";
+import { SchemaRefLink } from "./schema/SchemaRefLink.js";
+import { getSchemaRefName } from "./schema/utils.js";
 
 const Pattern = ({ pattern }: { pattern: string }) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -32,14 +34,25 @@ const getSchemaInfos = (schema?: SchemaObject) => {
       ? schema.items
       : undefined;
 
+  const getTypeLabel = () => {
+    if (items) {
+      const itemsRefName = getSchemaRefName(items);
+      if (itemsRefName) {
+        return <SchemaRefLink name={itemsRefName} suffix="[]" />;
+      }
+      if (items.type) {
+        return Array.isArray(items.type)
+          ? `(${items.type.join(" | ")})[]`
+          : `${items.type}[]`;
+      }
+    }
+    const refName = getSchemaRefName(schema);
+    if (refName) return <SchemaRefLink name={refName} />;
+    return Array.isArray(schema.type) ? schema.type.join(" | ") : schema.type;
+  };
+
   return [
-    items?.type
-      ? Array.isArray(items.type)
-        ? `(${items.type.join(" | ")})[]`
-        : `${items.type}[]`
-      : Array.isArray(schema.type)
-        ? schema.type.join(" | ")
-        : schema.type,
+    getTypeLabel(),
 
     schema.enum && "enum",
     schema.const && "const",

--- a/packages/zudoku/src/lib/plugins/openapi/SchemaList.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SchemaList.tsx
@@ -95,7 +95,7 @@ export function SchemaList() {
                 </CollapsibleTrigger>
               </Heading>
               <CollapsibleContent className="mt-4 CollapsibleContent">
-                <SchemaView schema={schema.schema} />
+                <SchemaView schema={schema.schema} hideRootRef />
               </CollapsibleContent>
             </Collapsible>
           ))}

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaRefLink.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaRefLink.tsx
@@ -1,0 +1,24 @@
+import { Link } from "react-router";
+import { cn } from "../../../util/cn.js";
+import { slugify } from "../../../util/slugify.js";
+
+export const SchemaRefLink = ({
+  name,
+  suffix,
+  className,
+}: {
+  name: string;
+  suffix?: string;
+  className?: string;
+}) => (
+  <Link
+    to={{ pathname: "../~schemas", hash: slugify(name) }}
+    className={cn(
+      "text-foreground underline decoration-dotted underline-offset-4 hover:decoration-solid",
+      className,
+    )}
+  >
+    {name}
+    {suffix}
+  </Link>
+);

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaRefLink.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaRefLink.tsx
@@ -13,10 +13,7 @@ export const SchemaRefLink = ({
 }) => (
   <Link
     to={{ pathname: "../~schemas", hash: slugify(name) }}
-    className={cn(
-      "text-foreground underline decoration-dotted underline-offset-4 hover:decoration-solid",
-      className,
-    )}
+    className={cn("text-foreground hover:underline", className)}
   >
     {name}
     {suffix}

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
@@ -15,8 +15,15 @@ import { EnumValues } from "../components/EnumValues.js";
 import { ParamInfos } from "../ParamInfos.js";
 import { SchemaExampleAndDefault } from "./SchemaExampleAndDefault.js";
 import { SchemaPropertyItem } from "./SchemaPropertyItem.js";
+import { SchemaRefLink } from "./SchemaRefLink.js";
 import { UnionView } from "./UnionView.js";
-import { isArrayType, isBasicType } from "./utils.js";
+import { getSchemaRefName, isArrayType, isBasicType } from "./utils.js";
+
+const RootRefLabel = ({ name }: { name: string }) => (
+  <div className="text-xs font-semibold flex items-center gap-1.5 px-4 py-2 border-b bg-muted/40">
+    <SchemaRefLink name={name} />
+  </div>
+);
 
 const renderMarkdown = (content?: string) =>
   content && (
@@ -108,11 +115,13 @@ const ObjectSchemaView = ({
   defaultOpen,
   cardHeader,
   embedded,
+  rootRefName,
 }: {
   schema: SchemaObject;
   defaultOpen: boolean;
   cardHeader?: React.ReactNode;
   embedded?: boolean;
+  rootRefName?: string;
 }) => {
   const [showDeprecated, setShowDeprecated] = useState(false);
   const deprecatedRef = useRef<HTMLDivElement>(null);
@@ -189,6 +198,11 @@ const ObjectSchemaView = ({
     );
   }
 
+  const hasPanelContent =
+    nonDeprecatedGroups.length > 0 ||
+    deprecatedProperties ||
+    additionalObjectProperties;
+
   return (
     <Frame>
       {cardHeader}
@@ -197,10 +211,9 @@ const ObjectSchemaView = ({
           <FrameDescription>{schema.description}</FrameDescription>
         </FrameHeader>
       )}
-      {(nonDeprecatedGroups.length > 0 ||
-        deprecatedProperties ||
-        additionalObjectProperties) && (
+      {(hasPanelContent || rootRefName) && (
         <FramePanel className="p-0!">
+          {rootRefName && <RootRefLabel name={rootRefName} />}
           {itemsList}
           {deprecatedProperties && (
             <div ref={deprecatedRef} id={deprecatedId} hidden={!showDeprecated}>
@@ -244,11 +257,13 @@ export const SchemaView = ({
   defaultOpen = false,
   cardHeader,
   embedded,
+  hideRootRef,
 }: {
   schema?: SchemaObject | null;
   defaultOpen?: boolean;
   cardHeader?: React.ReactNode;
   embedded?: boolean;
+  hideRootRef?: boolean;
 }) => {
   if (!schema || Object.keys(schema).length === 0) {
     return (
@@ -287,12 +302,15 @@ export const SchemaView = ({
   }
 
   if (schema.type === "object") {
+    const rootRefName =
+      !embedded && !hideRootRef ? getSchemaRefName(schema) : undefined;
     return (
       <ObjectSchemaView
         schema={schema}
         defaultOpen={defaultOpen}
         cardHeader={cardHeader}
         embedded={embedded}
+        rootRefName={rootRefName}
       />
     );
   }

--- a/packages/zudoku/src/lib/plugins/openapi/schema/utils.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaObject } from "../../../oas/parser/index.js";
+import { getSchemaRefName } from "./utils.js";
+
+describe("getSchemaRefName", () => {
+  it("returns the component name from a components/schemas ref", () => {
+    const schema = { type: "object", __$ref: "#/components/schemas/Pet" };
+    expect(getSchemaRefName(schema as SchemaObject)).toBe("Pet");
+  });
+
+  it("reads __$ref even when defined non-enumerable (build-time codegen)", () => {
+    const schema = { type: "object" } as SchemaObject;
+    Object.defineProperty(schema, "__$ref", {
+      value: "#/components/schemas/Pet",
+      enumerable: false,
+    });
+    expect(getSchemaRefName(schema)).toBe("Pet");
+  });
+
+  it("unescapes JSON Pointer tokens per RFC 6901", () => {
+    // ~1 → / and ~0 → ~; escaping order matters: ~1 must be substituted first
+    const schema = {
+      __$ref: "#/components/schemas/application~1json~0v2",
+    } as unknown as SchemaObject;
+    expect(getSchemaRefName(schema)).toBe("application/json~v2");
+  });
+
+  it("URI-decodes percent-encoded characters", () => {
+    const schema = {
+      __$ref: "#/components/schemas/Foo%20Bar",
+    } as unknown as SchemaObject;
+    expect(getSchemaRefName(schema)).toBe("Foo Bar");
+  });
+
+  it.each([
+    ["#/components/parameters/Limit"],
+    ["#/components/responses/NotFound"],
+    ["other.yaml#/components/schemas/Pet"],
+  ])("returns undefined for refs outside components/schemas: %s", (ref) => {
+    const schema = { __$ref: ref } as unknown as SchemaObject;
+    expect(getSchemaRefName(schema)).toBeUndefined();
+  });
+
+  it("returns undefined when __$ref is missing", () => {
+    expect(
+      getSchemaRefName({ type: "object" } as SchemaObject),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined schema", () => {
+    expect(getSchemaRefName(null)).toBeUndefined();
+    expect(getSchemaRefName(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for string schemas (circular refs serialized by handleCircularRefs)", () => {
+    // Regression lock: circular refs surface as "$ref:#/..." strings from
+    // handleCircularRefs; without the typeof guard, `"__$ref" in schema` throws.
+    expect(
+      getSchemaRefName(
+        "$ref:#/components/schemas/Organization" as unknown as SchemaObject,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
@@ -36,6 +36,22 @@ export const isArrayCircularRef = (
 ): schema is SchemaObject & { items: SchemaObject } =>
   isArrayType(schema) && "items" in schema && isCircularRef(schema.items);
 
+const COMPONENTS_SCHEMAS_PREFIX = "#/components/schemas/";
+
+// Unescape a JSON Pointer token per RFC 6901: ~1 → /, ~0 → ~, then URI decode.
+const unescapeJsonPointer = (token: string) =>
+  decodeURIComponent(token.replace(/~1/g, "/").replace(/~0/g, "~"));
+
+export const getSchemaRefName = (
+  schema?: SchemaObject | null,
+): string | undefined => {
+  const ref = schema && "__$ref" in schema ? schema.__$ref : undefined;
+  if (typeof ref !== "string") return;
+  if (!ref.startsWith(COMPONENTS_SCHEMAS_PREFIX)) return;
+
+  return unescapeJsonPointer(ref.slice(COMPONENTS_SCHEMAS_PREFIX.length));
+};
+
 export const extractCircularRefInfo = (
   ref?: string | SchemaObject,
 ): string | undefined => {

--- a/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
@@ -45,7 +45,9 @@ const unescapeJsonPointer = (token: string) =>
 export const getSchemaRefName = (
   schema?: SchemaObject | null,
 ): string | undefined => {
-  // Circular refs are serialized as strings (e.g. "$ref:#/components/...").
+  // Defensive: circular refs can arrive as "$ref:#/..." strings from
+  // handleCircularRefs despite the typed parameter, so the `in` check below
+  // would throw. Bail early.
   if (!schema || typeof schema !== "object") return;
 
   const ref = "__$ref" in schema ? schema.__$ref : undefined;

--- a/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/utils.ts
@@ -45,7 +45,10 @@ const unescapeJsonPointer = (token: string) =>
 export const getSchemaRefName = (
   schema?: SchemaObject | null,
 ): string | undefined => {
-  const ref = schema && "__$ref" in schema ? schema.__$ref : undefined;
+  // Circular refs are serialized as strings (e.g. "$ref:#/components/...").
+  if (!schema || typeof schema !== "object") return;
+
+  const ref = "__$ref" in schema ? schema.__$ref : undefined;
   if (typeof ref !== "string") return;
   if (!ref.startsWith(COMPONENTS_SCHEMAS_PREFIX)) return;
 


### PR DESCRIPTION
Properties that reference a named component now render the schema name (e.g. `Address`, `Package[]`) as a link to `/~schemas#<name>` instead of the generic `object` / `object[]`. Response/request bodies that resolve to a named schema also show the root schema name at the top of the properties panel.

<img width="600" src="https://github.com/user-attachments/assets/7a38f8d2-e1ed-4e3f-8708-84ab39f7164c" />
