### PR TITLE
fix: render parent properties alongside `oneOf`/`anyOf` union

### DIFF
--- a/examples/cosmo-cargo/schema/cargo-containers.json
+++ b/examples/cosmo-cargo/schema/cargo-containers.json
@@ -569,6 +569,33 @@
         ]
       },
       "PaymentMethod": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Shared transaction metadata for any payment method.",
+            "required": ["amount", "currencyCode"],
+            "properties": {
+              "amount": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Total amount to charge, in the given currency."
+              },
+              "currencyCode": {
+                "type": "string",
+                "description": "ISO-style currency code, e.g. GCR for Galactic Credits.",
+                "examples": ["GCR", "MCR"]
+              },
+              "transactionRef": {
+                "type": "string",
+                "description": "Optional client-side transaction reference for reconciliation."
+              },
+              "memo": {
+                "type": "string",
+                "description": "Free-form memo attached to the payment."
+              }
+            }
+          }
+        ],
         "oneOf": [
           {
             "type": "object",

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
@@ -167,6 +167,9 @@ const ObjectSchemaView = ({
   const additionalObjectProperties = typeof schema.additionalProperties ===
     "object" && <SchemaView schema={schema.additionalProperties} embedded />;
 
+  const hasUnion = Array.isArray(schema.oneOf) || Array.isArray(schema.anyOf);
+  const unionSection = hasUnion && <UnionView schema={schema} embedded />;
+
   const itemsList = nonDeprecatedGroups.map(({ group, properties }, index) => (
     <Fragment key={group}>
       {index > 0 && <ItemSeparator />}
@@ -194,6 +197,11 @@ const ObjectSchemaView = ({
       <>
         {itemsList}
         {deprecatedList}
+        {unionSection &&
+          (nonDeprecatedGroups.length > 0 || deprecatedProperties) && (
+            <ItemSeparator />
+          )}
+        {unionSection}
       </>
     );
   }
@@ -201,7 +209,8 @@ const ObjectSchemaView = ({
   const hasPanelContent =
     nonDeprecatedGroups.length > 0 ||
     deprecatedProperties ||
-    additionalObjectProperties;
+    additionalObjectProperties ||
+    unionSection;
 
   return (
     <Frame>
@@ -221,6 +230,11 @@ const ObjectSchemaView = ({
             </div>
           )}
           {additionalObjectProperties}
+          {unionSection &&
+            (nonDeprecatedGroups.length > 0 || deprecatedProperties) && (
+              <ItemSeparator />
+            )}
+          {unionSection}
         </FramePanel>
       )}
       {(schema.additionalProperties === true || deprecatedProperties) && (
@@ -282,7 +296,9 @@ export const SchemaView = ({
     return <ConstValue schema={schema} />;
   }
 
-  if (Array.isArray(schema.oneOf) || Array.isArray(schema.anyOf)) {
+  const hasUnion = Array.isArray(schema.oneOf) || Array.isArray(schema.anyOf);
+
+  if (hasUnion && !schema.properties) {
     return <UnionView schema={schema} cardHeader={cardHeader} />;
   }
 
@@ -301,7 +317,7 @@ export const SchemaView = ({
     );
   }
 
-  if (schema.type === "object") {
+  if (schema.type === "object" || schema.properties || hasUnion) {
     const rootRefName =
       !embedded && !hideRootRef ? getSchemaRefName(schema) : undefined;
     return (

--- a/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/SchemaView.tsx
@@ -231,9 +231,8 @@ const ObjectSchemaView = ({
           )}
           {additionalObjectProperties}
           {unionSection &&
-            (nonDeprecatedGroups.length > 0 || deprecatedProperties) && (
-              <ItemSeparator />
-            )}
+            (nonDeprecatedGroups.length > 0 ||
+              (showDeprecated && deprecatedProperties)) && <ItemSeparator />}
           {unionSection}
         </FramePanel>
       )}
@@ -299,7 +298,9 @@ export const SchemaView = ({
   const hasUnion = Array.isArray(schema.oneOf) || Array.isArray(schema.anyOf);
 
   if (hasUnion && !schema.properties) {
-    return <UnionView schema={schema} cardHeader={cardHeader} />;
+    return (
+      <UnionView schema={schema} cardHeader={cardHeader} embedded={embedded} />
+    );
   }
 
   if (isBasicType(schema.type)) {

--- a/packages/zudoku/src/lib/plugins/openapi/schema/UnionView.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/schema/UnionView.tsx
@@ -70,9 +70,11 @@ const DecisionTable = ({
 export const UnionView = ({
   schema,
   cardHeader,
+  embedded,
 }: {
   schema: SchemaObject;
   cardHeader?: React.ReactNode;
+  embedded?: boolean;
 }) => {
   const mode = Array.isArray(schema.oneOf)
     ? "oneOf"
@@ -107,26 +109,32 @@ export const UnionView = ({
   const currentVariant =
     currentVariantIndex >= 0 ? variants[currentVariantIndex] : null;
 
+  const body = (
+    <div className="text-sm flex flex-col gap-4 p-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">{mode}</Badge>
+        <div className="flex-1">
+          <span className="text-sm">{semanticsMessage}</span>
+        </div>
+      </div>
+
+      <DecisionTable
+        variants={variants}
+        schema={schema}
+        selectedVariant={selectedVariant}
+        onSelectVariant={setSelectedVariant}
+      />
+      <strong>Properties for {selectedVariant}:</strong>
+      {currentVariant && <SchemaView schema={currentVariant} />}
+    </div>
+  );
+
+  if (embedded) return body;
+
   return (
     <Frame>
       {cardHeader}
-      <FramePanel className="text-sm flex flex-col gap-4">
-        <div className="flex items-center gap-2">
-          <Badge variant="outline">{mode}</Badge>
-          <div className="flex-1 p-2">
-            <span className="text-sm">{semanticsMessage}</span>
-          </div>
-        </div>
-
-        <DecisionTable
-          variants={variants}
-          schema={schema}
-          selectedVariant={selectedVariant}
-          onSelectVariant={setSelectedVariant}
-        />
-        <strong>Properties for {selectedVariant}:</strong>
-        {currentVariant && <SchemaView schema={currentVariant} />}
-      </FramePanel>
+      <FramePanel className="p-0!">{body}</FramePanel>
     </Frame>
   );
 };


### PR DESCRIPTION
`SchemaView` short-circuits to `UnionView` whenever it sees `oneOf`/`anyOf`, so any sibling `properties` on the parent get silently dropped.

Fix: when the schema has both own `properties` and a union, dispatch to `ObjectSchemaView` and let it append `UnionView` (new `embedded` mode) as a sub-section. The existing required/optional/deprecated grouping then handles the parent properties without re-implementing it.

The cosmo-cargo `PaymentMethod` schema is updated with shared transaction metadata via `allOf` to demonstrate the case.

(Alternative to #2406, thanks @jedevc for the original report and fix.)