### PR TITLE
fix: render application/x-www-form-urlencoded bodies correctly

### DIFF
--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -55,6 +55,10 @@
       "description": "Endpoints for system health checks and retrieving API version information."
     },
     {
+      "name": "Authentication",
+      "description": "Endpoints for obtaining warp-grade OAuth tokens used to authorize cargo operations."
+    },
+    {
       "name": "Schemas",
       "description": "Endpoints for retrieving and validating data schemas used across the Cosmo Cargo platform.",
       "x-zudoku-collapsed": false
@@ -3650,6 +3654,116 @@
                       }
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth/token": {
+      "post": {
+        "summary": "Issue OAuth access token",
+        "description": "Exchange client credentials for a short-lived warp-grade access token. The request body must be sent as `application/x-www-form-urlencoded` per RFC 6749.",
+        "operationId": "issueOAuthToken",
+        "tags": ["Authentication"],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["grant_type", "client_id", "client_secret"],
+                "properties": {
+                  "grant_type": {
+                    "type": "string",
+                    "enum": ["client_credentials"],
+                    "description": "OAuth 2.0 grant type. Only `client_credentials` is supported for fleet integrations."
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "description": "Identifier issued when registering your fleet integration."
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "format": "password",
+                    "description": "Secret issued alongside the client_id. Treat as sensitive."
+                  },
+                  "scope": {
+                    "type": "string",
+                    "description": "Space-separated list of requested scopes (e.g. `shipments:read shipments:write`)."
+                  }
+                }
+              },
+              "example": {
+                "grant_type": "client_credentials",
+                "client_id": "cosmo-fleet-7421",
+                "client_secret": "warp-secret-xyz",
+                "scope": "shipments:read shipments:write"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["access_token", "token_type", "expires_in"],
+                  "properties": {
+                    "access_token": {
+                      "type": "string",
+                      "description": "Bearer token to send in the `Authorization` header."
+                    },
+                    "token_type": {
+                      "type": "string",
+                      "enum": ["Bearer"]
+                    },
+                    "expires_in": {
+                      "type": "integer",
+                      "description": "Token lifetime in seconds."
+                    },
+                    "scope": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "access_token": "warp.eyJhbGciOiJIUzI1NiJ9.cargo",
+                  "token_type": "Bearer",
+                  "expires_in": 3600,
+                  "scope": "shipments:read shipments:write"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "invalid_request",
+                        "invalid_client",
+                        "invalid_grant",
+                        "unsupported_grant_type"
+                      ]
+                    },
+                    "error_description": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "error": "invalid_client",
+                  "error_description": "Unknown client_id or bad credentials."
                 }
               }
             }

