### PR TITLE
feat: full-width page option with compact TOC popover

### DIFF
--- a/docs/pages/docs/configuration/docs.md
+++ b/docs/pages/docs/configuration/docs.md
@@ -194,7 +194,7 @@ Combine with `toc: false` to hide the table of contents entirely.
 ```tsx title="zudoku.config.tsx"
 docs: {
   defaultOptions: {
-    fullWidth: true; // Use full-width layout for all pages by default
+    fullWidth: true, // Use full-width layout for all pages by default
   }
 }
 ```

--- a/docs/pages/docs/configuration/docs.md
+++ b/docs/pages/docs/configuration/docs.md
@@ -183,6 +183,22 @@ The `url` should be a template where the file path will be appended. For example
 in a `docs/pages/` directory, the URL might be
 `https://github.com/your-org/your-repo/edit/main/docs/pages`.
 
+#### `fullWidth`
+
+**Type:** `boolean` **Default:** `false`
+
+Whether pages should use the full available width (hiding the table of contents sidebar) by default.
+When enabled, the table of contents is accessible via an "On this page" toggle in the page header.
+Combine with `toc: false` to hide the table of contents entirely.
+
+```tsx title="zudoku.config.tsx"
+docs: {
+  defaultOptions: {
+    fullWidth: true; // Use full-width layout for all pages by default
+  }
+}
+```
+
 #### `copyPage`
 
 **Type:** `boolean` **Default:** `undefined`

--- a/docs/pages/docs/markdown/frontmatter.md
+++ b/docs/pages/docs/markdown/frontmatter.md
@@ -95,6 +95,25 @@ toc: false
 ---
 ```
 
+### `fullWidth`
+
+Removes the table of contents sidebar and lets the page content span the full available width. When
+enabled, the table of contents is still accessible via an "On this page" toggle in the page header
+(unless `toc: false` is also set, in which case it is hidden entirely).
+
+```md
+---
+fullWidth: true
+---
+```
+
+| `fullWidth` | `toc`   | Result                                                          |
+| ----------- | ------- | --------------------------------------------------------------- |
+| `false`     | `true`  | TOC shown in the sidebar (default).                             |
+| `false`     | `false` | TOC hidden; content keeps its standard width.                   |
+| `true`      | `true`  | Content spans full width; TOC is available via a toggle button. |
+| `true`      | `false` | Content spans full width; TOC is not available at all.          |
+
 ### `disable_pager`
 
 Controls whether the previous/next page navigation is displayed at the bottom of the page. Set to

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -327,6 +327,7 @@ export const DocsConfigSchema = z.object({
       copyPage: z.boolean().optional(),
       disablePager: z.boolean(),
       showLastModified: z.boolean(),
+      fullWidth: z.boolean().optional(),
       suggestEdit: z
         .object({
           url: z.string(),

--- a/packages/zudoku/src/lib/components/Heading.tsx
+++ b/packages/zudoku/src/lib/components/Heading.tsx
@@ -73,7 +73,7 @@ export const Heading = ({
       {id && (
         <a
           href={`#${id}`}
-          className="ms-[0.33em] rounded text-[0.8em] text-muted-foreground p-0.5 -m-0.5 opacity-0 group-hover:opacity-50 hover:text-primary hover:!opacity-100 transition-opacity duration-200 inline-flex items-center align-middle"
+          className="ms-[0.33em] rounded text-[0.8em] text-muted-foreground p-0.5 -m-0.5 opacity-0 group-hover:opacity-50 hover:text-primary hover:opacity-100! transition-opacity duration-200 inline-flex items-center align-middle"
           aria-label={`Link to ${id}`}
         >
           <LinkIcon className="size-[0.75em] min-w-4 min-h-4" />

