### PR TITLE
fix: Render common properties in union view

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/schema/UnionView.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/UnionView.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import type { SchemaObject } from "../../../oas/parser/index.js";
 import { Badge } from "../../../ui/Badge.js";
 import { Frame, FramePanel } from "../../../ui/Frame.js";
+import { ItemGroup, ItemSeparator } from "zudoku/ui/Item.js";
 import { cn } from "../../../util/cn.js";
+import { SchemaPropertyItem } from "./SchemaPropertyItem.js";
 import { SchemaView } from "./SchemaView.js";
 import {
   decideExclusivity,
@@ -87,6 +89,14 @@ export const UnionView = ({
 
   if (!mode) return null;
 
+  // Determine common properties (those on parent but NOT in any variant)
+  const variantPropNames = new Set(
+    variants.flatMap((v) => Object.keys(v.properties ?? {})),
+  );
+  const commonEntries = Object.entries(schema.properties ?? {}).filter(
+    ([key]) => !variantPropNames.has(key),
+  );
+
   const exclusivity = decideExclusivity(schema);
 
   const semanticsMessage =
@@ -107,25 +117,86 @@ export const UnionView = ({
   const currentVariant =
     currentVariantIndex >= 0 ? variants[currentVariantIndex] : null;
 
+  const unionSection = (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">{mode}</Badge>
+        <div className="flex-1">
+          <span className="text-sm">{semanticsMessage}</span>
+        </div>
+      </div>
+
+      <DecisionTable
+        variants={variants}
+        schema={schema}
+        selectedVariant={selectedVariant}
+        onSelectVariant={setSelectedVariant}
+      />
+      <strong>Properties for {selectedVariant}:</strong>
+      {currentVariant && <SchemaView schema={currentVariant} embedded />}
+    </div>
+  );
+
+  // If there are common properties, render them as normal property items
+  // followed by the oneOf section inline
+  if (commonEntries.length > 0) {
+    const requiredCommon = commonEntries.filter(([name]) =>
+      schema.required?.includes(name),
+    );
+    const optionalCommon = commonEntries.filter(
+      ([name]) => !schema.required?.includes(name),
+    );
+
+    return (
+      <Frame>
+        {cardHeader}
+        <FramePanel className="p-0!">
+          {unionSection}
+          <ItemSeparator />
+          {requiredCommon.length > 0 && (
+            <ItemGroup className="overflow-clip">
+              {requiredCommon.map(([name, prop], index) => (
+                <Fragment key={name}>
+                  {index > 0 && <ItemSeparator />}
+                  <SchemaPropertyItem
+                    name={name}
+                    schema={prop as SchemaObject}
+                    group="required"
+                    defaultOpen={false}
+                  />
+                </Fragment>
+              ))}
+            </ItemGroup>
+          )}
+          {optionalCommon.length > 0 && (
+            <>
+              {requiredCommon.length > 0 && <ItemSeparator />}
+              <ItemGroup className="overflow-clip">
+                {optionalCommon.map(([name, prop], index) => (
+                  <Fragment key={name}>
+                    {index > 0 && <ItemSeparator />}
+                    <SchemaPropertyItem
+                      name={name}
+                      schema={prop as SchemaObject}
+                      group="optional"
+                      defaultOpen={false}
+                    />
+                  </Fragment>
+                ))}
+              </ItemGroup>
+            </>
+          )}
+        </FramePanel>
+      </Frame>
+    );
+  }
+
+  // No common properties — just render the union section
   return (
     <Frame>
       {cardHeader}
-      <FramePanel className="text-sm flex flex-col gap-4">
-        <div className="flex items-center gap-2">
-          <Badge variant="outline">{mode}</Badge>
-          <div className="flex-1 p-2">
-            <span className="text-sm">{semanticsMessage}</span>
-          </div>
-        </div>
-
-        <DecisionTable
-          variants={variants}
-          schema={schema}
-          selectedVariant={selectedVariant}
-          onSelectVariant={setSelectedVariant}
-        />
-        <strong>Properties for {selectedVariant}:</strong>
-        {currentVariant && <SchemaView schema={currentVariant} />}
+      <FramePanel className="p-0!">
+        {unionSection}
       </FramePanel>
     </Frame>
   );


### PR DESCRIPTION
Previously, if a type had a union (via `oneOf`), but also had properties set directly, we were skipping rendering of those common properties. For example of where we were seeing this https://unikraft.com/docs/api/platform/v1/instances#update-instances.

| Before | After |
| :----- | :---- |
| <img width="686" height="778" alt="image" src="https://github.com/user-attachments/assets/2c1a554a-1f30-4d82-8e7e-493d2f420a04" /> | <img width="696" height="985" alt="image" src="https://github.com/user-attachments/assets/2c2b41cb-bf4f-40af-80f3-0d85e73b2349" /> |

I don't really know if this is the desired rendering state, but it's definitely better than what we had before, which was completely empty!

This is possible to reach by having an `allOf` that contains `oneOf`s, imagine something like this:

```yaml
openapi: 3.1.0
info:
  title: Example
  version: 1.0.0
paths:
  /lookup:
    post:
      requestBody:
        content:
          application/json:
            schema:
              allOf:
                - type: object
                  properties:
                    tenant:
                      type: string
                  required: [tenant]
                - oneOf:
                    - type: object
                      properties:
                        name:
                          type: string
                      required: [name]
                    - type: object
                      properties:
                        uuid:
                          type: string
                          format: uuid
                      required: [uuid]
      responses:
        "200":
          description: OK
```

Or even just directly without the `allOf` as:

```yaml
openapi: 3.1.0
info:
  title: Example
  version: 1.0.0
paths:
  /lookup:
    post:
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties:
                tenant:
                  type: string
              required: [tenant]
              oneOf:
                - properties:
                    name:
                      type: string
                  required: [name]
                - properties:
                    uuid:
                      type: string
                      format: uuid
                  required: [uuid]
      responses:
        "200":
          description: OK
```