--- a/packages/zudoku/src/lib/plugins/openapi/GeneratedExampleSidecarBox.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/GeneratedExampleSidecarBox.tsx
@@ -11,10 +11,12 @@ import * as SidecarBox from "./SidecarBox.js";
 
 export const GeneratedExampleSidecarBox = ({
   code,
+  language = "json",
   isOnScreen,
   shouldLazyHighlight,
 }: {
   code: string;
+  language?: string;
   isOnScreen: boolean;
   shouldLazyHighlight?: boolean;
 }) => {
@@ -41,7 +43,7 @@ export const GeneratedExampleSidecarBox = ({
         ) : (
           <SyntaxHighlight
             embedded
-            language="json"
+            language={language}
             code={code}
             className="[--scrollbar-color:gray] rounded-none text-xs max-h-[200px]"
           />

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -30,6 +30,10 @@ import { ResponsesSidecarBox } from "./ResponsesSidecarBox.js";
 import * as SidecarBox from "./SidecarBox.js";
 import { createHttpSnippet, getConverted } from "./util/createHttpSnippet.js";
 import { extractOperationSecuritySchemes } from "./util/extractOperationSecuritySchemes.js";
+import {
+  formatRequestBodyForDisplay,
+  getLanguageForMediaType,
+} from "./util/formatRequestBody.js";
 import { generateSchemaExample } from "./util/generateSchemaExample.js";
 import { methodForColor } from "./util/methodToColor.js";
 import { useResolvedAuth } from "./util/useResolvedAuth.js";
@@ -247,7 +251,11 @@ export const Sidecar = ({
       exampleBody: currentExampleCode
         ? {
             mimeType: selectedContent?.mediaType ?? "application/json",
-            text: JSON.stringify(currentExampleCode, null, 2),
+            text:
+              formatRequestBodyForDisplay(
+                selectedContent?.mediaType,
+                currentExampleCode,
+              ) ?? "",
           }
         : { mimeType: selectedContent?.mediaType ?? "application/json" },
       resolvedAuth,
@@ -430,7 +438,13 @@ export const Sidecar = ({
         <GeneratedExampleSidecarBox
           isOnScreen={isOnScreen}
           shouldLazyHighlight={shouldLazyHighlight}
-          code={JSON.stringify(currentExampleCode, null, 2)}
+          language={getLanguageForMediaType(selectedContent?.mediaType)}
+          code={
+            formatRequestBodyForDisplay(
+              selectedContent?.mediaType,
+              currentExampleCode,
+            ) ?? ""
+          }
         />
       ) : null}
 

--- a/packages/zudoku/src/lib/plugins/openapi/SidecarExamples.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SidecarExamples.tsx
@@ -5,31 +5,10 @@ import { SyntaxHighlight } from "../../ui/SyntaxHighlight.js";
 import { NonHighlightedCode } from "./components/NonHighlightedCode.js";
 import type { MediaTypeObject } from "./graphql/graphql.js";
 import * as SidecarBox from "./SidecarBox.js";
-
-const formatForDisplay = (value: unknown): string | undefined => {
-  if (value == null) return;
-  if (typeof value === "string") return value.trim();
-  return JSON.stringify(value, null, 2);
-};
-
-const getLanguage = (mediaType?: string): string => {
-  if (!mediaType) return "text";
-  if (mediaType.endsWith("+json")) return "json";
-  if (mediaType.endsWith("+xml")) return "xml";
-  if (mediaType.endsWith("+yaml")) return "yaml";
-
-  const languages: Record<string, string> = {
-    "text/html": "html",
-    "application/x-ndjson": "json",
-    "application/json": "json",
-    "application/xml": "xml",
-    "application/x-yaml": "yaml",
-    "text/csv": "csv",
-    "application/javascript": "javascript",
-    "application/graphql": "graphql",
-  };
-  return languages[mediaType] ?? "text";
-};
+import {
+  formatRequestBodyForDisplay,
+  getLanguageForMediaType,
+} from "./util/formatRequestBody.js";
 
 export type SidecarExamplesProps = {
   content: MediaTypeObject[];
@@ -61,8 +40,11 @@ export const SidecarExamples = ({
   const examples = selectedContent?.examples ?? [];
   const selectedExample = examples?.[selectedExampleIndex];
 
-  const formattedExample = formatForDisplay(selectedExample?.value);
-  const language = getLanguage(selectedContent?.mediaType);
+  const formattedExample = formatRequestBodyForDisplay(
+    selectedContent?.mediaType,
+    selectedExample?.value,
+  );
+  const language = getLanguageForMediaType(selectedContent?.mediaType);
 
   return (
     <>

--- a/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.test.ts
@@ -81,3 +81,63 @@ describe("createHttpSnippet auth merge", () => {
     expect(out).not.toContain("example.com//things");
   });
 });
+
+const postOp = {
+  ...makeOp(),
+  method: "POST",
+} as OperationsFragmentFragment;
+
+const shellWithBody = (
+  exampleBody: { mimeType: string; text?: string },
+  op: OperationsFragmentFragment = postOp,
+) =>
+  getConverted(
+    createHttpSnippet({
+      operation: op,
+      selectedServer: "https://api.example.com",
+      exampleBody,
+    }),
+    "shell",
+  ) as string;
+
+describe("createHttpSnippet body encoding", () => {
+  it("emits urlencoded curl with form fields and matching Content-Type", () => {
+    const out = shellWithBody({
+      mimeType: "application/x-www-form-urlencoded",
+      text: "grant_type=client_credentials&client_id=abc&client_secret=xyz",
+    });
+    expect(out).toContain("Content-Type: application/x-www-form-urlencoded");
+    expect(out).toContain("grant_type=client_credentials");
+    expect(out).toContain("client_id=abc");
+    expect(out).toContain("client_secret=xyz");
+    expect(out).not.toContain("application/json");
+  });
+
+  it("preserves repeated keys in urlencoded bodies", () => {
+    const out = shellWithBody({
+      mimeType: "application/x-www-form-urlencoded",
+      text: "scope=read&scope=write",
+    });
+    expect(out).toContain("scope=read");
+    expect(out).toContain("scope=write");
+  });
+
+  it("emits multipart curl from JSON-stringified object body", () => {
+    const out = shellWithBody({
+      mimeType: "multipart/form-data",
+      text: JSON.stringify({ file: "report.pdf", note: "Q1" }),
+    });
+    expect(out).toContain("file=report.pdf");
+    expect(out).toContain("note=Q1");
+  });
+
+  it("sends JSON bodies with the correct Content-Type", () => {
+    const out = shellWithBody({
+      mimeType: "application/json",
+      text: JSON.stringify({ hello: "world" }),
+    });
+    expect(out).toContain("Content-Type: application/json");
+    expect(out).toContain("hello");
+    expect(out).toContain("world");
+  });
+});

--- a/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.ts
@@ -2,7 +2,7 @@ import { HTTPSnippet } from "@zudoku/httpsnippet";
 import { joinUrl } from "../../../util/joinUrl.js";
 import type { OperationsFragmentFragment } from "../graphql/graphql.js";
 
-const toFormDataParams = (text?: string) => {
+const toMultipartParams = (text?: string) => {
   const stringify = (v: unknown) =>
     typeof v === "string" ? v : JSON.stringify(v);
 
@@ -17,6 +17,13 @@ const toFormDataParams = (text?: string) => {
   } catch {
     return [];
   }
+};
+
+const toUrlEncodedParams = (text?: string) => {
+  if (!text) return [];
+  return Array.from(new URLSearchParams(text).entries()).map(
+    ([name, value]) => ({ name, value }),
+  );
 };
 
 export type ResolvedAuth = {
@@ -43,16 +50,18 @@ export const createHttpSnippet = ({
   };
   resolvedAuth?: ResolvedAuth;
 }) => {
-  const isMultipart =
-    exampleBody.mimeType === "multipart/form-data" ||
-    exampleBody.mimeType === "application/x-www-form-urlencoded";
-
-  const postData = isMultipart
-    ? {
-        mimeType: exampleBody.mimeType,
-        params: toFormDataParams(exampleBody.text),
-      }
-    : exampleBody;
+  const postData =
+    exampleBody.mimeType === "multipart/form-data"
+      ? {
+          mimeType: exampleBody.mimeType,
+          params: toMultipartParams(exampleBody.text),
+        }
+      : exampleBody.mimeType === "application/x-www-form-urlencoded"
+        ? {
+            mimeType: exampleBody.mimeType,
+            params: toUrlEncodedParams(exampleBody.text),
+          }
+        : exampleBody;
 
   const baseHeaders = [
     ...(exampleBody.text

--- a/packages/zudoku/src/lib/plugins/openapi/util/formatRequestBody.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/formatRequestBody.ts
@@ -1,0 +1,51 @@
+const stringifyValue = (v: unknown): string =>
+  typeof v === "string" ? v : JSON.stringify(v);
+
+export const isUrlEncodedMediaType = (mediaType?: string) =>
+  mediaType === "application/x-www-form-urlencoded";
+
+export const toUrlEncoded = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value == null || typeof value !== "object") return "";
+
+  const params = new URLSearchParams();
+  for (const [name, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (raw === undefined) continue;
+    const values = Array.isArray(raw) ? raw : [raw];
+    for (const v of values) {
+      if (v === undefined) continue;
+      params.append(name, stringifyValue(v));
+    }
+  }
+  return params.toString();
+};
+
+export const formatRequestBodyForDisplay = (
+  mediaType: string | undefined,
+  value: unknown,
+): string | undefined => {
+  if (value == null) return;
+  if (isUrlEncodedMediaType(mediaType)) return toUrlEncoded(value);
+  if (typeof value === "string") return value.trim();
+  return JSON.stringify(value, null, 2);
+};
+
+export const getLanguageForMediaType = (mediaType?: string): string => {
+  if (!mediaType) return "text";
+  if (mediaType.endsWith("+json")) return "json";
+  if (mediaType.endsWith("+xml")) return "xml";
+  if (mediaType.endsWith("+yaml")) return "yaml";
+
+  const languages: Record<string, string> = {
+    "text/html": "html",
+    "application/x-ndjson": "json",
+    "application/json": "json",
+    "application/xml": "xml",
+    "application/x-yaml": "yaml",
+    "text/csv": "csv",
+    "application/javascript": "javascript",
+    "application/graphql": "graphql",
+    "application/x-www-form-urlencoded": "text",
+  };
+  return languages[mediaType] ?? "text";
+};

--- a/packages/zudoku/src/lib/plugins/openapi/util/formatRequestBody.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/formatRequestBody.ts
@@ -1,8 +1,11 @@
 const stringifyValue = (v: unknown): string =>
   typeof v === "string" ? v : JSON.stringify(v);
 
+const normalizeMediaType = (mediaType?: string) =>
+  mediaType?.split(";")[0]?.trim().toLowerCase();
+
 export const isUrlEncodedMediaType = (mediaType?: string) =>
-  mediaType === "application/x-www-form-urlencoded";
+  normalizeMediaType(mediaType) === "application/x-www-form-urlencoded";
 
 export const toUrlEncoded = (value: unknown): string => {
   if (typeof value === "string") return value;
@@ -31,10 +34,11 @@ export const formatRequestBodyForDisplay = (
 };
 
 export const getLanguageForMediaType = (mediaType?: string): string => {
-  if (!mediaType) return "text";
-  if (mediaType.endsWith("+json")) return "json";
-  if (mediaType.endsWith("+xml")) return "xml";
-  if (mediaType.endsWith("+yaml")) return "yaml";
+  const normalized = normalizeMediaType(mediaType);
+  if (!normalized) return "text";
+  if (normalized.endsWith("+json")) return "json";
+  if (normalized.endsWith("+xml")) return "xml";
+  if (normalized.endsWith("+yaml")) return "yaml";
 
   const languages: Record<string, string> = {
     "text/html": "html",
@@ -47,5 +51,5 @@ export const getLanguageForMediaType = (mediaType?: string): string => {
     "application/graphql": "graphql",
     "application/x-www-form-urlencoded": "text",
   };
-  return languages[mediaType] ?? "text";
+  return languages[normalized] ?? "text";
 };


### PR DESCRIPTION
Fixes #2422.

`application/x-www-form-urlencoded` request bodies were rendered as JSON in both the Example Request Body panel and generated code samples. The schema-derived object was passed through `JSON.stringify` regardless of media type.

A shared `formatRequestBody` util now URL-encodes objects when the media type calls for it. It is wired into `SidecarExamples`, the generated-example fallback, and the body text passed to `createHttpSnippet`. The snippet builder now has separate paths for multipart and urlencoded, so an already-encoded string round-trips cleanly.

Cosmo-cargo gets a new `POST /oauth/token` endpoint under an `Authentication` tag to exercise the fix.

[See in preview deployment](https://zudoku-cosmo-cargo-git-form-urlencoded-request-body.zuplosite.com/api-shipments/authentication#issue-oauth-access-token)