### PR TITLE
Add config option to hide theme switch

### DIFF
--- a/docs/pages/docs/configuration/overview.md
+++ b/docs/pages/docs/configuration/overview.md
@@ -195,9 +195,13 @@ Configures the header navigation and placement of header elements (navigation, s
       search: "end",          // "start" | "center" | "end"
       auth: "end",            // "start" | "center" | "end" | "navigation"
     },
+    showThemeSwitch: false, // optional, defaults to true
   }
 }
 ```
+
+Use `showThemeSwitch: false` to hide the light/dark theme switch from the desktop header and mobile
+navigation drawer.
 
 ### `defaults`
 

--- a/docs/pages/docs/configuration/overview.md
+++ b/docs/pages/docs/configuration/overview.md
@@ -195,13 +195,15 @@ Configures the header navigation and placement of header elements (navigation, s
       search: "end",          // "start" | "center" | "end"
       auth: "end",            // "start" | "center" | "end" | "navigation"
     },
-    showThemeSwitch: false, // optional, defaults to true
+    themeSwitcher: {
+      enabled: false, // optional, defaults to true
+    },
   }
 }
 ```
 
-Use `showThemeSwitch: false` to hide the light/dark theme switch from the desktop header and mobile
-navigation drawer.
+Use `header.themeSwitcher.enabled: false` to hide the light/dark theme switch from the desktop
+header and mobile navigation drawer.
 
 ### `defaults`
 

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -63,7 +63,9 @@ export const convertZudokuConfigToOptions = (
     header: {
       navigation: configuredHeaderNavigation,
       placements: config.header?.placements,
-      showThemeSwitch: config.header?.showThemeSwitch ?? true,
+      themeSwitcher: {
+        enabled: config.header?.themeSwitcher?.enabled ?? true,
+      },
     },
     navigation: configuredNavigation,
     navigationRules: configuredNavigationRules,

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -63,6 +63,7 @@ export const convertZudokuConfigToOptions = (
     header: {
       navigation: configuredHeaderNavigation,
       placements: config.header?.placements,
+      showThemeSwitch: config.header?.showThemeSwitch ?? true,
     },
     navigation: configuredNavigation,
     navigationRules: configuredNavigationRules,

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -63,9 +63,7 @@ export const convertZudokuConfigToOptions = (
     header: {
       navigation: configuredHeaderNavigation,
       placements: config.header?.placements,
-      themeSwitcher: {
-        enabled: config.header?.themeSwitcher?.enabled ?? true,
-      },
+      themeSwitcher: config.header?.themeSwitcher,
     },
     navigation: configuredNavigation,
     navigationRules: configuredNavigationRules,

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -256,6 +256,21 @@ describe("validateConfig", () => {
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
+  it.each([true, false])(
+    "should accept header.showThemeSwitch with %s",
+    (showThemeSwitch) => {
+      const config = {
+        header: {
+          showThemeSwitch,
+        },
+      };
+
+      validateConfig(config);
+
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    },
+  );
+
   it('should accept metadata robots values like "noindex, nofollow"', () => {
     const config = {
       metadata: {

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -257,11 +257,13 @@ describe("validateConfig", () => {
   });
 
   it.each([true, false])(
-    "should accept header.showThemeSwitch with %s",
-    (showThemeSwitch) => {
+    "should accept header.themeSwitcher.enabled with %s",
+    (enabled) => {
       const config = {
         header: {
-          showThemeSwitch,
+          themeSwitcher: {
+            enabled,
+          },
         },
       };
 
@@ -270,6 +272,18 @@ describe("validateConfig", () => {
       expect(mockConsoleLog).not.toHaveBeenCalled();
     },
   );
+
+  it("should accept header.themeSwitcher when undefined", () => {
+    const config = {
+      header: {
+        themeSwitcher: undefined,
+      },
+    };
+
+    validateConfig(config);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
 
   it('should accept metadata robots values like "noindex, nofollow"', () => {
     const config = {

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -580,6 +580,7 @@ const PlacementPosition = z.enum(["start", "center", "end"]);
 const HeaderConfigSchema = z
   .object({
     navigation: HeaderNavigationSchema,
+    showThemeSwitch: z.boolean(),
     placements: z
       .object({
         navigation: PlacementPosition,
@@ -708,6 +709,7 @@ export type ZudokuConfig = Omit<
 > & {
   header?: {
     navigation?: z.infer<typeof HeaderNavigationSchema>;
+    showThemeSwitch?: boolean;
     placements?: {
       navigation?: "start" | "center" | "end";
       search?: "start" | "center" | "end";

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -580,7 +580,12 @@ const PlacementPosition = z.enum(["start", "center", "end"]);
 const HeaderConfigSchema = z
   .object({
     navigation: HeaderNavigationSchema,
-    showThemeSwitch: z.boolean(),
+    themeSwitcher: z
+      .object({
+        enabled: z.boolean(),
+      })
+      .partial()
+      .optional(),
     placements: z
       .object({
         navigation: PlacementPosition,
@@ -709,7 +714,9 @@ export type ZudokuConfig = Omit<
 > & {
   header?: {
     navigation?: z.infer<typeof HeaderNavigationSchema>;
-    showThemeSwitch?: boolean;
+    themeSwitcher?: {
+      enabled?: boolean;
+    };
     placements?: {
       navigation?: "start" | "center" | "end";
       search?: "start" | "center" | "end";

--- a/packages/zudoku/src/lib/components/Header.test.tsx
+++ b/packages/zudoku/src/lib/components/Header.test.tsx
@@ -3,9 +3,10 @@
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, render as testRender } from "@testing-library/react";
+import { act, render as testRender, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ZudokuContext } from "../core/ZudokuContext.js";
 import type { ZudokuContextOptions } from "../core/ZudokuContext.js";
 import { SlotProvider } from "./context/SlotProvider.js";
@@ -14,7 +15,10 @@ import { Header } from "./Header.js";
 
 vi.mock("react-router", async (importOriginal) => {
   const mod = await importOriginal<typeof import("react-router")>();
-  const LinkSpy = vi.fn(mod.Link);
+  const OriginalLink = mod.Link;
+  const LinkSpy = vi.fn((props: ComponentProps<typeof OriginalLink>) => (
+    <OriginalLink {...props} />
+  ));
   return { ...mod, Link: LinkSpy };
 });
 
@@ -57,12 +61,35 @@ const getLogoLinkProps = () => {
 };
 
 describe("Header", () => {
+  beforeEach(() => {
+    LinkMock.mockClear();
+  });
+
   describe("logo link", () => {
     it("defaults reloadDocument to true", async () => {
       await render({ site: { title: "Test Site" } });
 
       const props = getLogoLinkProps();
       expect(props?.reloadDocument).toBe(true);
+    });
+  });
+
+  describe("theme switch", () => {
+    it("renders by default in the desktop header", async () => {
+      await render({ site: { title: "Test Site" } });
+
+      expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+    });
+
+    it("does not render in the desktop header when disabled", async () => {
+      await render({
+        site: { title: "Test Site" },
+        header: { showThemeSwitch: false },
+      });
+
+      expect(
+        screen.queryByLabelText("Switch to dark mode"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/zudoku/src/lib/components/Header.test.tsx
+++ b/packages/zudoku/src/lib/components/Header.test.tsx
@@ -16,10 +16,10 @@ import { Header } from "./Header.js";
 vi.mock("react-router", async (importOriginal) => {
   const mod = await importOriginal<typeof import("react-router")>();
   const OriginalLink = mod.Link;
-  const LinkSpy = vi.fn((props: ComponentProps<typeof OriginalLink>) => (
+  const LinkMock = vi.fn((props: ComponentProps<typeof OriginalLink>) => (
     <OriginalLink {...props} />
   ));
-  return { ...mod, Link: LinkSpy };
+  return { ...mod, Link: LinkMock };
 });
 
 const { Link } = await import("react-router");
@@ -60,6 +60,8 @@ const getLogoLinkProps = () => {
   return call?.[0];
 };
 
+const themeSwitchName = /^(Toggle theme|Switch to (dark|light) mode)$/;
+
 describe("Header", () => {
   beforeEach(() => {
     LinkMock.mockClear();
@@ -78,17 +80,19 @@ describe("Header", () => {
     it("renders by default in the desktop header", async () => {
       await render({ site: { title: "Test Site" } });
 
-      expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: themeSwitchName }),
+      ).toBeInTheDocument();
     });
 
     it("does not render in the desktop header when disabled", async () => {
       await render({
         site: { title: "Test Site" },
-        header: { showThemeSwitch: false },
+        header: { themeSwitcher: { enabled: false } },
       });
 
       expect(
-        screen.queryByLabelText("Switch to dark mode"),
+        screen.queryByRole("button", { name: themeSwitchName }),
       ).not.toBeInTheDocument();
     });
   });

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -134,6 +134,7 @@ export const Header = memo(function HeaderInner() {
   const searchPosition = header?.placements?.search ?? "center";
   const navPosition = header?.placements?.navigation ?? "end";
   const authPlacement = header?.placements?.auth ?? "navigation";
+  const showThemeSwitch = header?.showThemeSwitch;
   const authPosition =
     authPlacement === "navigation" ? navPosition : authPlacement;
 
@@ -235,7 +236,7 @@ export const Header = memo(function HeaderInner() {
               {authPosition === "end" && <ProfileMenu />}
               {searchPosition === "end" && <Search />}
               <Slot.Target name="head-navigation-end" />
-              <ThemeSwitch />
+              {showThemeSwitch && <ThemeSwitch />}
             </div>
           </div>
         </div>

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -134,7 +134,7 @@ export const Header = memo(function HeaderInner() {
   const searchPosition = header?.placements?.search ?? "center";
   const navPosition = header?.placements?.navigation ?? "end";
   const authPlacement = header?.placements?.auth ?? "navigation";
-  const showThemeSwitch = header?.showThemeSwitch;
+  const themeSwitcherEnabled = header?.themeSwitcher?.enabled ?? true;
   const authPosition =
     authPlacement === "navigation" ? navPosition : authPlacement;
 
@@ -236,7 +236,7 @@ export const Header = memo(function HeaderInner() {
               {authPosition === "end" && <ProfileMenu />}
               {searchPosition === "end" && <Search />}
               <Slot.Target name="head-navigation-end" />
-              {showThemeSwitch && <ThemeSwitch />}
+              {themeSwitcherEnabled && <ThemeSwitch />}
             </div>
           </div>
         </div>

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  fireEvent,
+  render as testRender,
+  screen,
+} from "@testing-library/react";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import type { ZudokuContextOptions } from "../core/ZudokuContext.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { MobileTopNavigation } from "./MobileTopNavigation.js";
+
+const render = async (options: Partial<ZudokuContextOptions> = {}) => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(options, queryClient, {});
+
+  const router = createMemoryRouter(
+    [
+      {
+        element: (
+          <QueryClientProvider client={queryClient}>
+            <ZudokuProvider context={context}>
+              <MobileTopNavigation />
+              <Outlet />
+            </ZudokuProvider>
+          </QueryClientProvider>
+        ),
+        children: [{ path: "*", element: null }],
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+
+  await act(async () => {
+    testRender(<RouterProvider router={router} />);
+  });
+};
+
+describe("MobileTopNavigation", () => {
+  it("renders the theme switch by default in the mobile navigation drawer", async () => {
+    await render({ site: { title: "Test Site" } });
+
+    fireEvent.click(screen.getByLabelText("Open navigation menu"));
+
+    expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+  });
+
+  it("does not render the theme switch in the mobile navigation drawer when disabled", async () => {
+    await render({
+      site: { title: "Test Site" },
+      header: { showThemeSwitch: false },
+    });
+
+    fireEvent.click(screen.getByLabelText("Open navigation menu"));
+
+    expect(
+      screen.queryByLabelText("Switch to dark mode"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
@@ -3,12 +3,8 @@
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  act,
-  fireEvent,
-  render as testRender,
-  screen,
-} from "@testing-library/react";
+import { act, render as testRender, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
 import { describe, expect, it } from "vitest";
 import { ZudokuContext } from "../core/ZudokuContext.js";
@@ -42,25 +38,31 @@ const render = async (options: Partial<ZudokuContextOptions> = {}) => {
   });
 };
 
+const themeSwitchName = /^(Toggle theme|Switch to (dark|light) mode)$/;
+
 describe("MobileTopNavigation", () => {
   it("renders the theme switch by default in the mobile navigation drawer", async () => {
+    const user = userEvent.setup();
     await render({ site: { title: "Test Site" } });
 
-    fireEvent.click(screen.getByLabelText("Open navigation menu"));
+    await user.click(screen.getByLabelText("Open navigation menu"));
 
-    expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: themeSwitchName }),
+    ).toBeInTheDocument();
   });
 
   it("does not render the theme switch in the mobile navigation drawer when disabled", async () => {
+    const user = userEvent.setup();
     await render({
       site: { title: "Test Site" },
-      header: { showThemeSwitch: false },
+      header: { themeSwitcher: { enabled: false } },
     });
 
-    fireEvent.click(screen.getByLabelText("Open navigation menu"));
+    await user.click(screen.getByLabelText("Open navigation menu"));
 
     expect(
-      screen.queryByLabelText("Switch to dark mode"),
+      screen.queryByRole("button", { name: themeSwitchName }),
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -129,6 +129,7 @@ export const MobileTopNavigation = () => {
     getProfileMenuItems,
   } = context;
   const headerNavigation = header?.navigation ?? [];
+  const showThemeSwitch = header?.showThemeSwitch;
   const { isAuthenticated, profile, isAuthEnabled } = authState;
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -259,7 +260,7 @@ export const MobileTopNavigation = () => {
                   )}
                 </ClientOnly>
               )}
-              <ThemeSwitch />
+              {showThemeSwitch && <ThemeSwitch />}
             </div>
             {site?.showPoweredBy !== false && (
               <PoweredByZudoku className="grow-0 justify-center gap-1" />

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -129,7 +129,7 @@ export const MobileTopNavigation = () => {
     getProfileMenuItems,
   } = context;
   const headerNavigation = header?.navigation ?? [];
-  const showThemeSwitch = header?.showThemeSwitch;
+  const themeSwitcherEnabled = header?.themeSwitcher?.enabled ?? true;
   const { isAuthenticated, profile, isAuthEnabled } = authState;
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -260,7 +260,7 @@ export const MobileTopNavigation = () => {
                   )}
                 </ClientOnly>
               )}
-              {showThemeSwitch && <ThemeSwitch />}
+              {themeSwitcherEnabled && <ThemeSwitch />}
             </div>
             {site?.showPoweredBy !== false && (
               <PoweredByZudoku className="grow-0 justify-center gap-1" />

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -93,6 +93,7 @@ type Site = Partial<{
 
 type HeaderConfig = {
   navigation?: HeaderNavigation;
+  showThemeSwitch?: boolean;
   placements?: {
     navigation?: "start" | "center" | "end";
     search?: "start" | "center" | "end";
@@ -164,7 +165,13 @@ export class ZudokuContext {
   ) {
     this.queryClient = queryClient;
     this.env = env;
-    this.options = options;
+    this.options = {
+      ...options,
+      header: {
+        ...options.header,
+        showThemeSwitch: options.header?.showThemeSwitch ?? true,
+      },
+    };
     this.notFoundPage = options.site?.notFoundPage;
     this.plugins = options.plugins ?? [];
     this.authentication = this.plugins.find(isAuthenticationPlugin);

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -93,7 +93,9 @@ type Site = Partial<{
 
 type HeaderConfig = {
   navigation?: HeaderNavigation;
-  showThemeSwitch?: boolean;
+  themeSwitcher?: {
+    enabled?: boolean;
+  };
   placements?: {
     navigation?: "start" | "center" | "end";
     search?: "start" | "center" | "end";
@@ -165,13 +167,7 @@ export class ZudokuContext {
   ) {
     this.queryClient = queryClient;
     this.env = env;
-    this.options = {
-      ...options,
-      header: {
-        ...options.header,
-        showThemeSwitch: options.header?.showThemeSwitch ?? true,
-      },
-    };
+    this.options = options;
     this.notFoundPage = options.site?.notFoundPage;
     this.plugins = options.plugins ?? [];
     this.authentication = this.plugins.find(isAuthenticationPlugin);


### PR DESCRIPTION
## Changes

- Added a new `header.themeSwitcher.enabled` config option.
- When `header.themeSwitcher.enabled` is set to `false`, the light/dark theme switch is hidden from both the desktop header and the mobile navigation drawer.
- The option defaults to `true`, so existing sites keep the current behavior.
- Added documentation and test coverage for the new config option.

## How to test

Set the option in `zudoku.config.tsx`:

```ts
header: {
  themeSwitcher: {
    enabled: false,
  },
}
```

Then run:

```bash
pnpm nx run zudoku:typecheck
pnpm nx run cosmo-cargo:build
```

You can also run the example locally:

```bash
nx run cosmo-cargo:dev
```

## Expected successful behavior

- When header.themeSwitcher.enabled is unset or true, the theme switch remains visible in the desktop header and mobile navigation drawer.
- When header.themeSwitcher.enabled is false, the theme switch is not rendered in the desktop header.
- When header.themeSwitcher.enabled is false, the theme switch is not rendered in the mobile navigation drawer.
- Other header placement options, such as navigation, search, and auth, continue to work as before.

## Unexpected behavior

- The theme switch is hidden by default when header.themeSwitcher.enabled is not configured.
- The theme switch is still rendered in the desktop header when header.themeSwitcher.enabled is false.
- The theme switch is still rendered in the mobile navigation drawer when header.themeSwitcher.enabled is false.
- Existing header navigation, search, or auth placement behavior changes unexpectedly.
