### PR TITLE
Fix cancel subscription for plans with no current billables

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/ActiveSubscription.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/ActiveSubscription.tsx
@@ -8,6 +8,7 @@ import {
   DismissibleAlertAction,
 } from "zudoku/ui/DismissibleAlert";
 import type { Subscription } from "../../types/SubscriptionType.js";
+import { getActivePhase } from "../../utils/billables.js";
 import { ApiKeysList } from "./ApiKeysList";
 import { ManageSubscription } from "./ManageSubscription";
 import { SubscriptionPlanDetails } from "./SubscriptionPlanDetails";
@@ -45,11 +46,7 @@ const ActiveSubscription = ({
     usageQuery.data.paymentStatus.status !== "paid" &&
     usageQuery.data.paymentStatus.status !== "not_required";
 
-  const activePhase = subscription?.phases.find(
-    (p) =>
-      new Date(p.activeFrom) <= new Date() &&
-      (!p.activeTo || new Date(p.activeTo) >= new Date()),
-  );
+  const activePhase = getActivePhase(subscription);
 
   return (
     <>

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CancelSubscriptionDialog } from "./CancelSubscriptionDialog.js";
+
+vi.mock("zudoku/hooks", () => ({
+  useZudoku: () => ({ env: { ZUPLO_PUBLIC_DEPLOYMENT_NAME: "test-env" } }),
+}));
+
+vi.mock("../../hooks/useDeploymentName.js", () => ({
+  useDeploymentName: () => "test-deployment",
+}));
+
+const mutationStub = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  isPending: false,
+  isError: false,
+  isSuccess: false,
+  error: null as Error | null,
+  reset: vi.fn(),
+}));
+
+const useMutationMock = vi.hoisted(() =>
+  vi.fn((_options: { meta: { request: { body: string } } }) => mutationStub),
+);
+
+vi.mock("zudoku/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("zudoku/react-query")>();
+  return {
+    ...actual,
+    useMutation: useMutationMock,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  planName: "Growth",
+  subscriptionId: "sub-123",
+  billingPeriodEnd: "2025-08-01T00:00:00.000Z",
+};
+
+const lastMutationBody = () => {
+  const lastCall = useMutationMock.mock.calls.at(-1);
+  if (!lastCall) throw new Error("useMutation was not called");
+  return JSON.parse(lastCall[0].meta.request.body);
+};
+
+describe("CancelSubscriptionDialog", () => {
+  beforeEach(() => {
+    mutationStub.mutate.mockClear();
+    mutationStub.reset.mockClear();
+    useMutationMock.mockClear();
+    defaultProps.onOpenChange.mockClear();
+  });
+
+  it("sends timing 'next_billing_cycle' and shows scheduled-cancel copy for paid plans", () => {
+    render(
+      <CancelSubscriptionDialog
+        {...defaultProps}
+        hasCurrentBillables
+        hasFutureBillables={false}
+      />,
+    );
+
+    expect(lastMutationBody()).toEqual({ timing: "next_billing_cycle" });
+    expect(
+      screen.getByText(
+        "Your plan will be canceled at the end of your billing cycle.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You can still resume before then"),
+    ).toBeInTheDocument();
+  });
+
+  it("sends timing 'immediate' and shows immediate-cancel copy for free plans (no current or future billables)", () => {
+    render(
+      <CancelSubscriptionDialog
+        {...defaultProps}
+        hasCurrentBillables={false}
+        hasFutureBillables={false}
+      />,
+    );
+
+    expect(lastMutationBody()).toEqual({ timing: "immediate" });
+    expect(
+      screen.getByText("Cancel your Growth subscription?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your subscription will end immediately. You'll lose access to its entitlements right away.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You can subscribe again at any time"),
+    ).toBeInTheDocument();
+  });
+
+  it("sends timing 'immediate' and shows trial-specific copy when in trial (no current billables, future billables exist)", () => {
+    render(
+      <CancelSubscriptionDialog
+        {...defaultProps}
+        hasCurrentBillables={false}
+        hasFutureBillables
+      />,
+    );
+
+    expect(lastMutationBody()).toEqual({ timing: "immediate" });
+    expect(
+      screen.getByText("Cancel your trial of Growth?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your subscription will end now and you won't be charged when the trial would have converted to Growth.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You can subscribe again at any time"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.tsx
@@ -23,18 +23,28 @@ export const CancelSubscriptionDialog = ({
   planName,
   subscriptionId,
   billingPeriodEnd,
+  hasCurrentBillables,
+  hasFutureBillables,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   planName: string;
   subscriptionId: string;
   billingPeriodEnd: string;
+  hasCurrentBillables: boolean;
+  hasFutureBillables: boolean;
 }) => {
   const [confirmationText, setConfirmationText] = useState("");
   const isConfirmed = planName.startsWith(confirmationText);
   const deploymentName = useDeploymentName();
   const context = useZudoku();
   const queryClient = useQueryClient();
+
+  // Monetization backend rejects `next_billing_cycle` when the active phase has no
+  // billable items (free plans, in-trial paid plans). Fall back to immediate.
+  const cancelTiming = hasCurrentBillables ? "next_billing_cycle" : "immediate";
+  const isImmediateCancel = !hasCurrentBillables;
+  const isTrialCancel = isImmediateCancel && hasFutureBillables;
 
   const cancelSubscriptionMutation = useMutation({
     mutationKey: [
@@ -44,7 +54,7 @@ export const CancelSubscriptionDialog = ({
       context,
       request: {
         method: "POST",
-        body: JSON.stringify({ timing: "next_billing_cycle" }),
+        body: JSON.stringify({ timing: cancelTiming }),
       },
     },
     onSuccess: async () => {
@@ -64,24 +74,56 @@ export const CancelSubscriptionDialog = ({
         <div className="space-y-4 mt-4">
           <Alert variant="warning">
             <CalendarIcon className="size-4" />
-            <AlertTitle>
-              Your plan will be canceled at the end of your billing cycle.
-            </AlertTitle>
-            <AlertDescription>
-              You'll retain access until {formatDate(billingPeriodEnd)}. After
-              your billing period ends, this plan will not renew and you would
-              need to subscribe again to continue.
-            </AlertDescription>
+            {isTrialCancel ? (
+              <>
+                <AlertTitle>Cancel your trial of {planName}?</AlertTitle>
+                <AlertDescription>
+                  Your subscription will end now and you won't be charged when
+                  the trial would have converted to {planName}.
+                </AlertDescription>
+              </>
+            ) : isImmediateCancel ? (
+              <>
+                <AlertTitle>Cancel your {planName} subscription?</AlertTitle>
+                <AlertDescription>
+                  Your subscription will end immediately. You'll lose access to
+                  its entitlements right away.
+                </AlertDescription>
+              </>
+            ) : (
+              <>
+                <AlertTitle>
+                  Your plan will be canceled at the end of your billing cycle.
+                </AlertTitle>
+                <AlertDescription>
+                  You'll retain access until {formatDate(billingPeriodEnd)}.
+                  After your billing period ends, this plan will not renew and
+                  you would need to subscribe again to continue.
+                </AlertDescription>
+              </>
+            )}
           </Alert>
 
           <Alert variant="info">
             <InfoIcon className="size-4" />
-            <AlertTitle>You can still resume before then</AlertTitle>
-            <AlertDescription>
-              If you change your mind you have until{" "}
-              {formatDate(billingPeriodEnd)} to remove this cancellation from
-              Manage subscription.
-            </AlertDescription>
+            {isImmediateCancel ? (
+              <>
+                <AlertTitle>You can subscribe again at any time</AlertTitle>
+                <AlertDescription>
+                  After cancelling, you can return to the pricing page and start
+                  a new subscription whenever you're ready.
+                </AlertDescription>
+              </>
+            ) : (
+              <>
+                <AlertTitle>You can still resume before then</AlertTitle>
+                <AlertDescription>
+                  If you change your mind you have until{" "}
+                  {formatDate(billingPeriodEnd)} to remove this cancellation
+                  from Manage subscription.
+                </AlertDescription>
+              </>
+            )}
           </Alert>
 
           <div className="space-y-2">

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.tsx
@@ -110,7 +110,7 @@ export const CancelSubscriptionDialog = ({
               <>
                 <AlertTitle>You can subscribe again at any time</AlertTitle>
                 <AlertDescription>
-                  After cancelling, you can return to the pricing page and start
+                  After canceling, you can return to the pricing page and start
                   a new subscription whenever you're ready.
                 </AlertDescription>
               </>

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/ManageSubscription.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/ManageSubscription.tsx
@@ -5,6 +5,10 @@ import { Button } from "zudoku/ui/Button";
 import { Card, CardContent } from "zudoku/ui/Card";
 import { Separator } from "zudoku/ui/Separator";
 import type { Subscription } from "../../types/SubscriptionType.js";
+import {
+  activePhaseHasBillables,
+  hasFutureBillables,
+} from "../../utils/billables.js";
 import { CancelSubscriptionDialog } from "./CancelSubscriptionDialog.js";
 import { RestoreSubscriptionDialog } from "./RestoreSubscriptionDialog.js";
 import { SwitchPlanModal } from "./SwitchPlanModal.js";
@@ -24,6 +28,8 @@ export const ManageSubscription = ({
   const canResumeCanceledSubscription =
     subscription.status === "canceled" &&
     new Date(billingPeriodEnd) > new Date();
+  const hasCurrentBillables = activePhaseHasBillables(subscription);
+  const futureBillables = hasFutureBillables(subscription);
 
   return (
     <Card>
@@ -33,6 +39,8 @@ export const ManageSubscription = ({
         planName={planName}
         subscriptionId={subscription.id}
         billingPeriodEnd={billingPeriodEnd}
+        hasCurrentBillables={hasCurrentBillables}
+        hasFutureBillables={futureBillables}
       />
       <RestoreSubscriptionDialog
         open={restoreDialogOpen}

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/ManageSubscription.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/ManageSubscription.tsx
@@ -28,8 +28,6 @@ export const ManageSubscription = ({
   const canResumeCanceledSubscription =
     subscription.status === "canceled" &&
     new Date(billingPeriodEnd) > new Date();
-  const hasCurrentBillables = activePhaseHasBillables(subscription);
-  const futureBillables = hasFutureBillables(subscription);
 
   return (
     <Card>
@@ -39,8 +37,8 @@ export const ManageSubscription = ({
         planName={planName}
         subscriptionId={subscription.id}
         billingPeriodEnd={billingPeriodEnd}
-        hasCurrentBillables={hasCurrentBillables}
-        hasFutureBillables={futureBillables}
+        hasCurrentBillables={activePhaseHasBillables(subscription)}
+        hasFutureBillables={hasFutureBillables(subscription)}
       />
       <RestoreSubscriptionDialog
         open={restoreDialogOpen}

--- a/packages/plugin-zuplo-monetization/src/utils/billables.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/billables.ts
@@ -2,11 +2,16 @@ import type { Subscription } from "../types/SubscriptionType.js";
 
 export const getActivePhase = (sub: Subscription) => {
   const now = Date.now();
-  return sub.phases.find(
-    (p) =>
-      new Date(p.activeFrom).getTime() <= now &&
-      (!p.activeTo || new Date(p.activeTo).getTime() >= now),
-  );
+  return sub.phases
+    .filter(
+      (p) =>
+        new Date(p.activeFrom).getTime() <= now &&
+        (!p.activeTo || new Date(p.activeTo).getTime() >= now),
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.activeFrom).getTime() - new Date(a.activeFrom).getTime(),
+    )[0];
 };
 
 export const activePhaseHasBillables = (sub: Subscription) =>

--- a/packages/plugin-zuplo-monetization/src/utils/billables.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/billables.ts
@@ -1,0 +1,20 @@
+import type { Subscription } from "../types/SubscriptionType.js";
+
+export const getActivePhase = (sub: Subscription) => {
+  const now = Date.now();
+  return sub.phases.find(
+    (p) =>
+      new Date(p.activeFrom).getTime() <= now &&
+      (!p.activeTo || new Date(p.activeTo).getTime() >= now),
+  );
+};
+
+export const activePhaseHasBillables = (sub: Subscription) =>
+  getActivePhase(sub)?.items.some((i) => i.price != null) ?? false;
+
+export const hasFutureBillables = (sub: Subscription) => {
+  const now = Date.now();
+  return sub.phases
+    .filter((p) => new Date(p.activeFrom).getTime() > now)
+    .some((p) => p.items.some((i) => i.price != null));
+};


### PR DESCRIPTION
The monetization backend rejects timing=next_billing_cycle when the active phase has no billable items, which happens for free plans and subscriptions currently in a free-trial phase of a paid plan. Detect this client-side from phase.items[].price and fall back to timing=immediate, with copy variants for free, trial, and paid cases.

<img width="500" height="520" alt="image" src="https://github.com/user-attachments/assets/b64ad2b2-7c62-4ee5-bb73-b01ea27c6ca9" />
