### PR TITLE
Fix status page detection regex to match only root-level files

### DIFF
--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -140,7 +140,9 @@ const runPrerender = async (options: PrerenderOptions) => {
 
     // Move status pages (400, 404, 500) to root path
     const statusPages = workerResults.flatMap((r) =>
-      /400|404|500\.html$/.test(r.outputPath) ? r.outputPath : [],
+      /^(400|404|500)\.html$/.test(path.basename(r.outputPath))
+        ? r.outputPath
+        : [],
     );
     for (const statusPage of statusPages) {
       await rename(


### PR DESCRIPTION
## Summary
Fixed the regex pattern used to identify status pages (400, 404, 500) during the prerender build process to ensure it only matches files at the root level, not files with those numbers anywhere in their path.

## Key Changes
- Updated the regex pattern from `/400|404|500\.html$/` to `/^(400|404|500)\.html$/` to use anchored matching with proper grouping
- Changed the matching logic to use `path.basename(r.outputPath)` to extract only the filename before pattern matching, ensuring the regex operates on the filename alone rather than the full path

## Implementation Details
This change prevents false positives where files in subdirectories containing "400", "404", or "500" in their path would be incorrectly identified as status pages. For example, a file like `docs/400-errors/guide.html` would no longer be mistakenly matched. The fix ensures that only the actual status page files (`400.html`, `404.html`, `500.html`) at the root level are correctly identified and moved during the build process.

https://claude.ai/code/session_0116UJLh1paViEmqHVQormhu