--- a/packages/zudoku/src/lib/components/Main.tsx
+++ b/packages/zudoku/src/lib/components/Main.tsx
@@ -27,11 +27,14 @@ export const Main = ({ children }: PropsWithChildren) => {
         />
       )}
       {hasNavigation && (
-        <div className="lg:hidden m-0 p-0 md:-mx-4 md:px-4 py-2 sticky bg-background/80 backdrop-blur-xs z-10 top-0 start-0 end-0 border-b">
+        <div className="lg:hidden m-0 p-0 md:-mx-4 md:px-4 py-2 sticky bg-background/80 backdrop-blur-xs z-10 top-0 inset-x-0 border-b flex items-center gap-2">
           <DrawerTrigger className="flex items-center gap-2 px-4">
             <PanelLeftIcon size={16} strokeWidth={1.5} />
             <span className="text-sm">Menu</span>
           </DrawerTrigger>
+          <div className="ms-auto empty:hidden pe-4">
+            <Slot.Target name="mobile-top-bar-end" />
+          </div>
         </div>
       )}
       <main

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -33,7 +33,6 @@ import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
 import { PoweredByZudoku } from "./navigation/PoweredByZudoku.js";
 import { getFirstMatchingPath, shouldShowItem } from "./navigation/utils.js";
 import { PageProgress } from "./PageProgress.js";
-import { Slot } from "./Slot.js";
 import { ThemeSwitch } from "./ThemeSwitch.js";
 
 const MobileHeaderNavLink = ({
@@ -168,9 +167,6 @@ export const MobileTopNavigation = () => {
                 />
               ))}
               {headerNavigation.length > 0 && <Separator className="my-2" />}
