### PR TITLE
feat(auth): support custom authorize params on OIDC providers

### DIFF
--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -449,8 +449,6 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
-    authorizationParams: z.record(z.string(), z.string()).optional(),
-    forwardAuthorizationParams: z.array(z.string()).optional(),
   }),
 
   z.object({

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -435,6 +435,8 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    authorizationParams: z.record(z.string(), z.string()).optional(),
+    forwardAuthorizationParams: z.array(z.string()).optional(),
   }),
   z.object({
     type: z.literal("azureb2c"),
@@ -447,6 +449,8 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    authorizationParams: z.record(z.string(), z.string()).optional(),
+    forwardAuthorizationParams: z.array(z.string()).optional(),
   }),
 
   z.object({
@@ -472,6 +476,8 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
+    authorizationParams: z.record(z.string(), z.string()).optional(),
+    forwardAuthorizationParams: z.array(z.string()).optional(),
     options: z
       .object({
         alwaysPromptLogin: z.boolean().optional(),

--- a/packages/zudoku/src/lib/authentication/providers/auth0.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/auth0.tsx
@@ -11,6 +11,8 @@ import {
   OpenIDAuthenticationProvider,
 } from "./openid.js";
 
+const AUTH0_FORWARD_PARAMS = ["organization", "invitation", "connection"];
+
 class Auth0AuthenticationProvider
   extends OpenIDAuthenticationProvider
   implements AuthenticationPlugin
@@ -24,6 +26,11 @@ class Auth0AuthenticationProvider
       clientId: config.clientId,
       audience: config.audience,
       scopes: config.scopes,
+      authorizationParams: config.authorizationParams,
+      forwardAuthorizationParams: [
+        ...AUTH0_FORWARD_PARAMS,
+        ...(config.forwardAuthorizationParams ?? []),
+      ],
     });
     this.options = config.options;
   }

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -291,6 +291,123 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
     });
   });
 
+  describe("authorize URL params", () => {
+    let originalHref: string;
+
+    const setLocation = (url: string) => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: Object.assign(new URL(url), {
+          assign: vi.fn(),
+          replace: vi.fn(),
+        }),
+        writable: true,
+      });
+    };
+
+    beforeEach(() => {
+      originalHref = window.location.href;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL(originalHref),
+        writable: true,
+      });
+    });
+
+    const setAuthEndpoint = () => {
+      vi.mocked(oauth.processDiscoveryResponse).mockResolvedValue({
+        ...AUTH_SERVER,
+        authorization_endpoint: "https://issuer.example.com/authorize",
+      });
+    };
+
+    const captureAuthorizeUrl = async (
+      provider: OpenIDAuthenticationProvider,
+    ) => {
+      let captured: URL | undefined;
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: {
+          ...window.location,
+          origin: window.location.origin,
+          search: window.location.search,
+          set href(value: string) {
+            captured = new URL(value);
+          },
+          replace: (value: string) => {
+            captured = new URL(value);
+          },
+        },
+      });
+      await provider.signIn({ navigate: vi.fn() as never }, {});
+      if (!captured) throw new Error("authorize URL not captured");
+      return captured;
+    };
+
+    test("static authorizationParams reach the authorize URL", async () => {
+      setLocation("http://localhost/");
+      setAuthEndpoint();
+
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        authorizationParams: { organization: "org_static" },
+      });
+
+      const url = await captureAuthorizeUrl(provider);
+      expect(url.searchParams.get("organization")).toBe("org_static");
+    });
+
+    test("forwards allow-listed params from current URL", async () => {
+      setLocation("http://localhost/?login_hint=alice@example.com&foo=bar");
+      setAuthEndpoint();
+
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+      });
+
+      const url = await captureAuthorizeUrl(provider);
+      expect(url.searchParams.get("login_hint")).toBe("alice@example.com");
+      expect(url.searchParams.get("foo")).toBeNull();
+    });
+
+    test("URL params override static authorizationParams", async () => {
+      setLocation("http://localhost/?login_hint=runtime@example.com");
+      setAuthEndpoint();
+
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        authorizationParams: { login_hint: "static@example.com" },
+      });
+
+      const url = await captureAuthorizeUrl(provider);
+      expect(url.searchParams.get("login_hint")).toBe("runtime@example.com");
+    });
+
+    test("custom forwardAuthorizationParams extend the allow-list", async () => {
+      setLocation("http://localhost/?tenant=acme");
+      setAuthEndpoint();
+
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        forwardAuthorizationParams: ["tenant"],
+      });
+
+      const url = await captureAuthorizeUrl(provider);
+      expect(url.searchParams.get("tenant")).toBe("acme");
+    });
+  });
+
   test("self heals providerData when providerData.type is undefined", async () => {
     const provider = createProvider();
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -3,6 +3,7 @@ import * as oauth from "oauth4webapi";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { OAuthAuthorizationError } from "../errors.js";
 import { useAuthState } from "../state.js";
+import auth0Auth from "./auth0.js";
 import {
   OpenIDAuthenticationProvider,
   type OpenIdProviderData,
@@ -405,6 +406,68 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
 
       const url = await captureAuthorizeUrl(provider);
       expect(url.searchParams.get("tenant")).toBe("acme");
+    });
+
+    test("protected core params cannot be overridden via authorizationParams", async () => {
+      setLocation("http://localhost/");
+      setAuthEndpoint();
+
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        authorizationParams: {
+          client_id: "evil",
+          redirect_uri: "https://evil.example.com/cb",
+          response_type: "token",
+          scope: "evil",
+        },
+      });
+
+      const url = await captureAuthorizeUrl(provider);
+      expect(url.searchParams.get("client_id")).toBe("test-client");
+      expect(url.searchParams.get("redirect_uri")).toBe(
+        "http://localhost/oauth/callback",
+      );
+      expect(url.searchParams.get("response_type")).toBe("code");
+      expect(url.searchParams.get("scope")).toBe("openid profile email");
+    });
+
+    test("protected core params cannot be overridden via forwarded URL params", async () => {
+      setLocation("http://localhost/?redirect_uri=https://evil.example.com/cb");
+      setAuthEndpoint();
+
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        forwardAuthorizationParams: ["redirect_uri"],
+      });
+
+      const url = await captureAuthorizeUrl(provider);
+      expect(url.searchParams.get("redirect_uri")).toBe(
+        "http://localhost/oauth/callback",
+      );
+    });
+
+    test("Auth0 provider forwards organization, invitation, connection by default", async () => {
+      setLocation(
+        "http://localhost/?organization=org_x&invitation=inv_y&connection=google-oauth2",
+      );
+      setAuthEndpoint();
+
+      const provider = auth0Auth({
+        type: "auth0",
+        domain: "issuer.example.com",
+        clientId: "test-client",
+      });
+
+      const url = await captureAuthorizeUrl(
+        provider as OpenIDAuthenticationProvider,
+      );
+      expect(url.searchParams.get("organization")).toBe("org_x");
+      expect(url.searchParams.get("invitation")).toBe("inv_y");
+      expect(url.searchParams.get("connection")).toBe("google-oauth2");
     });
   });
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -282,19 +282,7 @@ export class OpenIDAuthenticationProvider
     redirectUrl.search = "";
     redirectUrl.hash = "";
 
