### PR TITLE
fix: use stable comparator for playground parameter sorting

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/PlaygroundDialogWrapper.tsx
@@ -18,7 +18,7 @@ export const PlaygroundDialogWrapper = ({
 }) => {
   const headers = operation.parameters
     ?.filter((p) => p.in === "header")
-    .sort((a, b) => (a.required && !b.required ? -1 : 1))
+    .sort((a, b) => Number(b.required ?? false) - Number(a.required ?? false))
     .map((p) => ({
       name: p.name,
       defaultValue:
@@ -31,7 +31,7 @@ export const PlaygroundDialogWrapper = ({
 
   const queryParams = operation.parameters
     ?.filter((p) => p.in === "query")
-    .sort((a, b) => (a.required && !b.required ? -1 : 1))
+    .sort((a, b) => Number(b.required ?? false) - Number(a.required ?? false))
     .map((p) => ({
       name: p.name,
       defaultActive: p.required ?? false,


### PR DESCRIPTION
The previous comparator returned 1 for equal-ranked items instead of 0, violating strict weak ordering. This made `Array.prototype.sort` behavior implementation-defined: Chrome's V8 preserved insertion order while Firefox's SpiderMonkey reversed the non-required tail.