### PR TITLE
feat: spread userInfo into UserProfile via shared buildUserProfile

### DIFF
--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -197,7 +197,7 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       setupCallback({
         userInfoEmailVerified: true,
         customClaims: {
-          resource_access: { api: { roles: "admin" } },
+          resource_access: { api: { roles: ["admin"] } },
           custom_role: "editor",
         },
       });
@@ -205,7 +205,7 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       await provider.handleCallback();
 
       const profile = useAuthState.getState().profile;
-      expect(profile?.resource_access).toEqual({ api: { roles: "admin" } });
+      expect(profile?.resource_access).toEqual({ api: { roles: ["admin"] } });
       expect(profile?.custom_role).toBe("editor");
       expect(profile?.sub).toBe("user-1");
       expect(profile?.email).toBe("user@example.com");
@@ -276,14 +276,14 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
         email: "user@example.com",
         name: "Test",
         email_verified: true,
-        resource_access: { api: { roles: "admin" } },
+        resource_access: { api: { roles: ["admin"] } },
         custom_role: "editor",
       });
 
       await provider.refreshUserProfile();
 
       const profile = useAuthState.getState().profile;
-      expect(profile?.resource_access).toEqual({ api: { roles: "admin" } });
+      expect(profile?.resource_access).toEqual({ api: { roles: ["admin"] } });
       expect(profile?.custom_role).toBe("editor");
       expect(profile?.sub).toBe("user-1");
       expect(profile?.email).toBe("user@example.com");

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -62,9 +62,11 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
     const setupCallback = ({
       claimsEmailVerified,
       userInfoEmailVerified,
+      customClaims,
     }: {
       claimsEmailVerified?: boolean;
       userInfoEmailVerified?: boolean;
+      customClaims?: Record<string, unknown>;
     }) => {
       Object.defineProperty(window, "location", {
         configurable: true,
@@ -108,6 +110,7 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
         email: "user@example.com",
         name: "Test User",
         picture: "https://example.com/pic.jpg",
+        ...customClaims,
       };
       if (userInfoEmailVerified !== undefined) {
         userInfo.email_verified = userInfoEmailVerified;
@@ -188,6 +191,27 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
 
       expect(useAuthState.getState().profile?.emailVerified).toBe(false);
     });
+
+    test("spreads custom claims from userInfo into profile", async () => {
+      const provider = createProvider();
+      setupCallback({
+        userInfoEmailVerified: true,
+        customClaims: {
+          resource_access: { api: { roles: "admin" } },
+          custom_role: "editor",
+        },
+      });
+
+      await provider.handleCallback();
+
+      const profile = useAuthState.getState().profile;
+      expect(profile?.resource_access).toEqual({ api: { roles: "admin" } });
+      expect(profile?.custom_role).toBe("editor");
+      expect(profile?.sub).toBe("user-1");
+      expect(profile?.email).toBe("user@example.com");
+      expect(profile?.emailVerified).toBe(true);
+      expect(profile?.pictureUrl).toBe("https://example.com/pic.jpg");
+    });
   });
 
   describe("refreshUserProfile", () => {
@@ -244,6 +268,26 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       await provider.refreshUserProfile();
 
       expect(useAuthState.getState().profile?.emailVerified).toBe(false);
+    });
+
+    test("spreads custom claims from userInfo into profile", async () => {
+      const provider = setupRefresh({
+        sub: "user-1",
+        email: "user@example.com",
+        name: "Test",
+        email_verified: true,
+        resource_access: { api: { roles: "admin" } },
+        custom_role: "editor",
+      });
+
+      await provider.refreshUserProfile();
+
+      const profile = useAuthState.getState().profile;
+      expect(profile?.resource_access).toEqual({ api: { roles: "admin" } });
+      expect(profile?.custom_role).toBe("editor");
+      expect(profile?.sub).toBe("user-1");
+      expect(profile?.email).toBe("user@example.com");
+      expect(profile?.emailVerified).toBe(true);
     });
   });
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -196,7 +196,7 @@ export class OpenIDAuthenticationProvider
       name: userInfo.name,
       emailVerified: Boolean(emailVerified),
       pictureUrl: userInfo.picture,
-    } as UserProfile;
+    };
   }
 
   public async refreshUserProfile(): Promise<boolean> {

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -183,6 +183,22 @@ export class OpenIDAuthenticationProvider
     });
   }
 
