### PR TITLE
Add null safety check for pricing table in PricingPage

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
@@ -122,6 +122,14 @@ describe("PricingPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("Renders without crashing and omits the tax legend when no plans are published", () => {
+    mockPricingData.items = [];
+    mockSubscriptionData.items = [];
+
+    expect(() => renderWithConfig()).not.toThrow();
+    expect(screen.queryByText("Tax & Pricing")).not.toBeInTheDocument();
+  });
+
   it("Shows 'Manage Subscriptions' if the user has any active subscriptions", () => {
     mockPricingData.items = [
       makePlan("1", "starter", "Starter"),

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
@@ -11,8 +11,7 @@ vi.mock("../utils/pricingTaxLegend.js", async (importOriginal) => {
   const original = (await importOriginal()) as Record<string, unknown>;
   return {
     ...original,
-    collectDefaultTaxBehaviors: (plan?: Plan) => {
-      if (!plan) return "unspecified";
+    collectDefaultTaxBehaviors: (plan: Plan) => {
       const behavior = plan.defaultTaxConfig?.behavior;
       if (typeof behavior !== "string" || behavior.trim().length === 0) {
         return "unspecified";

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
@@ -19,8 +19,10 @@ const PricingPage = () => {
   const auth = useAuth();
 
   const { data: pricingTable } = usePlans();
-  const taxLegendBehaviors = collectDefaultTaxBehaviors(pricingTable.items[0]);
-  const taxLegendSentence = taxBehaviorLegendSentence(taxLegendBehaviors);
+  const firstPlan = pricingTable.items[0];
+  const taxLegendSentence = firstPlan
+    ? taxBehaviorLegendSentence(collectDefaultTaxBehaviors(firstPlan))
+    : undefined;
 
   const { data: subscriptions = { items: [] } } =
     useQuery<SubscriptionsResponse>({


### PR DESCRIPTION
## Summary
This PR adds proper null safety handling for the pricing table's first plan item in the PricingPage component, preventing potential runtime errors when the plan data is unavailable.

## Key Changes
- **PricingPage.tsx**: Added null check before accessing `pricingTable.items[0]` to safely handle cases where the first plan may not exist
  - Extracted `firstPlan` variable for clarity
  - Made `taxLegendSentence` conditional, returning `undefined` when no plan is available
  - This prevents passing `undefined` to `collectDefaultTaxBehaviors()`

- **PricingPage.test.tsx**: Updated mock function signature to reflect the null safety change
  - Changed `collectDefaultTaxBehaviors` parameter from optional (`plan?: Plan`) to required (`plan: Plan`)
  - Removed the internal null check since the caller now guarantees a valid plan is passed

## Implementation Details
The change follows a defensive programming approach by validating data existence at the point of use rather than relying on internal null checks. This makes the data flow more explicit and prevents potential undefined reference errors when the pricing table hasn't loaded yet.

https://claude.ai/code/session_01Vb21T1AX7pg4Ux8QUzU276