### PR TITLE
Use api.rickandmorty.zuplo.io for gateway URLs in examples

### DIFF
--- a/examples/api-identity-plugin/openapi.json
+++ b/examples/api-identity-plugin/openapi.json
@@ -963,7 +963,9 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
+                      "examples": [
+                        "https://api.rickandmorty.zuplo.io/v1/locations/3"
+                      ]
                     },
                     "created": {
                       "type": "string",

--- a/examples/api-identity-plugin/openapi.json
+++ b/examples/api-identity-plugin/openapi.json
@@ -118,7 +118,7 @@
                           "default": "",
                           "title": "The next Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/characters/?page=2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/?page=2"
                           ]
                         },
                         "prev": {
@@ -132,7 +132,7 @@
                         {
                           "count": 826,
                           "pages": 42,
-                          "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                           "prev": null
                         }
                       ]
@@ -213,14 +213,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/1"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/1"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                               }
                             ]
                           },
@@ -241,14 +241,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/20"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/20"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                               }
                             ]
                           },
@@ -257,7 +257,7 @@
                             "default": "",
                             "title": "The image Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
                             ]
                           },
                           "episode": {
@@ -268,14 +268,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             ]
                           },
@@ -284,7 +284,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1"
                             ]
                           },
                           "created": {
@@ -304,18 +304,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -331,18 +331,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -354,7 +354,7 @@
                       "info": {
                         "count": 826,
                         "pages": 42,
-                        "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                         "prev": null
                       },
                       "results": [
@@ -367,18 +367,18 @@
                           "gender": "Male",
                           "origin": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                           },
                           "location": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                           },
-                          "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                          "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                           "episode": [
-                            "https://rickandmorty.zuplo.io/v1/episode/1",
-                            "https://rickandmorty.zuplo.io/v1/episode/2"
+                            "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                            "https://api.rickandmorty.zuplo.io/v1/episode/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                           "created": "2017-11-04T18:48:46.250Z"
                         }
                       ]
@@ -500,14 +500,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/1"
+                            "https://api.rickandmorty.zuplo.io/v1/location/1"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/1"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/1"
                         }
                       ]
                     },
@@ -528,14 +528,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/20"
+                            "https://api.rickandmorty.zuplo.io/v1/location/20"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/20"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/20"
                         }
                       ]
                     },
@@ -544,7 +544,7 @@
                       "default": "",
                       "title": "The image Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
                       ]
                     },
                     "episode": {
@@ -555,14 +555,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       ]
                     },
@@ -571,7 +571,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ]
                     },
                     "created": {
@@ -591,18 +591,18 @@
                       "gender": "Male",
                       "origin": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                       },
                       "location": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                       },
-                      "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
+                      "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
                       "episode": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/1",
-                        "https://rickandmorty.zuplo.io/v1/episodes/2"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/characters/2",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/characters/2",
                       "created": "2017-11-04T18:50:21.651Z"
                     }
                   ]
@@ -775,14 +775,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -791,7 +791,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             ]
                           },
                           "created": {
@@ -808,10 +808,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -824,10 +824,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -849,10 +849,10 @@
                           "type": "Planet",
                           "dimension": "Dimension C-137",
                           "residents": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                           "created": "2017-11-10T12:42:04.162Z"
                         }
                       ]
@@ -948,14 +948,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       ]
                     },
@@ -963,7 +963,7 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://rickandmorty.zuplo.io/locations/3"]
+                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
                     },
                     "created": {
                       "type": "string",
@@ -979,10 +979,10 @@
                       "type": "Space station",
                       "dimension": "unknown",
                       "residents": [
-                        "https://rickandmorty.zuplo.io/v1/characters/8",
-                        "https://rickandmorty.zuplo.io/v1/characters/14"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/14"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/locations/3",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/locations/3",
                       "created": "2017-11-10T13:08:13.191Z"
                     }
                   ]
@@ -1081,7 +1081,7 @@
                         {
                           "count": 51,
                           "pages": 3,
-                          "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                           "prev": null
                         }
                       ]
@@ -1136,14 +1136,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -1152,7 +1152,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/episodes/1"
+                              "https://api.rickandmorty.zuplo.io/v1/episodes/1"
                             ]
                           },
                           "created": {
@@ -1169,10 +1169,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1185,10 +1185,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1200,7 +1200,7 @@
                       "info": {
                         "count": 51,
                         "pages": 3,
-                        "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                         "prev": null
                       },
                       "results": [
@@ -1210,10 +1210,10 @@
                           "air_date": "December 2, 2013",
                           "episode": "S01E01",
                           "characters": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                           "created": "2017-11-10T12:56:33.798Z"
                         }
                       ]
@@ -1309,14 +1309,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       ]
                     },
@@ -1325,7 +1325,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/28"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/28"
                       ]
                     },
                     "created": {
@@ -1342,10 +1342,10 @@
                       "air_date": "September 10, 2017",
                       "episode": "S03E07",
                       "characters": [
-                        "https://rickandmorty.zuplo.io/v1/characters/1",
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/episodes/28",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/episodes/28",
                       "created": "2017-11-10T12:56:36.618Z"
                     }
                   ]
@@ -1380,7 +1380,7 @@
   },
   "servers": [
     {
-      "url": "https://rickandmorty.zuplo.io"
+      "url": "https://api.rickandmorty.zuplo.io"
     }
   ]
 }

