### PR TITLE
fix: preserve 'ansi' language in CodeTabs

### DIFF
--- a/packages/zudoku/src/lib/shiki.ts
+++ b/packages/zudoku/src/lib/shiki.ts
@@ -144,9 +144,12 @@ export const highlight = (
   meta?: string,
 ) => {
   const resolved = highlighter.resolveLangAlias(lang);
-  const effectiveLang = highlighter.getLoadedLanguages().includes(resolved)
-    ? lang
-    : "text";
+  // "ansi" is a special built-in shiki language that does not appear in
+  // getLoadedLanguages() but is always available.
+  const effectiveLang =
+    resolved === "ansi" || highlighter.getLoadedLanguages().includes(resolved)
+      ? lang
+      : "text";
 
   if (effectiveLang !== lang) warnUnloadedLanguage(lang, highlighter);
 


### PR DESCRIPTION
`ansi` language is a special built-in in shiki that does not appear in `highlighter.getLoadedLanguages()`, even though it is available.

This PR adds support for it, like in normal code blocks. This is useful for adding terminal coloring.