### PR TITLE
Add invite-only sign-up support to authentication providers

### DIFF
--- a/docs/pages/docs/configuration/authentication-firebase.md
+++ b/docs/pages/docs/configuration/authentication-firebase.md
@@ -53,9 +53,9 @@ export default {
     // "microsoft", "apple", "yahoo", "password", "emailLink"
     // If not specified, all enabled providers in Firebase will be available
     providers: ["google", "github", "password"],
-    // Optional: disable the sign-up UI for invite-only setups. Defaults to true.
-    // When false, the "Sign up" link is hidden and /signup shows a message.
-    allowSignUp: false,
+    // Optional: disable the sign-up UI for invite-only setups. Defaults to false.
+    // When true, the "Sign up" link is hidden and /signup shows a message.
+    disableSignUp: true,
     // Optional: configure redirect URLs after authentication
     redirectToAfterSignIn: "/docs",
     redirectToAfterSignUp: "/getting-started",

--- a/docs/pages/docs/configuration/authentication-firebase.md
+++ b/docs/pages/docs/configuration/authentication-firebase.md
@@ -53,6 +53,9 @@ export default {
     // "microsoft", "apple", "yahoo", "password", "emailLink"
     // If not specified, all enabled providers in Firebase will be available
     providers: ["google", "github", "password"],
+    // Optional: disable the sign-up UI for invite-only setups. Defaults to true.
+    // When false, the "Sign up" link is hidden and /signup shows a message.
+    allowSignUp: false,
     // Optional: configure redirect URLs after authentication
     redirectToAfterSignIn: "/docs",
     redirectToAfterSignUp: "/getting-started",

--- a/docs/pages/docs/configuration/authentication-supabase.md
+++ b/docs/pages/docs/configuration/authentication-supabase.md
@@ -248,11 +248,11 @@ authentication: {
   // Optional: When true, sign-in and sign-up pages show only OAuth buttons (no email/password)
   onlyThirdPartyProviders: true,
 
-  // Optional: When false, the sign-up UI is disabled (for invite-only setups).
+  // Optional: When true, the sign-up UI is disabled (for invite-only setups).
   // Must also be disabled in the Supabase dashboard under
   // Authentication → Configuration → Sign In / Providers → Allow new users to sign up.
-  // Defaults to true.
-  allowSignUp: false,
+  // Defaults to false.
+  disableSignUp: true,
 
   // Optional: Redirect URLs after authentication events
   redirectToAfterSignUp: "/welcome",
@@ -321,9 +321,9 @@ CREATE TRIGGER on_auth_user_created
 ## Invite-only sign-ups
 
 To launch an invite-only portal where new users can only be created by an admin, set
-`allowSignUp: false` in your Zudoku config **and** disable new sign-ups in the Supabase dashboard
+`disableSignUp: true` in your Zudoku config **and** disable new sign-ups in the Supabase dashboard
 (**Authentication** → **Configuration** → **Sign In / Providers** → clear **Allow new users to sign
-up**). When `allowSignUp` is `false`:
+up**). When `disableSignUp` is `true`:
 
 - The "Don't have an account? Sign up." link is hidden on the sign-in page.
 - Navigating to `/signup` shows an "Invitation required" message instead of a form.
@@ -334,7 +334,7 @@ export default {
     type: "supabase",
     supabaseUrl: "https://your-project.supabase.co",
     supabaseKey: "<your-publishable-key>",
-    allowSignUp: false,
+    disableSignUp: true,
   },
 };
 ```

--- a/docs/pages/docs/configuration/authentication-supabase.md
+++ b/docs/pages/docs/configuration/authentication-supabase.md
@@ -248,6 +248,12 @@ authentication: {
   // Optional: When true, sign-in and sign-up pages show only OAuth buttons (no email/password)
   onlyThirdPartyProviders: true,
 
+  // Optional: When false, the sign-up UI is disabled (for invite-only setups).
+  // Must also be disabled in the Supabase dashboard under
+  // Authentication → Configuration → Sign In / Providers → Allow new users to sign up.
+  // Defaults to true.
+  allowSignUp: false,
+
   // Optional: Redirect URLs after authentication events
   redirectToAfterSignUp: "/welcome",
   redirectToAfterSignIn: "/dashboard",
@@ -311,6 +317,30 @@ CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW EXECUTE PROCEDURE public.handle_new_user();
 ```
+
+## Invite-only sign-ups
+
+To launch an invite-only portal where new users can only be created by an admin, set
+`allowSignUp: false` in your Zudoku config **and** disable new sign-ups in the Supabase dashboard
+(**Authentication** → **Configuration** → **Sign In / Providers** → clear **Allow new users to sign
+up**). When `allowSignUp` is `false`:
+
+- The "Don't have an account? Sign up." link is hidden on the sign-in page.
+- Navigating to `/signup` shows an "Invitation required" message instead of a form.
+
+```ts title="zudoku.config.ts"
+export default {
+  authentication: {
+    type: "supabase",
+    supabaseUrl: "https://your-project.supabase.co",
+    supabaseKey: "<your-publishable-key>",
+    allowSignUp: false,
+  },
+};
+```
+
+Create users directly from the Supabase dashboard (**Authentication** → **Users** → **Add user**) or
+via the Supabase admin API.
 
 ## Troubleshooting
 

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -419,6 +419,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
         ]),
       )
       .optional(),