--- a/examples/auth-firebase/openapi.json
+++ b/examples/auth-firebase/openapi.json
@@ -963,7 +963,9 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
+                      "examples": [
+                        "https://api.rickandmorty.zuplo.io/v1/locations/3"
+                      ]
                     },
                     "created": {
                       "type": "string",

--- a/examples/auth-firebase/openapi.json
+++ b/examples/auth-firebase/openapi.json
@@ -118,7 +118,7 @@
                           "default": "",
                           "title": "The next Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/characters/?page=2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/?page=2"
                           ]
                         },
                         "prev": {
@@ -132,7 +132,7 @@
                         {
                           "count": 826,
                           "pages": 42,
-                          "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                           "prev": null
                         }
                       ]
@@ -213,14 +213,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/1"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/1"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                               }
                             ]
                           },
@@ -241,14 +241,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/20"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/20"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                               }
                             ]
                           },
@@ -257,7 +257,7 @@
                             "default": "",
                             "title": "The image Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
                             ]
                           },
                           "episode": {
@@ -268,14 +268,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             ]
                           },
@@ -284,7 +284,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1"
                             ]
                           },
                           "created": {
@@ -304,18 +304,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -331,18 +331,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -354,7 +354,7 @@
                       "info": {
                         "count": 826,
                         "pages": 42,
-                        "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                         "prev": null
                       },
                       "results": [
@@ -367,18 +367,18 @@
                           "gender": "Male",
                           "origin": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                           },
                           "location": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                           },
-                          "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                          "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                           "episode": [
-                            "https://rickandmorty.zuplo.io/v1/episode/1",
-                            "https://rickandmorty.zuplo.io/v1/episode/2"
+                            "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                            "https://api.rickandmorty.zuplo.io/v1/episode/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                           "created": "2017-11-04T18:48:46.250Z"
                         }
                       ]
@@ -500,14 +500,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/1"
+                            "https://api.rickandmorty.zuplo.io/v1/location/1"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/1"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/1"
                         }
                       ]
                     },
@@ -528,14 +528,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/20"
+                            "https://api.rickandmorty.zuplo.io/v1/location/20"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/20"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/20"
                         }
                       ]
                     },
@@ -544,7 +544,7 @@
                       "default": "",
                       "title": "The image Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
                       ]
                     },
                     "episode": {
@@ -555,14 +555,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       ]
                     },
@@ -571,7 +571,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ]
                     },
                     "created": {
@@ -591,18 +591,18 @@
                       "gender": "Male",
                       "origin": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                       },
                       "location": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                       },
-                      "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
+                      "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
                       "episode": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/1",
-                        "https://rickandmorty.zuplo.io/v1/episodes/2"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/characters/2",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/characters/2",
                       "created": "2017-11-04T18:50:21.651Z"
                     }
                   ]
@@ -775,14 +775,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -791,7 +791,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             ]
                           },
                           "created": {
@@ -808,10 +808,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -824,10 +824,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -849,10 +849,10 @@
                           "type": "Planet",
                           "dimension": "Dimension C-137",
                           "residents": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                           "created": "2017-11-10T12:42:04.162Z"
                         }
                       ]
@@ -948,14 +948,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       ]
                     },
@@ -963,7 +963,7 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://rickandmorty.zuplo.io/locations/3"]
+                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
                     },
                     "created": {
                       "type": "string",
@@ -979,10 +979,10 @@
                       "type": "Space station",
                       "dimension": "unknown",
                       "residents": [
-                        "https://rickandmorty.zuplo.io/v1/characters/8",
-                        "https://rickandmorty.zuplo.io/v1/characters/14"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/14"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/locations/3",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/locations/3",
                       "created": "2017-11-10T13:08:13.191Z"
                     }
                   ]
@@ -1081,7 +1081,7 @@
                         {
                           "count": 51,
                           "pages": 3,
-                          "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                           "prev": null
                         }
                       ]
@@ -1136,14 +1136,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -1152,7 +1152,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/episodes/1"
+                              "https://api.rickandmorty.zuplo.io/v1/episodes/1"
                             ]
                           },
                           "created": {
@@ -1169,10 +1169,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1185,10 +1185,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1200,7 +1200,7 @@
                       "info": {
                         "count": 51,
                         "pages": 3,
-                        "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                         "prev": null
                       },
                       "results": [
@@ -1210,10 +1210,10 @@
                           "air_date": "December 2, 2013",
                           "episode": "S01E01",
                           "characters": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                           "created": "2017-11-10T12:56:33.798Z"
                         }
                       ]
@@ -1309,14 +1309,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       ]
                     },
@@ -1325,7 +1325,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/28"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/28"
                       ]
                     },
                     "created": {
@@ -1342,10 +1342,10 @@
                       "air_date": "September 10, 2017",
                       "episode": "S03E07",
                       "characters": [
-                        "https://rickandmorty.zuplo.io/v1/characters/1",
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/episodes/28",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/episodes/28",
                       "created": "2017-11-10T12:56:36.618Z"
                     }
                   ]
@@ -1380,7 +1380,7 @@
   },
   "servers": [
     {
-      "url": "https://rickandmorty.zuplo.io"
+      "url": "https://api.rickandmorty.zuplo.io"
     }
   ]
 }