-              <li className="empty:hidden">
-                <Slot.Target name="top-navigation-side" />
-              </li>
 
               {filteredItems.map((item) => {
                 if (item.type === "separator") {

--- a/packages/zudoku/src/lib/components/Slot.tsx
+++ b/packages/zudoku/src/lib/components/Slot.tsx
@@ -25,7 +25,8 @@ type PredefinedSlotNames =
   | "content-before"
   | "content-after"
   | "navigation-after"
-  | "navigation-before";
+  | "navigation-before"
+  | "mobile-top-bar-end";
 
 export type SlotName = PredefinedSlotNames | CustomSlotNames;
 

--- a/packages/zudoku/src/lib/components/navigation/Navigation.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Navigation.tsx
@@ -31,8 +31,9 @@ export const Navigation = ({
       <Slot.Target name="navigation-after" />
     </NavigationWrapper>
     <DrawerContent
-      className="lg:hidden h-dvh start-0 w-[320px] rounded-none"
+      className="lg:hidden h-dvh inset-s-0 w-[320px] rounded-none"
       aria-describedby={undefined}
+      onCloseAutoFocus={(e) => e.preventDefault()}
     >
       <div className="p-4 overflow-y-auto overscroll-none">
         <VisuallyHidden>

--- a/packages/zudoku/src/lib/components/navigation/Toc.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Toc.tsx
@@ -52,7 +52,13 @@ const TocItem = ({
   </li>
 );
 
-export const Toc = ({ entries }: { entries: TocEntry[] }) => {
+export const TocContent = ({
+  entries,
+  showHeader = true,
+}: {
+  entries: TocEntry[];
+  showHeader?: boolean;
+}) => {
   const { activeAnchor } = useViewportAnchor();
   const listWrapperRef = useRef<HTMLUListElement>(null);
   const paintedOnce = useRef(false);
@@ -91,11 +97,13 @@ export const Toc = ({ entries }: { entries: TocEntry[] }) => {
   }, [activeAnchor]);
 
   return (
-    <aside className="sticky scrollbar top-8 lg:top-(--header-height) h-[calc(100vh-var(--header-height))] pt-(--padding-content-top) pb-(--padding-content-bottom) overflow-y-auto ps-1 text-sm">
-      <div className="flex items-center gap-2 font-medium mb-2">
-        <ListTreeIcon size={16} />
-        On this page
-      </div>
+    <>
+      {showHeader && (
+        <div className="flex items-center gap-2 font-medium mb-2">
+          <ListTreeIcon size={16} />
+          On this page
+        </div>
+      )}
       <div className="relative ms-px ps-4">
         <div className="absolute inset-0 end-auto bg-border w-[1.5px]" />
         <div
@@ -132,6 +140,12 @@ export const Toc = ({ entries }: { entries: TocEntry[] }) => {
           ))}
         </ul>
       </div>
-    </aside>
+    </>
   );
 };
+
+export const Toc = ({ entries }: { entries: TocEntry[] }) => (
+  <aside className="sticky scrollbar top-8 lg:top-(--header-height) h-[calc(100vh-var(--header-height))] pt-(--padding-content-top) pb-(--padding-content-bottom) overflow-y-auto ps-1 text-sm">
+    <TocContent entries={entries} />
+  </aside>
+);

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -51,21 +51,47 @@ declare global {
   }
 }
 
+const findTocEntry = (
+  entries: TocEntry[],
+  id: string,
+): TocEntry | undefined => {
+  for (const entry of entries) {
+    if (entry.id === id) return entry;
+    const found = entry.children ? findTocEntry(entry.children, id) : undefined;
+    if (found) return found;
+  }
+};
+
 const TocPopoverButton = ({
   tocEntries,
+  variant = "inline",
   className,
 }: {
   tocEntries: TocEntry[];
+  variant?: "inline" | "button";
   className?: string;
 }) => {
   const [open, setOpen] = useState(false);
   const { activeAnchor } = useViewportAnchor();
   const activeAnchorText = activeAnchor
-    ? document.getElementById(activeAnchor)?.textContent
+    ? findTocEntry(tocEntries, activeAnchor)?.text
     : null;
+  const label = activeAnchorText ?? "On this page";
 
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
+  const trigger =
+    variant === "button" ? (
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label="Toggle table of contents"
+          className={cn("max-w-48", className)}
+        >
+          <ListTreeIcon size={14} aria-hidden="true" />
+          <span className="truncate">{label}</span>
+        </Button>
+      </PopoverTrigger>
+    ) : (
       <PopoverTrigger
         className={cn(
           "flex items-center gap-1 text-muted-foreground hover:text-accent-foreground",
@@ -74,14 +100,17 @@ const TocPopoverButton = ({
         aria-label="Toggle table of contents"
       >
         <ListTreeIcon aria-hidden="true" className="size-3" />
-        <span className="text-xs font-medium">
-          {activeAnchorText ?? "On this page"}
-        </span>
+        <span className="text-xs font-medium truncate">{label}</span>
       </PopoverTrigger>
+    );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      {trigger}
       <PopoverContent
         align="end"
         sideOffset={8}
-        className="max-w-sm overflow-y-auto p-4 text-sm"
+        className="max-w-sm max-h-[calc(100vh-var(--header-height))] overflow-y-auto p-4 text-sm"
         onCloseAutoFocus={(e) => e.preventDefault()}
         onClick={(e) => {
           if (e.target instanceof HTMLElement && e.target.closest("a")) {
@@ -140,7 +169,6 @@ export const MdxPage = ({
   const location = useLocation();
   const { options } = useZudoku();
   const [isCopied, setIsCopied] = useState(false);
-  const [isTocOpen, setIsTocOpen] = useState(false);
 
   const title = frontmatter.title;
   const description = frontmatter.description ?? excerpt;
@@ -196,7 +224,6 @@ export const MdxPage = ({
   const showToc = !hideToc && tocEntries.length > 0;
   const showTocSidebar = showToc && !fullWidth;
   const showTocPopover = showToc && fullWidth;
-  const showTocDrawer = showToc && !fullWidth;
 
   const { prev, next } = usePrevNext();
 
@@ -238,7 +265,7 @@ export const MdxPage = ({
         )}
       >
         <header className="flow-root">
-          {showTocDrawer && (
+          {showTocSidebar && (
             <>
               <Slot.Source name="top-navigation-side" type="append">
                 <TocPopoverButton
@@ -258,29 +285,7 @@ export const MdxPage = ({
               aria-label="Page actions"
             >
               {showTocPopover && (
-                <Popover open={isTocOpen} onOpenChange={setIsTocOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      aria-label="Toggle table of contents"
-                    >
-                      <ListTreeIcon size={14} aria-hidden="true" />
-                      <span>On this page</span>
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    align="end"
-                    className="w-72 max-h-[calc(100vh-var(--header-height)-2rem)] overflow-y-auto p-3 text-sm"
-                    onClick={(e) => {
-                      if ((e.target as HTMLElement).closest("a")) {
-                        setIsTocOpen(false);
-                      }
-                    }}
-                  >
-                    <TocContent entries={tocEntries} showHeader={false} />
-                  </PopoverContent>
-                </Popover>
+                <TocPopoverButton tocEntries={tocEntries} variant="button" />
               )}
               {copyMarkdownConfig && (
                 <ButtonGroup>

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -7,6 +7,7 @@ import {
   EditIcon,
   ExternalLinkIcon,
   Link2Icon,
+  ListTreeIcon,
 } from "lucide-react";
 import { type PropsWithChildren, useEffect, useState } from "react";
 import { useLocation } from "react-router";
@@ -18,18 +19,20 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "zudoku/ui/DropdownMenu.js";
+import { Popover, PopoverContent, PopoverTrigger } from "zudoku/ui/Popover.js";
 import { AiAssistantMenuItems } from "../../components/AiAssistantMenuItems.js";
 import { CategoryHeading } from "../../components/CategoryHeading.js";
 import { useZudoku } from "../../components/context/ZudokuContext.js";
 import { DeveloperHint } from "../../components/DeveloperHint.js";
 import { Heading } from "../../components/Heading.js";
-import { Toc } from "../../components/navigation/Toc.js";
+import { Toc, TocContent } from "../../components/navigation/Toc.js";
 import {
   useCurrentItem,
   usePrevNext,
 } from "../../components/navigation/utils.js";
 import { Pagination } from "../../components/Pagination.js";
 import { Typography } from "../../components/Typography.js";
+import { cn } from "../../util/cn.js";
 import { joinUrl } from "../../util/joinUrl.js";
 import { getMarkdownPathname } from "../../util/markdown.js";
 import type { MdxComponentsType } from "../../util/MdxComponents.js";
@@ -78,11 +81,13 @@ export const MdxPage = ({
   const location = useLocation();
   const { options } = useZudoku();
   const [isCopied, setIsCopied] = useState(false);
+  const [isTocOpen, setIsTocOpen] = useState(false);
 
   const title = frontmatter.title;
   const description = frontmatter.description ?? excerpt;
   const category = frontmatter.category ?? categoryTitle;
   const hideToc = frontmatter.toc === false || defaultOptions?.toc === false;
+  const fullWidth = frontmatter.fullWidth ?? defaultOptions?.fullWidth ?? false;
   const pageTitle =
     title ?? tableOfContents.find((item) => item.depth === 1)?.text;
   const hidePager =
@@ -130,6 +135,8 @@ export const MdxPage = ({
     tableOfContents.filter((item) => item.depth === 2);
 
   const showToc = !hideToc && tocEntries.length > 0;
+  const showTocSidebar = showToc && !fullWidth;
+  const showTocPopover = showToc && fullWidth;
 
   const { prev, next } = usePrevNext();
 
@@ -149,7 +156,10 @@ export const MdxPage = ({
 
   return (
     <div
-      className="grid grid-cols-1 xl:grid-cols-(--sidecar-grid-cols) gap-8 justify-between"
+      className={cn(
+        "grid grid-cols-1 gap-8 justify-between",
+        !fullWidth && "xl:grid-cols-(--sidecar-grid-cols)",
+      )}
       data-pagefind-filter="section:markdown"
       data-pagefind-meta="section:markdown"
     >
@@ -161,72 +171,106 @@ export const MdxPage = ({
         )}
       </Helmet>
 
-      <Typography className="max-w-full xl:w-full xl:max-w-3xl flex-1 shrink pt-(--padding-content-top)">
+      <Typography
+        className={cn(
+          "max-w-full flex-1 shrink pt-(--padding-content-top)",
+          !fullWidth && "xl:w-full xl:max-w-3xl",
+        )}
+      >
         <header className="flow-root">
-          {copyMarkdownConfig && (
+          {(copyMarkdownConfig || showTocPopover) && (
             <div
-              className="float-end ms-4 mt-1"
+              className="float-end ms-4 mt-1 flex items-center gap-2"
               role="group"
               aria-label="Page actions"
             >
-              <ButtonGroup>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleCopyMarkdown}
-                >
-                  {isCopied ? (
-                    <CheckIcon
-                      size={14}
-                      className="text-emerald-600"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <CopyIcon size={14} aria-hidden="true" />
-                  )}
-                  <span>Copy page</span>
-                </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
+              {showTocPopover && (
+                <Popover open={isTocOpen} onOpenChange={setIsTocOpen}>
+                  <PopoverTrigger asChild>
                     <Button
                       variant="outline"
-                      size="icon-sm"
-                      aria-label="More actions"
+                      size="sm"
+                      aria-label="Toggle table of contents"
                     >
-                      <ChevronDownIcon size={14} aria-hidden="true" />
+                      <ListTreeIcon size={14} aria-hidden="true" />
+                      <span>On this page</span>
                     </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="gap-2"
-                      onClick={() =>
-                        void navigator.clipboard.writeText(window.location.href)
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="end"
+                    className="w-72 max-h-[calc(100vh-var(--header-height)-2rem)] overflow-y-auto p-3 text-sm"
+                    onClick={(e) => {
+                      if ((e.target as HTMLElement).closest("a")) {
+                        setIsTocOpen(false);
                       }
-                    >
-                      <Link2Icon className="size-4" aria-hidden="true" />
-                      Copy link to page
-                    </DropdownMenuItem>
-                    <DropdownMenuItem className="gap-2" asChild>
-                      <a
-                        href={markdownUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                    }}
+                  >
+                    <TocContent entries={tocEntries} showHeader={false} />
+                  </PopoverContent>
+                </Popover>
+              )}
+              {copyMarkdownConfig && (
+                <ButtonGroup>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCopyMarkdown}
+                  >
+                    {isCopied ? (
+                      <CheckIcon
+                        size={14}
+                        className="text-emerald-600"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <CopyIcon size={14} aria-hidden="true" />
+                    )}
+                    <span>Copy page</span>
+                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon-sm"
+                        aria-label="More actions"
                       >
-                        <ExternalLinkIcon
-                          className="size-4"
-                          aria-hidden="true"
-                        />
-                        Open Markdown page
-                      </a>
-                    </DropdownMenuItem>
-                    <AiAssistantMenuItems
-                      aiAssistants={options.aiAssistants}
-                      getPageUrl={() => window.location.href}
-                      type="docs"
-                    />
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </ButtonGroup>
+                        <ChevronDownIcon size={14} aria-hidden="true" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        className="gap-2"
+                        onClick={() =>
+                          void navigator.clipboard.writeText(
+                            window.location.href,
+                          )
+                        }
+                      >
+                        <Link2Icon className="size-4" aria-hidden="true" />
+                        Copy link to page
+                      </DropdownMenuItem>
+                      <DropdownMenuItem className="gap-2" asChild>
+                        <a
+                          href={markdownUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <ExternalLinkIcon
+                            className="size-4"
+                            aria-hidden="true"
+                          />
+                          Open Markdown page
+                        </a>
+                      </DropdownMenuItem>
+                      <AiAssistantMenuItems
+                        aiAssistants={options.aiAssistants}
+                        getPageUrl={() => window.location.href}
+                        type="docs"
+                      />
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </ButtonGroup>
+              )}
             </div>
           )}
           {category && <CategoryHeading>{category}</CategoryHeading>}
@@ -297,9 +341,11 @@ export const MdxPage = ({
           </>
         )}
       </Typography>
-      <div className="hidden xl:block" data-pagefind-ignore="all">
-        {showToc && <Toc entries={tocEntries} />}
-      </div>
+      {showTocSidebar && (
+        <div className="hidden xl:block" data-pagefind-ignore="all">
+          <Toc entries={tocEntries} />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -173,7 +173,7 @@ export const MdxPage = ({
   const title = frontmatter.title;
   const description = frontmatter.description ?? excerpt;
   const category = frontmatter.category ?? categoryTitle;
-  const hideToc = frontmatter.toc === false || defaultOptions?.toc === false;
+  const tocEnabled = frontmatter.toc ?? defaultOptions?.toc ?? true;
   const fullWidth = frontmatter.fullWidth ?? defaultOptions?.fullWidth ?? false;
   const pageTitle =
     title ?? tableOfContents.find((item) => item.depth === 1)?.text;
@@ -221,7 +221,7 @@ export const MdxPage = ({
     // if `title` is provided by frontmatter it does not appear in the table of contents
     tableOfContents.filter((item) => item.depth === 2);
 
-  const showToc = !hideToc && tocEntries.length > 0;
+  const showToc = tocEnabled && tocEntries.length > 0;
   const showTocSidebar = showToc && !fullWidth;
   const showTocPopover = showToc && fullWidth;
 

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -1,6 +1,7 @@
 import { useMDXComponents } from "@mdx-js/react";
 import { Helmet } from "@zudoku/react-helmet-async";
 import {
+  ArrowUpIcon,
   CheckIcon,
   ChevronDownIcon,
   CopyIcon,
@@ -20,8 +21,10 @@ import {
   DropdownMenuTrigger,
 } from "zudoku/ui/DropdownMenu.js";
 import { Popover, PopoverContent, PopoverTrigger } from "zudoku/ui/Popover.js";
+import type { TocEntry } from "../../../vite/mdx/rehype-extract-toc-with-jsx.js";
 import { AiAssistantMenuItems } from "../../components/AiAssistantMenuItems.js";
 import { CategoryHeading } from "../../components/CategoryHeading.js";
+import { useViewportAnchor } from "../../components/context/ViewportAnchorContext.js";
 import { useZudoku } from "../../components/context/ZudokuContext.js";
 import { DeveloperHint } from "../../components/DeveloperHint.js";
 import { Heading } from "../../components/Heading.js";
@@ -31,6 +34,7 @@ import {
   usePrevNext,
 } from "../../components/navigation/utils.js";
 import { Pagination } from "../../components/Pagination.js";
+import { Slot } from "../../components/Slot.js";
 import { Typography } from "../../components/Typography.js";
 import { cn } from "../../util/cn.js";
 import { joinUrl } from "../../util/joinUrl.js";
@@ -46,6 +50,61 @@ declare global {
     }) => string[] | undefined;
   }
 }
+
+const TocPopoverButton = ({
+  tocEntries,
+  className,
+}: {
+  tocEntries: TocEntry[];
+  className?: string;
+}) => {
+  const [open, setOpen] = useState(false);
+  const { activeAnchor } = useViewportAnchor();
+  const activeAnchorText = activeAnchor
+    ? document.getElementById(activeAnchor)?.textContent
+    : null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className={cn(
+          "flex items-center gap-1 text-muted-foreground hover:text-accent-foreground",
+          className,
+        )}
+        aria-label="Toggle table of contents"
+      >
+        <ListTreeIcon aria-hidden="true" className="size-3" />
+        <span className="text-xs font-medium">
+          {activeAnchorText ?? "On this page"}
+        </span>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="max-w-sm overflow-y-auto p-4 text-sm"
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        onClick={(e) => {
+          if (e.target instanceof HTMLElement && e.target.closest("a")) {
+            setOpen(false);
+          }
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+            setOpen(false);
+          }}
+          className="flex items-center gap-2 pb-3 -mx-1 font-medium"
+        >
+          <ArrowUpIcon size={14} aria-hidden="true" />
+          Return to top
+        </button>
+        <TocContent entries={tocEntries} showHeader={false} />
+      </PopoverContent>
+    </Popover>
+  );
+};
 
 const MarkdownHeadings = {
   h2: ({ children, id }) => (
@@ -137,6 +196,7 @@ export const MdxPage = ({
   const showToc = !hideToc && tocEntries.length > 0;
   const showTocSidebar = showToc && !fullWidth;
   const showTocPopover = showToc && fullWidth;
+  const showTocDrawer = showToc && !fullWidth;
 
   const { prev, next } = usePrevNext();
 
@@ -178,6 +238,19 @@ export const MdxPage = ({
         )}
       >
         <header className="flow-root">
+          {showTocDrawer && (
+            <>
+              <Slot.Source name="top-navigation-side" type="append">
+                <TocPopoverButton
+                  tocEntries={tocEntries}
+                  className="xl:hidden"
+                />
+              </Slot.Source>
+              <Slot.Source name="mobile-top-bar-end" type="append">
+                <TocPopoverButton tocEntries={tocEntries} />
+              </Slot.Source>
+            </>
+          )}
           {(copyMarkdownConfig || showTocPopover) && (
             <div
               className="float-end ms-4 mt-1 flex items-center gap-2"

--- a/packages/zudoku/src/lib/plugins/markdown/index.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/index.tsx
@@ -10,7 +10,12 @@ export interface MarkdownPluginOptions extends ZudokuDocsConfig {
 }
 export type MarkdownPluginDefaultOptions = Pick<
   Frontmatter,
-  "toc" | "disablePager" | "showLastModified" | "suggestEdit" | "copyPage"
+  | "toc"
+  | "disablePager"
+  | "showLastModified"
+  | "suggestEdit"
+  | "copyPage"
+  | "fullWidth"
 >;
 
 export type Frontmatter = {
@@ -25,6 +30,7 @@ export type Frontmatter = {
   lastModifiedTime?: number;
   suggestEdit?: { url: string; text?: string } | false;
   copyPage?: boolean;
+  fullWidth?: boolean;
 };
 
 export type MDXImport = {


### PR DESCRIPTION
Adds an opt-in full-width page layout for docs. Introduces a compact "On this page" popover that surfaces the TOC whenever the sidebar is hidden, whether because of screen size (mobile/tablet) or because the page opts into full-width. Setting `toc: false` still hides the TOC entirely.