+    allowSignUp: z.boolean().optional(),
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
@@ -485,6 +486,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     provider: z.string().optional(),
     providers: z.array(z.string()).optional(),
     onlyThirdPartyProviders: z.boolean().optional(),
+    allowSignUp: z.boolean().optional(),
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -419,7 +419,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
         ]),
       )
       .optional(),
-    allowSignUp: z.boolean().optional(),
+    disableSignUp: z.boolean().optional(),
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
@@ -486,7 +486,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     provider: z.string().optional(),
     providers: z.array(z.string()).optional(),
     onlyThirdPartyProviders: z.boolean().optional(),
-    allowSignUp: z.boolean().optional(),
+    disableSignUp: z.boolean().optional(),
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),

--- a/packages/zudoku/src/lib/authentication/providers/firebase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.tsx
@@ -34,6 +34,7 @@ import { EmailVerificationUi } from "../ui/EmailVerificationUi.js";
 import {
   ZudokuPasswordResetUi,
   ZudokuSignInUi,
+  ZudokuSignUpDisabledUi,
   ZudokuSignUpUi,
 } from "../ui/ZudokuAuthUi.js";
 
@@ -59,11 +60,13 @@ class FirebaseAuthenticationProvider
   private readonly providers: string[];
   private readonly enableUsernamePassword: boolean;
   private readonly enableEmailLink: boolean;