--- a/examples/auth-supabase/openapi.json
+++ b/examples/auth-supabase/openapi.json
@@ -963,7 +963,9 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
+                      "examples": [
+                        "https://api.rickandmorty.zuplo.io/v1/locations/3"
+                      ]
                     },
                     "created": {
                       "type": "string",

--- a/examples/auth-supabase/openapi.json
+++ b/examples/auth-supabase/openapi.json
@@ -118,7 +118,7 @@
                           "default": "",
                           "title": "The next Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/characters/?page=2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/?page=2"
                           ]
                         },
                         "prev": {
@@ -132,7 +132,7 @@
                         {
                           "count": 826,
                           "pages": 42,
-                          "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                           "prev": null
                         }
                       ]
@@ -213,14 +213,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/1"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/1"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                               }
                             ]
                           },
@@ -241,14 +241,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/20"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/20"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                               }
                             ]
                           },
@@ -257,7 +257,7 @@
                             "default": "",
                             "title": "The image Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
                             ]
                           },
                           "episode": {
@@ -268,14 +268,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             ]
                           },
@@ -284,7 +284,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1"
                             ]
                           },
                           "created": {
@@ -304,18 +304,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -331,18 +331,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -354,7 +354,7 @@
                       "info": {
                         "count": 826,
                         "pages": 42,
-                        "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                         "prev": null
                       },
                       "results": [
@@ -367,18 +367,18 @@
                           "gender": "Male",
                           "origin": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                           },
                           "location": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                           },
-                          "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                          "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                           "episode": [
-                            "https://rickandmorty.zuplo.io/v1/episode/1",
-                            "https://rickandmorty.zuplo.io/v1/episode/2"
+                            "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                            "https://api.rickandmorty.zuplo.io/v1/episode/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                           "created": "2017-11-04T18:48:46.250Z"
                         }
                       ]
@@ -500,14 +500,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/1"
+                            "https://api.rickandmorty.zuplo.io/v1/location/1"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/1"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/1"
                         }
                       ]
                     },
@@ -528,14 +528,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/20"
+                            "https://api.rickandmorty.zuplo.io/v1/location/20"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/20"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/20"
                         }
                       ]
                     },
@@ -544,7 +544,7 @@
                       "default": "",
                       "title": "The image Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
                       ]
                     },
                     "episode": {
@@ -555,14 +555,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       ]
                     },
@@ -571,7 +571,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ]
                     },
                     "created": {
@@ -591,18 +591,18 @@
                       "gender": "Male",
                       "origin": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                       },
                       "location": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                       },
-                      "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
+                      "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
                       "episode": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/1",
-                        "https://rickandmorty.zuplo.io/v1/episodes/2"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/characters/2",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/characters/2",
                       "created": "2017-11-04T18:50:21.651Z"
                     }
                   ]
@@ -775,14 +775,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -791,7 +791,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             ]
                           },
                           "created": {
@@ -808,10 +808,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -824,10 +824,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -849,10 +849,10 @@
                           "type": "Planet",
                           "dimension": "Dimension C-137",
                           "residents": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                           "created": "2017-11-10T12:42:04.162Z"
                         }
                       ]
@@ -948,14 +948,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       ]
                     },
@@ -963,7 +963,7 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://rickandmorty.zuplo.io/locations/3"]
+                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
                     },
                     "created": {
                       "type": "string",
@@ -979,10 +979,10 @@
                       "type": "Space station",
                       "dimension": "unknown",
                       "residents": [
-                        "https://rickandmorty.zuplo.io/v1/characters/8",
-                        "https://rickandmorty.zuplo.io/v1/characters/14"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/14"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/locations/3",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/locations/3",
                       "created": "2017-11-10T13:08:13.191Z"
                     }
                   ]
@@ -1081,7 +1081,7 @@
                         {
                           "count": 51,
                           "pages": 3,
-                          "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                           "prev": null
                         }
                       ]
@@ -1136,14 +1136,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -1152,7 +1152,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/episodes/1"
+                              "https://api.rickandmorty.zuplo.io/v1/episodes/1"
                             ]
                           },
                           "created": {
@@ -1169,10 +1169,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1185,10 +1185,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1200,7 +1200,7 @@
                       "info": {
                         "count": 51,
                         "pages": 3,
-                        "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                         "prev": null
                       },
                       "results": [
@@ -1210,10 +1210,10 @@
                           "air_date": "December 2, 2013",
                           "episode": "S01E01",
                           "characters": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                           "created": "2017-11-10T12:56:33.798Z"
                         }
                       ]
@@ -1309,14 +1309,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       ]
                     },
@@ -1325,7 +1325,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/28"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/28"
                       ]
                     },
                     "created": {
@@ -1342,10 +1342,10 @@
                       "air_date": "September 10, 2017",
                       "episode": "S03E07",
                       "characters": [
-                        "https://rickandmorty.zuplo.io/v1/characters/1",
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/episodes/28",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/episodes/28",
                       "created": "2017-11-10T12:56:36.618Z"
                     }
                   ]
@@ -1380,7 +1380,7 @@
   },
   "servers": [
     {
-      "url": "https://rickandmorty.zuplo.io"
+      "url": "https://api.rickandmorty.zuplo.io"
     }
   ]
 }

--- a/examples/with-auth0/openapi.json
+++ b/examples/with-auth0/openapi.json
@@ -963,7 +963,9 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
+                      "examples": [
+                        "https://api.rickandmorty.zuplo.io/v1/locations/3"
+                      ]
                     },
                     "created": {
                       "type": "string",

--- a/examples/with-auth0/openapi.json
+++ b/examples/with-auth0/openapi.json
@@ -118,7 +118,7 @@
                           "default": "",
                           "title": "The next Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/characters/?page=2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/?page=2"
                           ]
                         },
                         "prev": {
@@ -132,7 +132,7 @@
                         {
                           "count": 826,
                           "pages": 42,
-                          "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                           "prev": null
                         }
                       ]