+  private buildUserProfile(
+    userInfo: oauth.UserInfoResponse,
+    fallbackEmailVerified: oauth.JsonValue | undefined,
+  ): UserProfile {
+    const emailVerified =
+      userInfo.email_verified ?? fallbackEmailVerified ?? false;
+    return {
+      ...userInfo,
+      sub: userInfo.sub,
+      email: userInfo.email,
+      name: userInfo.name,
+      emailVerified: Boolean(emailVerified),
+      pictureUrl: userInfo.picture,
+    } as UserProfile;
+  }
+
   public async refreshUserProfile(): Promise<boolean> {
     const accessToken = await this.getAccessToken();
     const authServer = await this.getAuthServer();
@@ -200,13 +216,7 @@ export class OpenIDAuthenticationProvider
         ? providerData.claims?.email_verified
         : undefined;
 
-    const profile: UserProfile = {
-      sub: userInfo.sub,
-      email: userInfo.email,
-      name: userInfo.name,
-      emailVerified: userInfo.email_verified ?? emailVerified ?? false,
-      pictureUrl: userInfo.picture,
-    };
+    const profile = this.buildUserProfile(userInfo, emailVerified);
 
     useAuthState.setState({
       isAuthenticated: true,
@@ -494,14 +504,7 @@ export class OpenIDAuthenticationProvider
     );
     const userInfo = await userInfoResponse.json();
 
-    const profile: UserProfile = {
-      ...userInfo,
-      sub: userInfo.sub,
-      email: userInfo.email,
-      name: userInfo.name,
-      emailVerified: userInfo.email_verified ?? claims?.email_verified ?? false,
-      pictureUrl: userInfo.picture,
-    };
+    const profile = this.buildUserProfile(userInfo, claims?.email_verified);
 
     useAuthState.setState({
       isAuthenticated: true,

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -81,11 +81,16 @@ syncZustandState(authState);
 
 export const useAuthState = authState;
 
+export interface CustomClaimRecord {
+  [key: string]: CustomClaim;
+}
+export type CustomClaim = string | boolean | CustomClaimRecord | undefined;
+
 export interface UserProfile {
   sub: string;
   email: string | undefined;
   emailVerified: boolean;
   name: string | undefined;
   pictureUrl: string | undefined;
-  [key: string]: string | boolean | undefined;
+  [key: string]: CustomClaim;
 }

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -81,20 +81,18 @@ syncZustandState(authState);
 
 export const useAuthState = authState;
 
-export type NestedClaim =
+export type CustomClaim =
   | string
   | number
   | boolean
   | null
-  | NestedClaimRecord
-  | NestedClaimArray
+  | CustomClaimRecord
+  | CustomClaimArray
   | undefined;
-export interface NestedClaimRecord {
-  [key: string]: NestedClaim;
+export interface CustomClaimRecord {
+  [key: string]: CustomClaim;
 }
-export type NestedClaimArray = NestedClaim[];
-
-export type CustomClaim = string | boolean | NestedClaimRecord | undefined;
+export type CustomClaimArray = CustomClaim[];
 
 export interface UserProfile {
   sub: string;

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -81,10 +81,20 @@ syncZustandState(authState);
 
 export const useAuthState = authState;
 
-export interface CustomClaimRecord {
-  [key: string]: CustomClaim;
+export type NestedClaim =
+  | string
+  | number
+  | boolean
+  | null
+  | NestedClaimRecord
+  | NestedClaimArray
+  | undefined;
+export interface NestedClaimRecord {
+  [key: string]: NestedClaim;
 }
-export type CustomClaim = string | boolean | CustomClaimRecord | undefined;
+export type NestedClaimArray = NestedClaim[];
+
+export type CustomClaim = string | boolean | NestedClaimRecord | undefined;
 
 export interface UserProfile {
   sub: string;


### PR DESCRIPTION
Extract a private buildUserProfile helper in the OpenID provider so handleCallback and refreshUserProfile can't drift, and spread the full userInfo response into the profile so custom OIDC claims (e.g. Keycloak resource_access) survive. Extend UserProfile with a CustomClaim index signature so nested claim objects are representable.

https://claude.ai/code/session_01RbdcGmAGxfeyK3CKxX4tTy

Closes #2279