### PR TITLE
Pin publish workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,17 +47,17 @@ jobs:
       IS_RELEASE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.releaseType != 'prerelease' }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".tool-versions"
           registry-url: "https://registry.npmjs.org"
@@ -70,7 +70,7 @@ jobs:
 
       - run: pnpm install nx --global
 
-      - uses: nrwl/nx-set-shas@v5
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5
 
       # This must be a real github account otherwise vercel thows ugly errors
       - run: git config --global user.email "integrations@zuplo.com"
@@ -108,7 +108,7 @@ jobs:
       - name: Generate zudoku release token
         if: env.IS_RELEASE == 'true'
         id: zudoku-release-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: ${{ vars.ZUDOKU_RELEASE_APP_ID }}
           private-key: ${{ secrets.ZUDOKU_RELEASE_APP_PRIVATE_KEY }}
@@ -124,7 +124,7 @@ jobs:
           echo "::add-mask::${ZUDOKU_RELEASE_TOKEN}"
           git push "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git" main --follow-tags
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         name: ${{ env.IS_RELEASE == 'true' && 'Create Release' || 'Create Pre-release' }}
         id: create-release
         if: github.ref == 'refs/heads/main'
@@ -137,7 +137,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: github.ref == 'refs/heads/main'
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           token_format: access_token
           workload_identity_provider: ${{ vars.GCP_ACTIONS_IDENTITY_PROVIDER }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload CSS
         if: github.ref == 'refs/heads/main'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload Javascript
         if: github.ref == 'refs/heads/main'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload HTML (Latest)
         if: env.IS_RELEASE == 'true'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone/index.html
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload CSS (Latest)
         if: env.IS_RELEASE == 'true'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone
@@ -194,7 +194,7 @@ jobs:
 
       - name: Upload Javascript (Latest)
         if: env.IS_RELEASE == 'true'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone
@@ -217,7 +217,7 @@ jobs:
       - name: Generate a token
         if: env.IS_RELEASE == 'true'
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: ${{ vars.ZUDOKU_GH_APP_ID }}
           private-key: ${{ secrets.ZUDOKU_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -30,17 +30,17 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".tool-versions"
           registry-url: "https://registry.npmjs.org"
@@ -72,7 +72,7 @@ jobs:
 
       - name: Generate zudoku release token
         id: zudoku-release-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: ${{ vars.ZUDOKU_RELEASE_APP_ID }}
           private-key: ${{ secrets.ZUDOKU_RELEASE_APP_PRIVATE_KEY }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: Generate a token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: ${{ vars.ZUDOKU_GH_APP_ID }}
           private-key: ${{ secrets.ZUDOKU_GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Action in our two npm-publishing workflows to an explicit commit SHA. Tag comments (`# v6`) are preserved so Dependabot can still offer updates.

**Why**: mutable tags like `@v6` can be force-pushed to point at malicious commits — this is what happened to `tj-actions/changed-files` in March 2025 and is part of the Mini Shai-Hulud playbook (May 2026). Commit SHAs cannot be silently reassigned, so this closes the action-supply-chain attack class even if an action repo is fully compromised.

**Why only these two workflows**: `main.yaml` holds the npm publish OIDC, GCP workload identity, Cloudflare API token, and two GitHub App private keys. `release-monetization.yaml` holds the npm publish OIDC and the same App keys. These are the highest-value secrets we have anywhere — everything else is a much smaller blast radius. We can pin the rest later if we want consistency, but those secrets aren't worth attacking.

**Dependabot integration**: `.github/dependabot.yml` already has a `github-actions` entry that scans `uses:` lines. It reads the `# v6` tag comment and opens PRs for new versions automatically.

## SHA resolution

All SHAs resolved via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`. Annotated tags (`actions/github-script@v9`, `pnpm/action-setup@v5`) were dereferenced one more level to get the underlying commit SHA, since GitHub Actions requires a commit ref.

| Action | Tag | SHA |
| --- | --- | --- |
| `actions/checkout` | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-node` | v6 | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/github-script` | v9 | `3a2844b7e9c422d3c10d287c895573f7108da1b3` |
| `actions/create-github-app-token` | v3 | `1b10c78c7865c340bc4f6099eb2f838309f1e8c3` |
| `pnpm/action-setup` | v5 | `fc06bc1257f339d1d5d8b3a19a8cae5388b55320` |
| `nrwl/nx-set-shas` | v5 | `afb73a62d26e41464e9254689e1fd6122ee683c1` |
| `google-github-actions/auth` | v3 | `7c6bc770dae815cd3e89ee6cdf493a5fab2cc093` |
| `google-github-actions/upload-cloud-storage` | v3 | `6397bd7208e18d13ba2619ee21b9873edc94427a` |

## Test plan

- [ ] Trigger a dev prerelease (push to main) and confirm the publish step still succeeds end-to-end
- [ ] Confirm GCS upload, Cloudflare purge, and downstream `gh workflow run` triggers all run
- [ ] After merge, watch the first Dependabot PR that targets a github-actions update — confirm it updates both the SHA and the trailing `# vN` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)