@@ -213,14 +213,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/1"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/1"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                               }
                             ]
                           },
@@ -241,14 +241,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/20"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/20"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                               }
                             ]
                           },
@@ -257,7 +257,7 @@
                             "default": "",
                             "title": "The image Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
                             ]
                           },
                           "episode": {
@@ -268,14 +268,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             ]
                           },
@@ -284,7 +284,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1"
                             ]
                           },
                           "created": {
@@ -304,18 +304,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -331,18 +331,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -354,7 +354,7 @@
                       "info": {
                         "count": 826,
                         "pages": 42,
-                        "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                         "prev": null
                       },
                       "results": [
@@ -367,18 +367,18 @@
                           "gender": "Male",
                           "origin": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                           },
                           "location": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                           },
-                          "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                          "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                           "episode": [
-                            "https://rickandmorty.zuplo.io/v1/episode/1",
-                            "https://rickandmorty.zuplo.io/v1/episode/2"
+                            "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                            "https://api.rickandmorty.zuplo.io/v1/episode/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                           "created": "2017-11-04T18:48:46.250Z"
                         }
                       ]
@@ -500,14 +500,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/1"
+                            "https://api.rickandmorty.zuplo.io/v1/location/1"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/1"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/1"
                         }
                       ]
                     },
@@ -528,14 +528,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/20"
+                            "https://api.rickandmorty.zuplo.io/v1/location/20"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/20"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/20"
                         }
                       ]
                     },
@@ -544,7 +544,7 @@
                       "default": "",
                       "title": "The image Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
                       ]
                     },
                     "episode": {
@@ -555,14 +555,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       ]
                     },
@@ -571,7 +571,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ]
                     },
                     "created": {
@@ -591,18 +591,18 @@
                       "gender": "Male",
                       "origin": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                       },
                       "location": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                       },
-                      "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
+                      "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
                       "episode": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/1",
-                        "https://rickandmorty.zuplo.io/v1/episodes/2"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/characters/2",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/characters/2",
                       "created": "2017-11-04T18:50:21.651Z"
                     }
                   ]
@@ -775,14 +775,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -791,7 +791,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             ]
                           },
                           "created": {
@@ -808,10 +808,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -824,10 +824,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -849,10 +849,10 @@
                           "type": "Planet",
                           "dimension": "Dimension C-137",
                           "residents": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                           "created": "2017-11-10T12:42:04.162Z"
                         }
                       ]
@@ -948,14 +948,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       ]
                     },
@@ -963,7 +963,7 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://rickandmorty.zuplo.io/locations/3"]
+                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
                     },
                     "created": {
                       "type": "string",
@@ -979,10 +979,10 @@
                       "type": "Space station",
                       "dimension": "unknown",
                       "residents": [
-                        "https://rickandmorty.zuplo.io/v1/characters/8",
-                        "https://rickandmorty.zuplo.io/v1/characters/14"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/14"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/locations/3",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/locations/3",
                       "created": "2017-11-10T13:08:13.191Z"
                     }
                   ]
@@ -1081,7 +1081,7 @@
                         {
                           "count": 51,
                           "pages": 3,
-                          "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                           "prev": null
                         }
                       ]
@@ -1136,14 +1136,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -1152,7 +1152,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/episodes/1"
+                              "https://api.rickandmorty.zuplo.io/v1/episodes/1"
                             ]
                           },
                           "created": {
@@ -1169,10 +1169,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1185,10 +1185,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1200,7 +1200,7 @@
                       "info": {
                         "count": 51,
                         "pages": 3,
-                        "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                         "prev": null
                       },
                       "results": [
@@ -1210,10 +1210,10 @@
                           "air_date": "December 2, 2013",
                           "episode": "S01E01",
                           "characters": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                           "created": "2017-11-10T12:56:33.798Z"
                         }
                       ]
@@ -1309,14 +1309,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       ]
                     },
@@ -1325,7 +1325,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/28"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/28"
                       ]
                     },
                     "created": {
@@ -1342,10 +1342,10 @@
                       "air_date": "September 10, 2017",
                       "episode": "S03E07",
                       "characters": [
-                        "https://rickandmorty.zuplo.io/v1/characters/1",
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/episodes/28",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/episodes/28",
                       "created": "2017-11-10T12:56:36.618Z"
                     }
                   ]
@@ -1380,7 +1380,7 @@
   },
   "servers": [
     {
-      "url": "https://rickandmorty.zuplo.io"
+      "url": "https://api.rickandmorty.zuplo.io"
     }
   ]
 }

--- a/examples/with-base-path/openapi.json
+++ b/examples/with-base-path/openapi.json
@@ -963,7 +963,9 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
+                      "examples": [
+                        "https://api.rickandmorty.zuplo.io/v1/locations/3"
+                      ]
                     },
                     "created": {
                       "type": "string",

--- a/examples/with-base-path/openapi.json
+++ b/examples/with-base-path/openapi.json
@@ -118,7 +118,7 @@
                           "default": "",
                           "title": "The next Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/characters/?page=2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/?page=2"
                           ]
                         },
                         "prev": {
@@ -132,7 +132,7 @@
                         {
                           "count": 826,
                           "pages": 42,
-                          "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                           "prev": null
                         }
                       ]
