### PR TITLE
fix(auth): strip `basePath` from `RouteGuard` `redirectTo` when blocked

### DIFF
--- a/packages/zudoku/src/lib/core/RouteGuard.test.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.test.tsx
@@ -55,11 +55,13 @@ type CreateWrapperOptions = {
   shouldBypass?: boolean;
   initialPath?: string;
   wrapRouteGuard?: boolean;
+  basePath?: string;
 };
 
 const createWrapper = ({
   auth = {},
   protectedRoutes,
+  basePath,
 }: CreateWrapperOptions = {}) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -91,7 +93,7 @@ const createWrapper = ({
   };
 
   const context = new ZudokuContext(
-    { protectedRoutes, plugins: [] },
+    { protectedRoutes, plugins: [], basePath },
     queryClient,
     {},
   );
@@ -110,6 +112,7 @@ const render = async (
     wrapRouteGuard = true,
     shouldBypass = false,
     initialPath = "/",
+    basePath,
   } = options;
   const { context, queryClient, mockAuth, mockAuthentication } =
     createWrapper(options);
@@ -138,7 +141,10 @@ const render = async (
           : routes,
       },
     ],
-    { initialEntries: [initialPath] },
+    {
+      initialEntries: [(basePath ?? "") + initialPath],
+      basename: basePath,
+    },
   );
 
   let renderResult: unknown;
@@ -573,6 +579,51 @@ describe("RouteGuard", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "Login" }));
       expect(mockAuth.login).toHaveBeenCalledWith({ redirectTo: "/protected" });
