### PR TITLE
fix(ci): resolve zudoku version from Verdaccio in preview build

### DIFF
--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -90,7 +90,8 @@ jobs:
 
       - name: Update package.json
         run: |
-          VERSION=$(node -p "require('./packages/zudoku/package.json').version")
+          VERSION=$(pnpm view zudoku@local version --registry http://localhost:4873)
+          echo "Using locally-published zudoku version: $VERSION"
           cd examples/cosmo-cargo
           pnpm pkg set "devDependencies.zudoku=$VERSION"
 


### PR DESCRIPTION
The preview build was deploying the last public `zudoku` release from npm instead of the PR's code.

`publish:local` bumps the version, publishes to Verdaccio, then `postpublish` reverts the bump via `git checkout`. The workflow was reading the reverted version from `package.json` and pinning cosmo-cargo to it, so `pnpm install` resolved the real public release from npm (via Verdaccio's upstream proxy) instead of the locally-published prerelease.

Fix: query Verdaccio for the `local` dist-tag that `pnpm publish --tag local` just set.