@@ -213,14 +213,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/1"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/1"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                               }
                             ]
                           },
@@ -241,14 +241,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/20"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/20"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                               }
                             ]
                           },
@@ -257,7 +257,7 @@
                             "default": "",
                             "title": "The image Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
                             ]
                           },
                           "episode": {
@@ -268,14 +268,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             ]
                           },
@@ -284,7 +284,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1"
                             ]
                           },
                           "created": {
@@ -304,18 +304,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -331,18 +331,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -354,7 +354,7 @@
                       "info": {
                         "count": 826,
                         "pages": 42,
-                        "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                         "prev": null
                       },
                       "results": [
@@ -367,18 +367,18 @@
                           "gender": "Male",
                           "origin": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                           },
                           "location": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                           },
-                          "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                          "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                           "episode": [
-                            "https://rickandmorty.zuplo.io/v1/episode/1",
-                            "https://rickandmorty.zuplo.io/v1/episode/2"
+                            "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                            "https://api.rickandmorty.zuplo.io/v1/episode/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                           "created": "2017-11-04T18:48:46.250Z"
                         }
                       ]
@@ -500,14 +500,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/1"
+                            "https://api.rickandmorty.zuplo.io/v1/location/1"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/1"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/1"
                         }
                       ]
                     },
@@ -528,14 +528,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/20"
+                            "https://api.rickandmorty.zuplo.io/v1/location/20"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/20"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/20"
                         }
                       ]
                     },
@@ -544,7 +544,7 @@
                       "default": "",
                       "title": "The image Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
                       ]
                     },
                     "episode": {
@@ -555,14 +555,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       ]
                     },
@@ -571,7 +571,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ]
                     },
                     "created": {
@@ -591,18 +591,18 @@
                       "gender": "Male",
                       "origin": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                       },
                       "location": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                       },
-                      "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
+                      "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
                       "episode": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/1",
-                        "https://rickandmorty.zuplo.io/v1/episodes/2"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/characters/2",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/characters/2",
                       "created": "2017-11-04T18:50:21.651Z"
                     }
                   ]
@@ -775,14 +775,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -791,7 +791,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             ]
                           },
                           "created": {
@@ -808,10 +808,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -824,10 +824,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -849,10 +849,10 @@
                           "type": "Planet",
                           "dimension": "Dimension C-137",
                           "residents": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                           "created": "2017-11-10T12:42:04.162Z"
                         }
                       ]
@@ -948,14 +948,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       ]
                     },
@@ -963,7 +963,7 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://rickandmorty.zuplo.io/locations/3"]
+                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
                     },
                     "created": {
                       "type": "string",
@@ -979,10 +979,10 @@
                       "type": "Space station",
                       "dimension": "unknown",
                       "residents": [
-                        "https://rickandmorty.zuplo.io/v1/characters/8",
-                        "https://rickandmorty.zuplo.io/v1/characters/14"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/14"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/locations/3",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/locations/3",
                       "created": "2017-11-10T13:08:13.191Z"
                     }
                   ]
@@ -1081,7 +1081,7 @@
                         {
                           "count": 51,
                           "pages": 3,
-                          "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                           "prev": null
                         }
                       ]
@@ -1136,14 +1136,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -1152,7 +1152,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/episodes/1"
+                              "https://api.rickandmorty.zuplo.io/v1/episodes/1"
                             ]
                           },
                           "created": {
@@ -1169,10 +1169,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1185,10 +1185,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1200,7 +1200,7 @@
                       "info": {
                         "count": 51,
                         "pages": 3,
-                        "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                         "prev": null
                       },
                       "results": [
@@ -1210,10 +1210,10 @@
                           "air_date": "December 2, 2013",
                           "episode": "S01E01",
                           "characters": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                           "created": "2017-11-10T12:56:33.798Z"
                         }
                       ]
@@ -1309,14 +1309,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       ]
                     },
@@ -1325,7 +1325,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/28"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/28"
                       ]
                     },
                     "created": {
@@ -1342,10 +1342,10 @@
                       "air_date": "September 10, 2017",
                       "episode": "S03E07",
                       "characters": [
-                        "https://rickandmorty.zuplo.io/v1/characters/1",
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/episodes/28",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/episodes/28",
                       "created": "2017-11-10T12:56:36.618Z"
                     }
                   ]
@@ -1380,7 +1380,7 @@
   },
   "servers": [
     {
-      "url": "https://rickandmorty.zuplo.io"
+      "url": "https://api.rickandmorty.zuplo.io"
     }
   ]
 }

--- a/examples/with-config/openapi.json
+++ b/examples/with-config/openapi.json
@@ -963,7 +963,9 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
+                      "examples": [
+                        "https://api.rickandmorty.zuplo.io/v1/locations/3"
+                      ]
                     },
                     "created": {
                       "type": "string",

--- a/examples/with-config/openapi.json
+++ b/examples/with-config/openapi.json
@@ -118,7 +118,7 @@
                           "default": "",
                           "title": "The next Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/characters/?page=2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/?page=2"
                           ]
                         },
                         "prev": {
@@ -132,7 +132,7 @@
                         {
                           "count": 826,
                           "pages": 42,
-                          "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                           "prev": null
                         }
                       ]
@@ -213,14 +213,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/1"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/1"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                               }
                             ]
                           },
@@ -241,14 +241,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/20"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/20"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                               }
                             ]
                           },
