### PR TITLE
Customize sign-up across auth providers

### DIFF
--- a/docs/pages/docs/configuration/authentication-auth0.md
+++ b/docs/pages/docs/configuration/authentication-auth0.md
@@ -154,6 +154,28 @@ When the prompt parameter is omitted (empty string), Auth0 will:
 - Silently authenticate the user if they have a valid session
 - Redirect to the login page if no valid session exists
 
+### Customizing Sign-up
+
+By default Auth0 already adds `screen_hint=signup` when a user clicks Register. To send users to a
+different page (or hide Register entirely):
+
+```typescript
+authentication: {
+  type: "auth0",
+  domain: "your-domain.us.auth0.com",
+  clientId: "<your-auth0-client-id>",
+
+  // Send Register to a separate URL (absolute → external, relative → in-app)
+  signUp: { url: "/register" },
+
+  // Or pass extra params to the Auth0 authorize URL on sign-up
+  signUp: { authorizationParams: { connection: "your-signup-connection" } },
+
+  // Hide Register UI entirely. Visual only — configure Auth0 to actually block sign-ups.
+  disableSignUp: true,
+}
+```
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/pages/docs/configuration/authentication-azure-ad.md
+++ b/docs/pages/docs/configuration/authentication-azure-ad.md
@@ -178,6 +178,24 @@ To allow external partners access:
 3. Invite guest users to your directory
 4. Grant appropriate permissions to your application
 
+### Customizing Sign-up
+
+Azure AD B2C usually handles sign-up via a separate user flow. To send users there, point Register
+at the URL of that flow (or any other page):
+
+```typescript
+authentication: {
+  type: "azureb2c",
+  // ...
+
+  // Absolute URL → external redirect, relative path → in-app navigate
+  signUp: { url: "https://your-tenant.b2clogin.com/your-tenant.onmicrosoft.com/B2C_1_SignUp/oauth2/v2.0/authorize?..." },
+
+  // Hide Register entirely. Visual only — sign-ups are still controlled by your B2C policy.
+  disableSignUp: true,
+}
+```
+
 ## User Data
 
 Azure AD provides rich user profile data through OpenID Connect:

--- a/docs/pages/docs/configuration/authentication-clerk.md
+++ b/docs/pages/docs/configuration/authentication-clerk.md
@@ -84,6 +84,23 @@ that provides 10,000 monthly active users.
 
    You should also ensure your site's domain is added as an allowed origin in the Clerk dashboard.
 
+5. **Customizing Sign-up (Optional)**
+
+   To send Register to a different page, or hide it entirely:
+
+   ```typescript
+   authentication: {
+     type: "clerk",
+     clerkPubKey: "<your-clerk-publishable-key>",
+
+     // Absolute URL → external redirect, relative path → in-app navigate
+     signUp: { url: "/register" },
+
+     // Hide Register UI. Visual only — configure Clerk to actually block sign-ups.
+     disableSignUp: true,
+   },
+   ```
+
 </Stepper>
 
 ## Troubleshooting

