### PR TITLE
Update PricingCard button variants from secondary to outline

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/pricing/PricingCard.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/pricing/PricingCard.tsx
@@ -93,11 +93,11 @@ export const PricingCard = ({
       </div>
 
       {isSubscribed ? (
-        <Button variant={isPopular ? "default" : "secondary"} asChild>
+        <Button variant={isPopular ? "default" : "outline"} asChild>
           <Link to={`/subscriptions#manage`}>Manage Subscriptions</Link>
         </Button>
       ) : (
-        <Button variant={isPopular ? "default" : "secondary"} asChild>
+        <Button variant={isPopular ? "default" : "outline"} asChild>
           <Link to={`/checkout?planId=${encodeURIComponent(plan.id)}`}>
             Subscribe
           </Link>


### PR DESCRIPTION
## Summary
Updated the button variant styling in the PricingCard component to use the "outline" variant instead of "secondary" for non-popular pricing tiers.

## Changes
- Changed button variant from `"secondary"` to `"outline"` for the "Manage Subscriptions" button when not on a popular plan
- Changed button variant from `"secondary"` to `"outline"` for the "Subscribe" button when not on a popular plan
- Popular plan buttons continue to use the `"default"` variant

## Details
This change affects the visual presentation of pricing card action buttons. Non-popular pricing tiers now display with an outline style instead of a secondary style, while maintaining the default style for popular/featured plans. This creates a clearer visual hierarchy between standard and featured pricing options.

https://claude.ai/code/session_01KoiwqCm8d7Cxzu1Ny4tua8