@@ -257,7 +257,7 @@
                             "default": "",
                             "title": "The image Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
                             ]
                           },
                           "episode": {
@@ -268,14 +268,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             ]
                           },
@@ -284,7 +284,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1"
                             ]
                           },
                           "created": {
@@ -304,18 +304,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -331,18 +331,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -354,7 +354,7 @@
                       "info": {
                         "count": 826,
                         "pages": 42,
-                        "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                         "prev": null
                       },
                       "results": [
@@ -367,18 +367,18 @@
                           "gender": "Male",
                           "origin": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                           },
                           "location": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                           },
-                          "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                          "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                           "episode": [
-                            "https://rickandmorty.zuplo.io/v1/episode/1",
-                            "https://rickandmorty.zuplo.io/v1/episode/2"
+                            "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                            "https://api.rickandmorty.zuplo.io/v1/episode/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                           "created": "2017-11-04T18:48:46.250Z"
                         }
                       ]
@@ -500,14 +500,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/1"
+                            "https://api.rickandmorty.zuplo.io/v1/location/1"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/1"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/1"
                         }
                       ]
                     },
@@ -528,14 +528,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/20"
+                            "https://api.rickandmorty.zuplo.io/v1/location/20"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/20"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/20"
                         }
                       ]
                     },
@@ -544,7 +544,7 @@
                       "default": "",
                       "title": "The image Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
                       ]
                     },
                     "episode": {
@@ -555,14 +555,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       ]
                     },
@@ -571,7 +571,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ]
                     },
                     "created": {
@@ -591,18 +591,18 @@
                       "gender": "Male",
                       "origin": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                       },
                       "location": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                       },
-                      "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
+                      "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
                       "episode": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/1",
-                        "https://rickandmorty.zuplo.io/v1/episodes/2"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/characters/2",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/characters/2",
                       "created": "2017-11-04T18:50:21.651Z"
                     }
                   ]
@@ -775,14 +775,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -791,7 +791,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             ]
                           },
                           "created": {
@@ -808,10 +808,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -824,10 +824,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -849,10 +849,10 @@
                           "type": "Planet",
                           "dimension": "Dimension C-137",
                           "residents": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                           "created": "2017-11-10T12:42:04.162Z"
                         }
                       ]
@@ -948,14 +948,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       ]
                     },
@@ -963,7 +963,7 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://rickandmorty.zuplo.io/locations/3"]
+                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
                     },
                     "created": {
                       "type": "string",
@@ -979,10 +979,10 @@
                       "type": "Space station",
                       "dimension": "unknown",
                       "residents": [
-                        "https://rickandmorty.zuplo.io/v1/characters/8",
-                        "https://rickandmorty.zuplo.io/v1/characters/14"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/14"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/locations/3",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/locations/3",
                       "created": "2017-11-10T13:08:13.191Z"
                     }
                   ]
@@ -1081,7 +1081,7 @@
                         {
                           "count": 51,
                           "pages": 3,
-                          "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                           "prev": null
                         }
                       ]
@@ -1136,14 +1136,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -1152,7 +1152,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/episodes/1"
+                              "https://api.rickandmorty.zuplo.io/v1/episodes/1"
                             ]
                           },
                           "created": {
@@ -1169,10 +1169,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1185,10 +1185,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1200,7 +1200,7 @@
                       "info": {
                         "count": 51,
                         "pages": 3,
-                        "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                         "prev": null
                       },
                       "results": [
@@ -1210,10 +1210,10 @@
                           "air_date": "December 2, 2013",
                           "episode": "S01E01",
                           "characters": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                           "created": "2017-11-10T12:56:33.798Z"
                         }
                       ]
@@ -1309,14 +1309,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       ]
                     },
@@ -1325,7 +1325,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/28"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/28"
                       ]
                     },
                     "created": {
@@ -1342,10 +1342,10 @@
                       "air_date": "September 10, 2017",
                       "episode": "S03E07",
                       "characters": [
-                        "https://rickandmorty.zuplo.io/v1/characters/1",
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/episodes/28",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/episodes/28",
                       "created": "2017-11-10T12:56:36.618Z"
                     }
                   ]
@@ -1380,7 +1380,7 @@
   },
   "servers": [
     {
-      "url": "https://rickandmorty.zuplo.io"
+      "url": "https://api.rickandmorty.zuplo.io"
     }
   ]
 }

--- a/examples/with-vite-config/openapi.json
+++ b/examples/with-vite-config/openapi.json
@@ -963,7 +963,9 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
+                      "examples": [
+                        "https://api.rickandmorty.zuplo.io/v1/locations/3"
+                      ]
                     },
                     "created": {
                       "type": "string",

--- a/examples/with-vite-config/openapi.json
+++ b/examples/with-vite-config/openapi.json
@@ -118,7 +118,7 @@
                           "default": "",
                           "title": "The next Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/characters/?page=2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/?page=2"
                           ]
                         },
                         "prev": {
@@ -132,7 +132,7 @@
                         {
                           "count": 826,
                           "pages": 42,
-                          "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                           "prev": null
                         }
                       ]
@@ -213,14 +213,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/1"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/1"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                               }
                             ]
                           },
@@ -241,14 +241,14 @@
                                 "default": "",
                                 "title": "The url Schema",
                                 "examples": [
-                                  "https://rickandmorty.zuplo.io/v1/locations/20"
+                                  "https://api.rickandmorty.zuplo.io/v1/locations/20"
                                 ]
                               }
                             },
                             "examples": [
                               {
                                 "name": "Earth",
-                                "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                                "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                               }
                             ]
                           },
