### PR TITLE
fix: align playground URL box height with Send button

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/Playground.tsx
@@ -487,7 +487,7 @@ export const Playground = ({
   }, []);
 
   const serverSelect = (
-    <div className="inline-block opacity-50 hover:opacity-100 transition">
+    <div className="inline-block align-middle -translate-y-px opacity-50 hover:opacity-100 transition">
       {server ? (
         <span>{server.replace(/^https?:\/\//, "").replace(/\/$/, "")}</span>
       ) : (
@@ -499,7 +499,7 @@ export const Playground = ({
             value={selectedServer}
             defaultValue={selectedServer}
           >
-            <SelectTrigger className="p-0 h-fit shadow-none border-none flex-row-reverse bg-transparent text-xs gap-0.5 translate-y-[4px]">
+            <SelectTrigger className="p-0! h-6! shadow-none border-none flex-row-reverse bg-transparent text-xs gap-0.5">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -573,18 +573,18 @@ export const Playground = ({
 
           <div className="grid grid-cols-[1fr_1px_1fr] text-sm">
             <div className="col-span-3 p-4 border-b flex gap-2 items-stretch">
-              <div className="flex flex-1 items-center w-full border rounded-md relative overflow-hidden">
-                <div className="border-r p-2 bg-muted rounded-l-md self-stretch font-semibold font-mono flex items-center">
+              <div className="flex flex-1 items-stretch w-full min-h-8 border rounded-md relative overflow-hidden">
+                <div className="border-r px-2 bg-muted rounded-l-md font-semibold font-mono flex items-center">
                   {method.toUpperCase()}
                 </div>
-                <div className="items-center px-2 font-mono text-xs break-all leading-6 relative h-full w-full">
-                  <div className="h-full py-1.5">
+                <div className="flex-1 min-w-0 px-2 font-mono text-xs break-all leading-6 flex items-center">
+                  <div>
                     {serverSelect}
                     <UrlPath url={url} />
                     <UrlQueryParams />
                   </div>
                 </div>
-                <div className="px-1">
+                <div className="px-1 flex items-center">
                   <Button
                     type="button"
                     onClick={() => {


### PR DESCRIPTION
Playground URL path box rendered taller than Send button due to `SelectTrigger` CVA baking in `data-[size=default]:h-9`, which beat `h-fit` via specificity (class+attribute > class) and forced the inline server select to 36px.

Fixes with `h-6!` / `p-0!` important overrides, adds `min-h-8` to URL box, tightens GET badge padding, and nudges the select 1px to align baselines.