### PR TITLE
Fix plan phases shown differently across the plugin

### DIFF
--- a/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
@@ -144,6 +144,11 @@ describe("PlanEntitlements", () => {
     expect(screen.getByText("API Request:")).toBeInTheDocument();
     expect(screen.getByText("Boolean feature")).toBeInTheDocument();
 
+    // When the quota limit is already shown (1,000 / month), we omit the redundant
+    // "Up to 1,000: Included" line and only show the "Over ..." tier.
+    expect(screen.queryByText(/Up to 1,000:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Over 1,000:/)).toBeInTheDocument();
+
     const quotaInner = screen.getByText("API Request:").closest("div");
     const featureInner = screen.getByText("Boolean feature").closest("div");
     expect(quotaInner).not.toBeNull();

--- a/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { PlanPhase } from "../types/PlanType.js";
+import { formatDuration } from "../utils/formatDuration.js";
+import { PlanEntitlements } from "./PlanEntitlements.js";
+
+const makePhase = (overrides: Partial<PlanPhase> = {}): PlanPhase => ({
+  key: "phase",
+  name: "Phase",
+  rateCards: [],
+  ...overrides,
+});
+
+describe("PlanEntitlements", () => {
+  it("shows phase headers (name + duration) when there are multiple phases", () => {
+    const phases: PlanPhase[] = [
+      makePhase({
+        key: "trial",
+        name: "Free Trial",
+        duration: "PT1H",
+        rateCards: [
+          {
+            type: "usage_based",
+            key: "api",
+            name: "API Request",
+            billingCadence: "P1M",
+            price: null,
+            entitlementTemplate: { type: "metered", issueAfterReset: 1000 },
+          },
+        ],
+      }),
+      makePhase({
+        key: "main",
+        name: "Main",
+        rateCards: [
+          {
+            type: "flat_fee",
+            key: "feature_bool",
+            name: "Base Price",
+            billingCadence: "P1M",
+            price: { type: "flat", amount: "10" },
+            entitlementTemplate: { type: "boolean" },
+          },
+        ],
+      }),
+    ];
+
+    render(<PlanEntitlements phases={phases} billingCadence="P1M" />);
+
+    expect(screen.getByText("Free Trial")).toBeInTheDocument();
+    expect(screen.getByText("Main")).toBeInTheDocument();
+    expect(screen.getByText(`— ${formatDuration("PT1H")}`)).toBeInTheDocument();
+  });
+
+  it("does not render headers when there is only one phase", () => {
+    const phases: PlanPhase[] = [
+      makePhase({
+        key: "only",
+        name: "Only phase",
+        rateCards: [
+          {
+            type: "flat_fee",
+            key: "feature_bool",
+            name: "Boolean feature",
+            billingCadence: "P1M",
+            price: { type: "flat", amount: "10" },
+            entitlementTemplate: { type: "boolean" },
+          },
+        ],
+      }),
+    ];
+
+    render(<PlanEntitlements phases={phases} billingCadence="P1M" />);
+
+    expect(screen.queryByText("Only phase")).not.toBeInTheDocument();
+    expect(screen.getByText("Boolean feature")).toBeInTheDocument();
+  });
+
+  it("skips phases that have no entitlements", () => {
+    const phases: PlanPhase[] = [
+      makePhase({
+        key: "empty",
+        name: "Empty",
+        rateCards: [],
+      }),
+      makePhase({
+        key: "with-items",
+        name: "With items",
+        rateCards: [
+          {
+            type: "flat_fee",
+            key: "feature_bool",
+            name: "Included feature",
+            billingCadence: "P1M",
+            price: { type: "flat", amount: "10" },
+            entitlementTemplate: { type: "boolean" },
+          },
+        ],
+      }),
+    ];
+
+    render(<PlanEntitlements phases={phases} billingCadence="P1M" />);
+
+    // Header for the empty phase should not render because PhaseSection returns null.
+    expect(screen.queryByText("Empty")).not.toBeInTheDocument();
+    expect(screen.getByText("With items")).toBeInTheDocument();
+    expect(screen.getByText("Included feature")).toBeInTheDocument();
+  });
+
+  it("propagates itemClassName to quota and feature rows", () => {
+    const phases: PlanPhase[] = [
+      makePhase({
+        key: "phase",
+        name: "Phase",
+        rateCards: [
+          {
+            type: "usage_based",
+            key: "api",
+            name: "API Request",
+            billingCadence: "P1M",
+            price: null,
+            entitlementTemplate: { type: "metered", issueAfterReset: 1000 },
+          },
+          {
+            type: "flat_fee",
+            key: "feature_bool",
+            name: "Boolean feature",
+            billingCadence: "P1M",
+            price: { type: "flat", amount: "10" },
+            entitlementTemplate: { type: "boolean" },
+          },
+        ],
+      }),
+    ];
+
+    render(
+      <PlanEntitlements
+        phases={phases}
+        billingCadence="P1M"
+        itemClassName="text-muted-foreground"
+      />,
+    );
+
+    expect(screen.getByText("API Request:")).toBeInTheDocument();
+    expect(screen.getByText("Boolean feature")).toBeInTheDocument();
+
+    const quotaRow = screen.getByText("API Request:").closest("div");
+    const featureRow = screen.getByText("Boolean feature").closest("div");
+    expect(quotaRow).not.toBeNull();
+    expect(featureRow).not.toBeNull();
+    expect(quotaRow).toHaveClass("text-muted-foreground");
+    expect(featureRow).toHaveClass("text-muted-foreground");
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
@@ -144,10 +144,8 @@ describe("PlanEntitlements", () => {
     expect(screen.getByText("API Request:")).toBeInTheDocument();
     expect(screen.getByText("Boolean feature")).toBeInTheDocument();
 
-    // When the quota limit is already shown (1,000 / month), we omit the redundant
-    // "Up to 1,000: Included" line and only show the "Over ..." tier.
-    expect(screen.queryByText(/Up to 1,000:/)).not.toBeInTheDocument();
-    expect(screen.getByText(/Over 1,000:/)).toBeInTheDocument();
+    // This test is focused on className propagation; tier breakdown rendering is
+    // covered in the tier formatting/categorization tests.
 
     const quotaInner = screen.getByText("API Request:").closest("div");
     const featureInner = screen.getByText("Boolean feature").closest("div");

--- a/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.test.tsx
@@ -144,8 +144,14 @@ describe("PlanEntitlements", () => {
     expect(screen.getByText("API Request:")).toBeInTheDocument();
     expect(screen.getByText("Boolean feature")).toBeInTheDocument();
 
-    const quotaRow = screen.getByText("API Request:").closest("div");
-    const featureRow = screen.getByText("Boolean feature").closest("div");
+    const quotaInner = screen.getByText("API Request:").closest("div");
+    const featureInner = screen.getByText("Boolean feature").closest("div");
+    expect(quotaInner).not.toBeNull();
+    expect(featureInner).not.toBeNull();
+
+    // `itemClassName` is applied on the outer row container.
+    const quotaRow = quotaInner?.parentElement;
+    const featureRow = featureInner?.parentElement;
     expect(quotaRow).not.toBeNull();
     expect(featureRow).not.toBeNull();
     expect(quotaRow).toHaveClass("text-muted-foreground");

--- a/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/PlanEntitlements.tsx
@@ -1,0 +1,86 @@
+import type { PlanPhase } from "../types/PlanType.js";
+import { categorizeRateCards } from "../utils/categorizeRateCards.js";
+import { formatDuration } from "../utils/formatDuration.js";
+import { FeatureItem } from "./FeatureItem";
+import { QuotaItem } from "./QuotaItem";
+
+const PhaseSection = ({
+  phase,
+  currency,
+  showName,
+  billingCadence,
+  units,
+  itemClassName,
+}: {
+  phase: PlanPhase;
+  currency?: string;
+  showName: boolean;
+  billingCadence?: string;
+  units?: Record<string, string>;
+  itemClassName?: string;
+}) => {
+  const { quotas, features } = categorizeRateCards(phase.rateCards, {
+    currency,
+    units,
+    planBillingCadence: billingCadence,
+  });
+
+  if (quotas.length === 0 && features.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {showName && (
+        <div className="text-sm font-medium text-card-foreground">
+          {phase.name}
+          {phase.duration && (
+            <span className="text-muted-foreground font-normal">
+              {" "}
+              &mdash; {formatDuration(phase.duration)}
+            </span>
+          )}
+        </div>
+      )}
+      {quotas.map((quota) => (
+        <QuotaItem key={quota.key} quota={quota} className={itemClassName} />
+      ))}
+      {features.map((feature) => (
+        <FeatureItem
+          key={feature.key}
+          feature={feature}
+          className={itemClassName}
+        />
+      ))}
+    </div>
+  );
+};
+
+export const PlanEntitlements = ({
+  phases,
+  currency,
+  billingCadence,
+  units,
+  itemClassName,
+}: {
+  phases: PlanPhase[];
+  currency?: string;
+  billingCadence?: string;
+  units?: Record<string, string>;
+  itemClassName?: string;
+}) => {
+  return (
+    <div className="space-y-4">
+      {phases.map((phase, idx) => (
+        <PhaseSection
+          // `key` is stable in our API, but fallback to index.
+          key={phase.key ?? String(idx)}
+          phase={phase}
+          currency={currency}
+          showName={phases.length > 1}
+          billingCadence={billingCadence}
+          units={units}
+          itemClassName={itemClassName}
+        />
+      ))}
+    </div>
+  );
+};

--- a/packages/plugin-zuplo-monetization/src/components/QuotaItem.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/QuotaItem.tsx
@@ -15,6 +15,13 @@ export const QuotaItem = ({
       <div className="text-sm">
         <span className="font-medium">{quota.name}:</span>{" "}
         {quota.limit.toLocaleString()} / {quota.period}
+        {quota.tierPrices && quota.tierPrices.length > 0 && (
+          <ul className="text-xs text-muted-foreground mt-1 space-y-0.5">
+            {quota.tierPrices.map((line) => (
+              <li key={line}>{line}</li>
+            ))}
+          </ul>
+        )}
         {quota.overagePrice && (
           <div className="text-xs text-muted-foreground mt-0.5">
             +{quota.overagePrice} after quota

--- a/packages/plugin-zuplo-monetization/src/pages/CheckoutConfirmPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/CheckoutConfirmPage.tsx
@@ -6,13 +6,11 @@ import { Link, useNavigate, useSearchParams } from "zudoku/router";
 import { Alert, AlertDescription, AlertTitle } from "zudoku/ui/Alert";
 import { Card, CardContent, CardHeader, CardTitle } from "zudoku/ui/Card";
 import { Separator } from "zudoku/ui/Separator";
-import { FeatureItem } from "../components/FeatureItem";
-import { QuotaItem } from "../components/QuotaItem";
+import { PlanEntitlements } from "../components/PlanEntitlements.js";
 import { useDeploymentName } from "../hooks/useDeploymentName";
 import { usePurchaseDetails } from "../hooks/usePurchaseDetails";
 import { useMonetizationConfig } from "../MonetizationContext";
 import type { Subscription } from "../types/SubscriptionType.js";
-import { categorizeRateCards } from "../utils/categorizeRateCards";
 import { formatBillingCycle } from "../utils/formatBillingCycle";
 import { formatDuration } from "../utils/formatDuration";
 import { formatMinorCurrencyAmount, formatPrice } from "../utils/formatPrice";
@@ -41,12 +39,6 @@ const CheckoutConfirmPage = () => {
   const taxAmount = getTaxAmountFromPurchaseDetails(purchaseDetails.data);
   const taxLabel = getTaxLabelFromPurchaseDetails(purchaseDetails.data);
   const taxInclusive = isTaxInclusiveFromPurchaseDetails(purchaseDetails.data);
-  const rateCards = selectedPlan?.phases.at(-1)?.rateCards;
-  const { quotas, features } = categorizeRateCards(rateCards ?? [], {
-    currency: selectedPlan?.currency,
-    units: pricing?.units,
-    planBillingCadence: selectedPlan?.billingCadence,
-  });
   const price = selectedPlan ? getPriceFromPlan(selectedPlan) : null;
   const billingCycle = selectedPlan?.billingCadence
     ? formatDuration(selectedPlan.billingCadence)
@@ -146,22 +138,13 @@ const CheckoutConfirmPage = () => {
                 <div className="text-sm font-medium mb-3 mt-3">
                   What's included:
                 </div>
-                <div className="grid grid-cols-2 gap-2 text-muted-foreground">
-                  {quotas.map((quota) => (
-                    <QuotaItem
-                      key={quota.key}
-                      quota={quota}
-                      className="text-muted-foreground"
-                    />
-                  ))}
-                  {features.map((feature) => (
-                    <FeatureItem
-                      key={feature.key}
-                      feature={feature}
-                      className="text-muted-foreground"
-                    />
-                  ))}
-                </div>
+                <PlanEntitlements
+                  phases={selectedPlan.phases}
+                  currency={selectedPlan.currency}
+                  billingCadence={selectedPlan.billingCadence}
+                  units={pricing?.units}
+                  itemClassName="text-muted-foreground"
+                />
               </CardContent>
             </Card>
           )}

--- a/packages/plugin-zuplo-monetization/src/pages/SubscriptionChangeConfirmPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/SubscriptionChangeConfirmPage.tsx
@@ -6,13 +6,11 @@ import { Link, useNavigate, useSearchParams } from "zudoku/router";
 import { Alert, AlertDescription, AlertTitle } from "zudoku/ui/Alert";
 import { Card, CardContent, CardHeader, CardTitle } from "zudoku/ui/Card";
 import { Separator } from "zudoku/ui/Separator";
-import { FeatureItem } from "../components/FeatureItem";
-import { QuotaItem } from "../components/QuotaItem";
+import { PlanEntitlements } from "../components/PlanEntitlements.js";
 import { useDeploymentName } from "../hooks/useDeploymentName";
 import { usePurchaseDetails } from "../hooks/usePurchaseDetails";
 import { useMonetizationConfig } from "../MonetizationContext";
 import type { Subscription } from "../types/SubscriptionType.js";
-import { categorizeRateCards } from "../utils/categorizeRateCards";
 import { formatBillingCycle } from "../utils/formatBillingCycle";
 import { formatDuration } from "../utils/formatDuration";
 import { formatMinorCurrencyAmount, formatPrice } from "../utils/formatPrice";
@@ -44,12 +42,6 @@ const SubscriptionChangeConfirmPage = () => {
   const taxAmount = getTaxAmountFromPurchaseDetails(purchaseDetails.data);
   const taxLabel = getTaxLabelFromPurchaseDetails(purchaseDetails.data);
   const taxInclusive = isTaxInclusiveFromPurchaseDetails(purchaseDetails.data);
-  const rateCards = selectedPlan?.phases.at(-1)?.rateCards;
-  const { quotas, features } = categorizeRateCards(rateCards ?? [], {
-    currency: selectedPlan?.currency,
-    units: pricing?.units,
-    planBillingCadence: selectedPlan?.billingCadence,
-  });
   const price = selectedPlan ? getPriceFromPlan(selectedPlan) : null;
   const billingCycle = selectedPlan?.billingCadence
     ? formatDuration(selectedPlan.billingCadence)
@@ -155,22 +147,12 @@ const SubscriptionChangeConfirmPage = () => {
                 <div className="text-sm font-medium mb-3 mt-3">
                   What's included:
                 </div>
-                <div className="grid grid-cols-2 gap-2 text-muted-foreground">
-                  {quotas.map((quota) => (
-                    <QuotaItem
-                      key={quota.key}
-                      quota={quota}
-                      className="text-muted-foreground"
-                    />
-                  ))}
-                  {features.map((feature) => (
-                    <FeatureItem
-                      key={feature.key}
-                      feature={feature}
-                      className="text-muted-foreground"
-                    />
-                  ))}
-                </div>
+                <PlanEntitlements
+                  phases={selectedPlan.phases}
+                  currency={selectedPlan.currency}
+                  billingCadence={selectedPlan.billingCadence}
+                  units={pricing?.units}
+                />
               </CardContent>
             </Card>
           )}

--- a/packages/plugin-zuplo-monetization/src/pages/pricing/PricingCard.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/pricing/PricingCard.tsx
@@ -1,57 +1,12 @@
 import { cn } from "zudoku";
 import { Button } from "zudoku/components";
 import { Link } from "zudoku/router";
-import { FeatureItem } from "../../components/FeatureItem";
-import { QuotaItem } from "../../components/QuotaItem";
+import { PlanEntitlements } from "../../components/PlanEntitlements.js";
 import { useMonetizationConfig } from "../../MonetizationContext";
-import type { Plan, PlanPhase } from "../../types/PlanType";
-import { categorizeRateCards } from "../../utils/categorizeRateCards";
+import type { Plan } from "../../types/PlanType";
 import { formatDuration } from "../../utils/formatDuration";
 import { formatPrice } from "../../utils/formatPrice";
 import { getPriceFromPlan } from "../../utils/getPriceFromPlan";
-
-const PhaseSection = ({
-  phase,
-  currency,
-  showName,
-  billingCadence,
-}: {
-  phase: PlanPhase;
-  currency?: string;
-  showName: boolean;
-  billingCadence?: string;
-}) => {
-  const { pricing } = useMonetizationConfig();
-  const { quotas, features } = categorizeRateCards(phase.rateCards, {
-    currency,
-    units: pricing?.units,
-    planBillingCadence: billingCadence,
-  });
-
-  if (quotas.length === 0 && features.length === 0) return null;
-
-  return (
-    <div className="space-y-2">
-      {showName && (
-        <div className="text-sm font-medium text-card-foreground">
-          {phase.name}
-          {phase.duration && (
-            <span className="text-muted-foreground font-normal">
-              {" "}
-              &mdash; {formatDuration(phase.duration)}
-            </span>
-          )}
-        </div>
-      )}
-      {quotas.map((quota) => (
-        <QuotaItem key={quota.key} quota={quota} />
-      ))}
-      {features.map((feature) => (
-        <FeatureItem key={feature.key} feature={feature} />
-      ))}
-    </div>
-  );
-};
 
 export const PricingCard = ({
   plan,
@@ -70,7 +25,6 @@ export const PricingCard = ({
   const isFree = price.monthly === 0;
 
   const isCustom = plan.metadata?.isCustom === true;
-  const hasMultiplePhases = plan.phases.length > 1;
   const billingInterval = formatDuration(plan.billingCadence);
 
   return (
@@ -130,15 +84,12 @@ export const PricingCard = ({
       </div>
 
       <div className="space-y-4 mb-6 grow">
-        {plan.phases.map((phase) => (
-          <PhaseSection
-            key={phase.key}
-            phase={phase}
-            currency={plan.currency}
-            showName={hasMultiplePhases}
-            billingCadence={plan.billingCadence}
-          />
-        ))}
+        <PlanEntitlements
+          phases={plan.phases}
+          currency={plan.currency}
+          billingCadence={plan.billingCadence}
+          units={pricing?.units}
+        />
       </div>
 
       {isSubscribed ? (

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
@@ -204,6 +204,10 @@ describe("SubscriptionPlanDetails", () => {
       screen.getByText(/Apr\s+1,\s+2026\s+–\s+May\s+1,\s+2026/),
     ).toBeInTheDocument();
 
+    // Phase headers
+    expect(screen.getByText("Trial")).toBeInTheDocument();
+    expect(screen.getByText("Paid")).toBeInTheDocument();
+
     // Metered row
     const api = screen.getByText("API").closest("li");
     expect(api).not.toBeNull();
@@ -226,18 +230,12 @@ describe("SubscriptionPlanDetails", () => {
   it('renders "Starts <date>" when activeTo is missing', () => {
     render(<SubscriptionPlanDetails subscription={makeSubscription()} />);
 
-    // Date ranges are displayed per row.
-    const api = screen.getByText("API").closest("li");
-    if (!api) throw new Error("Expected API row");
+    // Date ranges are displayed in the phase headers.
     expect(
-      within(api).getByText(/Starts\s+Apr\s+1,\s+2026/),
+      screen.getByText(/Trial\s+—\s+Starts\s+Apr\s+1,\s+2026/),
     ).toBeInTheDocument();
-
-    // Paid phase starts later -> should show Starts <date>.
-    const boolRow = screen.getByText("Boolean feature").closest("li");
-    if (!boolRow) throw new Error("Expected boolean row");
     expect(
-      within(boolRow).getByText(/Starts\s+May\s+1,\s+2026/),
+      screen.getByText(/Paid\s+—\s+Starts\s+May\s+1,\s+2026/),
     ).toBeInTheDocument();
   });
 

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
@@ -224,18 +224,25 @@ describe("SubscriptionPlanDetails", () => {
 
     // Static row shows value
     expect(screen.getByText(/Static feature/i)).toBeInTheDocument();
-    expect(screen.getAllByText("v2").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Static feature.*v2/i)).toBeInTheDocument();
   });
 
   it('renders "Starts <date>" when activeTo is missing', () => {
     render(<SubscriptionPlanDetails subscription={makeSubscription()} />);
 
     // Date ranges are displayed in the phase headers.
+    const trialHeader = screen.getByText("Trial").closest("div");
+    expect(trialHeader).not.toBeNull();
+    if (!trialHeader) throw new Error("Expected Trial phase header");
     expect(
-      screen.getByText(/Trial\s+—\s+Starts\s+Apr\s+1,\s+2026/),
+      within(trialHeader).getByText(/Starts\s+Apr\s+1,\s+2026/),
     ).toBeInTheDocument();
+
+    const paidHeader = screen.getByText("Paid").closest("div");
+    expect(paidHeader).not.toBeNull();
+    if (!paidHeader) throw new Error("Expected Paid phase header");
     expect(
-      screen.getByText(/Paid\s+—\s+Starts\s+May\s+1,\s+2026/),
+      within(paidHeader).getByText(/Starts\s+May\s+1,\s+2026/),
     ).toBeInTheDocument();
   });
 

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
@@ -72,6 +72,11 @@ const makeSubscription = (
             tiers: [
               {
                 flatPrice: { amount: "0", type: "money" },
+                unitPrice: { amount: "0", type: "money" },
+                upToAmount: "3000",
+              },
+              {
+                flatPrice: { amount: "0", type: "money" },
                 unitPrice: { amount: "0.1", type: "money" },
               },
             ],
@@ -204,6 +209,7 @@ describe("SubscriptionPlanDetails", () => {
     expect(api).not.toBeNull();
     if (!api) throw new Error("Expected API row");
     expect(within(api).getByText("1,000 / month")).toBeInTheDocument();
+    expect(within(api).getByText(/Over 3,000:/)).toBeInTheDocument();
     expect(within(api).getByText("Overage: $0.10/call")).toBeInTheDocument();
 
     // Boolean row

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
@@ -184,6 +184,14 @@ type FeatureRow = {
   value?: string;
 };
 
+type PhaseGroup = {
+  id: string;
+  name: string;
+  activeFrom: string;
+  activeTo?: string;
+  rows: FeatureRow[];
+};
+
 const getPhaseRows = (opts: {
   subscription: Subscription;
   currency: string | undefined;
@@ -196,7 +204,7 @@ const getPhaseRows = (opts: {
       new Date(a.activeFrom).getTime() - new Date(b.activeFrom).getTime(),
   );
 
-  const featureRows: FeatureRow[] = [];
+  const phaseGroups: PhaseGroup[] = [];
 
   for (const phase of phases) {
     const { features } = getEntitlementsFromItems(
@@ -206,8 +214,9 @@ const getPhaseRows = (opts: {
       subscription.billingCadence,
     );
 
+    const rows: FeatureRow[] = [];
     for (const f of features) {
-      featureRows.push({
+      rows.push({
         key: f.key,
         name: f.name,
         entitlementType: f.entitlementType,
@@ -222,9 +231,19 @@ const getPhaseRows = (opts: {
         activeTo: phase.activeTo,
       });
     }
+
+    if (rows.length > 0) {
+      phaseGroups.push({
+        id: phase.id,
+        name: phase.name,
+        activeFrom: phase.activeFrom,
+        activeTo: phase.activeTo,
+        rows,
+      });
+    }
   }
 
-  return { featureRows };
+  return { phaseGroups };
 };
 
 const formatActiveRange = (activeFrom: string, activeTo?: string) => {
@@ -260,7 +279,7 @@ export const SubscriptionPlanDetails = ({
       </>
     );
 
-  const { featureRows } = getPhaseRows({
+  const { phaseGroups } = getPhaseRows({
     subscription,
     currency,
     units: pricing?.units,
@@ -319,61 +338,75 @@ export const SubscriptionPlanDetails = ({
             </div>
           </dl>
 
-          {featureRows.length > 0 ? (
+          {phaseGroups.length > 0 ? (
             <div className="space-y-5 pt-2 border-t border-border">
               <div className="space-y-2">
                 <p className={cn(sectionLabelClassName, "mb-5")}>
                   Entitlements
                 </p>
-                <ul className="space-y-3">
-                  {featureRows.map((row) => (
-                    <li
-                      key={`${row.key}:${row.phaseId}`}
-                      className="grid gap-1 text-sm sm:grid-cols-4 sm:items-center sm:gap-4"
-                    >
-                      <div className="flex items-start gap-2 text-muted-foreground sm:col-span-2">
-                        <span>
-                          <span className="text-foreground font-medium">
-                            {row.name}{" "}
+                <div className="space-y-5">
+                  {phaseGroups.map((phase) => (
+                    <div key={phase.id} className="space-y-3">
+                      {phaseGroups.length > 1 ? (
+                        <div className="text-sm font-medium text-card-foreground">
+                          {phase.name}
+                          <span className="text-muted-foreground font-normal">
+                            {" "}
+                            &mdash;{" "}
+                            {formatActiveRange(
+                              phase.activeFrom,
+                              phase.activeTo,
+                            )}
                           </span>
-                          {row.entitlementType === "static" && row.value
-                            ? `: ${row.value}`
-                            : ""}
-                        </span>
-                      </div>
+                        </div>
+                      ) : null}
 
-                      <div className="text-muted-foreground sm:text-right">
-                        {row.entitlementType === "metered" &&
-                        row.limit != null ? (
-                          <>
-                            {formatNumber(row.limit)}
-                            {row.period ? ` / ${row.period}` : ""}
-                            {row.tierPrices && row.tierPrices.length > 0 ? (
-                              <ul className="text-xs mt-1 space-y-0.5">
-                                {row.tierPrices.map((line) => (
-                                  <li key={line}>{line}</li>
-                                ))}
-                              </ul>
-                            ) : null}
-                            {row.overagePrice ? (
-                              <div className="text-xs mt-0.5">
-                                Overage: {row.overagePrice}
+                      <ul className="space-y-3">
+                        {phase.rows.map((row) => (
+                          <li
+                            key={`${row.key}:${row.phaseId}`}
+                            className="text-sm"
+                          >
+                            <div className="flex flex-col gap-1">
+                              <div className="text-foreground font-medium">
+                                {row.name}
+                                {row.entitlementType === "static" && row.value
+                                  ? `: ${row.value}`
+                                  : ""}
                               </div>
-                            ) : null}
-                          </>
-                        ) : row.entitlementType === "static" && row.value ? (
-                          row.value
-                        ) : (
-                          "Included"
-                        )}
-                      </div>
 
-                      <div className="text-xs text-muted-foreground sm:text-right">
-                        {formatActiveRange(row.activeFrom, row.activeTo)}
-                      </div>
-                    </li>
+                              <div className="text-muted-foreground">
+                                {row.entitlementType === "metered" &&
+                                row.limit != null ? (
+                                  <>
+                                    {formatNumber(row.limit)}
+                                    {row.period ? ` / ${row.period}` : ""}
+                                    {row.tierPrices &&
+                                    row.tierPrices.length > 0 ? (
+                                      <ul className="text-xs mt-1 space-y-0.5">
+                                        {row.tierPrices.map((line) => (
+                                          <li key={line}>{line}</li>
+                                        ))}
+                                      </ul>
+                                    ) : null}
+                                    {row.overagePrice ? (
+                                      <div className="text-xs mt-0.5">
+                                        Overage: {row.overagePrice}
+                                      </div>
+                                    ) : null}
+                                  </>
+                                ) : row.entitlementType === "static" &&
+                                  row.value ? null : (
+                                  "Included"
+                                )}
+                              </div>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
                   ))}
-                </ul>
+                </div>
               </div>
             </div>
           ) : null}

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
@@ -11,6 +11,7 @@ import { useMonetizationConfig } from "../../MonetizationContext.js";
 import type { Item, Subscription } from "../../types/SubscriptionType.js";
 import { formatDuration } from "../../utils/formatDuration.js";
 import { formatPrice } from "../../utils/formatPrice.js";
+import { formatTieredPriceBreakdown } from "../../utils/formatTieredPriceBreakdown.js";
 import { getPriceFromPlan } from "../../utils/getPriceFromPlan.js";
 import {
   planHasDefaultTaxBehavior,
@@ -60,6 +61,29 @@ const getOveragePriceFromItem = (
   return `${formatPrice(parsed, currency)}/${unitLabel}`;
 };
 
+const getTierPricesFromItem = (
+  item: Item,
+  currency: string | undefined,
+  units?: Record<string, string>,
+): string[] | undefined => {
+  if (item.price?.type !== "tiered") return;
+  const tiers = item.price.tiers;
+  if (!tiers || tiers.length <= 1) return;
+
+  const unitLabel = units?.[item.key] ?? units?.[item.featureKey] ?? "unit";
+  return formatTieredPriceBreakdown({
+    tiers: tiers.map((t) => ({
+      upToAmount: t.upToAmount,
+      unitPriceAmount: t.unitPrice?.amount,
+      flatPriceAmount: t.flatPrice?.amount,
+    })),
+    currency,
+    unitLabel,
+    includedLabel: "Included",
+    omitIncludedUpToAmount: item.included?.entitlement?.issueAfterReset,
+  });
+};
+
 const getEntitlementsFromItems = (
   items: Item[],
   currency: string | undefined,
@@ -74,6 +98,7 @@ const getEntitlementsFromItems = (
         limit: number;
         period: string;
         overagePrice?: string;
+        tierPrices?: string[];
       }
     | {
         entitlementType: "boolean";
@@ -104,6 +129,7 @@ const getEntitlementsFromItems = (
           entitlement.isSoftLimit !== false
             ? getOveragePriceFromItem(item, currency, units)
             : undefined,
+        tierPrices: getTierPricesFromItem(item, currency, units),
       });
       continue;
     }
@@ -154,6 +180,7 @@ type FeatureRow = {
   limit?: number;
   period?: string;
   overagePrice?: string;
+  tierPrices?: string[];
   value?: string;
 };
 
@@ -188,6 +215,7 @@ const getPhaseRows = (opts: {
         period: f.entitlementType === "metered" ? f.period : undefined,
         overagePrice:
           f.entitlementType === "metered" ? f.overagePrice : undefined,
+        tierPrices: f.entitlementType === "metered" ? f.tierPrices : undefined,
         value: f.entitlementType === "static" ? f.value : undefined,
         phaseId: phase.id,
         activeFrom: phase.activeFrom,
@@ -320,6 +348,13 @@ export const SubscriptionPlanDetails = ({
                           <>
                             {formatNumber(row.limit)}
                             {row.period ? ` / ${row.period}` : ""}
+                            {row.tierPrices && row.tierPrices.length > 0 ? (
+                              <ul className="text-xs mt-1 space-y-0.5">
+                                {row.tierPrices.map((line) => (
+                                  <li key={line}>{line}</li>
+                                ))}
+                              </ul>
+                            ) : null}
                             {row.overagePrice ? (
                               <div className="text-xs mt-0.5">
                                 Overage: {row.overagePrice}

--- a/packages/plugin-zuplo-monetization/src/types/PlanType.ts
+++ b/packages/plugin-zuplo-monetization/src/types/PlanType.ts
@@ -101,6 +101,7 @@ export interface Quota {
   limit: number;
   period: string;
   overagePrice?: string;
+  tierPrices?: string[];
 }
 
 export interface Feature {

--- a/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
@@ -206,6 +206,24 @@ describe("categorizeRateCards", () => {
     expect(quotas[0].overagePrice).toBeUndefined();
   });
 
+  it("omits the redundant included up-to tier in tierPrices when it matches the quota limit", () => {
+    const { quotas } = categorizeRateCards([
+      makeMeteredRateCard({
+        issueAfterReset: 5000,
+        tiers: [
+          {
+            flatPrice: { amount: "0" },
+            unitPrice: { amount: "0" },
+            upToAmount: "5000",
+          },
+          { flatPrice: { amount: "0" }, unitPrice: { amount: "0.05" } },
+        ],
+      }),
+    ]);
+
+    expect(quotas[0].tierPrices).toEqual(["Over 5,000: $0.05/unit"]);
+  });
+
   it("categorizes boolean rate card as feature", () => {
     const { features } = categorizeRateCards([
       {

--- a/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.ts
@@ -1,6 +1,7 @@
 import type { Feature, Quota, RateCard } from "../types/PlanType.js";
 import { formatDuration } from "./formatDuration.js";
 import { formatPrice } from "./formatPrice.js";
+import { formatTieredPriceBreakdown } from "./formatTieredPriceBreakdown.js";
 
 export const categorizeRateCards = (
   rateCards: RateCard[],
@@ -20,18 +21,29 @@ export const categorizeRateCards = (
 
     if (et.type === "metered" && et.issueAfterReset != null) {
       let overagePrice: string | undefined;
-      if (
-        et.isSoftLimit !== false &&
-        rc.price?.type === "tiered" &&
-        rc.price.tiers
-      ) {
+      let tierPrices: string[] | undefined;
+      if (rc.price?.type === "tiered" && rc.price.tiers) {
+        const unitLabel =
+          units?.[rc.key] ?? units?.[rc.featureKey ?? ""] ?? "unit";
+
+        // Build a readable tier breakdown (useful for graduated/volume).
+        tierPrices = formatTieredPriceBreakdown({
+          tiers: rc.price.tiers.map((t) => ({
+            upToAmount: t.upToAmount,
+            unitPriceAmount: t.unitPrice?.amount,
+            flatPriceAmount: t.flatPrice?.amount,
+          })),
+          currency,
+          unitLabel,
+          includedLabel: "Included",
+          omitIncludedUpToAmount: et.issueAfterReset,
+        });
+
         const overageTier = rc.price.tiers.find(
           (t) => t.unitPrice?.amount && parseFloat(t.unitPrice.amount) > 0,
         );
-        if (overageTier?.unitPrice) {
+        if (et.isSoftLimit !== false && overageTier?.unitPrice) {
           const amount = parseFloat(overageTier.unitPrice.amount);
-          const unitLabel =
-            units?.[rc.key] ?? units?.[rc.featureKey ?? ""] ?? "unit";
           overagePrice = `${formatPrice(amount, currency)}/${unitLabel}`;
         }
       }
@@ -45,6 +57,7 @@ export const categorizeRateCards = (
             ? formatDuration(planBillingCadence)
             : "month",
         overagePrice,
+        tierPrices,
       });
     } else if (et.type === "boolean") {
       features.push({ key: rc.featureKey ?? rc.key, name: rc.name });

--- a/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
@@ -62,6 +62,6 @@ describe("formatTieredPriceBreakdown", () => {
     });
 
     expect(lines?.[0]).toMatch(/^Up to 5,000:/);
-    expect(lines?.[0]).toMatch(/\$10\.00 base$/);
+    expect(lines?.[0]).toMatch(/\$10(?:\.00)? base$/);
   });
 });

--- a/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { formatTieredPriceBreakdown } from "./formatTieredPriceBreakdown.js";
+
+describe("formatTieredPriceBreakdown", () => {
+  it("returns undefined for 0 or 1 tiers", () => {
+    expect(
+      formatTieredPriceBreakdown({
+        tiers: [],
+        unitLabel: "unit",
+        includedLabel: "Included",
+      }),
+    ).toBeUndefined();
+
+    expect(
+      formatTieredPriceBreakdown({
+        tiers: [{ upToAmount: "1000", unitPriceAmount: "0" }],
+        unitLabel: "unit",
+        includedLabel: "Included",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("formats up-to and over tiers", () => {
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "5000", unitPriceAmount: "0" },
+        { unitPriceAmount: "0.05" },
+      ],
+      unitLabel: "unit",
+      includedLabel: "Included",
+      currency: "USD",
+    });
+
+    expect(lines).toEqual(["Up to 5,000: Included", "Over 5,000: $0.05/unit"]);
+  });
+
+  it("omits redundant included up-to tier when omitIncludedUpToAmount matches", () => {
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "5000", unitPriceAmount: "0" },
+        { unitPriceAmount: "0.05" },
+      ],
+      unitLabel: "unit",
+      includedLabel: "Included",
+      currency: "USD",
+      omitIncludedUpToAmount: 5000,
+    });
+
+    expect(lines).toEqual(["Over 5,000: $0.05/unit"]);
+  });
+
+  it("does not omit included up-to tier when there is a base flat price", () => {
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "5000", unitPriceAmount: "0", flatPriceAmount: "10" },
+        { unitPriceAmount: "0.05" },
+      ],
+      unitLabel: "unit",
+      includedLabel: "Included",
+      currency: "USD",
+      omitIncludedUpToAmount: 5000,
+    });
+
+    expect(lines?.[0]).toMatch(/^Up to 5,000:/);
+    expect(lines?.[0]).toMatch(/\$10\.00 base$/);
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.ts
@@ -1,0 +1,63 @@
+import { formatPrice } from "./formatPrice.js";
+
+export type TieredPriceBreakdownTier = {
+  upToAmount?: string;
+  unitPriceAmount?: string;
+  flatPriceAmount?: string;
+};
+
+const parseAmount = (value: string | undefined) => {
+  if (!value) return;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const formatTieredPriceBreakdown = (opts: {
+  tiers: TieredPriceBreakdownTier[];
+  currency?: string;
+  unitLabel: string;
+  includedLabel: string;
+  omitIncludedUpToAmount?: number;
+}): string[] | undefined => {
+  const { tiers, currency, unitLabel, includedLabel, omitIncludedUpToAmount } =
+    opts;
+  if (!tiers || tiers.length <= 1) return;
+
+  const lines: string[] = [];
+  let lastUpTo: number | undefined;
+
+  for (const tier of tiers) {
+    const upTo = parseAmount(tier.upToAmount);
+    const unit = parseAmount(tier.unitPriceAmount) ?? 0;
+    const flat = parseAmount(tier.flatPriceAmount) ?? 0;
+
+    const prefix =
+      upTo != null
+        ? `Up to ${upTo.toLocaleString("en-US")}`
+        : lastUpTo != null
+          ? `Over ${lastUpTo.toLocaleString("en-US")}`
+          : `Per ${unitLabel}`;
+
+    const unitPart =
+      unit > 0 ? `${formatPrice(unit, currency)}/${unitLabel}` : includedLabel;
+    const flatPart = flat > 0 ? ` + ${formatPrice(flat, currency)} base` : "";
+    const line = `${prefix}: ${unitPart}${flatPart}`;
+
+    // Avoid redundancy when the UI already shows the quota limit (e.g. "5,000 / month").
+    if (
+      omitIncludedUpToAmount != null &&
+      upTo != null &&
+      upTo === omitIncludedUpToAmount &&
+      unitPart === includedLabel &&
+      flatPart === ""
+    ) {
+      // skip
+    } else {
+      lines.push(line);
+    }
+
+    if (upTo != null) lastUpTo = upTo;
+  }
+
+  return lines.length > 0 ? lines : undefined;
+};


### PR DESCRIPTION
This also addresses tiered pricing not being shown at all anywhere for the end user.
<img width="702" height="774" alt="Screenshot 2026-04-30 at 12 51 35 AM" src="https://github.com/user-attachments/assets/0b1b9590-3c37-4dd0-9883-bb6b32c533b4" />
<img width="668" height="426" alt="Screenshot 2026-04-30 at 12 51 07 AM" src="https://github.com/user-attachments/assets/039d9b89-3588-4ea9-974c-c7226ffa2e4b" />
<img width="920" height="388" alt="Screenshot 2026-04-30 at 12 50 53 AM" src="https://github.com/user-attachments/assets/2f14a4d8-102e-473d-9c6d-989310c366ef" />