@@ -257,7 +257,7 @@
                             "default": "",
                             "title": "The image Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg"
                             ]
                           },
                           "episode": {
@@ -268,14 +268,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/episode/1",
-                                "https://rickandmorty.zuplo.io/v1/episode/2"
+                                "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                                "https://api.rickandmorty.zuplo.io/v1/episode/2"
                               ]
                             ]
                           },
@@ -284,7 +284,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1"
                             ]
                           },
                           "created": {
@@ -304,18 +304,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -331,18 +331,18 @@
                             "gender": "Male",
                             "origin": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             },
                             "location": {
                               "name": "Earth",
-                              "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                              "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                             },
-                            "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                            "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                             "episode": [
-                              "https://rickandmorty.zuplo.io/v1/episode/1",
-                              "https://rickandmorty.zuplo.io/v1/episode/2"
+                              "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                              "https://api.rickandmorty.zuplo.io/v1/episode/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                             "created": "2017-11-04T18:48:46.250Z"
                           }
                         ]
@@ -354,7 +354,7 @@
                       "info": {
                         "count": 826,
                         "pages": 42,
-                        "next": "https://rickandmorty.zuplo.io/v1/characters/?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/characters/?page=2",
                         "prev": null
                       },
                       "results": [
@@ -367,18 +367,18 @@
                           "gender": "Male",
                           "origin": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                           },
                           "location": {
                             "name": "Earth",
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                           },
-                          "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
+                          "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/1.jpeg",
                           "episode": [
-                            "https://rickandmorty.zuplo.io/v1/episode/1",
-                            "https://rickandmorty.zuplo.io/v1/episode/2"
+                            "https://api.rickandmorty.zuplo.io/v1/episode/1",
+                            "https://api.rickandmorty.zuplo.io/v1/episode/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/characters/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/characters/1",
                           "created": "2017-11-04T18:48:46.250Z"
                         }
                       ]
@@ -500,14 +500,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/1"
+                            "https://api.rickandmorty.zuplo.io/v1/location/1"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/1"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/1"
                         }
                       ]
                     },
@@ -528,14 +528,14 @@
                           "default": "",
                           "title": "The url Schema",
                           "examples": [
-                            "https://rickandmorty.zuplo.io/v1/location/20"
+                            "https://api.rickandmorty.zuplo.io/v1/location/20"
                           ]
                         }
                       },
                       "examples": [
                         {
                           "name": "Earth",
-                          "url": "https://rickandmorty.zuplo.io/v1/location/20"
+                          "url": "https://api.rickandmorty.zuplo.io/v1/location/20"
                         }
                       ]
                     },
@@ -544,7 +544,7 @@
                       "default": "",
                       "title": "The image Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg"
                       ]
                     },
                     "episode": {
@@ -555,14 +555,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/episodes/1",
-                          "https://rickandmorty.zuplo.io/v1/episodes/2"
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                          "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                         ]
                       ]
                     },
@@ -571,7 +571,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ]
                     },
                     "created": {
@@ -591,18 +591,18 @@
                       "gender": "Male",
                       "origin": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/1"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/1"
                       },
                       "location": {
                         "name": "Earth",
-                        "url": "https://rickandmorty.zuplo.io/v1/locations/20"
+                        "url": "https://api.rickandmorty.zuplo.io/v1/locations/20"
                       },
-                      "image": "https://rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
+                      "image": "https://api.rickandmorty.zuplo.io/v1/characters/avatar/2.jpeg",
                       "episode": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/1",
-                        "https://rickandmorty.zuplo.io/v1/episodes/2"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/1",
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/characters/2",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/characters/2",
                       "created": "2017-11-04T18:50:21.651Z"
                     }
                   ]
@@ -775,14 +775,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -791,7 +791,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/locations/1"
+                              "https://api.rickandmorty.zuplo.io/v1/locations/1"
                             ]
                           },
                           "created": {
@@ -808,10 +808,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -824,10 +824,10 @@
                             "type": "Planet",
                             "dimension": "Dimension C-137",
                             "residents": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                             "created": "2017-11-10T12:42:04.162Z"
                           }
                         ]
@@ -849,10 +849,10 @@
                           "type": "Planet",
                           "dimension": "Dimension C-137",
                           "residents": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/locations/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/locations/1",
                           "created": "2017-11-10T12:42:04.162Z"
                         }
                       ]
@@ -948,14 +948,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/8",
-                          "https://rickandmorty.zuplo.io/v1/characters/14"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/14"
                         ]
                       ]
                     },
@@ -963,7 +963,7 @@
                       "type": "string",
                       "default": "",
                       "title": "The url Schema",
-                      "examples": ["https://rickandmorty.zuplo.io/locations/3"]
+                      "examples": ["https://api.rickandmorty.zuplo.io/v1/locations/3"]
                     },
                     "created": {
                       "type": "string",
@@ -979,10 +979,10 @@
                       "type": "Space station",
                       "dimension": "unknown",
                       "residents": [
-                        "https://rickandmorty.zuplo.io/v1/characters/8",
-                        "https://rickandmorty.zuplo.io/v1/characters/14"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/8",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/14"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/locations/3",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/locations/3",
                       "created": "2017-11-10T13:08:13.191Z"
                     }
                   ]
