### PR TITLE
Refactor MCP security extraction to use in-memory schema

### DIFF
--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
@@ -213,10 +213,26 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(op["x-zuplo-route"]).toBeUndefined();
   });
 
-  it("should add security to x-mcp-server when referenced operations have security", async () => {
+  it("should add security to x-mcp-server from in-memory schema operations", async () => {
+    // External file has NO security (raw source)
     await writeApiFile("config/routes.oas.json", {
       openapi: "3.1.0",
       info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    // In-memory schema has security (enriched by enrichWithZuploData)
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
       components: {
         securitySchemes: {
           api_key: { type: "http", scheme: "bearer" },
@@ -231,13 +247,6 @@ describe("enrichWithZuploMcpServerData", () => {
             responses: { "200": { description: "OK" } },
           },
         },
-      },
-    });
-
-    const schema = {
-      openapi: "3.1.0",
-      info: { title: "Test MCP API", version: "1.0.0" },
-      paths: {
         "/mcp": {
           post: {
             summary: "MCP Server",
@@ -263,18 +272,27 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(op["x-mcp-server"].securitySchemes).toEqual({
       api_key: { type: "http", scheme: "bearer" },
     });
-
-    // Security scheme should be copied to main schema
-    expect(result.components?.securitySchemes?.api_key).toEqual({
-      type: "http",
-      scheme: "bearer",
-    });
   });
 
-  it("should inherit doc-level security when operations have none", async () => {
+  it("should inherit doc-level security from in-memory schema", async () => {
     await writeApiFile("config/routes.oas.json", {
       openapi: "3.1.0",
       info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    // In-memory schema has doc-level security
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
       security: [{ bearer_auth: [] }],
       components: {
         securitySchemes: {
@@ -289,13 +307,6 @@ describe("enrichWithZuploMcpServerData", () => {
             responses: { "200": { description: "OK" } },
           },
         },
-      },
-    });
-
-    const schema = {
-      openapi: "3.1.0",
-      info: { title: "Test MCP API", version: "1.0.0" },
-      paths: {
         "/mcp": {
           post: {
             summary: "MCP Server",
@@ -316,9 +327,8 @@ describe("enrichWithZuploMcpServerData", () => {
     // biome-ignore lint/suspicious/noExplicitAny: test assertion
     const op = result.paths?.["/mcp"]?.post as Record<string, any>;
     expect(op["x-mcp-server"].security).toEqual([{ bearer_auth: [] }]);
-    expect(result.components?.securitySchemes?.bearer_auth).toEqual({
-      type: "http",
-      scheme: "bearer",
+    expect(op["x-mcp-server"].securitySchemes).toEqual({
+      bearer_auth: { type: "http", scheme: "bearer" },
     });
   });
 
@@ -368,6 +378,26 @@ describe("enrichWithZuploMcpServerData", () => {
     await writeApiFile("config/routes.oas.json", {
       openapi: "3.1.0",
       info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+          post: {
+            operationId: "create-user",
+            summary: "Create a user",
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      },
+    });
+
+    // In-memory schema has security on both operations
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
       components: {
         securitySchemes: {
           api_key: { type: "http", scheme: "bearer" },
@@ -388,13 +418,6 @@ describe("enrichWithZuploMcpServerData", () => {
             responses: { "201": { description: "Created" } },
           },
         },
-      },
-    });
-
-    const schema = {
-      openapi: "3.1.0",
-      info: { title: "Test MCP API", version: "1.0.0" },
-      paths: {
         "/mcp": {
           post: {
             summary: "MCP Server",

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -88,19 +88,33 @@ const buildOperationLookup = (
   return operationMap;
 };
 
-interface DocumentExtractionResult {
-  tools: ExtensionMcpServerTool[];
+// Extracts tool metadata from a disk file for the given operation IDs
+const extractToolsFromDocument = (
+  document: OpenAPIV3_1.Document,
+  operationIds: string[],
+): ExtensionMcpServerTool[] => {
+  const operationLookup = buildOperationLookup(document);
+
+  return operationIds.flatMap((operationId) => {
+    const operation = operationLookup.get(operationId);
+    if (!operation) return [];
+
+    const tool = extractOperationSchema(operation);
+    return tool ? [tool] : [];
+  });
+};
+
+interface SecurityExtractionResult {
   security: OpenAPIV3_1.SecurityRequirementObject[];
   securitySchemes: Record<string, OpenAPIV3_1.SecuritySchemeObject>;
 }
 
-// Extracts tools, security requirements, and security schemes from referenced operations
-const extractFromDocument = (
-  document: OpenAPIV3_1.Document,
+// Extracts security from the in-memory schema (already enriched by enrichWithZuploData)
+const extractSecurityFromSchema = (
+  schema: OpenAPIV3_1.Document,
   operationIds: string[],
-): DocumentExtractionResult => {
-  const operationLookup = buildOperationLookup(document);
-  const tools: ExtensionMcpServerTool[] = [];
+): SecurityExtractionResult => {
+  const operationLookup = buildOperationLookup(schema);
   const securityReqs: OpenAPIV3_1.SecurityRequirementObject[] = [];
   const referencedSchemeNames = new Set<string>();
 
@@ -108,11 +122,8 @@ const extractFromDocument = (
     const operation = operationLookup.get(operationId);
     if (!operation) continue;
 
-    const tool = extractOperationSchema(operation);
-    if (tool) tools.push(tool);
-
-    // Collect security: operation-level takes precedence, fall back to doc-level
-    const opSecurity = operation.security ?? document.security;
+    // operation-level security takes precedence, fall back to doc-level
+    const opSecurity = operation.security ?? schema.security;
     if (opSecurity) {
       for (const req of opSecurity) {
         securityReqs.push(req);
@@ -123,9 +134,8 @@ const extractFromDocument = (
     }
   }
 
-  // Grab referenced security scheme definitions from the document
   const securitySchemes: Record<string, OpenAPIV3_1.SecuritySchemeObject> = {};
-  const docSchemes = document.components?.securitySchemes;
+  const docSchemes = schema.components?.securitySchemes;
   if (docSchemes) {
     for (const name of referencedSchemeNames) {
       const scheme = docSchemes[name];
@@ -135,7 +145,7 @@ const extractFromDocument = (
     }
   }
 
-  return { tools, security: securityReqs, securitySchemes };
+  return { security: securityReqs, securitySchemes };
 };
 
 // Deduplicates security requirements by stringified key
@@ -163,10 +173,6 @@ export const enrichWithZuploMcpServerData = ({
     if (!modifiedSchema?.paths) return modifiedSchema;
 
     let assignedDefaultMcpTag = false;
-    const collectedSecuritySchemes: Record<
-      string,
-      OpenAPIV3_1.SecuritySchemeObject
-    > = {};
 
     await traverseAsync(modifiedSchema, async (node, nodePath) => {
       // Check if we're at a "post" operation (paths -> /some/path -> "post").
@@ -196,21 +202,25 @@ export const enrichWithZuploMcpServerData = ({
 
       if (operationsByFile.size === 0) return node;
 
+      // Extract tools from disk files (source of truth for tool metadata)
       const allTools: ExtensionMcpServerTool[] = [];
-      const allSecurity: OpenAPIV3_1.SecurityRequirementObject[] = [];
-
       for (const [filePath, operationIds] of operationsByFile) {
         const resolvedPath = path.resolve(rootDir, "../", filePath);
         const fileContent = await fs.readFile(resolvedPath, "utf-8");
         const document = JSON.parse(fileContent);
 
         if (document) {
-          const result = extractFromDocument(document, operationIds);
-          allTools.push(...result.tools);
-          allSecurity.push(...result.security);
-          Object.assign(collectedSecuritySchemes, result.securitySchemes);
+          allTools.push(...extractToolsFromDocument(document, operationIds));
         }
       }
+
+      // Extract security from the in-memory schema (already enriched by enrichWithZuploData)
+      const allOperationIds = [...operationsByFile.values()].flat();
+      const { security: allSecurity, securitySchemes } =
+        extractSecurityFromSchema(
+          modifiedSchema as OpenAPIV3_1.Document,
+          allOperationIds,
+        );
 
       const mcpExtension: ExtensionMcpServer = {
         name: DEFAULT_MCP_SERVER_NAME,
@@ -228,8 +238,7 @@ export const enrichWithZuploMcpServerData = ({
       if (dedupedSecurity.length > 0) {
         const ext = node["x-mcp-server"] as RecordAny;
         ext.security = dedupedSecurity;
-        // Include scheme definitions so the UI can generate auth headers
-        ext.securitySchemes = { ...collectedSecuritySchemes };
+        ext.securitySchemes = { ...securitySchemes };
       }
 
       // Assign default MCP tag if the operation has no tags
@@ -249,19 +258,6 @@ export const enrichWithZuploMcpServerData = ({
           name: MCP_TAG_NAME,
           description: MCP_TAG_DESCRIPTION,
         });
-      }
-    }
-
-    // Merge collected security schemes into the main schema
-    if (Object.keys(collectedSecuritySchemes).length > 0) {
-      if (!modifiedSchema.components) modifiedSchema.components = {};
-      if (!modifiedSchema.components.securitySchemes) {
-        modifiedSchema.components.securitySchemes = {};
-      }
-      for (const [name, scheme] of Object.entries(collectedSecuritySchemes)) {
-        if (!modifiedSchema.components.securitySchemes[name]) {
-          modifiedSchema.components.securitySchemes[name] = scheme;
-        }
       }
     }
 


### PR DESCRIPTION
## Summary
This PR refactors the MCP server security extraction logic to source security information from the in-memory schema (which is already enriched by `enrichWithZuploData`) rather than from disk files. This simplifies the implementation and ensures security metadata is consistently derived from the enriched schema.

## Key Changes
- **Separated concerns**: Split `extractFromDocument` into two focused functions:
  - `extractToolsFromDocument`: Extracts tool metadata from disk files (source of truth for tool definitions)
  - `extractSecurityFromSchema`: Extracts security requirements and schemes from the in-memory schema (already enriched)

- **Security source of truth**: Security information is now extracted from the in-memory `modifiedSchema` rather than from external disk files, ensuring it reflects any enrichments applied by `enrichWithZuploData`

- **Removed schema mutation**: Eliminated the logic that merged collected security schemes back into the main schema's `components.securitySchemes`, as security schemes are now only attached to individual `x-mcp-server` extensions

- **Updated test expectations**: Modified tests to reflect the new behavior:
  - External files no longer contain security definitions
  - In-memory schema contains the security definitions (enriched state)
  - Security schemes are attached to `x-mcp-server` extensions rather than the main schema

## Implementation Details
- Security requirements are deduplicated using the existing `deduplicateSecurityRequirements` function
- The extraction respects the precedence: operation-level security takes priority over document-level security
- All referenced security scheme definitions are collected and included in the MCP server extension

https://claude.ai/code/session_01XNSWhhk2EUiBmyzBUtekL4