### PR TITLE
[codex] ZUP-5851: Fix static entitlement display

### DIFF
--- a/packages/plugin-zuplo-monetization/src/components/FeatureItem.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/FeatureItem.test.tsx
@@ -21,6 +21,17 @@ describe("FeatureItem", () => {
     expect(screen.getByText("100 req/s")).toBeInTheDocument();
   });
 
+  it("renders feature label even when the value is an empty string", () => {
+    const feature: Feature = {
+      key: "region",
+      name: "Region",
+      value: "",
+    };
+    render(<FeatureItem feature={feature} />);
+    expect(screen.getByText("Region:")).toBeInTheDocument();
+    expect(screen.queryByText(/^undefined$/i)).not.toBeInTheDocument();
+  });
+
   it("renders check icon", () => {
     const feature: Feature = { key: "support", name: "Email Support" };
     const { container } = render(<FeatureItem feature={feature} />);

--- a/packages/plugin-zuplo-monetization/src/components/FeatureItem.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/FeatureItem.tsx
@@ -13,7 +13,7 @@ export const FeatureItem = ({
     <div className={cn("flex items-start gap-2", className)}>
       <CheckIcon className="w-4 h-4 text-primary shrink-0 mt-0.5" />
       <div className="text-sm">
-        {feature.value ? (
+        {feature.value !== undefined ? (
           <>
             <span className="font-medium">{feature.name}:</span> {feature.value}
           </>

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
@@ -191,6 +191,46 @@ const makeSubscription = (
   ...overrides,
 });
 
+const makeSubscriptionWithStaticConfig = (config: string): Subscription => {
+  const base = makeSubscription();
+  const phase = base.phases[1];
+  const staticItem = phase.items[1];
+  const entitlement = staticItem.included.entitlement;
+  if (!entitlement) {
+    throw new Error("Expected static entitlement");
+  }
+
+  return {
+    ...base,
+    phases: [
+      {
+        ...phase,
+        items: [
+          {
+            ...staticItem,
+            included: {
+              ...staticItem.included,
+              entitlement: {
+                ...entitlement,
+                config,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+};
+
+const getStaticFeatureRow = () => {
+  const row = screen
+    .getAllByRole("listitem")
+    .find((item) => item.textContent?.startsWith("Static feature") === true);
+  expect(row).toBeDefined();
+  if (!row) throw new Error("Expected static row");
+  return row;
+};
+
 describe("SubscriptionPlanDetails", () => {
   it("renders metered + boolean + static features with correct values and overage", () => {
     render(<SubscriptionPlanDetails subscription={makeSubscription()} />);
@@ -225,6 +265,47 @@ describe("SubscriptionPlanDetails", () => {
     // Static row shows value
     expect(screen.getByText(/Static feature/i)).toBeInTheDocument();
     expect(screen.getByText(/Static feature.*v2/i)).toBeInTheDocument();
+  });
+
+  it.each([
+    ["empty string config", JSON.stringify(""), ""],
+    [
+      "object config without value",
+      JSON.stringify({ mode: "strict", limit: 3 }),
+      JSON.stringify({ mode: "strict", limit: 3 }),
+    ],
+    ["primitive config", JSON.stringify(42), "42"],
+    [
+      "array config",
+      JSON.stringify(["jobs", "exports"]),
+      JSON.stringify(["jobs", "exports"]),
+    ],
+  ])("renders static entitlement %s", (_label, config, expected) => {
+    render(
+      <SubscriptionPlanDetails
+        subscription={makeSubscriptionWithStaticConfig(config)}
+      />,
+    );
+
+    const row = getStaticFeatureRow();
+    if (expected) {
+      expect(row).toHaveTextContent(expected);
+    } else {
+      expect(row).toHaveTextContent(/^Static feature:$/);
+    }
+    expect(within(row).queryByText(/undefined/i)).not.toBeInTheDocument();
+  });
+
+  it("renders invalid static entitlement config as included", () => {
+    render(
+      <SubscriptionPlanDetails
+        subscription={makeSubscriptionWithStaticConfig("{invalid-json")}
+      />,
+    );
+
+    const row = getStaticFeatureRow();
+    expect(within(row).getByText("Included")).toBeInTheDocument();
+    expect(within(row).queryByText(/undefined/i)).not.toBeInTheDocument();
   });
 
   it('renders "Starts <date>" when activeTo is missing', () => {

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
@@ -11,6 +11,7 @@ import { useMonetizationConfig } from "../../MonetizationContext.js";
 import type { Item, Subscription } from "../../types/SubscriptionType.js";
 import { formatDuration } from "../../utils/formatDuration.js";
 import { formatPrice } from "../../utils/formatPrice.js";
+import { formatStaticEntitlementConfig } from "../../utils/formatStaticEntitlementConfig.js";
 import { formatTieredPriceBreakdown } from "../../utils/formatTieredPriceBreakdown.js";
 import { getPriceFromPlan } from "../../utils/getPriceFromPlan.js";
 import {
@@ -154,16 +155,11 @@ const getEntitlementsFromItems = (
         continue;
       }
 
-      try {
-        const parsed = JSON.parse(entitlement.config) as { value?: unknown };
-        features.push({
-          entitlementType: "static",
-          ...base,
-          value: parsed?.value != null ? String(parsed.value) : undefined,
-        });
-      } catch {
-        features.push({ entitlementType: "static", ...base });
-      }
+      features.push({
+        entitlementType: "static",
+        ...base,
+        value: formatStaticEntitlementConfig(entitlement.config),
+      });
     }
   }
 
@@ -370,7 +366,8 @@ export const SubscriptionPlanDetails = ({
                             <div className="flex flex-col gap-1">
                               <div className="text-foreground font-medium">
                                 {row.name}
-                                {row.entitlementType === "static" && row.value
+                                {row.entitlementType === "static" &&
+                                row.value !== undefined
                                   ? `: ${row.value}`
                                   : ""}
                               </div>
@@ -396,7 +393,7 @@ export const SubscriptionPlanDetails = ({
                                     ) : null}
                                   </>
                                 ) : row.entitlementType === "static" &&
-                                  row.value ? null : (
+                                  row.value !== undefined ? null : (
                                   "Included"
                                 )}
                               </div>

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
@@ -181,7 +181,11 @@ const comparePlans = (
 
     if (current && target) {
       let change: FeatureChange["change"] = "same";
-      if (current.value && target.value && current.value !== target.value) {
+      if (
+        current.value !== undefined &&
+        target.value !== undefined &&
+        current.value !== target.value
+      ) {
         change = isUpgrade ? "upgraded" : "downgraded";
       }
       featureChanges.push({

--- a/packages/plugin-zuplo-monetization/src/types/PlanType.ts
+++ b/packages/plugin-zuplo-monetization/src/types/PlanType.ts
@@ -14,7 +14,7 @@ export interface MeteredEntitlementTemplate {
 
 export interface StaticEntitlementTemplate {
   type: "static";
-  config: string; // JSON parsable config object
+  config: string; // JSON parsable config
 }
 
 export interface BooleanEntitlementTemplate {

--- a/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
@@ -242,7 +242,21 @@ describe("categorizeRateCards", () => {
     });
   });
 
-  it("categorizes static rate card as feature with value", () => {
+  it.each([
+    ["empty string config", JSON.stringify(""), ""],
+    ["object value field", JSON.stringify({ value: 5 }), "5"],
+    [
+      "object config without value",
+      JSON.stringify({ mode: "strict", limit: 3 }),
+      JSON.stringify({ mode: "strict", limit: 3 }),
+    ],
+    ["primitive config", JSON.stringify(42), "42"],
+    [
+      "array config",
+      JSON.stringify(["jobs", "exports"]),
+      JSON.stringify(["jobs", "exports"]),
+    ],
+  ])("categorizes static rate card with %s", (_label, config, value) => {
     const { features } = categorizeRateCards([
       {
         type: "flat_fee",
@@ -252,15 +266,37 @@ describe("categorizeRateCards", () => {
         price: null,
         entitlementTemplate: {
           type: "static",
-          config: JSON.stringify({ value: 5 }),
+          config,
         },
       },
     ]);
     expect(features[0]).toMatchObject({
       key: "seats",
       name: "Seats",
-      value: "5",
+      value,
     });
+  });
+
+  it("categorizes invalid static config without a value", () => {
+    const { features } = categorizeRateCards([
+      {
+        type: "flat_fee",
+        key: "seats",
+        name: "Seats",
+        billingCadence: null,
+        price: null,
+        entitlementTemplate: {
+          type: "static",
+          config: "{invalid-json}",
+        },
+      },
+    ]);
+
+    expect(features[0]).toMatchObject({
+      key: "seats",
+      name: "Seats",
+    });
+    expect(features[0].value).toBeUndefined();
   });
 
   it("skips rate cards without entitlement template", () => {

--- a/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.ts
@@ -1,6 +1,7 @@
 import type { Feature, Quota, RateCard } from "../types/PlanType.js";
 import { formatDuration } from "./formatDuration.js";
 import { formatPrice } from "./formatPrice.js";
+import { formatStaticEntitlementConfig } from "./formatStaticEntitlementConfig.js";
 import { formatTieredPriceBreakdown } from "./formatTieredPriceBreakdown.js";
 
 export const categorizeRateCards = (
@@ -62,16 +63,11 @@ export const categorizeRateCards = (
     } else if (et.type === "boolean") {
       features.push({ key: rc.featureKey ?? rc.key, name: rc.name });
     } else if (et.type === "static" && et.config) {
-      try {
-        const config = JSON.parse(et.config);
-        features.push({
-          key: rc.featureKey ?? rc.key,
-          name: rc.name,
-          value: String(config.value),
-        });
-      } catch {
-        features.push({ key: rc.featureKey ?? rc.key, name: rc.name });
-      }
+      features.push({
+        key: rc.featureKey ?? rc.key,
+        name: rc.name,
+        value: formatStaticEntitlementConfig(et.config),
+      });
     }
   }
 

--- a/packages/plugin-zuplo-monetization/src/utils/formatStaticEntitlementConfig.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatStaticEntitlementConfig.ts
@@ -1,0 +1,29 @@
+const hasValueField = (value: unknown): value is { value: unknown } =>
+  typeof value === "object" && value !== null && "value" in value;
+
+const formatJsonValue = (value: unknown): string | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  if (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+};
+
+export const formatStaticEntitlementConfig = (
+  config: string | undefined,
+): string | undefined => {
+  if (!config) return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(config);
+    return formatJsonValue(hasValueField(parsed) ? parsed.value : parsed);
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
## Summary
Fix static entitlement rendering so valid JSON values are displayed correctly instead of falling back to missing-value behavior.

## What changed
- add a shared `formatStaticEntitlementConfig` helper for static entitlement JSON parsing
- reuse that helper in subscription details and rate-card categorization
- treat only `undefined` as missing when rendering feature values and when comparing plan feature values
- add regression coverage for primitive, array, object, empty-string, and invalid static entitlement configs

## Root cause
The UI paths were too strict about static entitlement config shape and relied on truthiness checks. That caused valid JSON values like arrays, numbers, and empty strings to be mishandled, and in some cases surfaced `undefined` in the rendered output.

## Impact
Static entitlements now render consistently across monetization pricing and subscription flows.

## Validation
- `pnpm --filter @zuplo/zudoku-plugin-monetization typecheck`
- `pnpm vitest run packages/plugin-zuplo-monetization/src`