-    authorizationUrl.searchParams.set("client_id", this.client.client_id);
-    authorizationUrl.searchParams.set("redirect_uri", redirectUrl.toString());
-    authorizationUrl.searchParams.set("response_type", "code");
-    authorizationUrl.searchParams.set("scope", this.scopes.join(" "));
-    authorizationUrl.searchParams.set("code_challenge", codeChallenge);
-    authorizationUrl.searchParams.set(
-      "code_challenge_method",
-      code_challenge_method,
-    );
-    if (this.audience) {
-      authorizationUrl.searchParams.set("audience", this.audience);
-    }
-
+    // Apply user-supplied params first so core OIDC params below cannot be overridden (client_id, etc.)
     if (this.authorizationParams) {
       for (const [key, value] of Object.entries(this.authorizationParams)) {
         authorizationUrl.searchParams.set(key, value);
@@ -309,6 +297,19 @@ export class OpenIDAuthenticationProvider
           authorizationUrl.searchParams.set(name, value);
         }
       }
+    }
+
+    authorizationUrl.searchParams.set("client_id", this.client.client_id);
+    authorizationUrl.searchParams.set("redirect_uri", redirectUrl.toString());
+    authorizationUrl.searchParams.set("response_type", "code");
+    authorizationUrl.searchParams.set("scope", this.scopes.join(" "));
+    authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+    authorizationUrl.searchParams.set(
+      "code_challenge_method",
+      code_challenge_method,
+    );
+    if (this.audience) {
+      authorizationUrl.searchParams.set("audience", this.audience);
     }
 
     this.onAuthorizationUrl?.(authorizationUrl, {

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -60,6 +60,14 @@ export class OpenIDAuthenticationProvider
   protected readonly redirectToAfterSignOut: string;
   private readonly audience?: string;
   private readonly scopes: string[];
+  protected readonly authorizationParams?: Record<string, string>;
+  protected readonly forwardAuthorizationParams: string[];
+  protected static readonly DEFAULT_FORWARD_AUTHORIZATION_PARAMS = [
+    "login_hint",
+    "domain_hint",
+    "ui_locales",
+    "acr_values",
+  ];
 
   constructor({
     issuer,
@@ -70,6 +78,8 @@ export class OpenIDAuthenticationProvider
     redirectToAfterSignOut = "/",
     basePath,
     scopes,
+    authorizationParams,
+    forwardAuthorizationParams,
   }: OpenIDAuthenticationConfig) {
     super();
     this.client = {
@@ -85,6 +95,13 @@ export class OpenIDAuthenticationProvider
     this.redirectToAfterSignUp = redirectToAfterSignUp;
     this.redirectToAfterSignIn = redirectToAfterSignIn;
     this.redirectToAfterSignOut = redirectToAfterSignOut;
+    this.authorizationParams = authorizationParams;
+    this.forwardAuthorizationParams = Array.from(
+      new Set([
+        ...OpenIDAuthenticationProvider.DEFAULT_FORWARD_AUTHORIZATION_PARAMS,
+        ...(forwardAuthorizationParams ?? []),
+      ]),
+    );
   }
 
   protected async getAuthServer() {
@@ -276,6 +293,22 @@ export class OpenIDAuthenticationProvider
     );
     if (this.audience) {
       authorizationUrl.searchParams.set("audience", this.audience);
+    }
+
+    if (this.authorizationParams) {
+      for (const [key, value] of Object.entries(this.authorizationParams)) {
+        authorizationUrl.searchParams.set(key, value);
+      }
+    }
+
+    if (typeof window !== "undefined") {
+      const incoming = new URLSearchParams(window.location.search);
+      for (const name of this.forwardAuthorizationParams) {
+        const value = incoming.get(name);
+        if (value !== null) {
+          authorizationUrl.searchParams.set(name, value);
+        }
+      }
     }
 
     this.onAuthorizationUrl?.(authorizationUrl, {


### PR DESCRIPTION
Adds `authorizationParams` (static) and `forwardAuthorizationParams` (allow-list of URL params to forward) to OpenID and Auth0 configs. Auth0 forwards `organization`, `invitation`, `connection` by default so Auth0 Organizations and invitation links work without config. User params apply before core OIDC params, so PKCE/redirect_uri/etc. can't be overridden.