--- a/docs/pages/docs/configuration/authentication-firebase.md
+++ b/docs/pages/docs/configuration/authentication-firebase.md
@@ -54,8 +54,12 @@ export default {
     // If not specified, all enabled providers in Firebase will be available
     providers: ["google", "github", "password"],
     // Optional: disable the sign-up UI for invite-only setups. Defaults to false.
-    // When true, the "Sign up" link is hidden and /signup shows a message.
+    // When true, the Register button and "Sign up" link are hidden, and /signup shows a message.
+    // Visual only — also disable sign-ups in your Firebase project for real enforcement.
     disableSignUp: true,
+    // Optional: send Register to a separate URL instead of /signup
+    // (absolute URL → external redirect, relative path → in-app navigate)
+    signUp: { url: "/register" },
     // Optional: configure redirect URLs after authentication
     redirectToAfterSignIn: "/docs",
     redirectToAfterSignUp: "/getting-started",

--- a/docs/pages/docs/configuration/authentication-openid.md
+++ b/docs/pages/docs/configuration/authentication-openid.md
@@ -92,6 +92,33 @@ You can confirm your issuer URL is correct by opening `<issuer>/.well-known/open
 a browser. It should return a JSON document listing `authorization_endpoint`, `token_endpoint`,
 `userinfo_endpoint`, and `jwks_uri`.
 
+## Customizing Sign-up
+
+By default Register and Sign in both call the OIDC authorize endpoint, so users land on the same
+login page. Two options change that:
+
+```typescript title="zudoku.config.ts"
+{
+  authentication: {
+    type: "openid",
+    clientId: "<your-client-id>",
+    issuer: "<the-issuer-url>",
+
+    // Send Register to a separate URL (absolute → external redirect, relative → in-app navigate)
+    signUp: { url: "/register" },
+
+    // Or pass extra params to the authorize URL on sign-up only (e.g. Keycloak)
+    signUp: { authorizationParams: { kc_action: "register" } },
+
+    // Hide Register UI entirely. Visual only — still configure your IdP to block sign-ups.
+    disableSignUp: true,
+  },
+}
+```
+
+When `disableSignUp` is `true`, the Register button on the protected-route login dialog is hidden
+and `/signup` shows an "Invitation required" page.
+
 ## User Profile
 
 After sign-in Zudoku calls the provider's

--- a/docs/pages/docs/configuration/authentication-supabase.md
+++ b/docs/pages/docs/configuration/authentication-supabase.md
@@ -254,6 +254,10 @@ authentication: {
   // Defaults to false.
   disableSignUp: true,
 
+  // Optional: send Register to a separate URL instead of /signup
+  // (absolute URL → external redirect, relative path → in-app navigate)
+  signUp: { url: "/register" },
+
   // Optional: Redirect URLs after authentication events
   redirectToAfterSignUp: "/welcome",
   redirectToAfterSignIn: "/dashboard",
@@ -326,6 +330,7 @@ To launch an invite-only portal where new users can only be created by an admin,
 up**). When `disableSignUp` is `true`:
 
 - The "Don't have an account? Sign up." link is hidden on the sign-in page.
+- The Register button is hidden on the protected-route login dialog.
 - Navigating to `/signup` shows an "Invitation required" message instead of a form.
 
 ```ts title="zudoku.config.ts"

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -383,6 +383,14 @@ const SearchSchema = z
   ])
   .optional();
 
+const SignUpUrlSchema = z.object({ url: z.string().min(1) });
+const SignUpOpenIdSchema = z.union([
+  SignUpUrlSchema,
+  z.object({
+    authorizationParams: z.record(z.string(), z.string()),
+  }),
+]);
+
 const AuthenticationSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("clerk"),
@@ -395,6 +403,8 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    signUp: SignUpUrlSchema.optional(),
+    disableSignUp: z.boolean().optional(),
   }),
   z.object({
     type: z.literal("firebase"),
@@ -424,6 +434,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    signUp: SignUpUrlSchema.optional(),
   }),
   z.object({
     type: z.literal("openid"),
@@ -435,6 +446,8 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    signUp: SignUpOpenIdSchema.optional(),
+    disableSignUp: z.boolean().optional(),
   }),
   z.object({
     type: z.literal("azureb2c"),
@@ -447,6 +460,8 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    signUp: SignUpUrlSchema.optional(),
+    disableSignUp: z.boolean().optional(),
   }),
 
   z.object({
@@ -478,6 +493,8 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
         prompt: z.string().optional(),
       })
       .optional(),
+    signUp: SignUpOpenIdSchema.optional(),
+    disableSignUp: z.boolean().optional(),
   }),
   z.object({
     type: z.literal("supabase"),
@@ -491,6 +508,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    signUp: SignUpUrlSchema.optional(),
   }),
 ]);
 

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -383,12 +383,20 @@ const SearchSchema = z
   ])
   .optional();
 
