### PR TITLE
fix(typography): use `currentColor` for prose text

### DIFF
--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -533,7 +533,7 @@ const config: ZudokuConfig = {
   theme: {
     light: {
       background: "oklch(0.995 0.002 80)",
-      foreground: "20 14.3% 4.1%",
+      foreground: "#262626",
       card: "#fff",
       cardForeground: "#262626",
       primary: "#f4bf32",

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -51,6 +51,59 @@
   --font-serif: var(--font-serif);
 }
 
+@utility typography {
+  --tw-prose-body: color-mix(in oklch, currentColor 90%, transparent);
+  --tw-prose-headings: currentColor;
+  --tw-prose-lead: color-mix(in oklch, currentColor 65%, transparent);
+  --tw-prose-links: currentColor;
+  --tw-prose-bold: currentColor;
+  --tw-prose-counters: color-mix(in oklch, currentColor 55%, transparent);
+  --tw-prose-bullets: color-mix(in oklch, currentColor 30%, transparent);
+  --tw-prose-hr: color-mix(in oklch, currentColor 20%, transparent);
+  --tw-prose-quotes: currentColor;
+  --tw-prose-quote-borders: color-mix(in oklch, currentColor 20%, transparent);
+  --tw-prose-captions: color-mix(in oklch, currentColor 55%, transparent);
+  --tw-prose-code: currentColor;
+  --tw-prose-kbd: currentColor;
+  --tw-prose-th-borders: color-mix(in oklch, currentColor 30%, transparent);
+  --tw-prose-td-borders: color-mix(in oklch, currentColor 20%, transparent);
+  --tw-prose-invert-body: color-mix(in oklch, currentColor 90%, transparent);
+  --tw-prose-invert-headings: currentColor;
+  --tw-prose-invert-lead: color-mix(in oklch, currentColor 65%, transparent);
+  --tw-prose-invert-links: currentColor;
+  --tw-prose-invert-bold: currentColor;
+  --tw-prose-invert-counters: color-mix(
+    in oklch,
+    currentColor 55%,
+    transparent
+  );
+  --tw-prose-invert-bullets: color-mix(in oklch, currentColor 30%, transparent);
+  --tw-prose-invert-hr: color-mix(in oklch, currentColor 20%, transparent);
+  --tw-prose-invert-quotes: currentColor;
+  --tw-prose-invert-quote-borders: color-mix(
+    in oklch,
+    currentColor 20%,
+    transparent
+  );
+  --tw-prose-invert-captions: color-mix(
+    in oklch,
+    currentColor 55%,
+    transparent
+  );
+  --tw-prose-invert-code: currentColor;
+  --tw-prose-invert-kbd: currentColor;
+  --tw-prose-invert-th-borders: color-mix(
+    in oklch,
+    currentColor 30%,
+    transparent
+  );
+  --tw-prose-invert-td-borders: color-mix(
+    in oklch,
+    currentColor 20%,
+    transparent
+  );
+}
+
 @utility prose {
   a {
     @apply font-normal underline-offset-4 hover:text-primary;

--- a/packages/zudoku/src/lib/components/Typography.tsx
+++ b/packages/zudoku/src/lib/components/Typography.tsx
@@ -2,7 +2,7 @@ import type { AllHTMLAttributes } from "react";
 import { cn } from "../util/cn.js";
 
 // other styles are defined in main.css .prose
-export const ProseClasses = "prose dark:prose-invert prose-neutral typography";
+export const ProseClasses = "prose dark:prose-invert typography";
 
 export const Typography = ({
   className,


### PR DESCRIPTION
Prose was using `prose-neutral` which hardcoded its own color palette, so it never respected the theme's `foreground` variable and overrode any parent color context (e.g. `Markdown` inside a `Callout`).

This switches prose color tokens to `currentColor` (with `color-mix` for muted variants) and adds the matching `--tw-prose-invert-*` values for dark mode. Prose now follows the theme and inherits from its parent, while link/heading/spacing styles stay intact.

Fixes #2367