+  private readonly allowSignUp: boolean;
   private readonly redirectToAfterSignOut: string;
 
   constructor(config: FirebaseAuthenticationConfig) {
     super();
     this.redirectToAfterSignOut = config.redirectToAfterSignOut ?? "/";
+    this.allowSignUp = config.allowSignUp ?? true;
 
     this.app = initializeApp({
       apiKey: config.apiKey,
@@ -217,6 +220,7 @@ class FirebaseAuthenticationProvider
           <ZudokuSignInUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
+            allowSignUp={this.allowSignUp}
             onOAuthSignIn={async (providerId: string) => {
               useAuthState.setState({ isPending: true });
               const provider = await getProviderForId(providerId);
@@ -261,7 +265,7 @@ class FirebaseAuthenticationProvider
       },
       {
         path: "/signup",
-        element: (
+        element: this.allowSignUp ? (
           <ZudokuSignUpUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
@@ -288,6 +292,8 @@ class FirebaseAuthenticationProvider
               await this.setUserLoggedIn(createUser.user);
             }}
           />
+        ) : (
+          <ZudokuSignUpDisabledUi />
         ),
       },
       {
@@ -445,7 +451,10 @@ const getFirebaseErrorMessage = (error: unknown): string => {
     case "auth/operation-not-allowed":
       return "This sign-in method is not enabled. Please contact support.";
     case "auth/weak-password":
-      return "The password must be at least 6 characters long.";
+      return (
+        error.message ||
+        "The password doesn't meet the minimum requirements. Please choose a stronger password."
+      );
     case "auth/user-disabled":
       return "This account has been disabled. Please contact support.";
     case "auth/user-not-found":

--- a/packages/zudoku/src/lib/authentication/providers/firebase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.tsx
@@ -60,13 +60,13 @@ class FirebaseAuthenticationProvider
   private readonly providers: string[];
   private readonly enableUsernamePassword: boolean;
   private readonly enableEmailLink: boolean;
-  private readonly allowSignUp: boolean;
+  private readonly disableSignUp: boolean;
   private readonly redirectToAfterSignOut: string;
 
   constructor(config: FirebaseAuthenticationConfig) {
     super();
     this.redirectToAfterSignOut = config.redirectToAfterSignOut ?? "/";
-    this.allowSignUp = config.allowSignUp ?? true;
+    this.disableSignUp = config.disableSignUp ?? false;
 
     this.app = initializeApp({
       apiKey: config.apiKey,
@@ -220,7 +220,7 @@ class FirebaseAuthenticationProvider
           <ZudokuSignInUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
-            allowSignUp={this.allowSignUp}
+            disableSignUp={this.disableSignUp}
             onOAuthSignIn={async (providerId: string) => {
               useAuthState.setState({ isPending: true });
               const provider = await getProviderForId(providerId);
@@ -265,7 +265,9 @@ class FirebaseAuthenticationProvider
       },
       {
         path: "/signup",
-        element: this.allowSignUp ? (
+        element: this.disableSignUp ? (
+          <ZudokuSignUpDisabledUi />
+        ) : (
           <ZudokuSignUpUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
@@ -292,8 +294,6 @@ class FirebaseAuthenticationProvider
               await this.setUserLoggedIn(createUser.user);
             }}
           />
-        ) : (
-          <ZudokuSignUpDisabledUi />
         ),
       },
       {

--- a/packages/zudoku/src/lib/authentication/providers/supabase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.tsx
@@ -45,7 +45,7 @@ class SupabaseAuthenticationProvider
   private readonly config: SupabaseAuthenticationConfig;
   private readonly providers: string[];
   private readonly enableUsernamePassword: boolean;
-  private readonly allowSignUp: boolean;
+  private readonly disableSignUp: boolean;
 
   constructor(config: SupabaseAuthenticationConfig) {
     const { supabaseUrl, supabaseKey } = config;
@@ -65,7 +65,7 @@ class SupabaseAuthenticationProvider
       : (config.providers ?? []);
     this.providers = configuredProviders;
     this.enableUsernamePassword = !config.onlyThirdPartyProviders;
-    this.allowSignUp = config.allowSignUp ?? true;
+    this.disableSignUp = config.disableSignUp ?? false;
 
     this.client.auth.onAuthStateChange(async (event, session) => {
       if (session && (event === "SIGNED_IN" || event === "TOKEN_REFRESHED")) {
@@ -316,7 +316,7 @@ class SupabaseAuthenticationProvider
           <ZudokuSignInUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
-            allowSignUp={this.allowSignUp}
+            disableSignUp={this.disableSignUp}
             onOAuthSignIn={this.onOAuthSignIn}
             onUsernamePasswordSignIn={this.onUsernamePasswordSignIn}
           />
@@ -324,15 +324,15 @@ class SupabaseAuthenticationProvider
       },
       {
         path: "/signup",
-        element: this.allowSignUp ? (
+        element: this.disableSignUp ? (
+          <ZudokuSignUpDisabledUi />
+        ) : (
           <ZudokuSignUpUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
             onOAuthSignUp={this.onOAuthSignIn}
             onUsernamePasswordSignUp={this.onUsernamePasswordSignUp}
           />
-        ) : (
-          <ZudokuSignUpDisabledUi />
         ),
       },
       {

--- a/packages/zudoku/src/lib/authentication/providers/supabase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.tsx
@@ -22,6 +22,7 @@ import {
   ZudokuPasswordResetUi,
   ZudokuPasswordUpdateUi,
   ZudokuSignInUi,
+  ZudokuSignUpDisabledUi,
   ZudokuSignUpUi,
 } from "../ui/ZudokuAuthUi.js";
 
@@ -44,6 +45,7 @@ class SupabaseAuthenticationProvider
   private readonly config: SupabaseAuthenticationConfig;
   private readonly providers: string[];
   private readonly enableUsernamePassword: boolean;
+  private readonly allowSignUp: boolean;
 
   constructor(config: SupabaseAuthenticationConfig) {
     const { supabaseUrl, supabaseKey } = config;
@@ -63,6 +65,7 @@ class SupabaseAuthenticationProvider
       : (config.providers ?? []);
     this.providers = configuredProviders;
     this.enableUsernamePassword = !config.onlyThirdPartyProviders;
+    this.allowSignUp = config.allowSignUp ?? true;
 
     this.client.auth.onAuthStateChange(async (event, session) => {
       if (session && (event === "SIGNED_IN" || event === "TOKEN_REFRESHED")) {
@@ -313,6 +316,7 @@ class SupabaseAuthenticationProvider
           <ZudokuSignInUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
+            allowSignUp={this.allowSignUp}
             onOAuthSignIn={this.onOAuthSignIn}
             onUsernamePasswordSignIn={this.onUsernamePasswordSignIn}
           />
@@ -320,13 +324,15 @@ class SupabaseAuthenticationProvider
       },
       {
         path: "/signup",
-        element: (
+        element: this.allowSignUp ? (
           <ZudokuSignUpUi
             providers={this.providers}
             enableUsernamePassword={this.enableUsernamePassword}
             onOAuthSignUp={this.onOAuthSignIn}
             onUsernamePasswordSignUp={this.onUsernamePasswordSignUp}
           />
+        ) : (
+          <ZudokuSignUpDisabledUi />
         ),
       },
       {
@@ -378,12 +384,6 @@ const getSupabaseErrorMessage = (error: unknown): string => {
   }
   if (errorMessage.includes("User already registered")) {
     return "The email address is already used by another account.";
-  }
-  if (
-    errorMessage.includes("Password should be at least") ||
-    errorMessage.includes("Password must be at least")
-  ) {
-    return "The password must be at least 6 characters long.";
   }
   if (errorMessage.includes("Invalid email")) {
     return "That email address isn't correct.";

--- a/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
+++ b/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
@@ -139,12 +139,12 @@ export const ZudokuSignInUi = ({
   onUsernamePasswordSignIn,
   enableUsernamePassword,
   enableEmailLink,
-  allowSignUp = true,
+  disableSignUp = false,
 }: {
   providers: string[];
   enableUsernamePassword: boolean;
   enableEmailLink?: boolean;
-  allowSignUp?: boolean;
+  disableSignUp?: boolean;
   onOAuthSignIn: (providerId: string) => Promise<void>;
   onUsernamePasswordSignIn: (email: string, password: string) => Promise<void>;
 }) => {
@@ -254,7 +254,7 @@ export const ZudokuSignInUi = ({
               Sign in with email link
             </Link>
           )}
-          {allowSignUp && (
+          {!disableSignUp && (
             <Link to="/signup" className="text-sm text-muted-foreground">
               Don't have an account? Sign up.
             </Link>

--- a/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
+++ b/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
@@ -139,10 +139,12 @@ export const ZudokuSignInUi = ({
   onUsernamePasswordSignIn,
   enableUsernamePassword,
   enableEmailLink,
+  allowSignUp = true,
 }: {
   providers: string[];
   enableUsernamePassword: boolean;
   enableEmailLink?: boolean;
+  allowSignUp?: boolean;
   onOAuthSignIn: (providerId: string) => Promise<void>;
   onUsernamePasswordSignIn: (email: string, password: string) => Promise<void>;
 }) => {
@@ -252,10 +254,37 @@ export const ZudokuSignInUi = ({
               Sign in with email link
             </Link>
           )}
-          <Link to="/signup" className="text-sm text-muted-foreground">
-            Don't have an account? Sign up.
-          </Link>
+          {allowSignUp && (
+            <Link to="/signup" className="text-sm text-muted-foreground">
+              Don't have an account? Sign up.
+            </Link>
+          )}
         </div>
+      </CardContent>
+    </AuthCard>
+  );
+};
+
+export const ZudokuSignUpDisabledUi = () => {
+  return (
+    <AuthCard>
+      <CardHeader>
+        <CardTitle>Sign up</CardTitle>
+        <CardDescription>Sign ups are not currently available.</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <Alert>
+          <AlertTitle>Invitation required</AlertTitle>
+          <AlertDescription>
+            New accounts are by invitation only. If you already have an account,
+            you can sign in below.
+          </AlertDescription>
+        </Alert>
+        <Link to="/signin">
+          <Button variant="outline" className="w-full">
+            Back to sign in
+          </Button>
+        </Link>
       </CardContent>
     </AuthCard>
   );


### PR DESCRIPTION
## Summary
This PR adds support for invite-only authentication flows by introducing an `allowSignUp` configuration option that disables the sign-up UI while keeping sign-in functional. This is useful for portals that want to restrict new user creation to admin-only operations.

## Key Changes

- **New UI Component**: Added `ZudokuSignUpDisabledUi` component that displays an "Invitation required" message instead of a sign-up form when sign-ups are disabled
- **Configuration Option**: Added `allowSignUp` boolean option (defaults to `true`) to both Firebase and Supabase authentication configs
- **Sign-in Page Updates**: The "Don't have an account? Sign up." link is now conditionally rendered based on the `allowSignUp` setting
- **Route Handling**: The `/signup` route now renders either the sign-up form or the disabled UI based on the configuration
- **Provider Implementation**: Updated both `FirebaseAuthenticationProvider` and `SupabaseAuthenticationProvider` to respect the new setting
- **Documentation**: Added comprehensive documentation for Supabase with an "Invite-only sign-ups" section explaining the setup process and how to create users via the Supabase dashboard or admin API
- **Error Message Improvement**: Improved Firebase password validation error message to be more user-friendly
- **Config Validation**: Updated Zod schema to include the new `allowSignUp` optional field for both authentication types

## Implementation Details

- The `allowSignUp` parameter is optional and defaults to `true` to maintain backward compatibility
- When disabled, users navigating to `/signup` see a helpful message directing them to sign in instead
- The configuration must be coordinated with the authentication provider's settings (e.g., Supabase dashboard) for complete enforcement
- Removed overly specific Supabase password length error message in favor of the provider's actual error response

https://claude.ai/code/session_01TQ3ZzFE1P2o6CPiLi1Qy6s