### PR TITLE
Improve text wrapping and add schema documentation examples

### DIFF
--- a/examples/cosmo-cargo/schema/ai-cargo.json
+++ b/examples/cosmo-cargo/schema/ai-cargo.json
@@ -629,7 +629,7 @@
     },
     {
       "name": "Quantum Transport",
-      "description": "Experimental quantum tunneling transport routes"
+      "description": "Experimental quantum tunneling transport routes.\n\nA tunneling request body looks like:\n\n```json\n{\"originCoords\":\"QC-X7a3f9b2c4d8e1f5a6b9c2d4e8f1a3b5c7d9e0f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f-Y0a2b4c6d8e0f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f-Z0f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b4c6d8e0f2a4b6c8d0e2f\"}\n```\n"
     }
   ]
 }

--- a/examples/cosmo-cargo/schema/interplanetary.json
+++ b/examples/cosmo-cargo/schema/interplanetary.json
@@ -88,7 +88,9 @@
           },
           "trackingNumber": {
             "type": "string",
-            "readOnly": true
+            "readOnly": true,
+            "description": "Quantum-entangled tracking signature emitted by the launch beacon. The full string encodes origin coordinates, warp class, customs handshake, and tamper-evident checksum.",
+            "example": "QM-ENTANGLED-7a3f9b2c4d8e1f5a6b9c2d4e8f1a3b5c7d9e0f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b4c6d8e0f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b4c6d8e0f2a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f-CHECKSUM-3f5a7b9c1d3e5f7a9b1c3d5e7f"
           },
           "createdAt": {
             "type": "string",

--- a/examples/cosmo-cargo/schema/webhooks.json
+++ b/examples/cosmo-cargo/schema/webhooks.json
@@ -76,7 +76,8 @@
           "secret": {
             "type": "string",
             "writeOnly": true,
-            "description": "Secret used to sign webhook payloads"
+            "description": "Secret used to sign webhook payloads. Generated via quantum key distribution; rotate from the developer portal if compromised.",
+            "example": "whsec_quantum_3a8f2c5e9b1d4f7a6c0e2b8d5f1a4c7e9b2d6f0a3c5e8b1d4f7a2c0e6b9d3f5a8c1e4b7d0f2a5c8e3b6d9f1a4c7e0b2d5f8a3c6e9b1d4f7a0c2e5b8d3f6a9c1e4b7d0f2a5c8e3b6d9f1a4c7e0b2d5f8a3c6e9b1d4f7a0c2e5b8d3f6a9c1e4b7d0f2a5c8e_signed_with_QKD_protocol_v3_2026"
           }
         }
       },

--- a/packages/zudoku/src/lib/components/Main.tsx
+++ b/packages/zudoku/src/lib/components/Main.tsx
@@ -40,7 +40,7 @@ export const Main = ({ children }: PropsWithChildren) => {
       <main
         data-pagefind-body
         className={cn(
-          "px-4 lg:pe-8 lg:px-8",
+          "min-w-0 px-4 lg:pe-8 lg:px-8",
           !hasNavigation && "col-span-full",
           isNavigating && "animate-pulse",
         )}

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaExampleAndDefault.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaExampleAndDefault.tsx
@@ -16,7 +16,7 @@ export const SchemaExampleAndDefault = ({
       {example !== undefined && (
         <div>
           <span className="text-muted-foreground">Example: </span>
-          <SelectOnClick className="border rounded-sm px-1 font-mono">
+          <SelectOnClick className="border rounded-sm px-1 font-mono wrap-anywhere">
             {typeof example === "object" || typeof example === "boolean"
               ? JSON.stringify(example)
               : example}
@@ -26,7 +26,7 @@ export const SchemaExampleAndDefault = ({
       {defaultValue !== undefined && (
         <div>
           <span className="text-muted-foreground">Default: </span>
-          <SelectOnClick className="border rounded-sm px-1 font-mono">
+          <SelectOnClick className="border rounded-sm px-1 font-mono wrap-anywhere">
             {typeof defaultValue === "object" ||
             typeof defaultValue === "boolean"
               ? JSON.stringify(defaultValue)

--- a/packages/zudoku/src/lib/ui/Item.tsx
+++ b/packages/zudoku/src/lib/ui/Item.tsx
@@ -111,7 +111,7 @@ function ItemContent({
     <div
       data-slot="item-content"
       className={cn(
-        "flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none",
+        "flex flex-1 flex-col gap-1 min-w-0 [&+[data-slot=item-content]]:flex-none",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
This PR enhances documentation and UI rendering by adding descriptive examples to API schema definitions and improving text wrapping behavior for long content in the UI.

Fix #2382
Fix #2383