+    });
+
+    it("strips basePath from redirectTo when blocked target equals basePath", async () => {
+      const { mockAuth } = await render(
+        [
+          {
+            path: "/other",
+            element: (
+              <div>
+                Other <Link to="/">Go</Link>
+              </div>
+            ),
+          },
+          { path: "/", element: <div>Protected</div> },
+        ],
+        {
+          auth: {
+            isAuthEnabled: true,
+            isPending: false,
+            isAuthenticated: false,
+          },
+          protectedRoutes: { "/": () => false },
+          initialPath: "/other",
+          basePath: "/docs",
+        },
+      );
+
+      await userEvent.click(screen.getByText("Go"));
+      await userEvent.click(screen.getByRole("button", { name: "Login" }));
+
+      expect(mockAuth.login).toHaveBeenCalledWith({ redirectTo: "/" });
+    });
+
+    it("strips basePath from redirectTo when blocked", async () => {
+      const { mockAuth } = await render(navRoutes, {
+        ...navBlockingOptions,
+        basePath: "/docs",
+      });
+
+      await userEvent.click(screen.getByText("Go"));
+      await userEvent.click(screen.getByRole("button", { name: "Login" }));
+
+      expect(mockAuth.login).toHaveBeenCalledWith({
+        redirectTo: "/protected",
+      });
     });
 
     it("resets blocker when cancel clicked", async () => {

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -22,6 +22,7 @@ import { RenderContext } from "../components/context/RenderContext.js";
 import { useZudoku } from "../components/context/ZudokuContext.js";
 import { Layout } from "../components/Layout.js";
 import { ZudokuError } from "../util/invariant.js";
+import { stripBasepath } from "../util/url.js";
 
 export const SEARCH_PROTECTED_SECTION = "protected";
 
@@ -101,6 +102,7 @@ export const RouteGuard = () => {
     [auth, zudoku],
   );
   const { protectedRoutes } = zudoku;
+  const { basePath } = zudoku.options;
 
   const getAuthCheck = useCallback(
     (pathname: string) => {
@@ -175,8 +177,12 @@ export const RouteGuard = () => {
   }
 
   const showDialog = needsToSignIn || isBlocked;
+
+  // Workaround: `blocker.location.pathname` includes basename, but `useLocation` does not.
+  // Remove this `react-router-blocker-basename.test.tsx` when React Router fixes the issue.
   const redirectTo = isBlocked
-    ? blocker.location.pathname + blocker.location.search
+    ? stripBasepath(blocker.location.pathname, basePath) +
+      blocker.location.search
     : location.pathname + location.search;
 
   return (

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -22,7 +22,7 @@ import { RenderContext } from "../components/context/RenderContext.js";
 import { useZudoku } from "../components/context/ZudokuContext.js";
 import { Layout } from "../components/Layout.js";
 import { ZudokuError } from "../util/invariant.js";
-import { stripBasepath } from "../util/url.js";
+import { stripBasePath } from "../util/url.js";
 
 export const SEARCH_PROTECTED_SECTION = "protected";
 
@@ -179,9 +179,10 @@ export const RouteGuard = () => {
   const showDialog = needsToSignIn || isBlocked;
 
   // Workaround: `blocker.location.pathname` includes basename, but `useLocation` does not.
-  // Remove this `react-router-blocker-basename.test.tsx` when React Router fixes the issue.
+  // Remove this when React Router fixes the issue. The canary test
+  // `react-router-useblocker-basepath-bug.test.tsx` will fail when that happens.
   const redirectTo = isBlocked
-    ? stripBasepath(blocker.location.pathname, basePath) +
+    ? stripBasePath(blocker.location.pathname, basePath) +
       blocker.location.search
     : location.pathname + location.search;
 

--- a/packages/zudoku/src/lib/util/react-router-useblocker-basepath-bug.test.tsx
+++ b/packages/zudoku/src/lib/util/react-router-useblocker-basepath-bug.test.tsx
@@ -8,7 +8,7 @@
  * it exposes on the returned `Blocker`. This is inconsistent with
  * `useLocation`, which strips.
  *
- * `RouteGuard.tsx` works around this with `stripBasename`. When/if RR fixes
+ * `RouteGuard.tsx` works around this with `stripBasePath`. When/if RR fixes
  * the inconsistency upstream, this test will fail and we can drop the
  * workaround.
  */
@@ -73,7 +73,7 @@ describe("React Router useBlocker basename inconsistency (canary)", () => {
       "/protected",
     );
     // If this assertion ever fails (i.e. RR strips basename here too), drop
-    // the `stripBasename` workaround in RouteGuard.tsx.
+    // the `stripBasePath` workaround in RouteGuard.tsx.
     expect(screen.getByTestId("blocker-pathname")).toHaveTextContent(
       "/docs/protected",
     );

--- a/packages/zudoku/src/lib/util/react-router-useblocker-basepath-bug.test.tsx
+++ b/packages/zudoku/src/lib/util/react-router-useblocker-basepath-bug.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Canary test for a React Router bug.
+ *
+ * `useBlocker` strips the router `basename` from the `nextLocation` it passes
+ * to the `shouldBlock` predicate, but does NOT strip it from the `location`
+ * it exposes on the returned `Blocker`. This is inconsistent with
+ * `useLocation`, which strips.
+ *
+ * `RouteGuard.tsx` works around this with `stripBasename`. When/if RR fixes
+ * the inconsistency upstream, this test will fail and we can drop the
+ * workaround.
+ */
+
+import {
+  act,
+  render as testRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { useState } from "react";
+import {
+  createMemoryRouter,
+  Link,
+  RouterProvider,
+  useBlocker,
+} from "react-router";
+import { describe, expect, it } from "vitest";
+
+const Probe = () => {
+  const [predicateNextPath, setPredicateNextPath] = useState<string | null>(
+    null,
+  );
+  const blocker = useBlocker(({ nextLocation }) => {
+    setPredicateNextPath(nextLocation.pathname);
+    return true;
+  });
+
+  return (
+    <div>
+      <Link to="/protected">Go</Link>
+      <div data-testid="predicate-next-path">{predicateNextPath ?? ""}</div>
+      <div data-testid="blocker-pathname">
+        {blocker.location?.pathname ?? ""}
+      </div>
+    </div>
+  );
+};
+
+describe("React Router useBlocker basename inconsistency (canary)", () => {
+  it("predicate's nextLocation strips basename but blocker.location does not", async () => {
+    const router = createMemoryRouter(
+      [
+        { path: "/", element: <Probe /> },
+        { path: "/protected", element: <div>Protected</div> },
+      ],
+      { initialEntries: ["/docs/"], basename: "/docs" },
+    );
+
+    await act(async () => {
+      testRender(<RouterProvider router={router} />);
+    });
+
+    await userEvent.click(screen.getByText("Go"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("blocker-pathname")).not.toBeEmptyDOMElement();
+    });
+
+    expect(screen.getByTestId("predicate-next-path")).toHaveTextContent(
+      "/protected",
+    );
+    // If this assertion ever fails (i.e. RR strips basename here too), drop
+    // the `stripBasename` workaround in RouteGuard.tsx.
+    expect(screen.getByTestId("blocker-pathname")).toHaveTextContent(
+      "/docs/protected",
+    );
+  });
+});

--- a/packages/zudoku/src/lib/util/url.test.ts
+++ b/packages/zudoku/src/lib/util/url.test.ts
@@ -1,30 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { normalizeRedirectUrl, stripBasepath } from "./url.js";
+import { normalizeRedirectUrl, stripBasePath } from "./url.js";
 
 describe("stripBasename", () => {
-  it("returns pathname unchanged when basename is empty or '/'", () => {
-    expect(stripBasepath("/foo", "")).toBe("/foo");
-    expect(stripBasepath("/foo", "/")).toBe("/foo");
+  it("returns pathname unchanged when basePath is empty or '/'", () => {
+    expect(stripBasePath("/foo", "")).toBe("/foo");
+    expect(stripBasePath("/foo", "/")).toBe("/foo");
   });
 
-  it("strips a matching basename prefix", () => {
-    expect(stripBasepath("/docs/checkout", "/docs")).toBe("/checkout");
+  it("strips a matching basePath prefix", () => {
+    expect(stripBasePath("/docs/checkout", "/docs")).toBe("/checkout");
   });
 
-  it("returns '/' when pathname equals basename exactly", () => {
-    expect(stripBasepath("/docs", "/docs")).toBe("/");
+  it("returns '/' when pathname equals basePath exactly", () => {
+    expect(stripBasePath("/docs", "/docs")).toBe("/");
   });
 
   it("returns pathname unchanged when prefix matches but boundary doesn't", () => {
-    expect(stripBasepath("/docsearch", "/docs")).toBe("/docsearch");
+    expect(stripBasePath("/docsearch", "/docs")).toBe("/docsearch");
   });
 
-  it("handles basename with trailing slash", () => {
-    expect(stripBasepath("/docs/checkout", "/docs/")).toBe("/checkout");
+  it("handles basePath with trailing slash", () => {
+    expect(stripBasePath("/docs/checkout", "/docs/")).toBe("/checkout");
   });
 
   it("matches case-insensitively", () => {
-    expect(stripBasepath("/Docs/checkout", "/docs")).toBe("/checkout");
+    expect(stripBasePath("/Docs/checkout", "/docs")).toBe("/checkout");
   });
 });
 

--- a/packages/zudoku/src/lib/util/url.test.ts
+++ b/packages/zudoku/src/lib/util/url.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { normalizeRedirectUrl } from "./url.js";
+import { normalizeRedirectUrl, stripBasepath } from "./url.js";
+
+describe("stripBasename", () => {
+  it("returns pathname unchanged when basename is empty or '/'", () => {
+    expect(stripBasepath("/foo", "")).toBe("/foo");
+    expect(stripBasepath("/foo", "/")).toBe("/foo");
+  });
+
+  it("strips a matching basename prefix", () => {
+    expect(stripBasepath("/docs/checkout", "/docs")).toBe("/checkout");
+  });
+
+  it("returns '/' when pathname equals basename exactly", () => {
+    expect(stripBasepath("/docs", "/docs")).toBe("/");
+  });
+
+  it("returns pathname unchanged when prefix matches but boundary doesn't", () => {
+    expect(stripBasepath("/docsearch", "/docs")).toBe("/docsearch");
+  });
+
+  it("handles basename with trailing slash", () => {
+    expect(stripBasepath("/docs/checkout", "/docs/")).toBe("/checkout");
+  });
+
+  it("matches case-insensitively", () => {
+    expect(stripBasepath("/Docs/checkout", "/docs")).toBe("/checkout");
+  });
+});
 
 describe("normalizeRedirectUrl", () => {
   const mockOrigin = "https://example.com";

--- a/packages/zudoku/src/lib/util/url.ts
+++ b/packages/zudoku/src/lib/util/url.ts
@@ -1,11 +1,26 @@
-/**
- * Normalizes a redirect URL by removing the origin and optionally the root path
- */
-export function normalizeRedirectUrl(
+// Removes the basepath from a pathname if present
+// Returns the pathname unchanged if it's not under the basepath
+export const stripBasepath = (pathname: string, basepath = ""): string => {
+  if (!basepath || basepath === "/") return pathname;
+  if (!pathname.toLowerCase().startsWith(basepath.toLowerCase())) {
+    return pathname;
+  }
+
+  const startIndex = basepath.endsWith("/")
+    ? basepath.length - 1
+    : basepath.length;
+  const nextChar = pathname.charAt(startIndex);
+  if (nextChar && nextChar !== "/") return pathname;
+
+  return pathname.slice(startIndex) || "/";
+};
+
+// Normalizes a redirect URL by removing the origin and optionally the root path
+export const normalizeRedirectUrl = (
   redirectTo: string,
   origin: string,
-  basePath: string = "/",
-): string {
+  basePath = "/",
+): string => {
   if (!redirectTo.startsWith(origin)) {
     return redirectTo;
   }
@@ -15,4 +30,4 @@ export function normalizeRedirectUrl(
   }
 
   return redirectTo.slice(origin.length);
-}
+};

--- a/packages/zudoku/src/lib/util/url.ts
+++ b/packages/zudoku/src/lib/util/url.ts
@@ -1,14 +1,14 @@
-// Removes the basepath from a pathname if present
-// Returns the pathname unchanged if it's not under the basepath
-export const stripBasepath = (pathname: string, basepath = ""): string => {
-  if (!basepath || basepath === "/") return pathname;
-  if (!pathname.toLowerCase().startsWith(basepath.toLowerCase())) {
+// Removes the basePath from a pathname if present
+// Returns the pathname unchanged if it's not under the basePath
+export const stripBasePath = (pathname: string, basePath = ""): string => {
+  if (!basePath || basePath === "/") return pathname;
+  if (!pathname.toLowerCase().startsWith(basePath.toLowerCase())) {
     return pathname;
   }
 
-  const startIndex = basepath.endsWith("/")
-    ? basepath.length - 1
-    : basepath.length;
+  const startIndex = basePath.endsWith("/")
+    ? basePath.length - 1
+    : basePath.length;
   const nextChar = pathname.charAt(startIndex);
   if (nextChar && nextChar !== "/") return pathname;
 


### PR DESCRIPTION
Clicking Subscribe while logged out (or any link to a protected route) was sending users to a doubled-basePath URL after login, e.g. `/docs/docs/checkout`. 404 instead of the checkout page.

It's a React Router bug. `useBlocker` strips the router basename from the `nextLocation` it passes to the predicate, but not from the `blocker.location` it returns. `useLocation` strips. `RouteGuard` was stashing `/docs/checkout` as the post-login redirect, then `<Navigate>` added the basename again.

Workaround: strip the basename before storing. Added `stripBasename` (adapted from RR's internal helper) next to `normalizeRedirectUrl` in `util/url.ts`. There's a canary test that asserts the upstream bug still exists; if RR ever fixes it the test fails and we can drop the workaround. The comment in `RouteGuard.tsx` points at the test.

Will file a separate bug upstream.