### PR TITLE
feat(auth): propagate allowInsecureRequests for oauth providers

### DIFF
--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -77,6 +77,36 @@ describe("validateConfig", () => {
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
+  it("should accept allowInsecureRequests as a boolean in openid config", () => {
+    const config = {
+      authentication: {
+        type: "openid" as const,
+        clientId: "client123",
+        issuer: "https://example.auth0.com",
+        allowInsecureRequests: true,
+      },
+    };
+
+    validateConfig(config);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("should reject non-boolean allowInsecureRequests in openid config", () => {
+    process.env.NODE_ENV = "production";
+
+    const config = {
+      authentication: {
+        type: "openid" as const,
+        clientId: "client123",
+        issuer: "https://example.auth0.com",
+        allowInsecureRequests: "yes" as unknown as boolean,
+      },
+    };
+
+    expect(() => validateConfig(config)).toThrow();
+  });
+
   it("should validate openid issuer format correctly", () => {
     const configWithValidAuth0 = {
       authentication: {

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -451,6 +451,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     issuer: z.string(),
     audience: z.string().optional(),
     scopes: z.array(z.string()).optional(),
+    allowInsecureRequests: z.boolean().optional(),
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -563,6 +563,214 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
     });
   });
 
+  describe("allowInsecureRequests", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL(
+          "http://localhost/oauth/callback?state=test-state&code=test-code",
+        ),
+      });
+      sessionStorage.setItem("oauth-state", "test-state");
+      sessionStorage.setItem("code-verifier", "test-verifier");
+    });
+
+    test("passes allowInsecureRequests to discoveryRequest when enabled", async () => {
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        allowInsecureRequests: true,
+      });
+
+      vi.mocked(oauth.processDiscoveryResponse).mockResolvedValue(AUTH_SERVER);
+      vi.mocked(oauth.discoveryRequest).mockResolvedValue(new Response());
+
+      // Trigger discovery via signIn
+      vi.mocked(oauth.processDiscoveryResponse).mockResolvedValue({
+        ...AUTH_SERVER,
+        authorization_endpoint: "https://issuer.example.com/authorize",
+      });
+
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: {
+          ...window.location,
+          origin: "http://localhost",
+          search: "",
+          set href(_: string) {},
+          replace: vi.fn(),
+        },
+      });
+
+      await provider.signIn({ navigate: vi.fn() as never }, {});
+
+      expect(oauth.discoveryRequest).toHaveBeenCalledWith(
+        expect.any(URL),
+        expect.objectContaining({ [oauth.allowInsecureRequests]: true }),
+      );
+    });
+
+    test("does not pass allowInsecureRequests to discoveryRequest when disabled", async () => {
+      const provider = createProvider();
+
+      vi.mocked(oauth.discoveryRequest).mockResolvedValue(new Response());
+      vi.mocked(oauth.processDiscoveryResponse).mockResolvedValue({
+        ...AUTH_SERVER,
+        authorization_endpoint: "https://issuer.example.com/authorize",
+      });
+
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: {
+          ...window.location,
+          origin: "http://localhost",
+          search: "",
+          set href(_: string) {},
+          replace: vi.fn(),
+        },
+      });
+
+      await provider.signIn({ navigate: vi.fn() as never }, {});
+
+      expect(oauth.discoveryRequest).toHaveBeenCalledWith(
+        expect.any(URL),
+        expect.not.objectContaining({ [oauth.allowInsecureRequests]: true }),
+      );
+    });
+
+    test("passes allowInsecureRequests to authorizationCodeGrantRequest", async () => {
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        allowInsecureRequests: true,
+      });
+
+      vi.mocked(oauth.validateAuthResponse).mockReturnValue(
+        new URLSearchParams({ code: "test-code" }),
+      );
+      vi.mocked(oauth.authorizationCodeGrantRequest).mockResolvedValue(
+        new Response(),
+      );
+      vi.mocked(oauth.processAuthorizationCodeResponse).mockResolvedValue({
+        access_token: "header.payload.signature",
+        token_type: "bearer",
+        expires_in: 3600,
+        refresh_token: "test-refresh-token",
+      } as oauth.TokenEndpointResponse);
+      vi.mocked(oauth.userInfoRequest).mockImplementation(() =>
+        Promise.resolve(
+          Response.json({ sub: "user-1", email: "u@e.com", name: "U" }),
+        ),
+      );
+
+      await provider.handleCallback();
+
+      expect(oauth.authorizationCodeGrantRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ [oauth.allowInsecureRequests]: true }),
+      );
+    });
+
+    test("passes allowInsecureRequests to refreshTokenGrantRequest", async () => {
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        allowInsecureRequests: true,
+      });
+
+      useAuthState.setState({
+        isAuthenticated: true,
+        isPending: false,
+        profile: {
+          sub: "user-1",
+          email: "u@e.com",
+          emailVerified: false,
+          name: "Test",
+          pictureUrl: undefined,
+        },
+        providerData: {
+          type: "openid",
+          accessToken: FAKE_ACCESS_TOKEN,
+          expiresOn: new Date(Date.now() - 1000),
+          refreshToken: "test-refresh-token",
+          tokenType: "bearer",
+          claims: undefined,
+        } satisfies OpenIdProviderData,
+      });
+
+      vi.mocked(oauth.refreshTokenGrantRequest).mockResolvedValue(
+        new Response(),
+      );
+      vi.mocked(oauth.processRefreshTokenResponse).mockResolvedValue({
+        access_token: FAKE_NEW_ACCESS_TOKEN,
+        token_type: "bearer",
+        expires_in: 3600,
+      } as oauth.TokenEndpointResponse);
+      vi.mocked(oauth.userInfoRequest).mockResolvedValue(
+        Response.json({ sub: "user-1", email: "u@e.com", name: "Test" }),
+      );
+
+      await provider.refreshUserProfile();
+
+      expect(oauth.refreshTokenGrantRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ [oauth.allowInsecureRequests]: true }),
+      );
+    });
+
+    test("passes allowInsecureRequests to userInfoRequest", async () => {
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        allowInsecureRequests: true,
+      });
+
+      useAuthState.setState({
+        isAuthenticated: true,
+        isPending: false,
+        profile: {
+          sub: "user-1",
+          email: "u@e.com",
+          emailVerified: false,
+          name: "Test",
+          pictureUrl: undefined,
+        },
+        providerData: {
+          type: "openid",
+          accessToken: FAKE_ACCESS_TOKEN,
+          expiresOn: new Date(Date.now() + 3600_000),
+          tokenType: "bearer",
+          claims: undefined,
+        } satisfies OpenIdProviderData,
+      });
+
+      vi.mocked(oauth.userInfoRequest).mockResolvedValue(
+        Response.json({ sub: "user-1", email: "u@e.com", name: "Test" }),
+      );
+
+      await provider.refreshUserProfile();
+
+      expect(oauth.userInfoRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ [oauth.allowInsecureRequests]: true }),
+      );
+    });
+  });
+
   test("self heals providerData when providerData.type is undefined", async () => {
     const provider = createProvider();
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -71,6 +71,7 @@ export class OpenIDAuthenticationProvider
     "ui_locales",
     "acr_values",
   ];
+  private readonly allowInsecureRequests: boolean;
 
   constructor({
     issuer,
@@ -85,6 +86,7 @@ export class OpenIDAuthenticationProvider
     disableSignUp,
     authorizationParams,
     forwardAuthorizationParams,
+    allowInsecureRequests,
   }: OpenIDAuthenticationConfig) {
     super();
     this.client = {
@@ -96,6 +98,7 @@ export class OpenIDAuthenticationProvider
     // This is the callback URL for the OAuth provider. So it needs the base path.
     this.callbackUrlPath = joinUrl(basePath, OPENID_CALLBACK_PATH);
     this.scopes = scopes ?? ["openid", "profile", "email"];
+    this.allowInsecureRequests = allowInsecureRequests ?? false;
 
     this.redirectToAfterSignUp = redirectToAfterSignUp;
     this.redirectToAfterSignIn = redirectToAfterSignIn;
@@ -111,10 +114,19 @@ export class OpenIDAuthenticationProvider
     );
   }
 
+  protected get oauthOptions() {
+    return this.allowInsecureRequests
+      ? { [oauth.allowInsecureRequests]: true }
+      : {};
+  }
+
   protected async getAuthServer() {
     if (!this.authorizationServer) {
       const issuerUrl = new URL(this.issuer);
-      const response = await oauth.discoveryRequest(issuerUrl);
+      const response = await oauth.discoveryRequest(
+        issuerUrl,
+        this.oauthOptions,
+      );
       this.authorizationServer = await oauth.processDiscoveryResponse(
         issuerUrl,
         response,
@@ -235,6 +247,7 @@ export class OpenIDAuthenticationProvider
       authServer,
       this.client,
       accessToken,
+      this.oauthOptions,
     );
     const userInfo = await userInfoResponse.json();
 
@@ -380,7 +393,9 @@ export class OpenIDAuthenticationProvider
         this.client,
         oauth.None(),
         tokenState.refreshToken,
+        this.oauthOptions,
       );
+
       const result = await oauth.processRefreshTokenResponse(
         as,
         this.client,
@@ -473,6 +488,7 @@ export class OpenIDAuthenticationProvider
           this.client,
           oauth.None(),
           tokenState.refreshToken,
+          this.oauthOptions,
         );
         const result = await oauth.processRefreshTokenResponse(
           as,
@@ -538,6 +554,7 @@ export class OpenIDAuthenticationProvider
       params,
       redirectUrl.toString(),
       codeVerifier,
+      this.oauthOptions,
     );
 
     const oauthResult = await oauth.processAuthorizationCodeResponse(
@@ -558,6 +575,7 @@ export class OpenIDAuthenticationProvider
       authServer,
       this.client,
       accessToken,
+      this.oauthOptions,
     );
     const userInfo = await userInfoResponse.json();
 


### PR DESCRIPTION
I've been working with a local oauth provider, and trying to get zudoku to integrate with it, which wasn't possible without this option.