### PR TITLE
SSR auth: server-side token verification + logged-out signal

### DIFF
--- a/llm/ssr-auth-architecture.md
+++ b/llm/ssr-auth-architecture.md
@@ -1,0 +1,123 @@
+# SSR auth: token storage & cookie lifecycle
+
+This document explains where auth secrets (access / refresh tokens) live at runtime and why the
+answer differs between the SSR and SSG deployment modes. Audience: contributors touching
+`packages/zudoku/src/lib/authentication/*`.
+
+## Deployment modes
+
+Zudoku supports two runtime shapes:
+
+| Mode | Runtime server                   | Cookie endpoint `/__z/auth/session`                               | First paint auth state                  |
+| ---- | -------------------------------- | ----------------------------------------------------------------- | --------------------------------------- |
+| SSR  | Yes (Node / Vercel / Cloudflare) | Available                                                         | Server-rendered from cookies            |
+| SSG  | No (static hosting)              | Absent (server bundle deleted after prerender in `vite/build.ts`) | Client-only, hydrated from localStorage |
+
+The mode is selected at build time: `zudoku build --ssr` keeps the server bundle; plain
+`zudoku build` prerenders and drops the server bundle.
+
+The client detects the mode at runtime via `window.ZUDOKU_SSR_AUTH`: the SSR server injects this
+object (even with `profile: null`) whenever auth is configured; SSG never injects it.
+
+## Token storage
+
+There are up to three places a token can live in the browser:
+
+1. **httpOnly cookies** set by `/__z/auth/session` after the server calls
+   `provider.verifyAccessToken()`. Cookies: `zudoku-access-token`, `zudoku-refresh-token`,
+   `zudoku-auth-profile`. JS cannot read them. Lifetime is bounded by the verifier's `expiresAt` /
+   `refreshExpiresAt`.
+2. **Zustand `auth-state` in `localStorage`**, persisted via `zustand/middleware`'s `persist`. The
+   full store shape includes `providerData`, which each built-in provider stuffs the current access
+   / refresh tokens into so that `cookie-sync` can POST them.
+3. **Provider SDK storage** (out of Zudoku's direct control):
+   - `supabase-js`: `persistSession: true` writes `sb-<project>-auth-token` to `localStorage`.
+   - `@azure/msal-browser` (Azure B2C): `cacheLocation: "sessionStorage"`.
+   - `@clerk/clerk-js`: its own `__session` cookie + internal caches.
+   - `openid`: no SDK storage; relies on zustand persist and sessionStorage for the PKCE handshake
+     only (code verifier / state), not tokens.
+
+## Why tokens in `localStorage` is a problem (but not a catastrophe)
+
+`localStorage` is readable by any JavaScript executing on the origin — a single successful XSS
+exfiltrates the session. The httpOnly cookie is immune to this. When both exist, the cookie does not
+compensate for the storage exposure: an attacker with JS execution reads the refresh token from
+`localStorage` and keeps minting new access tokens off-origin.
+
+## The mode-aware split
+
+Since SSR has a cookie fallback but SSG does not, the persisted zustand shape differs between modes:
+
+```ts
+// packages/zudoku/src/lib/authentication/state.ts
+const partialize = (state: AuthState) =>
+  ssrAuthInitial !== undefined
+    ? // SSR: don't write tokens to localStorage. The httpOnly cookie is
+      // the durable store; `providerData` stays only in memory.
+      { isAuthenticated: state.isAuthenticated, profile: state.profile }
+    : // SSG: persist full state including `providerData`. Without a server
+      // there is no cookie to recover tokens on reload, so localStorage is
+      // the only continuity store. Weaker posture but the only option in
+      // a pure-static deployment.
+      state;
+```
+
+### Reload behavior (SSR mode)
+
+1. Browser requests page. Server reads cookies via `parseCookies`, calls `configuredAuthProvider` as
+   needed, injects `window.ZUDOKU_SSR_AUTH = { profile }` into the HTML.
+2. Client boots. `state.ts` seeds `isAuthenticated` / `profile` from `ZUDOKU_SSR_AUTH`.
+   `providerData` is `null` — the persisted snapshot doesn't carry it.
+3. Provider SDK initializes. On detecting a live session (from its own storage or silent-refresh
+   against the IdP) it calls `setLoggedIn` with a freshly populated `providerData`.
+4. `cookie-sync`'s zustand subscriber fires. It POSTs the new `{ accessToken, refreshToken }` to
+   `/__z/auth/session`. The server re-verifies, re-writes the cookie with an updated `maxAge`.
+5. User-initiated SSR navigations see the refreshed cookie on the next request.
+
+### Reload behavior (SSG mode)
+
+1. Browser requests prerendered HTML. No server; no cookie is read. `ZUDOKU_SSR_AUTH` is not
+   injected.
+2. Client boots. `state.ts` hydrates full state (including `providerData`) from `localStorage` —
+   this is the continuity mechanism.
+3. `cookie-sync` is still wired up but all its POSTs fail harmlessly (no server). The provider SDK
+   drives refresh against the IdP directly using the persisted tokens.
+
+## `cookie-sync` contract (both modes)
+
+`setupCookieSync(store)` subscribes to the zustand store:
+
+- `isAuthenticated` false → true with `providerData.accessToken`: POST `/__z/auth/session`.
+- `providerData` reference changes while authed: POST (treated as rotation).
+- `isAuthenticated` true → false: DELETE `/__z/auth/session`.
+- Initial rehydrate: POST only if persisted state is authed AND `window.ZUDOKU_SSR_AUTH?.profile` is
+  falsy (i.e. SSR didn't see a cookie, so we're pushing up).
+
+In SSR mode the rehydrate post rarely fires — `providerData` isn't persisted, so `readTokens`
+returns `{}` and `postSession` early-returns. The SDK's subsequent `setLoggedIn` carries the tokens
+instead.
+
+## Known residual exposure
+
+Provider SDK storage (supabase localStorage, MSAL sessionStorage) is not yet stripped. Closing that
+gap requires either:
+
+1. Running the OAuth code-exchange server-side (pure BFF) so the browser never sees a refresh token.
+   Constrained by which providers' SDKs permit it (openid/Auth0 possible; MSAL/Clerk resist).
+2. Configuring each SDK to use in-memory storage only and proxying refresh through the server via
+   the httpOnly cookie. This forces a full re-login on any tab refresh that happens before the SDK's
+   silent-refresh window, which is a UX regression.
+
+Both are out of scope for this PR. The change here closes the duplicate copy that Zudoku itself
+introduced (`providerData` in zustand persist) while leaving provider SDK storage untouched.
+
+## File map
+
+| File                 | Role                                                |
+| -------------------- | --------------------------------------------------- |
+| `authentication.ts`  | `verifyAccessToken` plugin contract                 |
+| `session-handler.ts` | `/__z/auth/session` POST/DELETE Hono sub-app        |
+| `cookie-sync.ts`     | Client → server mirror of token state               |
+| `state.ts`           | Zustand store + mode-aware `partialize`             |
+| `hook.ts`            | `useAuth`; SSR override via `RenderContext.ssrAuth` |
+| `providers/*.tsx`    | Per-provider `verifyAccessToken` implementations    |

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -148,6 +148,7 @@
     "hono": "4.12.12",
     "http-terminator": "3.2.0",
     "javascript-stringify": "2.1.0",
+    "jose": "6.2.2",
     "json-schema-to-typescript-lite": "15.0.0",
     "loglevel": "1.9.2",
     "lucide-react": "0.577.0",

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -15,16 +15,14 @@ const routes = getRoutesByConfig(config);
 // biome-ignore lint/style/noNonNullAssertion: We know the root element exists
 const root = document.getElementById("root")!;
 
-// Injected by entry.server.tsx into a <script> tag before </body>.
-// ZUDOKU_DATA: dehydrated React Query cache for SSR.
-// ZUDOKU_SSR_AUTH: auth profile from httpOnly cookies (no tokens, client-safe).
-// Used by the zustand auth store (state.ts) to seed initial state so the
-// client renders the same auth UI the server did, avoiding hydration mismatch.
+// Injected by entry.server.tsx before </body>. `ZUDOKU_SSR_AUTH` present
+// signals "server checked auth"; `profile: null` is an authoritative
+// logged-out. state.ts reads this to seed the client store.
 declare global {
   interface Window {
     ZUDOKU_VERSION: string;
     ZUDOKU_DATA?: DehydratedState;
-    ZUDOKU_SSR_AUTH?: { profile: UserProfile };
+    ZUDOKU_SSR_AUTH?: { profile: UserProfile | null };
   }
 }
 

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -10,9 +10,10 @@ import {
   type RouteObject,
 } from "react-router";
 import "vite/modulepreload-polyfill";
+import { configuredAuthProvider } from "virtual:zudoku-auth";
 import config from "virtual:zudoku-config";
 import { parseCookies } from "../lib/authentication/cookies.js";
-import { sessionHandler } from "../lib/authentication/session-handler.js";
+import { createSessionHandler } from "../lib/authentication/session-handler.js";
 import { BootstrapStatic } from "../lib/components/Bootstrap.js";
 import { NO_DEHYDRATE } from "../lib/components/cache.js";
 import type { SSRAuthState } from "../lib/components/context/RenderContext.js";
@@ -20,7 +21,6 @@ import { ServerError } from "../lib/errors/ServerError.js";
 import { highlighterPromise } from "../lib/shiki.js";
 import { getRoutesByConfig } from "./main.js";
 export { getRoutesByConfig };
-export { sessionHandler };
 
 const safeSerialize = (data: unknown) =>
   JSON.stringify(data).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
@@ -72,8 +72,10 @@ export const handleRequest = async ({
   }
 
   const { accessToken, profile } = parseCookies(request);
-  const ssrAuth: SSRAuthState | undefined = profile
-    ? { accessToken, profile }
+  // Emit auth state when configured, even if profile is null, so the client
+  // knows whether the server checked auth.
+  const ssrAuth: SSRAuthState | undefined = configuredAuthProvider
+    ? { accessToken, profile: profile ?? null }
     : undefined;
 
   const router = createStaticRouter(dataRoutes, context);
@@ -167,7 +169,9 @@ export const handleRequest = async ({
     const headers: HeadersInit = {
       "Content-Type": "text/html; charset=utf-8",
     };
-    if (ssrAuth) {
+    // Only suppress caching for pages that embed a per-user profile.
+    // Anonymous renders (auth configured but no session) stay cacheable.
+    if (ssrAuth?.profile) {
       headers["Cache-Control"] = "private, no-store";
     }
 
@@ -191,7 +195,7 @@ export const createServer = (options: {
   const routes = getRoutesByConfig(config);
   const app = new Hono();
 
-  app.route("/__z/auth/session", sessionHandler);
+  app.route("/__z/auth/session", createSessionHandler(configuredAuthProvider));
   app.all("*", (c) =>
     handleRequest({
       template: options.template,

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -18,6 +18,8 @@ import "virtual:zudoku-theme.css";
 import { Zudoku } from "zudoku/components";
 import { Outlet } from "zudoku/router";
 import type { ZudokuConfig } from "../config/config.js";
+import { setupCookieSync } from "../lib/authentication/cookie-sync.js";
+import { authState } from "../lib/authentication/state.js";
 import { BuildCheck } from "../lib/components/BuildCheck.js";
 import "./main.css";
 import { Meta } from "../lib/components/Meta.js";
@@ -30,6 +32,8 @@ import { RouterError } from "../lib/errors/RouterError.js";
 import { ZuploEnv } from "./env.js";
 import { processRoutes } from "./processRoutes.js";
 import { createRedirectRoutes } from "./utils/createRedirectRoutes.js";
+
+setupCookieSync(authState);
 
 export const shikiReady: Promise<HighlighterCore> =
   import("../lib/shiki.js").then(async ({ highlighterPromise }) => {

--- a/packages/zudoku/src/lib/authentication/authentication.ts
+++ b/packages/zudoku/src/lib/authentication/authentication.ts
@@ -1,8 +1,12 @@
 import type { NavigateFunction } from "react-router";
 import type { ZudokuContext } from "../core/ZudokuContext.js";
+import type { UserProfile } from "./state.js";
 
 export type AuthActionContext = { navigate: NavigateFunction };
 export type AuthActionOptions = { redirectTo?: string; replace?: boolean };
+export type VerifyAccessTokenResult =
+  | { profile: UserProfile; expiresAt?: number; refreshExpiresAt?: number }
+  | undefined;
 
 export interface AuthenticationPlugin {
   initialize?(context: ZudokuContext): Promise<void>;
@@ -41,6 +45,17 @@ export interface AuthenticationPlugin {
    * @deprecated use the navigate function from the AuthActionContext instead
    */
   setNavigate?(navigate: NavigateFunction): void;
+
+  /**
+   * Server-side verification of a client-submitted access token, called by
+   * the session-handler before setting the SSR auth cookies. Implementations
+   * MUST validate against the IdP (signature, issuer, audience, expiry) and
+   * return the verified profile. Return undefined for a rejected token
+   * (→ 401); throw for misconfig / upstream failure (→ 502). `expiresAt` /
+   * `refreshExpiresAt` are unix seconds used to bound cookie lifetimes so
+   * SSR can't outlive a revoked token. Omit to opt out of SSR auth (→ 501).
+   */
+  verifyAccessToken?(token: string): Promise<VerifyAccessTokenResult>;
 }
 
 export type AuthenticationProviderInitializer<TConfig> = (

--- a/packages/zudoku/src/lib/authentication/cookie-sync.test.ts
+++ b/packages/zudoku/src/lib/authentication/cookie-sync.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createStore } from "zustand";
+import { setupCookieSync } from "./cookie-sync.js";
+import type { UserProfile } from "./state.js";
+
+// cookie-sync is intentionally provider-agnostic: it reads top-level
+// access/refresh tokens off providerData. Use a loose shape so tests can
+// exercise the contract without pulling in a specific provider's schema.
+type LooseState = {
+  isAuthenticated: boolean;
+  profile: UserProfile | null;
+  providerData: unknown;
+};
+
+const PROFILE: UserProfile = {
+  sub: "u1",
+  email: "u@example.com",
+  emailVerified: true,
+  name: "U",
+  pictureUrl: undefined,
+};
+
+const createSlice = (initial: Partial<LooseState> = {}) =>
+  createStore<LooseState>(() => ({
+    isAuthenticated: false,
+    profile: null,
+    providerData: null,
+    ...initial,
+  }));
+
+const setup = (store: ReturnType<typeof createSlice>) =>
+  setupCookieSync(store as unknown as Parameters<typeof setupCookieSync>[0]);
+
+describe("setupCookieSync", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    delete (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("is a no-op on the server", () => {
+    const original = globalThis.window;
+    // @ts-expect-error simulate SSR
+    delete globalThis.window;
+    try {
+      const store = createSlice();
+      setup(store);
+      store.setState({
+        isAuthenticated: true,
+        profile: PROFILE,
+        providerData: { accessToken: "t" },
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.window = original;
+    }
+  });
+
+  test("posts access + refresh tokens when login transitions false → true", async () => {
+    const store = createSlice();
+    setup(store);
+    store.setState({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "atok", refreshToken: "rtok" },
+    });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("/__z/auth/session");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      accessToken: "atok",
+      refreshToken: "rtok",
+    });
+  });
+
+  test("re-posts when providerData changes while authenticated (token refresh)", async () => {
+    const store = createSlice({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "first" },
+    });
+    (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH = {
+      profile: PROFILE,
+    };
+    setup(store);
+    expect(fetchMock).not.toHaveBeenCalled(); // SSR already had cookies
+
+    store.setState({ providerData: { accessToken: "second" } });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1].body)).toEqual({
+      accessToken: "second",
+    });
+  });
+
+  test("skips initial post when SSR already hydrated the session", () => {
+    (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH = {
+      profile: PROFILE,
+    };
+    const store = createSlice({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+    setup(store);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("posts on initial rehydrate when SSR did not see cookies", () => {
+    const store = createSlice({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+    setup(store);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/__z/auth/session",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  test("DELETEs on logout transition true → false", async () => {
+    const store = createSlice({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+    (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH = {
+      profile: PROFILE,
+    };
+    setup(store);
+    store.setState({
+      isAuthenticated: false,
+      profile: null,
+      providerData: null,
+    });
+    await vi.waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/__z/auth/session",
+        expect.objectContaining({ method: "DELETE" }),
+      ),
+    );
+  });
+
+  test("no-ops when providerData has no access token", () => {
+    const store = createSlice();
+    setup(store);
+    store.setState({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { foo: "bar" }, // no accessToken
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("treats 501 as a benign no-op (no error logged)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 501 }));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createSlice();
+    setup(store);
+    store.setState({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  test("logs an error for non-501 failures", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 502 }));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createSlice();
+    setup(store);
+    store.setState({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+    await vi.waitFor(() => expect(errSpy).toHaveBeenCalled());
+    errSpy.mockRestore();
+  });
+});

--- a/packages/zudoku/src/lib/authentication/cookie-sync.ts
+++ b/packages/zudoku/src/lib/authentication/cookie-sync.ts
@@ -1,67 +1,74 @@
-import type { StateCreator, StoreMutatorIdentifier } from "zustand";
-import type { AuthState, UserProfile } from "./state.js";
+import type { StoreApi } from "zustand";
+import type { AuthState } from "./state.js";
 
-type CookieSync = <
-  T extends Pick<AuthState, "isAuthenticated" | "profile" | "providerData">,
-  Mps extends [StoreMutatorIdentifier, unknown][] = [],
-  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
->(
-  config: StateCreator<T, Mps, Mcs>,
-) => StateCreator<T, Mps, Mcs>;
+type TokenBearer = { accessToken?: string; refreshToken?: string };
 
-const cookieSyncImpl: CookieSync = (config) => (set, get, api) => {
-  const result = config(set, get, api);
-
-  if (typeof window !== "undefined") {
-    // Subscribe for ongoing state changes (login/logout actions)
-    api.subscribe((next, prev) => {
-      if (next.isAuthenticated && next.profile) {
-        if (!prev.isAuthenticated || next.providerData !== prev.providerData) {
-          syncSessionCookie(next.profile, next.providerData);
-        }
-      } else if (!next.isAuthenticated && prev.isAuthenticated) {
-        void fetch("/__z/auth/session", { method: "DELETE" }).catch((e) => {
-          // biome-ignore lint/suspicious/noConsole: Log session clear failures
-          console.warn("Failed to clear session cookie:", e);
-        });
-      }
-    });
-
-    // Sync immediately if persist already rehydrated an authenticated session
-    // but SSR didn't have cookies yet (subscribe misses the initial rehydration)
-    const state = api.getState();
-    if (state.isAuthenticated && state.profile && !window.ZUDOKU_SSR_AUTH) {
-      syncSessionCookie(state.profile, state.providerData);
-    }
-  }
-
-  return result;
+const readTokens = (providerData: unknown): TokenBearer => {
+  if (!providerData || typeof providerData !== "object") return {};
+  const { accessToken, refreshToken } = providerData as TokenBearer;
+  return {
+    accessToken: typeof accessToken === "string" ? accessToken : undefined,
+    refreshToken: typeof refreshToken === "string" ? refreshToken : undefined,
+  };
 };
 
-export const cookieSync = cookieSyncImpl as CookieSync;
+const postSession = async (providerData: unknown) => {
+  const { accessToken, refreshToken } = readTokens(providerData);
+  if (!accessToken) return;
 
-const syncSessionCookie = (profile: UserProfile, providerData: unknown) => {
-  const data = providerData as
-    | { accessToken?: string; refreshToken?: string }
-    | undefined;
-
-  void fetch("/__z/auth/session", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      accessToken: data?.accessToken,
-      refreshToken: data?.refreshToken,
-      profile,
-    }),
-  })
-    .then((r) => {
-      if (!r.ok) {
-        // biome-ignore lint/suspicious/noConsole: Debug cookie sync
-        console.warn("Cookie sync failed:", r.status);
-      }
-    })
-    .catch((e) => {
-      // biome-ignore lint/suspicious/noConsole: Debug cookie sync
-      console.warn("Cookie sync error:", e);
+  try {
+    const r = await fetch("/__z/auth/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ accessToken, refreshToken }),
     });
+    // 501 = provider opted out of SSR auth; any other failure is surfaced.
+    if (!r.ok && r.status !== 501) {
+      // biome-ignore lint/suspicious/noConsole: Surface SSR auth failures
+      console.error("SSR auth cookie sync failed:", r.status);
+    }
+  } catch (e) {
+    // biome-ignore lint/suspicious/noConsole: Surface SSR auth failures
+    console.error("SSR auth cookie sync error:", e);
+  }
+};
+
+const clearSession = () =>
+  fetch("/__z/auth/session", { method: "DELETE" }).catch((e) => {
+    // biome-ignore lint/suspicious/noConsole: Surface SSR auth failures
+    console.error("SSR auth cookie clear failed:", e);
+  });
+
+/**
+ * Mirror the client auth state to SSR cookies so the next HTML render is
+ * authenticated on first paint. Reads tokens from `providerData` — each
+ * built-in provider puts them there. No-op on the server.
+ */
+export const setupCookieSync = (
+  store: StoreApi<
+    Pick<AuthState, "isAuthenticated" | "profile" | "providerData">
+  >,
+) => {
+  if (typeof window === "undefined") return;
+
+  store.subscribe((next, prev) => {
+    if (next.isAuthenticated && next.profile) {
+      if (!prev.isAuthenticated || next.providerData !== prev.providerData) {
+        void postSession(next.providerData);
+      }
+    } else if (!next.isAuthenticated && prev.isAuthenticated) {
+      void clearSession();
+    }
+  });
+
+  // If persist rehydrated an authed session that SSR didn't see, push tokens
+  // up so the next navigation is server-authed.
+  const state = store.getState();
+  if (
+    state.isAuthenticated &&
+    state.profile &&
+    !window.ZUDOKU_SSR_AUTH?.profile
+  ) {
+    void postSession(state.providerData);
+  }
 };

--- a/packages/zudoku/src/lib/authentication/hook.ts
+++ b/packages/zudoku/src/lib/authentication/hook.ts
@@ -76,8 +76,8 @@ export const useAuth = () => {
 
   useRefreshUserProfile();
 
-  // On the server, the zustand store can't read window.ZUDOKU_SSR_AUTH,
-  // so we override from RenderContext which carries the per-request auth state
+  // On the server, the zustand store can't read window.ZUDOKU_SSR_AUTH, so
+  // override from RenderContext which carries the per-request auth state.
   const { ssrAuth } = use(RenderContext);
   const isSSR = typeof window === "undefined";
 
@@ -86,7 +86,7 @@ export const useAuth = () => {
     ...authState,
     ...(isSSR &&
       ssrAuth && {
-        isAuthenticated: true,
+        isAuthenticated: !!ssrAuth.profile,
         isPending: false,
         profile: ssrAuth.profile,
       }),

--- a/packages/zudoku/src/lib/authentication/providers/azureb2c.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/azureb2c.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import azureB2CAuth from "./azureb2c.js";
+
+const jwtVerify = vi.fn();
+const createRemoteJWKSet = vi.fn((_url: URL) => ({}));
+
+class FakeJOSEError extends Error {}
+
+vi.mock("jose", () => ({
+  jwtVerify: (token: string, keys: unknown, opts?: unknown) =>
+    jwtVerify(token, keys, opts),
+  createRemoteJWKSet: (url: URL) => createRemoteJWKSet(url),
+  errors: { JOSEError: FakeJOSEError },
+}));
+
+// MSAL's constructor kicks off async init work; stub it so the tests don't
+// hit the network and we don't need to wait for any of it.
+vi.mock("@azure/msal-browser", () => {
+  class FakeMsal {
+    initialize() {
+      return Promise.resolve();
+    }
+    handleRedirectPromise() {
+      return Promise.resolve(null);
+    }
+    addEventCallback() {
+      return undefined;
+    }
+  }
+  return {
+    EventType: { LOGIN_SUCCESS: "login_success" },
+    PublicClientApplication: FakeMsal,
+  };
+});
+
+const TENANT = "mytenant";
+const POLICY = "B2C_1_signin";
+const CLIENT_ID = "client-id";
+const ISSUER = `https://${TENANT}.b2clogin.com/tenant-guid/v2.0/`;
+const JWKS_URI = `https://${TENANT}.b2clogin.com/${TENANT}.onmicrosoft.com/${POLICY}/discovery/v2.0/keys`;
+
+const discoveryResponse = () =>
+  Response.json({ issuer: ISSUER, jwks_uri: JWKS_URI });
+
+const buildProvider = () =>
+  azureB2CAuth({
+    type: "azureb2c",
+    clientId: CLIENT_ID,
+    tenantName: TENANT,
+    policyName: POLICY,
+    issuer: ISSUER,
+  });
+
+describe("azureb2c verifyAccessToken", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValue(discoveryResponse());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns profile + expiresAt from a verified token", async () => {
+    jwtVerify.mockResolvedValueOnce({
+      payload: {
+        oid: "oid-1",
+        sub: "sub-1",
+        emails: ["u@example.com"],
+        given_name: "Given",
+        family_name: "Family",
+        exp: 1_700_000_000,
+      },
+    });
+    const provider = buildProvider();
+    const result = await provider.verifyAccessToken?.("jwt");
+    expect(result).toEqual({
+      profile: {
+        sub: "oid-1",
+        email: "u@example.com",
+        name: "Given Family",
+        emailVerified: true,
+        pictureUrl: undefined,
+      },
+      expiresAt: 1_700_000_000,
+    });
+  });
+
+  test("validates against the discovered issuer", async () => {
+    jwtVerify.mockResolvedValueOnce({
+      payload: { oid: "oid-1" },
+    });
+    const provider = buildProvider();
+    await provider.verifyAccessToken?.("jwt");
+    // biome-ignore lint/style/noNonNullAssertion: test setup asserts the call
+    const [, , opts] = jwtVerify.mock.calls[0]!;
+    expect(opts).toEqual({ issuer: ISSUER });
+  });
+
+  test("caches discovery + JWKS per provider instance", async () => {
+    jwtVerify.mockResolvedValue({ payload: { oid: "oid-1" } });
+    const provider = buildProvider();
+    await provider.verifyAccessToken?.("t");
+    await provider.verifyAccessToken?.("t");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(createRemoteJWKSet).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns undefined for JOSE errors (bad signature / expired)", async () => {
+    jwtVerify.mockRejectedValueOnce(new FakeJOSEError("expired"));
+    const provider = buildProvider();
+    expect(await provider.verifyAccessToken?.("jwt")).toBeUndefined();
+  });
+
+  test("rethrows non-JOSE errors (e.g. JWKS fetch) → 502", async () => {
+    jwtVerify.mockRejectedValueOnce(new Error("jwks network error"));
+    const provider = buildProvider();
+    await expect(provider.verifyAccessToken?.("jwt")).rejects.toThrow(
+      "jwks network error",
+    );
+  });
+
+  test("rethrows when discovery endpoint returns non-ok", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const provider = buildProvider();
+    await expect(provider.verifyAccessToken?.("t")).rejects.toThrow(
+      /Azure B2C discovery failed/,
+    );
+  });
+
+  test("returns undefined when no sub/oid claim is present", async () => {
+    jwtVerify.mockResolvedValueOnce({ payload: { email: "u@example.com" } });
+    const provider = buildProvider();
+    expect(await provider.verifyAccessToken?.("jwt")).toBeUndefined();
+  });
+
+  test("falls back to given_name + family_name when name claim is missing", async () => {
+    jwtVerify.mockResolvedValueOnce({
+      payload: { oid: "oid-1", given_name: "Ada", family_name: "Lovelace" },
+    });
+    const provider = buildProvider();
+    const result = await provider.verifyAccessToken?.("jwt");
+    expect(result?.profile.name).toBe("Ada Lovelace");
+  });
+});

--- a/packages/zudoku/src/lib/authentication/providers/azureb2c.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/azureb2c.tsx
@@ -8,6 +8,7 @@ import type {
   AuthActionContext,
   AuthenticationPlugin,
   AuthenticationProviderInitializer,
+  VerifyAccessTokenResult,
 } from "../authentication.js";
 import { CoreAuthenticationPlugin } from "../AuthenticationPlugin.js";
 import { CallbackHandler } from "../components/CallbackHandler.js";
@@ -40,6 +41,10 @@ export class AzureB2CAuthPlugin
   private readonly redirectToAfterSignUp?: string;
   private readonly redirectToAfterSignIn?: string;
   private readonly redirectToAfterSignOut: string;
+  private readonly authority: string;
+  // The issuer carries the tenant GUID we don't know up-front, so discover.
+  private discoveryPromise?: Promise<{ issuer: string; jwks_uri: string }>;
+  private jwks?: ReturnType<typeof import("jose").createRemoteJWKSet>;
 
   constructor({
     clientId,
@@ -57,13 +62,13 @@ export class AzureB2CAuthPlugin
     this.redirectToAfterSignIn = redirectToAfterSignIn;
     this.redirectToAfterSignOut = redirectToAfterSignOut;
 
-    const authority = `https://${tenantName}.b2clogin.com/${tenantName}.onmicrosoft.com/${policyName}`;
+    this.authority = `https://${tenantName}.b2clogin.com/${tenantName}.onmicrosoft.com/${policyName}`;
     const redirectUri = joinUrl(basePath, AZUREB2C_CALLBACK_PATH);
 
     this.msalInstance = new PublicClientApplication({
       auth: {
         clientId,
-        authority,
+        authority: this.authority,
         redirectUri,
         knownAuthorities: [`${tenantName}.b2clogin.com`],
       },
@@ -176,6 +181,69 @@ export class AzureB2CAuthPlugin
     request.headers.set("Authorization", `Bearer ${accessToken}`);
     return request;
   };
+
+  private async getDiscovery() {
+    this.discoveryPromise ??= fetch(
+      `${this.authority}/v2.0/.well-known/openid-configuration`,
+    ).then(async (response) => {
+      if (!response.ok) {
+        throw new Error(
+          `Azure B2C discovery failed: ${response.status} ${response.statusText}`,
+        );
+      }
+      return (await response.json()) as { issuer: string; jwks_uri: string };
+    });
+    return this.discoveryPromise;
+  }
+
+  async verifyAccessToken(token: string): Promise<VerifyAccessTokenResult> {
+    const jose = await import("jose");
+    const { issuer, jwks_uri } = await this.getDiscovery();
+    if (!this.jwks) {
+      this.jwks = jose.createRemoteJWKSet(new URL(jwks_uri));
+    }
+    try {
+      const { payload } = await jose.jwtVerify(token, this.jwks, { issuer });
+      // Match client-side sub (handleAuthResponse uses account.localAccountId, which is oid).
+      const sub =
+        typeof payload.oid === "string"
+          ? payload.oid
+          : typeof payload.sub === "string"
+            ? payload.sub
+            : undefined;
+      if (!sub) return undefined;
+
+      const emails = Array.isArray(payload.emails) ? payload.emails : [];
+      const email =
+        typeof payload.email === "string"
+          ? payload.email
+          : typeof emails[0] === "string"
+            ? emails[0]
+            : undefined;
+
+      const fullName = [payload.given_name, payload.family_name]
+        .filter((s): s is string => typeof s === "string" && s.length > 0)
+        .join(" ");
+      const name =
+        typeof payload.name === "string" ? payload.name : fullName || undefined;
+
+      return {
+        profile: {
+          sub,
+          email,
+          name,
+          emailVerified: true,
+          pictureUrl: undefined,
+        },
+        expiresAt: typeof payload.exp === "number" ? payload.exp : undefined,
+      };
+    } catch (e) {
+      // JOSEError = invalid token (→ 401). Rethrow anything else so the
+      // handler can surface 502 for misconfig / JWKS fetch failures.
+      if (e instanceof jose.errors.JOSEError) return undefined;
+      throw e;
+    }
+  }
 
   signOut = async (_: AuthActionContext) => {
     const account = this.msalInstance.getAllAccounts()[0];

--- a/packages/zudoku/src/lib/authentication/providers/clerk.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import { afterEach, describe, expect, test, vi } from "vitest";
+import clerkAuth from "./clerk.js";
+
+const jwtVerify = vi.fn();
+const createRemoteJWKSet = vi.fn((_url: URL) => ({}));
+
+class FakeJOSEError extends Error {}
+
+vi.mock("jose", () => ({
+  jwtVerify: (token: string, keys: unknown, opts?: unknown) =>
+    jwtVerify(token, keys, opts),
+  createRemoteJWKSet: (url: URL) => createRemoteJWKSet(url),
+  errors: { JOSEError: FakeJOSEError },
+}));
+
+// atob("clerk.example.com$") === "Y2xlcmsuZXhhbXBsZS5jb20k"
+const TEST_PUB_KEY = "pk_test_Y2xlcmsuZXhhbXBsZS5jb20k" as const;
+
+const buildProvider = () =>
+  clerkAuth({
+    type: "clerk",
+    clerkPubKey: TEST_PUB_KEY,
+    jwtTemplateName: "default",
+  });
+
+describe("clerk verifyAccessToken", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("asserts issuer when verifying", async () => {
+    jwtVerify.mockResolvedValueOnce({
+      payload: { sub: "u1", exp: 9999999999 },
+    });
+    const provider = buildProvider();
+    await provider.verifyAccessToken?.("jwt");
+    // biome-ignore lint/style/noNonNullAssertion: For testing purposes
+    const [, , opts] = jwtVerify.mock.calls[0]!;
+    expect(opts).toEqual({ issuer: "https://clerk.example.com" });
+  });
+
+  test("returns profile and expiresAt on success", async () => {
+    jwtVerify.mockResolvedValueOnce({
+      payload: {
+        sub: "u1",
+        email: "u@example.com",
+        name: "U",
+        email_verified: true,
+        picture: "https://example.com/p.png",
+        exp: 1_700_000_000,
+      },
+    });
+    const provider = buildProvider();
+    const result = await provider.verifyAccessToken?.("jwt");
+    expect(result).toEqual({
+      profile: {
+        sub: "u1",
+        email: "u@example.com",
+        name: "U",
+        emailVerified: true,
+        pictureUrl: "https://example.com/p.png",
+      },
+      expiresAt: 1_700_000_000,
+    });
+  });
+
+  test("returns undefined for a JOSE error (bad signature / expired)", async () => {
+    jwtVerify.mockRejectedValueOnce(new FakeJOSEError("bad signature"));
+    const provider = buildProvider();
+    const result = await provider.verifyAccessToken?.("jwt");
+    expect(result).toBeUndefined();
+  });
+
+  test("rethrows non-JOSE errors (e.g. JWKS fetch failure → 502)", async () => {
+    jwtVerify.mockRejectedValueOnce(new Error("jwks network error"));
+    const provider = buildProvider();
+    await expect(provider.verifyAccessToken?.("jwt")).rejects.toThrow(
+      "jwks network error",
+    );
+  });
+
+  test("returns undefined when payload has no sub", async () => {
+    jwtVerify.mockResolvedValueOnce({ payload: { exp: 1 } });
+    const provider = buildProvider();
+    const result = await provider.verifyAccessToken?.("jwt");
+    expect(result).toBeUndefined();
+  });
+
+  test("JWKS cache is per provider instance, not module-global", async () => {
+    jwtVerify.mockResolvedValue({ payload: { sub: "u1" } });
+
+    const a = buildProvider();
+    const b = buildProvider();
+    await a.verifyAccessToken?.("t");
+    await a.verifyAccessToken?.("t");
+    await b.verifyAccessToken?.("t");
+
+    // Each instance builds its own JWKS once, so two instances = two calls.
+    expect(createRemoteJWKSet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/zudoku/src/lib/authentication/providers/clerk.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.tsx
@@ -5,6 +5,7 @@ import type {
   AuthActionContext,
   AuthenticationPlugin,
   AuthenticationProviderInitializer,
+  VerifyAccessTokenResult,
 } from "../authentication.js";
 import { SignIn } from "../components/SignIn.js";
 import { SignOut } from "../components/SignOut.js";
@@ -15,6 +16,7 @@ import { getClerkFrontendApi } from "./util.js";
 export type ClerkProviderData = {
   type: "clerk";
   user: NonNullable<Clerk["session"]>["user"] | undefined;
+  accessToken?: string;
 };
 
 declare module "../state.js" {
@@ -70,6 +72,10 @@ const clerkAuth: AuthenticationProviderInitializer<
     return loadClerk(clerkPubKey);
   };
 
+  const frontendApi = getClerkFrontendApi(clerkPubKey);
+  const issuer = `https://${frontendApi}`;
+  let jwks: ReturnType<typeof import("jose").createRemoteJWKSet> | undefined;
+
   async function getAccessToken() {
     const clerk = await getClerk();
 
@@ -123,6 +129,8 @@ const clerkAuth: AuthenticationProviderInitializer<
       return false;
     }
 
+    const accessToken = await getAccessToken().catch(() => undefined);
+
     useAuthState.setState({
       isAuthenticated: true,
       isPending: false,
@@ -130,6 +138,7 @@ const clerkAuth: AuthenticationProviderInitializer<
       providerData: {
         type: "clerk",
         user: clerk.session?.user,
+        accessToken,
       },
     });
 
@@ -140,6 +149,38 @@ const clerkAuth: AuthenticationProviderInitializer<
     const response = await getAccessToken();
     request.headers.set("Authorization", `Bearer ${response}`);
     return request;
+  }
+
+  async function verifyAccessToken(
+    token: string,
+  ): Promise<VerifyAccessTokenResult> {
+    const jose = await import("jose");
+    if (!jwks) {
+      jwks = jose.createRemoteJWKSet(
+        new URL(`${issuer}/.well-known/jwks.json`),
+      );
+    }
+    try {
+      const { payload } = await jose.jwtVerify(token, jwks, { issuer });
+      if (!payload.sub) return undefined;
+      return {
+        profile: {
+          sub: String(payload.sub),
+          email: (payload.email ?? payload.email_address) as string | undefined,
+          name: payload.name as string | undefined,
+          emailVerified: Boolean(payload.email_verified),
+          pictureUrl: (payload.picture ?? payload.image_url) as
+            | string
+            | undefined,
+        },
+        expiresAt: typeof payload.exp === "number" ? payload.exp : undefined,
+      };
+    } catch (e) {
+      // JOSEError = invalid token (→ 401). Rethrow anything else so the
+      // handler can surface 502 for misconfig / JWKS fetch failures.
+      if (e instanceof jose.errors.JOSEError) return undefined;
+      throw e;
+    }
   }
 
   return {
@@ -170,11 +211,14 @@ const clerkAuth: AuthenticationProviderInitializer<
           return;
         }
 
+        const accessToken = await getAccessToken().catch(() => undefined);
+
         useAuthState.getState().setLoggedIn({
           profile,
           providerData: {
             type: "clerk",
             user: clerk.session.user,
+            accessToken,
           },
         });
       } else {
@@ -183,6 +227,7 @@ const clerkAuth: AuthenticationProviderInitializer<
     },
     getAccessToken,
     signRequest,
+    verifyAccessToken,
     signOut: async () => {
       const clerk = await getClerk();
       useAuthState.getState().setLoggedOut();

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -234,6 +234,32 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       expect(useAuthState.getState().profile?.emailVerified).toBe(true);
     });
 
+    test("returns false without evicting state when providerData is null (SSR reload)", async () => {
+      const provider = createProvider();
+      vi.mocked(oauth.userInfoRequest).mockClear();
+
+      // SSR-seeded: profile is set, but providerData wasn't persisted.
+      useAuthState.setState({
+        isAuthenticated: true,
+        isPending: false,
+        profile: {
+          sub: "user-1",
+          email: "user@example.com",
+          emailVerified: true,
+          name: "Test",
+          pictureUrl: undefined,
+        },
+        providerData: null,
+      });
+
+      const result = await provider.refreshUserProfile();
+
+      expect(result).toBe(false);
+      expect(oauth.userInfoRequest).not.toHaveBeenCalled();
+      expect(useAuthState.getState().isAuthenticated).toBe(true);
+      expect(useAuthState.getState().profile?.sub).toBe("user-1");
+    });
+
     test("defaults emailVerified to false when userInfo omits it", async () => {
       const provider = setupRefresh({
         sub: "user-1",

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -247,6 +247,59 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
     });
   });
 
+  describe("verifyAccessToken", () => {
+    // Header {"alg":"none"}, payload {"sub":"u1","exp":1700000000}.
+    // Content doesn't matter for decoding since jose.decodeJwt skips signature.
+    const TOKEN_WITH_EXP =
+      "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ1MSIsImV4cCI6MTcwMDAwMDAwMH0.sig";
+
+    test("returns verified profile and expiresAt from access token JWT", async () => {
+      const provider = createProvider();
+      vi.mocked(oauth.userInfoRequest).mockResolvedValueOnce(
+        Response.json({
+          sub: "u1",
+          email: "u@example.com",
+          name: "U",
+          email_verified: true,
+          picture: "https://example.com/p.png",
+        }),
+      );
+      const result = await provider.verifyAccessToken(TOKEN_WITH_EXP);
+      expect(result).toEqual({
+        profile: {
+          sub: "u1",
+          email: "u@example.com",
+          name: "U",
+          emailVerified: true,
+          pictureUrl: "https://example.com/p.png",
+        },
+        expiresAt: 1_700_000_000,
+      });
+    });
+
+    test("returns null when userInfo responds not-ok", async () => {
+      const provider = createProvider();
+      vi.mocked(oauth.userInfoRequest).mockResolvedValueOnce(
+        new Response(null, { status: 401 }),
+      );
+      expect(await provider.verifyAccessToken("t")).toBeUndefined();
+    });
+
+    test("throws when userInfo transport fails (→ 502 at the handler)", async () => {
+      const provider = createProvider();
+      vi.mocked(oauth.userInfoRequest).mockRejectedValueOnce(new Error("boom"));
+      await expect(provider.verifyAccessToken("t")).rejects.toThrow("boom");
+    });
+
+    test("returns null when userInfo has no sub", async () => {
+      const provider = createProvider();
+      vi.mocked(oauth.userInfoRequest).mockResolvedValueOnce(
+        Response.json({ email: "u@example.com" }),
+      );
+      expect(await provider.verifyAccessToken("t")).toBeUndefined();
+    });
+  });
+
   test("self heals providerData when providerData.type is undefined", async () => {
     const provider = createProvider();
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -9,6 +9,7 @@ import type {
   AuthActionOptions,
   AuthenticationPlugin,
   AuthenticationProviderInitializer,
+  VerifyAccessTokenResult,
 } from "../authentication.js";
 import { CoreAuthenticationPlugin } from "../AuthenticationPlugin.js";
 import { CallbackHandler } from "../components/CallbackHandler.js";
@@ -19,6 +20,16 @@ import { type UserProfile, useAuthState } from "../state.js";
 
 const CODE_VERIFIER_KEY = "code-verifier";
 const STATE_KEY = "oauth-state";
+
+const decodeJwtExp = async (token: string): Promise<number | undefined> => {
+  try {
+    const { decodeJwt } = await import("jose");
+    const payload = decodeJwt(token);
+    return typeof payload.exp === "number" ? payload.exp : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 export interface OpenIdProviderData {
   // just for easy migration we also allow for undefined type. can be removed in the future.
@@ -181,6 +192,36 @@ export class OpenIDAuthenticationProvider
       redirectTo: this.redirectToAfterSignIn ?? redirectTo ?? "/",
       replace,
     });
+  }
+
+  public async verifyAccessToken(
+    token: string,
+  ): Promise<VerifyAccessTokenResult> {
+    const authServer = await this.getAuthServer();
+    const response = await oauth.userInfoRequest(
+      authServer,
+      this.client,
+      token,
+    );
+    if (!response.ok) return undefined;
+    const userInfo = (await response.json()) as Record<string, unknown>;
+    if (!userInfo.sub) return undefined;
+
+    // userInfoRequest authenticated the token upstream; parsing `exp` here
+    // lets us bound the cookie lifetime to the token's. Opaque tokens just
+    // yield undefined and fall back to the handler's default.
+    const expiresAt = await decodeJwtExp(token);
+
+    return {
+      profile: {
+        sub: String(userInfo.sub),
+        email: userInfo.email as string | undefined,
+        name: userInfo.name as string | undefined,
+        emailVerified: Boolean(userInfo.email_verified),
+        pictureUrl: userInfo.picture as string | undefined,
+      },
+      expiresAt,
+    };
   }
 
   public async refreshUserProfile(): Promise<boolean> {

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -225,6 +225,11 @@ export class OpenIDAuthenticationProvider
   }
 
   public async refreshUserProfile(): Promise<boolean> {
+    // SSR mode doesn't persist `providerData`; tokens live only in the
+    // httpOnly cookie. Without client-side tokens we can't call userInfo —
+    // the SSR-supplied profile stays authoritative.
+    if (!useAuthState.getState().providerData) return false;
+
     const accessToken = await this.getAccessToken();
     const authServer = await this.getAuthServer();
 

--- a/packages/zudoku/src/lib/authentication/providers/supabase.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import supabaseAuth from "./supabase.js";
+
+const getUser = vi.fn();
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    auth: {
+      onAuthStateChange: () => undefined,
+      getSession: () =>
+        Promise.resolve({ data: { session: null }, error: null }),
+      getUser: (token: string) => getUser(token),
+    },
+  }),
+}));
+
+const buildProvider = () =>
+  supabaseAuth({
+    type: "supabase",
+    supabaseUrl: "https://example.supabase.co",
+    supabaseKey: "anon",
+  });
+
+describe("supabase verifyAccessToken", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  test("returns profile from verified user", async () => {
+    getUser.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: "u1",
+          email: "u@example.com",
+          email_confirmed_at: "2024-01-01T00:00:00Z",
+          user_metadata: {
+            full_name: "Full Name",
+            avatar_url: "https://example.com/a.png",
+          },
+        },
+      },
+      error: null,
+    });
+    const provider = buildProvider();
+    const result = await provider.verifyAccessToken?.("token");
+    expect(result).toEqual({
+      profile: {
+        sub: "u1",
+        email: "u@example.com",
+        name: "Full Name",
+        emailVerified: true,
+        pictureUrl: "https://example.com/a.png",
+      },
+    });
+    expect(getUser).toHaveBeenCalledWith("token");
+  });
+
+  test("returns null on error response", async () => {
+    getUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: "invalid" },
+    });
+    const provider = buildProvider();
+    expect(await provider.verifyAccessToken?.("token")).toBeUndefined();
+  });
+
+  test("propagates transport errors (→ 502 at the handler)", async () => {
+    getUser.mockRejectedValueOnce(new Error("network"));
+    const provider = buildProvider();
+    await expect(provider.verifyAccessToken?.("token")).rejects.toThrow(
+      "network",
+    );
+  });
+
+  test("emailVerified is false when email_confirmed_at is null", async () => {
+    getUser.mockResolvedValueOnce({
+      data: {
+        user: {
+          id: "u1",
+          email: "u@example.com",
+          email_confirmed_at: null,
+          user_metadata: {},
+        },
+      },
+      error: null,
+    });
+    const provider = buildProvider();
+    const result = await provider.verifyAccessToken?.("token");
+    expect(result?.profile.emailVerified).toBe(false);
+  });
+});

--- a/packages/zudoku/src/lib/authentication/providers/supabase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.tsx
@@ -12,6 +12,7 @@ import type {
   AuthActionOptions,
   AuthenticationPlugin,
   AuthenticationProviderInitializer,
+  VerifyAccessTokenResult,
 } from "../authentication.js";
 import { CoreAuthenticationPlugin } from "../AuthenticationPlugin.js";
 import { SignOut } from "../components/SignOut.js";
@@ -28,6 +29,8 @@ import {
 export type SupabaseProviderData = {
   type: "supabase";
   session: Session;
+  accessToken: string;
+  refreshToken?: string;
 };
 
 declare module "../state.js" {
@@ -86,7 +89,12 @@ class SupabaseAuthenticationProvider
 
     useAuthState.getState().setLoggedIn({
       profile,
-      providerData: { type: "supabase", session },
+      providerData: {
+        type: "supabase",
+        session,
+        accessToken: session.access_token,
+        refreshToken: session.refresh_token,
+      },
     });
   }
 
@@ -98,6 +106,21 @@ class SupabaseAuthenticationProvider
     }
 
     return data.session.access_token;
+  }
+
+  async verifyAccessToken(token: string): Promise<VerifyAccessTokenResult> {
+    const { data, error } = await this.client.auth.getUser(token);
+    if (error || !data.user) return undefined;
+    const user = data.user;
+    return {
+      profile: {
+        sub: user.id,
+        email: user.email,
+        name: user.user_metadata.full_name || user.user_metadata.name,
+        emailVerified: user.email_confirmed_at != null,
+        pictureUrl: user.user_metadata.avatar_url,
+      },
+    };
   }
 
   async signRequest(request: Request): Promise<Request> {
@@ -204,7 +227,12 @@ class SupabaseAuthenticationProvider
 
       useAuthState.getState().setLoggedIn({
         profile,
-        providerData: { type: "supabase", session: data.session },
+        providerData: {
+          type: "supabase",
+          session: data.session,
+          accessToken: data.session.access_token,
+          refreshToken: data.session.refresh_token,
+        },
       });
     }
   };

--- a/packages/zudoku/src/lib/authentication/session-handler.test.ts
+++ b/packages/zudoku/src/lib/authentication/session-handler.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment node
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createSessionHandler } from "./session-handler.js";
+
+const verifyAccessToken = vi.fn();
+const provider = { verifyAccessToken } as unknown as Parameters<
+  typeof createSessionHandler
+>[0];
+
+const handler = createSessionHandler(provider);
+const noProviderHandler = createSessionHandler(undefined);
+
+const sameOriginHeaders = () => ({
+  origin: "http://localhost",
+  host: "localhost",
+  "content-type": "application/json",
+});
+
+const post = (body: unknown, extraHeaders: Record<string, string> = {}) =>
+  new Request("http://localhost/", {
+    method: "POST",
+    headers: { ...sameOriginHeaders(), ...extraHeaders },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+const VERIFIED_PROFILE = {
+  sub: "u1",
+  email: "u@example.com",
+  emailVerified: true,
+  name: "U",
+  pictureUrl: undefined,
+};
+
+const verifierResult = (
+  expiresAt?: number,
+): { profile: typeof VERIFIED_PROFILE; expiresAt?: number } => ({
+  profile: VERIFIED_PROFILE,
+  expiresAt,
+});
+
+const maxAgeOf = (res: Response, cookieName: string): number | undefined => {
+  const cookie = res.headers
+    .getSetCookie()
+    .find((c) => c.startsWith(`${cookieName}=`));
+  if (!cookie) return undefined;
+  const match = /Max-Age=(\d+)/.exec(cookie);
+  return match ? Number(match[1]) : undefined;
+};
+
+describe("sessionHandler POST", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("rejects cross-origin requests with 403", async () => {
+    const res = await handler.fetch(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: {
+          origin: "http://evil.example",
+          host: "localhost",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ accessToken: "t" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("accepts Sec-Fetch-Site same-origin when Origin is missing", async () => {
+    verifyAccessToken.mockResolvedValueOnce(verifierResult());
+    const res = await handler.fetch(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: {
+          host: "localhost",
+          "content-type": "application/json",
+          "sec-fetch-site": "same-origin",
+        },
+        body: JSON.stringify({ accessToken: "t" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects Sec-Fetch-Site cross-site with 403", async () => {
+    const res = await handler.fetch(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: {
+          host: "localhost",
+          "content-type": "application/json",
+          "sec-fetch-site": "cross-site",
+        },
+        body: JSON.stringify({ accessToken: "t" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects when neither Origin nor Sec-Fetch-Site is present", async () => {
+    const res = await handler.fetch(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: { host: "localhost", "content-type": "application/json" },
+        body: JSON.stringify({ accessToken: "t" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects malformed Origin header with 403", async () => {
+    const res = await handler.fetch(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: {
+          origin: "://not a url",
+          host: "localhost",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ accessToken: "t" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("returns 502 when verifier throws (misconfig / IdP outage)", async () => {
+    verifyAccessToken.mockRejectedValueOnce(new Error("jwks fetch failed"));
+    const res = await handler.fetch(post({ accessToken: "t" }));
+    expect(res.status).toBe(502);
+  });
+
+  test("rejects oversized refresh token with 400", async () => {
+    const res = await handler.fetch(
+      post({ accessToken: "ok", refreshToken: "x".repeat(4001) }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("refresh cookie Max-Age is bounded by verifier refreshExpiresAt", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    verifyAccessToken.mockResolvedValueOnce({
+      profile: VERIFIED_PROFILE,
+      expiresAt: nowSec + 60,
+      refreshExpiresAt: nowSec + 3600,
+    });
+    const res = await handler.fetch(
+      post({ accessToken: "t", refreshToken: "rtok" }),
+    );
+    expect(res.status).toBe(200);
+    const maxAge = maxAgeOf(res, "zudoku-refresh-token");
+    expect(maxAge).toBeGreaterThan(0);
+    expect(maxAge).toBeLessThanOrEqual(3600);
+  });
+
+  test("returns 501 when provider has no verifier", async () => {
+    const res = await noProviderHandler.fetch(post({ accessToken: "t" }));
+    expect(res.status).toBe(501);
+  });
+
+  test("rejects missing access token with 400", async () => {
+    const res = await handler.fetch(post({}));
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects invalid access token with 401", async () => {
+    verifyAccessToken.mockResolvedValueOnce(null);
+    const res = await handler.fetch(post({ accessToken: "bogus" }));
+    expect(res.status).toBe(401);
+  });
+
+  test("ignores client-submitted profile and uses verifier result", async () => {
+    verifyAccessToken.mockResolvedValueOnce(verifierResult());
+    const res = await handler.fetch(
+      post({
+        accessToken: "valid-token",
+        // Attacker tries to forge a privileged profile:
+        profile: { sub: "admin", email: "admin@corp.com", role: "admin" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const cookies = res.headers.getSetCookie().join(";");
+    expect(cookies).toContain("zudoku-auth-profile=");
+    expect(cookies).toContain(encodeURIComponent("u@example.com"));
+    expect(cookies).not.toContain(encodeURIComponent("admin@corp.com"));
+  });
+
+  test("sets access + refresh token cookies when provided", async () => {
+    verifyAccessToken.mockResolvedValueOnce(verifierResult());
+    const res = await handler.fetch(
+      post({ accessToken: "valid-token", refreshToken: "rtok" }),
+    );
+    expect(res.status).toBe(200);
+    const cookies = res.headers.getSetCookie().join(";");
+    expect(cookies).toContain("zudoku-access-token=valid-token");
+    expect(cookies).toContain("zudoku-refresh-token=rtok");
+  });
+
+  test("session cookie Max-Age is bounded by verifier expiresAt", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    verifyAccessToken.mockResolvedValueOnce(verifierResult(nowSec + 120));
+    const res = await handler.fetch(post({ accessToken: "valid-token" }));
+    expect(res.status).toBe(200);
+    const maxAge = maxAgeOf(res, "zudoku-access-token");
+    expect(maxAge).toBeGreaterThan(0);
+    expect(maxAge).toBeLessThanOrEqual(120);
+  });
+
+  test("refresh cookie Max-Age uses long TTL regardless of access expiry", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    verifyAccessToken.mockResolvedValueOnce(verifierResult(nowSec + 60));
+    const res = await handler.fetch(
+      post({ accessToken: "valid-token", refreshToken: "rtok" }),
+    );
+    expect(res.status).toBe(200);
+    const maxAge = maxAgeOf(res, "zudoku-refresh-token");
+    expect(maxAge).toBeGreaterThan(60 * 60 * 24); // clearly > 1 day
+  });
+
+  test("oversized access token is rejected", async () => {
+    const res = await handler.fetch(post({ accessToken: "x".repeat(4001) }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("sessionHandler DELETE", () => {
+  test("clears all auth cookies", async () => {
+    const res = await handler.fetch(
+      new Request("http://localhost/", { method: "DELETE" }),
+    );
+    expect(res.status).toBe(200);
+    const cookies = res.headers.getSetCookie().join(";");
+    expect(cookies).toContain("zudoku-access-token=;");
+    expect(cookies).toContain("zudoku-refresh-token=;");
+    expect(cookies).toContain("zudoku-auth-profile=;");
+  });
+});

--- a/packages/zudoku/src/lib/authentication/session-handler.ts
+++ b/packages/zudoku/src/lib/authentication/session-handler.ts
@@ -1,23 +1,35 @@
 import { Hono } from "hono";
 import { deleteCookie, setCookie } from "hono/cookie";
 import type { CookieOptions } from "hono/utils/cookie";
+import type { AuthenticationPlugin } from "./authentication.js";
 import {
   ACCESS_TOKEN_COOKIE,
   AUTH_PROFILE_COOKIE,
   REFRESH_TOKEN_COOKIE,
 } from "./cookies.js";
 
-const cookieOptions: CookieOptions = {
+const baseCookieOptions: Omit<CookieOptions, "maxAge"> = {
   httpOnly: true,
   path: "/",
   sameSite: "Lax",
-  maxAge: 60 * 60 * 24 * 30, // 30 days
   secure: import.meta.env.PROD,
+};
+
+const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+const DEFAULT_SESSION_MAX_AGE = 60 * 60; // 1 hour fallback when verifier omits expiresAt
+
+const cookieMaxAge = (
+  expiresAt: number | undefined,
+  fallback: number,
+): number => {
+  if (typeof expiresAt !== "number") return fallback;
+  const remaining = Math.floor(expiresAt - Date.now() / 1000);
+  return remaining > 0 ? Math.min(remaining, fallback) : fallback;
 };
 
 const MAX_COOKIE_SIZE = 3900; // Leave margin under 4096 browser limit
 
-const csrfCheck = (c: {
+const sameOriginCheck = (c: {
   req: { header: (name: string) => string | undefined };
 }): boolean => {
   const origin = c.req.header("Origin");
@@ -31,66 +43,99 @@ const csrfCheck = (c: {
     }
   }
 
-  // When Origin is missing, fall back to Sec-Fetch-Site
   const fetchSite = c.req.header("Sec-Fetch-Site");
   if (fetchSite) {
     return fetchSite === "same-origin" || fetchSite === "same-site";
   }
 
-  // Neither header present — reject by default
   return false;
 };
 
-export const sessionHandler = new Hono()
-  .post("/", async (c) => {
-    if (!csrfCheck(c)) {
-      return c.json({ error: "CSRF check failed" }, 403);
-    }
+/**
+ * Build the Hono sub-app that manages SSR auth cookies.
+ *
+ * The endpoint only trusts the provider's `verifyAccessToken` to determine
+ * the profile. A client-submitted profile is ignored. Callers must send
+ * only `{ accessToken, refreshToken? }`.
+ */
+export const createSessionHandler = (
+  provider: AuthenticationPlugin | undefined,
+) =>
+  new Hono()
+    .post("/", async (c) => {
+      if (!sameOriginCheck(c)) {
+        return c.json({ error: "CSRF check failed" }, 403);
+      }
 
-    const body = await c.req.json<{
-      accessToken?: string;
-      refreshToken?: string;
-      profile: {
-        sub: string;
-        email?: string;
-        name?: string;
-        emailVerified?: boolean;
-        pictureUrl?: string;
-      };
-    }>();
+      if (!provider?.verifyAccessToken) {
+        return c.json(
+          { error: "SSR authentication is not supported for this provider" },
+          501,
+        );
+      }
 
-    if (!body.profile) {
-      return c.json({ error: "Missing required fields" }, 400);
-    }
+      const body = await c.req
+        .json<{ accessToken?: unknown; refreshToken?: unknown } | undefined>()
+        .catch(() => undefined);
 
-    setCookie(
-      c,
-      AUTH_PROFILE_COOKIE,
-      JSON.stringify(body.profile),
-      cookieOptions,
-    );
-    if (body.accessToken) {
-      if (body.accessToken.length > MAX_COOKIE_SIZE) {
+      const accessToken =
+        typeof body?.accessToken === "string" ? body.accessToken : undefined;
+      if (!accessToken) {
+        return c.json({ error: "Missing access token" }, 400);
+      }
+      if (accessToken.length > MAX_COOKIE_SIZE) {
         return c.json({ error: "Access token exceeds cookie size limit" }, 400);
       }
-      setCookie(c, ACCESS_TOKEN_COOKIE, body.accessToken, cookieOptions);
-    }
-    if (body.refreshToken) {
-      if (body.refreshToken.length > MAX_COOKIE_SIZE) {
+
+      const refreshToken =
+        typeof body?.refreshToken === "string" ? body.refreshToken : undefined;
+      if (refreshToken && refreshToken.length > MAX_COOKIE_SIZE) {
         return c.json(
           { error: "Refresh token exceeds cookie size limit" },
           400,
         );
       }
-      setCookie(c, REFRESH_TOKEN_COOKIE, body.refreshToken, cookieOptions);
-    }
 
-    return c.json({ ok: true });
-  })
-  .delete("/", (c) => {
-    deleteCookie(c, ACCESS_TOKEN_COOKIE, cookieOptions);
-    deleteCookie(c, REFRESH_TOKEN_COOKIE, cookieOptions);
-    deleteCookie(c, AUTH_PROFILE_COOKIE, cookieOptions);
+      let verified: Awaited<
+        ReturnType<NonNullable<AuthenticationPlugin["verifyAccessToken"]>>
+      >;
+      try {
+        verified = await provider.verifyAccessToken(accessToken);
+      } catch (e) {
+        // biome-ignore lint/suspicious/noConsole: Surface verifier failures
+        console.error("SSR auth verifier error:", e);
+        return c.json({ error: "Verifier error" }, 502);
+      }
+      if (!verified) {
+        return c.json({ error: "Invalid access token" }, 401);
+      }
 
-    return c.json({ ok: true });
-  });
+      const sessionOptions: CookieOptions = {
+        ...baseCookieOptions,
+        maxAge: cookieMaxAge(verified.expiresAt, DEFAULT_SESSION_MAX_AGE),
+      };
+      const refreshOptions: CookieOptions = {
+        ...baseCookieOptions,
+        maxAge: cookieMaxAge(verified.refreshExpiresAt, REFRESH_TOKEN_MAX_AGE),
+      };
+
+      setCookie(
+        c,
+        AUTH_PROFILE_COOKIE,
+        JSON.stringify(verified.profile),
+        sessionOptions,
+      );
+      setCookie(c, ACCESS_TOKEN_COOKIE, accessToken, sessionOptions);
+      if (refreshToken) {
+        setCookie(c, REFRESH_TOKEN_COOKIE, refreshToken, refreshOptions);
+      }
+
+      return c.json({ ok: true });
+    })
+    .delete("/", (c) => {
+      deleteCookie(c, ACCESS_TOKEN_COOKIE, baseCookieOptions);
+      deleteCookie(c, REFRESH_TOKEN_COOKIE, baseCookieOptions);
+      deleteCookie(c, AUTH_PROFILE_COOKIE, baseCookieOptions);
+
+      return c.json({ ok: true });
+    });

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -49,6 +49,14 @@ const noopStorage: StateStorage = {
 const ssrAuthInitial =
   typeof window !== "undefined" ? window.ZUDOKU_SSR_AUTH : undefined;
 
+// When the server injected ZUDOKU_SSR_AUTH, cookies are authoritative and
+// tokens stay out of localStorage. SSG has no such injection, so persist the
+// full snapshot for reload continuity.
+const partialize = (state: AuthState) =>
+  ssrAuthInitial !== undefined
+    ? { isAuthenticated: state.isAuthenticated, profile: state.profile }
+    : state;
+
 export const authState = create<AuthState>()(
   persist(
     (set) => ({
@@ -90,6 +98,7 @@ export const authState = create<AuthState>()(
       storage: createJSONStorage(() =>
         typeof window !== "undefined" ? localStorage : noopStorage,
       ),
+      partialize,
     },
   ),
 );

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -5,7 +5,6 @@ import {
   type StateStorage,
 } from "zustand/middleware";
 import { syncZustandState } from "../util/syncZustandState.js";
-import { cookieSync } from "./cookie-sync.js";
 
 /**
  * Registry interface for provider-specific data types.
@@ -45,54 +44,53 @@ const noopStorage: StateStorage = {
   removeItem: () => {},
 };
 
-// Read SSR auth state injected by entry.server.tsx to avoid hydration mismatch
+// Seed from the SSR-injected signal. Object present = server checked;
+// `profile: null` = authoritative anon. Absent = fall back to pending.
 const ssrAuthInitial =
   typeof window !== "undefined" ? window.ZUDOKU_SSR_AUTH : undefined;
 
 export const authState = create<AuthState>()(
-  cookieSync(
-    persist(
-      (set) => ({
-        isAuthenticated: !!ssrAuthInitial,
-        isPending: !ssrAuthInitial,
-        profile: ssrAuthInitial?.profile ?? null,
-        providerData: null,
-        setAuthenticationPending: () =>
-          set(() => ({
-            isAuthenticated: false,
-            isPending: false,
-            profile: null,
-            providerData: null,
-          })),
-        setLoggedOut: () =>
-          set(() => ({
-            isAuthenticated: false,
-            isPending: false,
-            profile: null,
-            providerData: null,
-          })),
-        setLoggedIn: ({ profile, providerData }) =>
-          set(() => ({
-            isAuthenticated: true,
-            isPending: false,
-            profile,
-            providerData,
-          })),
-      }),
-      {
-        merge: (persistedState, currentState) => {
-          return {
-            ...currentState,
-            isPending: false,
-            ...(typeof persistedState === "object" ? persistedState : {}),
-          };
-        },
-        name: "auth-state",
-        storage: createJSONStorage(() =>
-          typeof window !== "undefined" ? localStorage : noopStorage,
-        ),
+  persist(
+    (set) => ({
+      isAuthenticated: !!ssrAuthInitial?.profile,
+      isPending: ssrAuthInitial === undefined,
+      profile: ssrAuthInitial?.profile ?? null,
+      providerData: null,
+      setAuthenticationPending: () =>
+        set(() => ({
+          isAuthenticated: false,
+          isPending: false,
+          profile: null,
+          providerData: null,
+        })),
+      setLoggedOut: () =>
+        set(() => ({
+          isAuthenticated: false,
+          isPending: false,
+          profile: null,
+          providerData: null,
+        })),
+      setLoggedIn: ({ profile, providerData }) =>
+        set(() => ({
+          isAuthenticated: true,
+          isPending: false,
+          profile,
+          providerData,
+        })),
+    }),
+    {
+      merge: (persistedState, currentState) => {
+        return {
+          ...currentState,
+          isPending: false,
+          ...(typeof persistedState === "object" ? persistedState : {}),
+        };
       },
-    ),
+      name: "auth-state",
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined" ? localStorage : noopStorage,
+      ),
+    },
   ),
 );
 

--- a/packages/zudoku/src/lib/components/context/RenderContext.ts
+++ b/packages/zudoku/src/lib/components/context/RenderContext.ts
@@ -3,7 +3,8 @@ import type { UserProfile } from "../../authentication/state.js";
 
 export type SSRAuthState = {
   accessToken?: string;
-  profile: UserProfile;
+  // `null` means the user is logged out; undefined means auth isn't configured.
+  profile: UserProfile | null;
 };
 
 export type RenderContextValue = {

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -43,7 +43,6 @@ export type BuildOptions = {
 export async function runBuild(options: BuildOptions) {
   const { dir, ssr, adapter = "node" } = options;
 
-  // Build client and server bundles
   const viteClientConfig = await getViteConfig(dir, {
     mode: "production",
     command: "build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,7 +661,7 @@ importers:
         version: 3.23.0
       '@supabase/supabase-js':
         specifier: ^2.49.4
-        version: 2.50.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 2.50.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.2.1)
@@ -727,7 +727,7 @@ importers:
         version: 6.0.0
       firebase:
         specifier: ^12.6.0
-        version: 12.6.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))
+        version: 12.6.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
       glob:
         specifier: 13.0.6
         version: 13.0.6
@@ -12426,10 +12426,10 @@ snapshots:
       idb: 7.1.1
       tslib: 2.8.1
 
-  '@firebase/auth-compat@0.6.1(@firebase/app-compat@0.5.6)(@firebase/app-types@0.9.3)(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))':
+  '@firebase/auth-compat@0.6.1(@firebase/app-compat@0.5.6)(@firebase/app-types@0.9.3)(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))':
     dependencies:
       '@firebase/app-compat': 0.5.6
-      '@firebase/auth': 1.11.1(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))
+      '@firebase/auth': 1.11.1(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
       '@firebase/auth-types': 0.13.0(@firebase/app-types@0.9.3)(@firebase/util@1.13.0)
       '@firebase/component': 0.7.0
       '@firebase/util': 1.13.0
@@ -12464,7 +12464,7 @@ snapshots:
       '@firebase/app-types': 0.9.3
       '@firebase/util': 1.14.0
 
-  '@firebase/auth@1.11.1(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))':
+  '@firebase/auth@1.11.1(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))':
     dependencies:
       '@firebase/app': 0.14.6
       '@firebase/component': 0.7.0
@@ -12472,7 +12472,7 @@ snapshots:
       '@firebase/util': 1.13.0
       tslib: 2.8.1
     optionalDependencies:
-      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))
+      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))
 
   '@firebase/auth@1.12.1(@firebase/app@0.14.9)':
     dependencies:
@@ -13581,7 +13581,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.9.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -15329,7 +15329,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.6(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.83.6(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.83.6(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.6
       semver: 7.7.4
     transitivePeerDependencies:
@@ -16171,12 +16171,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@supabase/realtime-js@2.11.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@supabase/realtime-js@2.11.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@supabase/node-fetch': 2.6.15
       '@types/phoenix': 1.6.6
       '@types/ws': 8.18.1
-      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16201,13 +16201,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@supabase/supabase-js@2.50.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@supabase/supabase-js@2.50.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@supabase/auth-js': 2.70.0
       '@supabase/functions-js': 2.4.4
       '@supabase/node-fetch': 2.6.15
       '@supabase/postgrest-js': 1.19.4
-      '@supabase/realtime-js': 2.11.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@supabase/realtime-js': 2.11.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@supabase/storage-js': 2.7.1
     transitivePeerDependencies:
       - bufferutil
@@ -16666,7 +16666,7 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 25.6.0
 
   '@types/ws@8.18.1':
     dependencies:
@@ -18249,7 +18249,7 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
 
-  firebase@12.6.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))):
+  firebase@12.6.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))):
     dependencies:
       '@firebase/ai': 2.6.0(@firebase/app-types@0.9.3)(@firebase/app@0.14.6)
       '@firebase/analytics': 0.10.19(@firebase/app@0.14.6)
@@ -18259,8 +18259,8 @@ snapshots:
       '@firebase/app-check-compat': 0.4.0(@firebase/app-compat@0.5.6)(@firebase/app@0.14.6)
       '@firebase/app-compat': 0.5.6
       '@firebase/app-types': 0.9.3
-      '@firebase/auth': 1.11.1(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))
-      '@firebase/auth-compat': 0.6.1(@firebase/app-compat@0.5.6)(@firebase/app-types@0.9.3)(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))
+      '@firebase/auth': 1.11.1(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
+      '@firebase/auth-compat': 0.6.1(@firebase/app-compat@0.5.6)(@firebase/app-types@0.9.3)(@firebase/app@0.14.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
       '@firebase/data-connect': 0.3.12(@firebase/app@0.14.6)
       '@firebase/database': 1.1.0
       '@firebase/database-compat': 2.1.0
@@ -19716,21 +19716,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.83.6(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.6(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-cache: 0.83.6
-      metro-core: 0.83.6
-      metro-runtime: 0.83.6
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-config@0.83.6(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -19882,7 +19867,7 @@ snapshots:
       metro-babel-transformer: 0.83.6
       metro-cache: 0.83.6
       metro-cache-key: 0.83.6
-      metro-config: 0.83.6(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.83.6(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.6
       metro-file-map: 0.83.6
       metro-resolver: 0.83.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,9 @@ importers:
       javascript-stringify:
         specifier: 2.1.0
         version: 2.1.0
+      jose:
+        specifier: 6.2.2
+        version: 6.2.2
       json-schema-to-typescript-lite:
         specifier: 15.0.0
         version: 15.0.0
@@ -8087,6 +8090,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
@@ -19095,6 +19101,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.6.1: {}
+
+  jose@6.2.2: {}
 
   js-base64@3.7.8: {}
 


### PR DESCRIPTION
Stacked on #2320. Two commits:

1. **Server-verified tokens.** The session endpoint no longer trusts a client-submitted profile — each provider implements `verifyAccessToken` and the server derives the profile from the verified token. Cookie lifetimes are bounded by the token's `exp`. cookie-sync is now provider-agnostic (reads tokens from `providerData`), which keeps provider internals off the critical path. Also emits an authoritative SSR "logged out" signal (`profile: null`) so logged-out users render the Login button on first paint instead of flashing a skeleton.

2. **Azure B2C** opts into SSR auth via OIDC discovery + jose. Auth0 already covered by openid inheritance. Firebase deferred (idToken rotation in the SDK doesn't map cleanly without more work).