-const SignUpUrlSchema = z.object({ url: z.string().min(1) });
+const SignUpUrlValueSchema = z
+  .string()
+  .min(1)
+  .refine((v) => v.startsWith("/") || URL.canParse(v), {
+    message: "signUp.url must be an absolute URL or a path starting with '/'",
+  });
+const SignUpUrlSchema = z.object({ url: SignUpUrlValueSchema }).strict();
 const SignUpOpenIdSchema = z.union([
   SignUpUrlSchema,
-  z.object({
-    authorizationParams: z.record(z.string(), z.string()),
-  }),
+  z
+    .object({
+      authorizationParams: z.record(z.string(), z.string()),
+    })
+    .strict(),
 ]);
 
 const AuthenticationSchema = z.discriminatedUnion("type", [

--- a/packages/zudoku/src/lib/authentication/authentication.ts
+++ b/packages/zudoku/src/lib/authentication/authentication.ts
@@ -5,6 +5,12 @@ export type AuthActionContext = { navigate: NavigateFunction };
 export type AuthActionOptions = { redirectTo?: string; replace?: boolean };
 
 export interface AuthenticationPlugin {
+  /**
+   * When true, the UI hides Register/Sign up affordances. This is purely
+   * visual; sign-ups are still enforced at the identity provider.
+   */
+  disableSignUp?: boolean;
+
   initialize?(context: ZudokuContext): Promise<void>;
   onPageLoad?(): void;
 

--- a/packages/zudoku/src/lib/authentication/authentication.ts
+++ b/packages/zudoku/src/lib/authentication/authentication.ts
@@ -5,10 +5,7 @@ export type AuthActionContext = { navigate: NavigateFunction };
 export type AuthActionOptions = { redirectTo?: string; replace?: boolean };
 
 export interface AuthenticationPlugin {
-  /**
-   * When true, the UI hides Register/Sign up affordances. This is purely
-   * visual; sign-ups are still enforced at the identity provider.
-   */
+  // Hides Register UI; real enforcement still belongs at the IdP.
   disableSignUp?: boolean;
 
   initialize?(context: ZudokuContext): Promise<void>;

--- a/packages/zudoku/src/lib/authentication/components/SignUp.test.tsx
+++ b/packages/zudoku/src/lib/authentication/components/SignUp.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import {
+  act,
+  cleanup,
+  render as testRender,
+  screen,
+} from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UseAuthReturn } from "../hook.js";
+import { SignUp } from "./SignUp.js";
+
+vi.mock("../hook.js", () => ({
+  useAuth: vi.fn(),
+}));
+
+const { useAuth } = await import("../hook.js");
+const mockUseAuth = vi.mocked(useAuth);
+
+const buildAuth = (overrides: Partial<UseAuthReturn> = {}): UseAuthReturn => ({
+  isAuthenticated: false,
+  isPending: false,
+  isAuthEnabled: true,
+  disableSignUp: false,
+  profile: null,
+  providerData: null,
+  setAuthenticationPending: vi.fn(),
+  setLoggedOut: vi.fn(),
+  setLoggedIn: vi.fn(),
+  login: vi.fn(),
+  logout: vi.fn(),
+  signup: vi.fn(),
+  requestEmailVerification: vi.fn(),
+  ...overrides,
+});
+
+const renderAt = async (path: string) => {
+  const router = createMemoryRouter(
+    [{ path: "/signup", element: <SignUp /> }],
+    { initialEntries: [path] },
+  );
+
+  await act(async () => {
+    testRender(<RouterProvider router={router} />);
+  });
+};
+
+describe("SignUp page", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("redirects via signup() when not disabled", async () => {
+    const signup = vi.fn();
+    mockUseAuth.mockReturnValue(buildAuth({ signup }));
+
+    await renderAt("/signup?redirect=/dashboard");
+
+    expect(signup).toHaveBeenCalledWith({ redirectTo: "/dashboard" });
+    expect(screen.queryByText("Invitation required")).not.toBeInTheDocument();
+  });
+
+  it("renders disabled UI and does not call signup when disableSignUp is true", async () => {
+    const signup = vi.fn();
+    mockUseAuth.mockReturnValue(buildAuth({ signup, disableSignUp: true }));
+
+    await renderAt("/signup");
+
+    expect(signup).not.toHaveBeenCalled();
+    expect(screen.getByText("Invitation required")).toBeInTheDocument();
+  });
+
+  it("falls back to '/' when redirect query param missing", async () => {
+    const signup = vi.fn();
+    mockUseAuth.mockReturnValue(buildAuth({ signup }));
+
+    await renderAt("/signup");
+
+    expect(signup).toHaveBeenCalledWith({ redirectTo: "/" });
+  });
+});

--- a/packages/zudoku/src/lib/authentication/components/SignUp.tsx
+++ b/packages/zudoku/src/lib/authentication/components/SignUp.tsx
@@ -10,6 +10,7 @@ import {
 } from "zudoku/ui/Card.js";
 import { useLatest } from "../../util/useLatest.js";
 import { useAuth } from "../hook.js";
+import { ZudokuSignUpDisabledUi } from "../ui/ZudokuAuthUi.js";
 
 export const SignUp = () => {
   const auth = useAuth();
@@ -17,10 +18,16 @@ export const SignUp = () => {
   const redirectTo = search.get("redirect") ?? "/";
 
   const signup = useLatest(auth.signup);
+  const disabled = auth.disableSignUp;
 
   useEffect(() => {
+    if (disabled) return;
     void signup.current({ redirectTo });
-  }, [signup, redirectTo]);
+  }, [signup, redirectTo, disabled]);
+
+  if (disabled) {
+    return <ZudokuSignUpDisabledUi />;
+  }
 
   return (
     <div className="flex items-center justify-center mt-8">

--- a/packages/zudoku/src/lib/authentication/hook.ts
+++ b/packages/zudoku/src/lib/authentication/hook.ts
@@ -76,6 +76,7 @@ export const useAuth = () => {
 
   return {
     isAuthEnabled,
+    disableSignUp: authentication?.disableSignUp ?? false,
     ...authState,
 
     login: async (options?: AuthActionOptions) => {

--- a/packages/zudoku/src/lib/authentication/providers/azureb2c.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/azureb2c.tsx
@@ -14,6 +14,7 @@ import { CallbackHandler } from "../components/CallbackHandler.js";
 import { OAuthErrorPage } from "../components/OAuthErrorPage.js";
 import { AuthorizationError } from "../errors.js";
 import { useAuthState } from "../state.js";
+import { redirectToSignUpUrl } from "./util.js";
 
 export type AzureB2CProviderData = {
   type: "azureb2c";
@@ -40,6 +41,8 @@ export class AzureB2CAuthPlugin
   private readonly redirectToAfterSignUp?: string;
   private readonly redirectToAfterSignIn?: string;
   private readonly redirectToAfterSignOut: string;
+  private readonly signUpConfig?: AzureB2CAuthenticationConfig["signUp"];
+  public readonly disableSignUp: boolean;
 
   constructor({
     clientId,
@@ -50,12 +53,16 @@ export class AzureB2CAuthPlugin
     redirectToAfterSignIn,
     redirectToAfterSignOut = "/",
     basePath = "",
+    signUp,
+    disableSignUp,
   }: AzureB2CAuthenticationConfig) {
     super();
     this.scopes = scopes ?? ["openid", "profile", "email"];
     this.redirectToAfterSignUp = redirectToAfterSignUp;
     this.redirectToAfterSignIn = redirectToAfterSignIn;
     this.redirectToAfterSignOut = redirectToAfterSignOut;
+    this.signUpConfig = signUp;
+    this.disableSignUp = disableSignUp ?? false;
 
     const authority = `https://${tenantName}.b2clogin.com/${tenantName}.onmicrosoft.com/${policyName}`;
     const redirectUri = joinUrl(basePath, AZUREB2C_CALLBACK_PATH);
@@ -122,9 +129,17 @@ export class AzureB2CAuthPlugin
   }
 
   async signUp(
-    _: AuthActionContext,
-    { redirectTo }: { redirectTo?: string } = {},
+    { navigate }: AuthActionContext,
+    {
+      redirectTo,
+      replace = false,
+    }: { redirectTo?: string; replace?: boolean } = {},
   ) {
+    if (this.signUpConfig) {
+      redirectToSignUpUrl(this.signUpConfig.url, navigate, replace);
+      return;
+    }
+
     const redirectUri = this.redirectToAfterSignUp ?? redirectTo ?? "/";
     sessionStorage.setItem("redirect-to", redirectUri);
 

--- a/packages/zudoku/src/lib/authentication/providers/clerk.test.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import clerkAuth from "./clerk.js";
+
+describe("clerkAuth signUp short-circuit", () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    document.head.innerHTML = "";
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    document.head.innerHTML = "";
+  });
+
+  test("signUp({ url }) skips Clerk SDK and uses location.assign for absolute URL", async () => {
+    const loc = { assign: vi.fn(), replace: vi.fn() };
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: loc,
+    });
+
+    const provider = clerkAuth({
+      type: "clerk",
+      // Format only matters for the Zod validator; provider does not parse it
+      // unless loadClerk runs. The short-circuit must prevent that.
+      clerkPubKey: "pk_test_fake.clerk.dev$" as `pk_test_${string}`,
+      jwtTemplateName: "dev-portal",
+      signUp: { url: "https://app.example.com/register" },
+    });
+
+    await provider.signUp({ navigate: vi.fn() }, {});
+
+    expect(loc.assign).toHaveBeenCalledWith("https://app.example.com/register");
+    // No Clerk script should have been injected
+    expect(document.head.querySelector("script")).toBeNull();
+  });
+
+  test("signUp({ url }) with relative path uses navigate, no SDK load", async () => {
+    const navigate = vi.fn();
+
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: "pk_test_fake.clerk.dev$" as `pk_test_${string}`,
+      jwtTemplateName: "dev-portal",
+      signUp: { url: "/register" },
+    });
+
+    await provider.signUp({ navigate }, {});
+
+    expect(navigate).toHaveBeenCalledWith("/register", { replace: false });
+    expect(document.head.querySelector("script")).toBeNull();
+  });
+});

--- a/packages/zudoku/src/lib/authentication/providers/clerk.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.tsx
@@ -10,7 +10,7 @@ import { SignIn } from "../components/SignIn.js";
 import { SignOut } from "../components/SignOut.js";
 import { SignUp } from "../components/SignUp.js";
 import { type UserProfile, useAuthState } from "../state.js";
-import { getClerkFrontendApi } from "./util.js";
+import { getClerkFrontendApi, redirectToSignUpUrl } from "./util.js";
 
 export type ClerkProviderData = {
   type: "clerk";
@@ -62,6 +62,8 @@ const clerkAuth: AuthenticationProviderInitializer<
   redirectToAfterSignOut = "/",
   redirectToAfterSignUp,
   redirectToAfterSignIn,
+  signUp: signUpConfig,
+  disableSignUp,
 }): AuthenticationPlugin & ZudokuPlugin => {
   const getClerk = (): Promise<Clerk> => {
     if (typeof window === "undefined") {
@@ -143,6 +145,7 @@ const clerkAuth: AuthenticationProviderInitializer<
   }
 
   return {
+    disableSignUp: disableSignUp ?? false,
     getRoutes: () => [
       { path: "/signout", element: <SignOut /> },
       { path: "/signin", element: <SignIn /> },
@@ -205,9 +208,16 @@ const clerkAuth: AuthenticationProviderInitializer<
       });
     },
     signUp: async (
-      _: AuthActionContext,
-      { redirectTo }: { redirectTo?: string } = {},
+      { navigate }: AuthActionContext,
+      {
+        redirectTo,
+        replace = false,
+      }: { redirectTo?: string; replace?: boolean } = {},
     ) => {
+      if (signUpConfig) {
+        redirectToSignUpUrl(signUpConfig.url, navigate, replace);
+        return;
+      }
       const clerk = await getClerk();
       await clerk.redirectToSignUp({
         signInForceRedirectUrl: redirectToAfterSignIn

--- a/packages/zudoku/src/lib/authentication/providers/firebase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.tsx
@@ -37,6 +37,7 @@ import {
   ZudokuSignUpDisabledUi,
   ZudokuSignUpUi,
 } from "../ui/ZudokuAuthUi.js";
+import { redirectToSignUpUrl } from "./util.js";
 
 export type FirebaseProviderData = {
   type: "firebase";
@@ -60,13 +61,15 @@ class FirebaseAuthenticationProvider
   private readonly providers: string[];
   private readonly enableUsernamePassword: boolean;
   private readonly enableEmailLink: boolean;
-  private readonly disableSignUp: boolean;
+  public readonly disableSignUp: boolean;
   private readonly redirectToAfterSignOut: string;
+  private readonly signUpConfig?: FirebaseAuthenticationConfig["signUp"];
 
   constructor(config: FirebaseAuthenticationConfig) {
     super();
     this.redirectToAfterSignOut = config.redirectToAfterSignOut ?? "/";
     this.disableSignUp = config.disableSignUp ?? false;
+    this.signUpConfig = config.signUp;
 
     this.app = initializeApp({
       apiKey: config.apiKey,
@@ -101,8 +104,12 @@ class FirebaseAuthenticationProvider
 
   signUp = async (
     { navigate }: AuthActionContext,
-    { redirectTo }: AuthActionOptions,
+    { redirectTo, replace = false }: AuthActionOptions = {},
   ) => {
+    if (this.signUpConfig) {
+      redirectToSignUpUrl(this.signUpConfig.url, navigate, replace);
+      return;
+    }
     void navigate(
       redirectTo
         ? `/signup?redirectTo=${encodeURIComponent(redirectTo)}`

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -291,6 +291,98 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
     });
   });
 
+  describe("signUp config", () => {
+    const mockLocation = () => {
+      const loc = {
+        href: "http://localhost/",
+        origin: "http://localhost",
+        pathname: "/",
+        search: "",
+        hash: "",
+        assign: vi.fn(),
+        replace: vi.fn(),
+      };
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: loc,
+      });
+      return loc;
+    };
+
+    test("signUp({ url }) bypasses OpenID flow via location.assign", async () => {
+      const loc = mockLocation();
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        signUp: { url: "https://app.example.com/register" },
+      });
+
+      await provider.signUp({ navigate: vi.fn() }, {});
+
+      expect(loc.assign).toHaveBeenCalledWith(
+        "https://app.example.com/register",
+      );
+      expect(loc.replace).not.toHaveBeenCalled();
+    });
+
+    test("signUp({ url }) with relative path uses navigate", async () => {
+      mockLocation();
+      const navigate = vi.fn();
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        signUp: { url: "/register" },
+      });
+
+      await provider.signUp({ navigate }, { replace: true });
+
+      expect(navigate).toHaveBeenCalledWith("/register", { replace: true });
+    });
+
+    test("signUp({ url }) with replace uses location.replace", async () => {
+      const loc = mockLocation();
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        signUp: { url: "https://app.example.com/register" },
+      });
+
+      await provider.signUp({ navigate: vi.fn() }, { replace: true });
+
+      expect(loc.replace).toHaveBeenCalledWith(
+        "https://app.example.com/register",
+      );
+      expect(loc.assign).not.toHaveBeenCalled();
+    });
+
+    test("signUp({ authorizationParams }) merges params on signup but not signin", async () => {
+      vi.mocked(oauth.processDiscoveryResponse).mockResolvedValue({
+        ...AUTH_SERVER,
+        authorization_endpoint: "https://issuer.example.com/authorize",
+      });
+
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        signUp: { authorizationParams: { kc_action: "register" } },
+      });
+
+      const signupLoc = mockLocation();
+      await provider.signUp({ navigate: vi.fn() }, {});
+      const signupUrl = new URL(signupLoc.href);
+      expect(signupUrl.searchParams.get("kc_action")).toBe("register");
+
+      const signinLoc = mockLocation();
+      await provider.signIn({ navigate: vi.fn() }, {});
+      const signinUrl = new URL(signinLoc.href);
+      expect(signinUrl.searchParams.get("kc_action")).toBeNull();
+    });
+  });
+
   test("self heals providerData when providerData.type is undefined", async () => {
     const provider = createProvider();
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -16,6 +16,7 @@ import { LogoutCallbackHandler } from "../components/LogoutCallbackHandler.js";
 import { OAuthErrorPage } from "../components/OAuthErrorPage.js";
 import { AuthorizationError, OAuthAuthorizationError } from "../errors.js";
 import { type UserProfile, useAuthState } from "../state.js";
+import { redirectToSignUpUrl } from "./util.js";
 
 const CODE_VERIFIER_KEY = "code-verifier";
 const STATE_KEY = "oauth-state";
@@ -60,6 +61,8 @@ export class OpenIDAuthenticationProvider
   protected readonly redirectToAfterSignOut: string;
   private readonly audience?: string;
   private readonly scopes: string[];
+  private readonly signUpConfig?: OpenIDAuthenticationConfig["signUp"];
+  public readonly disableSignUp: boolean;
 
   constructor({
     issuer,
@@ -70,6 +73,8 @@ export class OpenIDAuthenticationProvider
     redirectToAfterSignOut = "/",
     basePath,
     scopes,
+    signUp,
+    disableSignUp,
   }: OpenIDAuthenticationConfig) {
     super();
     this.client = {
@@ -85,6 +90,8 @@ export class OpenIDAuthenticationProvider
     this.redirectToAfterSignUp = redirectToAfterSignUp;
     this.redirectToAfterSignIn = redirectToAfterSignIn;
     this.redirectToAfterSignOut = redirectToAfterSignOut;
+    this.signUpConfig = signUp;
+    this.disableSignUp = disableSignUp ?? false;
   }
 
   protected async getAuthServer() {
@@ -157,7 +164,7 @@ export class OpenIDAuthenticationProvider
   }
 
   async signUp(
-    _: { navigate: NavigateFunction },
+    { navigate }: { navigate: NavigateFunction },
     {
       redirectTo,
       replace = false,
@@ -166,6 +173,10 @@ export class OpenIDAuthenticationProvider
       replace?: boolean;
     } = {},
   ) {
+    if (this.signUpConfig && "url" in this.signUpConfig) {
+      redirectToSignUpUrl(this.signUpConfig.url, navigate, replace);
+      return;
+    }
     return this.authorize({
       redirectTo: this.redirectToAfterSignUp ?? redirectTo ?? "/",
       replace,
@@ -264,6 +275,18 @@ export class OpenIDAuthenticationProvider
     redirectUrl.pathname = this.callbackUrlPath;
     redirectUrl.search = "";
     redirectUrl.hash = "";
+
+    if (
+      isSignUp &&
+      this.signUpConfig &&
+      "authorizationParams" in this.signUpConfig
+    ) {
+      for (const [key, value] of Object.entries(
+        this.signUpConfig.authorizationParams,
+      )) {
+        authorizationUrl.searchParams.set(key, value);
+      }
+    }
 
     authorizationUrl.searchParams.set("client_id", this.client.client_id);
     authorizationUrl.searchParams.set("redirect_uri", redirectUrl.toString());

--- a/packages/zudoku/src/lib/authentication/providers/supabase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.tsx
@@ -25,6 +25,7 @@ import {
   ZudokuSignUpDisabledUi,
   ZudokuSignUpUi,
 } from "../ui/ZudokuAuthUi.js";
+import { redirectToSignUpUrl } from "./util.js";
 
 export type SupabaseProviderData = {
   type: "supabase";
@@ -45,7 +46,8 @@ class SupabaseAuthenticationProvider
   private readonly config: SupabaseAuthenticationConfig;
   private readonly providers: string[];
   private readonly enableUsernamePassword: boolean;
-  private readonly disableSignUp: boolean;
+  public readonly disableSignUp: boolean;
+  private readonly signUpConfig?: SupabaseAuthenticationConfig["signUp"];
 
   constructor(config: SupabaseAuthenticationConfig) {
     const { supabaseUrl, supabaseKey } = config;
@@ -66,6 +68,7 @@ class SupabaseAuthenticationProvider
     this.providers = configuredProviders;
     this.enableUsernamePassword = !config.onlyThirdPartyProviders;
     this.disableSignUp = config.disableSignUp ?? false;
+    this.signUpConfig = config.signUp;
 
     this.client.auth.onAuthStateChange(async (event, session) => {
       if (session && (event === "SIGNED_IN" || event === "TOKEN_REFRESHED")) {
@@ -111,8 +114,12 @@ class SupabaseAuthenticationProvider
 
   signUp = async (
     { navigate }: AuthActionContext,
-    { redirectTo }: AuthActionOptions,
+    { redirectTo, replace = false }: AuthActionOptions = {},
   ) => {
+    if (this.signUpConfig) {
+      redirectToSignUpUrl(this.signUpConfig.url, navigate, replace);
+      return;
+    }
     void navigate(
       redirectTo
         ? `/signup?redirectTo=${encodeURIComponent(redirectTo)}`

--- a/packages/zudoku/src/lib/authentication/providers/util.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/util.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { redirectToSignUpUrl } from "./util.js";
+
+describe("redirectToSignUpUrl", () => {
+  let originalLocation: Location;
+
+  const mockLocation = () => {
+    const loc = {
+      assign: vi.fn(),
+      replace: vi.fn(),
+    };
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: loc,
+    });
+    return loc;
+  };
+
+  beforeEach(() => {
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.restoreAllMocks();
+  });
+
+  test("absolute URL uses location.assign by default", () => {
+    const loc = mockLocation();
+    const navigate = vi.fn();
+
+    redirectToSignUpUrl("https://example.com/register", navigate);
+
+    expect(loc.assign).toHaveBeenCalledWith("https://example.com/register");
+    expect(loc.replace).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test("absolute URL with replace=true uses location.replace", () => {
+    const loc = mockLocation();
+    const navigate = vi.fn();
+
+    redirectToSignUpUrl("https://example.com/register", navigate, true);
+
+    expect(loc.replace).toHaveBeenCalledWith("https://example.com/register");
+    expect(loc.assign).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test("relative path uses navigate", () => {
+    const loc = mockLocation();
+    const navigate = vi.fn();
+
+    redirectToSignUpUrl("/register", navigate);
+
+    expect(navigate).toHaveBeenCalledWith("/register", { replace: false });
+    expect(loc.assign).not.toHaveBeenCalled();
+  });
+
+  test("relative path with replace=true forwards replace", () => {
+    mockLocation();
+    const navigate = vi.fn();
+
+    redirectToSignUpUrl("/register", navigate, true);
+
+    expect(navigate).toHaveBeenCalledWith("/register", { replace: true });
+  });
+});

--- a/packages/zudoku/src/lib/authentication/providers/util.ts
+++ b/packages/zudoku/src/lib/authentication/providers/util.ts
@@ -1,3 +1,17 @@
+import type { NavigateFunction } from "react-router";
+
+export const redirectToSignUpUrl = (
+  url: string,
+  navigate: NavigateFunction,
+  replace = false,
+) => {
+  if (URL.canParse(url)) {
+    window.location[replace ? "replace" : "assign"](url);
+  } else {
+    navigate(url, { replace });
+  }
+};
+
 export const getClerkFrontendApi = (publishableKey: string) => {
   // Split by underscore and get the base64 encoded part (3rd segment)
   const parts = publishableKey.split("_");

--- a/packages/zudoku/src/lib/core/RouteGuard.test.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.test.tsx
@@ -69,6 +69,7 @@ const createWrapper = ({
     isAuthenticated: false,
     isPending: false,
     isAuthEnabled: false,
+    disableSignUp: false,
     profile: null,
     providerData: null,
     setAuthenticationPending: vi.fn(),

--- a/packages/zudoku/src/lib/core/RouteGuard.test.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.test.tsx
@@ -332,6 +332,30 @@ describe("RouteGuard", () => {
       );
     });
 
+    it("hides Register button when disableSignUp is true", async () => {
+      await render(
+        { path: "/protected", element: <div>Protected</div> },
+        {
+          initialPath: "/protected",
+          auth: {
+            isAuthEnabled: true,
+            isPending: false,
+            isAuthenticated: false,
+            disableSignUp: true,
+          },
+          protectedRoutes: { "/protected": () => false },
+        },
+      );
+
+      const dialog = screen.getByRole("dialog");
+      expect(
+        within(dialog).queryByRole("button", { name: "Register" }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(dialog).getByRole("button", { name: "Login" }),
+      ).toBeInTheDocument();
+    });
+
     it("calls signup when register button clicked", async () => {
       const { mockAuth } = await render(
         { path: "/protected", element: <div>Protected</div> },

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -30,6 +30,7 @@ type LoginDialogProps = {
   onCancel: () => void;
   onLogin: () => void;
   onRegister: () => void;
+  showRegister: boolean;
 };
 
 const LoginDialog = ({
@@ -37,6 +38,7 @@ const LoginDialog = ({
   onCancel,
   onLogin,
   onRegister,
+  showRegister,
 }: LoginDialogProps) => (
   <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onCancel()}>
     <DialogContent>
@@ -49,9 +51,11 @@ const LoginDialog = ({
           Cancel
         </Button>
         <div className="w-full" />
-        <Button variant="secondary" onClick={onRegister}>
-          Register
-        </Button>
+        {showRegister && (
+          <Button variant="secondary" onClick={onRegister}>
+            Register
+          </Button>
+        )}
         <Button onClick={onLogin}>Login</Button>
       </DialogFooter>
     </DialogContent>
@@ -187,6 +191,7 @@ export const RouteGuard = () => {
         onCancel={needsToSignIn ? () => navigate(-1) : () => blocker.reset?.()}
         onLogin={() => void auth.login({ redirectTo })}
         onRegister={() => void auth.signup({ redirectTo })}
+        showRegister={!auth.disableSignUp}
       />
     </>
   );

--- a/packages/zudoku/src/lib/plugins/openapi/playground/PlaygroundDialog.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/PlaygroundDialog.tsx
@@ -15,8 +15,14 @@ export type PlaygroundDialogProps = PropsWithChildren<PlaygroundContentProps>;
 
 const PlaygroundDialog = (props: PlaygroundDialogProps) => {
   const [open, setOpen] = useState(false);
-  const { isAuthEnabled, login, signup, isPending, isAuthenticated } =
-    useAuth();
+  const {
+    isAuthEnabled,
+    login,
+    signup,
+    isPending,
+    isAuthenticated,
+    disableSignUp,
+  } = useAuth();
 
   return (
     <Dialog onOpenChange={(open) => setOpen(open)}>
@@ -44,7 +50,7 @@ const PlaygroundDialog = (props: PlaygroundDialogProps) => {
           <Playground
             requiresLogin={isAuthEnabled && !isAuthenticated && !isPending}
             onLogin={() => login()}
-            onSignUp={() => signup()}
+            onSignUp={disableSignUp ? undefined : () => signup()}
             {...props}
           />
         )}


### PR DESCRIPTION
Register and Sign in went to the same OIDC authorize endpoint, so there was no way to send users to a separate sign-up page or hide Register on invite-only sites.

This change adds two options to every auth provider. `signUp: { url }` redirects Register to a separate URL (absolute goes external, relative navigates in-app). For openid/auth0 there is also `signUp: { authorizationParams }` to add extra params to the authorize URL on sign-up only (e.g. `kc_action=register` for Keycloak, `screen_hint=signup` for custom OIDC). `disableSignUp: true` hides the Register button on the protected-route login dialog and shows an "Invitation required" page on `/signup`. It is purely visual, real enforcement still belongs at the IdP.