### PR TITLE
Replace login dialog with auto-redirect to auth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@ See: https://github.com/zuplo/zudoku/releases
 - Merged `topNavigation`, `sidebar` and `customPages` into a single `navigation` configuration.
 - Plugins now require a `path` property instead of `navigationId`.
 - Added migration guide in `docs/pages/guides/navigation-migration.md`.
+- **Breaking:** Protected routes now redirect unauthenticated users straight to the authentication
+  provider instead of showing a "Login to continue" dialog. The `redirectTo` URL also preserves the
+  hash fragment. The Cancel and Register affordances on the dialog are gone; if you have
+  `redirectToAfterSignIn` configured, it still takes precedence over the originally-requested URL.

--- a/docs/pages/docs/configuration/protected-routes.md
+++ b/docs/pages/docs/configuration/protected-routes.md
@@ -38,9 +38,9 @@ authenticated to access these routes.
 }
 ```
 
-When a user tries to access a protected route, a login dialog will appear prompting them to sign in
-or register. After logging in, they are automatically redirected back to the route they were trying
-to access.
+When a user tries to access a protected route, they are automatically redirected to the
+authentication provider's sign-up flow. After signing in, they are returned to the route they were
+trying to access (including any query string and hash fragment).
 
 ## Object Format
 
@@ -81,20 +81,20 @@ The callback function receives an object with:
 
 The callback can return a `boolean` or a reason code string:
 
-| Return value              | Behavior                                          |
-| ------------------------- | ------------------------------------------------- |
-| `true`                    | Allow access to the route                         |
-| `false`                   | Treated as `UNAUTHORIZED` - prompts login         |
-| `reasonCode.UNAUTHORIZED` | Show a login dialog prompting the user to sign in |
-| `reasonCode.FORBIDDEN`    | Show a 403 "Access Denied" page                   |
+| Return value              | Behavior                                                   |
+| ------------------------- | ---------------------------------------------------------- |
+| `true`                    | Allow access to the route                                  |
+| `false`                   | Treated as `UNAUTHORIZED` — redirects to the auth provider |
+| `reasonCode.UNAUTHORIZED` | Redirect to the authentication provider                    |
+| `reasonCode.FORBIDDEN`    | Show a 403 "Access Denied" page                            |
 
 ## Reason Codes
 
 Reason codes allow you to distinguish between users who need to sign in and users who are signed in
 but lack permission. This is useful for building role-based or attribute-based access control.
 
-- **`UNAUTHORIZED`** - The user is not authenticated. A login dialog is shown, and navigation to the
-  route is blocked until the user signs in.
+- **`UNAUTHORIZED`** - The user is not authenticated. They are automatically redirected to the
+  authentication provider, and returned to the route after signing in.
 - **`FORBIDDEN`** - The user is authenticated but does not have permission. A 403 "Access Denied"
   page is displayed instead of the route content.
 
@@ -121,13 +121,13 @@ but lack permission. This is useful for building role-based or attribute-based a
 
 ## Navigation Blocking
 
-When a user navigates to a route that returns `false` or `UNAUTHORIZED`, navigation is intercepted
-before the page changes. The user stays on the current page while a login dialog is displayed. If
-the user cancels, they remain on the current page. If they log in successfully, navigation
-automatically proceeds to the protected route.
+When a user navigates to a route that returns `false` or `UNAUTHORIZED`, the redirect to the
+authentication provider is initiated immediately. If they have configured `redirectToAfterSignIn`,
+they will land there after signing in; otherwise they are returned to the route they originally
+requested.
 
-Routes that return `FORBIDDEN` do not block navigation — the user navigates to the route and sees
-the "Access Denied" page.
+Routes that return `FORBIDDEN` do not redirect — the user navigates to the route and sees the
+"Access Denied" page.
 
 ## Path Patterns
 

--- a/packages/zudoku/src/lib/core/RouteGuard.test.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.test.tsx
@@ -10,7 +10,6 @@ import {
   screen,
   render as testRender,
   waitFor,
-  within,
 } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { HelmetProvider } from "@zudoku/react-helmet-async";
@@ -278,37 +277,7 @@ describe("RouteGuard", () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it("shows login dialog when user needs to sign in", async () => {
-      await render(
-        { path: "/protected", element: <div>Protected</div> },
-        {
-          initialPath: "/protected",
-          auth: {
-            isAuthEnabled: true,
-            isPending: false,
-            isAuthenticated: false,
-          },
-          protectedRoutes: { "/protected": () => false },
-        },
-      );
-
-      const dialog = screen.getByRole("dialog");
-      expect(within(dialog).getByText("Login to continue")).toBeInTheDocument();
-      expect(
-        within(dialog).getByText("Please login to access this page."),
-      ).toBeInTheDocument();
-      expect(
-        within(dialog).getByRole("button", { name: "Login" }),
-      ).toBeInTheDocument();
-      expect(
-        within(dialog).getByRole("button", { name: "Register" }),
-      ).toBeInTheDocument();
-      expect(
-        within(dialog).getByRole("button", { name: "Cancel" }),
-      ).toBeInTheDocument();
-    });
-
-    it("calls login when login button clicked", async () => {
+    it("auto-redirects to signup and renders redirecting message when user needs to sign in", async () => {
       const { mockAuth } = await render(
         { path: "/protected", element: <div>Protected</div> },
         {
@@ -322,38 +291,52 @@ describe("RouteGuard", () => {
         },
       );
 
-      const dialog = screen.getByRole("dialog");
-      const loginButton = within(dialog).getByRole("button", { name: "Login" });
-      await userEvent.click(loginButton);
-
-      expect(mockAuth.login).toHaveBeenCalledWith(
-        expect.objectContaining({ redirectTo: "/protected" }),
-      );
-    });
-
-    it("calls signup when register button clicked", async () => {
-      const { mockAuth } = await render(
-        { path: "/protected", element: <div>Protected</div> },
-        {
-          initialPath: "/protected",
-          auth: {
-            isAuthEnabled: true,
-            isPending: false,
-            isAuthenticated: false,
-          },
-          protectedRoutes: { "/protected": () => false },
-        },
-      );
-
-      const dialog = screen.getByRole("dialog");
-      const registerButton = within(dialog).getByRole("button", {
-        name: "Register",
-      });
-      await userEvent.click(registerButton);
-
+      expect(screen.getByText("Redirecting to login…")).toBeInTheDocument();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.queryByText("Protected")).not.toBeInTheDocument();
       expect(mockAuth.signup).toHaveBeenCalledWith(
         expect.objectContaining({ redirectTo: "/protected" }),
       );
+      expect(mockAuth.login).not.toHaveBeenCalled();
+    });
+
+    it("preserves search and hash in redirectTo", async () => {
+      const { mockAuth } = await render(
+        { path: "/protected", element: <div>Protected</div> },
+        {
+          initialPath: "/protected?foo=bar#section-2",
+          auth: {
+            isAuthEnabled: true,
+            isPending: false,
+            isAuthenticated: false,
+          },
+          protectedRoutes: { "/protected": () => false },
+        },
+      );
+
+      expect(mockAuth.signup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          redirectTo: "/protected?foo=bar#section-2",
+        }),
+      );
+    });
+
+    it("does not redirect while auth is pending", async () => {
+      const { mockAuth } = await render(
+        { path: "/protected", element: <div>Protected</div> },
+        {
+          initialPath: "/protected",
+          auth: {
+            isAuthEnabled: true,
+            isPending: true,
+            isAuthenticated: false,
+          },
+          protectedRoutes: { "/protected": () => false },
+        },
+      );
+
+      expect(mockAuth.signup).not.toHaveBeenCalled();
+      expect(mockAuth.login).not.toHaveBeenCalled();
     });
 
     it("renders protected when auth check passes", async () => {
@@ -432,7 +415,7 @@ describe("RouteGuard", () => {
 
   describe("path matching", () => {
     it("matches exact paths with end: true", async () => {
-      await render(
+      const { mockAuth } = await render(
         { path: "/protected/nested", element: <div>Protected</div> },
         {
           initialPath: "/protected/nested",
@@ -445,8 +428,10 @@ describe("RouteGuard", () => {
         },
       );
 
-      const dialog = screen.getByRole("dialog");
-      expect(within(dialog).getByText("Login to continue")).toBeInTheDocument();
+      expect(screen.getByText("Redirecting to login…")).toBeInTheDocument();
+      expect(mockAuth.signup).toHaveBeenCalledWith(
+        expect.objectContaining({ redirectTo: "/protected/nested" }),
+      );
     });
 
     it("does not match partial paths", async () => {
@@ -496,7 +481,7 @@ describe("RouteGuard", () => {
       expect(screen.queryByText("VIP Content")).not.toBeInTheDocument();
     });
 
-    it("does not block navigation to FORBIDDEN route with login dialog", async () => {
+    it("does not block navigation to FORBIDDEN route", async () => {
       const navRoutes: RouteObject[] = [
         {
           path: "/",
@@ -532,11 +517,13 @@ describe("RouteGuard", () => {
 
       await userEvent.click(screen.getByText("Go VIP"));
 
-      // Should show ForbiddenPage, not a login dialog
+      // Should show ForbiddenPage, not a redirect to login
       await waitFor(() => {
         expect(screen.getByText("Access Denied")).toBeInTheDocument();
       });
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Redirecting to login…"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -559,32 +546,23 @@ describe("RouteGuard", () => {
       { path: "/protected", element: <div>Protected</div> },
     ];
 
-    it("blocks navigation and shows dialog while keeping current page", async () => {
-      const { mockAuth } = await render(navRoutes, navBlockingOptions);
+    it("blocks navigation and auto-redirects to signup with the destination", async () => {
+      const { mockAuth, router } = await render(navRoutes, navBlockingOptions);
 
       expect(screen.getByText("Public")).toBeInTheDocument();
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
       await userEvent.click(screen.getByText("Go"));
 
-      // Dialog appears, but still on public page
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-      expect(screen.getByText("Public")).toBeInTheDocument();
-
-      await userEvent.click(screen.getByRole("button", { name: "Login" }));
-      expect(mockAuth.login).toHaveBeenCalledWith({ redirectTo: "/protected" });
-    });
-
-    it("resets blocker when cancel clicked", async () => {
-      await render(navRoutes, navBlockingOptions);
-
-      await userEvent.click(screen.getByText("Go"));
-      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
-
       await waitFor(() => {
-        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        expect(screen.getByText("Redirecting to login…")).toBeInTheDocument();
       });
-      expect(screen.getByText("Public")).toBeInTheDocument();
+      // Blocker keeps the URL on the source page until OAuth takes over.
+      expect(router.state.location.pathname).toBe("/");
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(mockAuth.signup).toHaveBeenCalledWith(
+        expect.objectContaining({ redirectTo: "/protected" }),
+      );
     });
   });
 });

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -1,21 +1,6 @@
 import { Helmet } from "@zudoku/react-helmet-async";
-import { use, useCallback, useEffect, useMemo } from "react";
-import {
-  matchPath,
-  Outlet,
-  useBlocker,
-  useLocation,
-  useNavigate,
-} from "react-router";
-import { Button } from "zudoku/ui/Button.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "zudoku/ui/Dialog.js";
+import { use, useCallback, useEffect, useMemo, useRef } from "react";
+import { matchPath, Outlet, useBlocker, useLocation } from "react-router";
 import { REASON_CODES } from "../../config/validators/reason-codes.js";
 import { useAuth } from "../authentication/hook.js";
 import { RenderContext } from "../components/context/RenderContext.js";
@@ -24,39 +9,6 @@ import { Layout } from "../components/Layout.js";
 import { ZudokuError } from "../util/invariant.js";
 
 export const SEARCH_PROTECTED_SECTION = "protected";
-
-type LoginDialogProps = {
-  open: boolean;
-  onCancel: () => void;
-  onLogin: () => void;
-  onRegister: () => void;
-};
-
-const LoginDialog = ({
-  open,
-  onCancel,
-  onLogin,
-  onRegister,
-}: LoginDialogProps) => (
-  <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onCancel()}>
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>Login to continue</DialogTitle>
-      </DialogHeader>
-      <DialogDescription>Please login to access this page.</DialogDescription>
-      <DialogFooter>
-        <Button variant="outline" onClick={onCancel}>
-          Cancel
-        </Button>
-        <div className="w-full" />
-        <Button variant="secondary" onClick={onRegister}>
-          Register
-        </Button>
-        <Button onClick={onLogin}>Login</Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
-);
 
 const BypassRoute = ({ isProtectedRoute }: { isProtectedRoute: boolean }) => (
   <>
@@ -89,10 +41,15 @@ const ForbiddenPage = () => {
   );
 };
 
+const RedirectingToLogin = () => (
+  <div className="flex items-center justify-center min-h-[50vh]">
+    <p className="text-muted-foreground">Redirecting to login…</p>
+  </div>
+);
+
 export const RouteGuard = () => {
   const auth = useAuth();
   const zudoku = useZudoku();
-  const navigate = useNavigate();
   const location = useLocation();
   const renderContext = use(RenderContext);
   const shouldBypass = renderContext.bypassProtection;
@@ -133,7 +90,7 @@ export const RouteGuard = () => {
   });
   const isBlocked = blocker.state === "blocked";
 
-  // Proceed after successful login
+  // Proceed after successful login (e.g. user authenticated in another tab while we were redirecting)
   useEffect(() => {
     if (!auth.isAuthenticated || !isBlocked) return;
     const check = getAuthCheck(blocker.location.pathname);
@@ -154,6 +111,35 @@ export const RouteGuard = () => {
     getAuthCheck,
   ]);
 
+  const isUnauthorizedDestination = needsToSignIn || isBlocked;
+  const blockerLocation = isBlocked ? blocker.location : null;
+  const redirectTo = blockerLocation
+    ? blockerLocation.pathname + blockerLocation.search + blockerLocation.hash
+    : location.pathname + location.search + location.hash;
+
+  // Auto-redirect to the auth provider when unauthorized.
+  // Ref guard prevents duplicate calls if auth.signup's identity changes between renders.
+  const redirectInitiatedRef = useRef(false);
+  useEffect(() => {
+    if (!isUnauthorizedDestination) {
+      redirectInitiatedRef.current = false;
+      return;
+    }
+    if (auth.isPending) return;
+    if (!auth.isAuthEnabled) return;
+    if (shouldBypass) return;
+    if (redirectInitiatedRef.current) return;
+    redirectInitiatedRef.current = true;
+    void auth.signup({ redirectTo });
+  }, [
+    isUnauthorizedDestination,
+    auth.isPending,
+    auth.isAuthEnabled,
+    auth.signup,
+    redirectTo,
+    shouldBypass,
+  ]);
+
   if (isForbidden) {
     return <ForbiddenPage />;
   }
@@ -170,24 +156,17 @@ export const RouteGuard = () => {
     });
   }
 
-  if (needsToSignIn && auth.isPending && typeof window !== "undefined") {
+  if (
+    isUnauthorizedDestination &&
+    auth.isPending &&
+    typeof window !== "undefined"
+  ) {
     return null;
   }
 
-  const showDialog = needsToSignIn || isBlocked;
-  const redirectTo = isBlocked
-    ? blocker.location.pathname + blocker.location.search
-    : location.pathname + location.search;
+  if (isUnauthorizedDestination) {
+    return <RedirectingToLogin />;
+  }
 
-  return (
-    <>
-      {!needsToSignIn && <Outlet />}
-      <LoginDialog
-        open={showDialog}
-        onCancel={needsToSignIn ? () => navigate(-1) : () => blocker.reset?.()}
-        onLogin={() => void auth.login({ redirectTo })}
-        onRegister={() => void auth.signup({ redirectTo })}
-      />
-    </>
-  );
+  return <Outlet />;
 };


### PR DESCRIPTION
## Summary
Replaced the modal login dialog with automatic redirection to the authentication provider when users attempt to access protected routes. This simplifies the UX by removing the intermediate dialog step and leveraging the auth provider's native sign-up/login flows.

## Key Changes
- **Removed LoginDialog component**: Eliminated the modal dialog that prompted users to login or register
- **Implemented auto-redirect flow**: Added automatic redirection to `auth.signup()` when users are unauthorized, with a loading state ("Redirecting to login…") displayed while the redirect is in progress
- **Preserved URL state**: Updated redirect logic to include search parameters and hash fragments in the `redirectTo` URL, ensuring users return to the exact location they requested
- **Simplified RouteGuard logic**: Removed `useNavigate` hook and dialog state management; replaced with a `useRef`-guarded effect that initiates the redirect once per unauthorized session
- **Updated navigation blocking**: When users attempt to navigate to protected routes, the blocker now triggers the auto-redirect instead of showing a dialog with cancel/login/register buttons
- **Updated documentation**: Revised protected routes docs to reflect the new auto-redirect behavior and removed references to the login dialog

## Implementation Details
- Added `RedirectingToLogin` component to display a simple loading message during the redirect
- Used `redirectInitiatedRef` to prevent duplicate `auth.signup()` calls across re-renders
- Consolidated authorization checks into `isUnauthorizedDestination` variable for clearer logic
- Preserved hash fragments in redirect URLs (previously only pathname and search were included)
- Tests updated to verify auto-redirect behavior and removal of dialog UI

https://claude.ai/code/session_018ptAjFRWx35ioE4Gzk8tGV