@@ -1081,7 +1081,7 @@
                         {
                           "count": 51,
                           "pages": 3,
-                          "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                          "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                           "prev": null
                         }
                       ]
@@ -1136,14 +1136,14 @@
                               "type": "string",
                               "title": "A Schema",
                               "examples": [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             },
                             "examples": [
                               [
-                                "https://rickandmorty.zuplo.io/v1/characters/1",
-                                "https://rickandmorty.zuplo.io/v1/characters/2"
+                                "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                                "https://api.rickandmorty.zuplo.io/v1/characters/2"
                               ]
                             ]
                           },
@@ -1152,7 +1152,7 @@
                             "default": "",
                             "title": "The url Schema",
                             "examples": [
-                              "https://rickandmorty.zuplo.io/v1/episodes/1"
+                              "https://api.rickandmorty.zuplo.io/v1/episodes/1"
                             ]
                           },
                           "created": {
@@ -1169,10 +1169,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1185,10 +1185,10 @@
                             "air_date": "December 2, 2013",
                             "episode": "S01E01",
                             "characters": [
-                              "https://rickandmorty.zuplo.io/v1/characters/1",
-                              "https://rickandmorty.zuplo.io/v1/characters/2"
+                              "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                              "https://api.rickandmorty.zuplo.io/v1/characters/2"
                             ],
-                            "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                            "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                             "created": "2017-11-10T12:56:33.798Z"
                           }
                         ]
@@ -1200,7 +1200,7 @@
                       "info": {
                         "count": 51,
                         "pages": 3,
-                        "next": "https://rickandmorty.zuplo.io/v1/episodes?page=2",
+                        "next": "https://api.rickandmorty.zuplo.io/v1/episodes?page=2",
                         "prev": null
                       },
                       "results": [
@@ -1210,10 +1210,10 @@
                           "air_date": "December 2, 2013",
                           "episode": "S01E01",
                           "characters": [
-                            "https://rickandmorty.zuplo.io/v1/characters/1",
-                            "https://rickandmorty.zuplo.io/v1/characters/2"
+                            "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                            "https://api.rickandmorty.zuplo.io/v1/characters/2"
                           ],
-                          "url": "https://rickandmorty.zuplo.io/v1/episodes/1",
+                          "url": "https://api.rickandmorty.zuplo.io/v1/episodes/1",
                           "created": "2017-11-10T12:56:33.798Z"
                         }
                       ]
@@ -1309,14 +1309,14 @@
                         "type": "string",
                         "title": "A Schema",
                         "examples": [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       },
                       "examples": [
                         [
-                          "https://rickandmorty.zuplo.io/v1/characters/1",
-                          "https://rickandmorty.zuplo.io/v1/characters/2"
+                          "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                          "https://api.rickandmorty.zuplo.io/v1/characters/2"
                         ]
                       ]
                     },
@@ -1325,7 +1325,7 @@
                       "default": "",
                       "title": "The url Schema",
                       "examples": [
-                        "https://rickandmorty.zuplo.io/v1/episodes/28"
+                        "https://api.rickandmorty.zuplo.io/v1/episodes/28"
                       ]
                     },
                     "created": {
@@ -1342,10 +1342,10 @@
                       "air_date": "September 10, 2017",
                       "episode": "S03E07",
                       "characters": [
-                        "https://rickandmorty.zuplo.io/v1/characters/1",
-                        "https://rickandmorty.zuplo.io/v1/characters/2"
+                        "https://api.rickandmorty.zuplo.io/v1/characters/1",
+                        "https://api.rickandmorty.zuplo.io/v1/characters/2"
                       ],
-                      "url": "https://rickandmorty.zuplo.io/v1/episodes/28",
+                      "url": "https://api.rickandmorty.zuplo.io/v1/episodes/28",
                       "created": "2017-11-10T12:56:36.618Z"
                     }
                   ]
@@ -1380,7 +1380,7 @@
   },
   "servers": [
     {
-      "url": "https://rickandmorty.zuplo.io"
+      "url": "https://api.rickandmorty.zuplo.io"
     }
   ]
 }


### PR DESCRIPTION
## Summary
The Rick & Morty demo at `zuplo-samples/rick-and-morty` recently restructured: Zudoku is now served from the apex `rickandmorty.zuplo.io`, and the gateway moved to the `api.rickandmorty.zuplo.io` subdomain. The example `openapi.json` files in this repo still reference `rickandmorty.zuplo.io/v1/...`, which now hits the docs site (HTML 404) instead of the gateway.

This PR updates 7 example specs to use `api.rickandmorty.zuplo.io` for:
- The `servers[0].url`
- All example response URLs (`url`, `next`, `image`, embedded `episode`/`location`/`character` URLs)

Also fixes a pre-existing `https://rickandmorty.zuplo.io/locations/3` example in `with-config` that was missing the `/v1` prefix entirely.

## Files changed
- `examples/api-identity-plugin/openapi.json`
- `examples/auth-firebase/openapi.json`
- `examples/auth-supabase/openapi.json`
- `examples/with-auth0/openapi.json`
- `examples/with-base-path/openapi.json`
- `examples/with-config/openapi.json`
- `examples/with-vite-config/openapi.json`

## Test plan
- [x] Open any updated example's API Reference page in the playground
- [x] Send a request — confirm it goes to `api.rickandmorty.zuplo.io` and returns 200 (with API key) or 401 (without)
- [x] Click any URL in the response body — resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)