### PR TITLE
feat(openapi): Add config option to override download filename

### DIFF
--- a/docs/pages/docs/configuration/api-reference.md
+++ b/docs/pages/docs/configuration/api-reference.md
@@ -212,6 +212,7 @@ const config = {
       showInfoPage: true, // Show API information page as the index route
       schemaDownload: {
         enabled: true, // Enable schema download button
+        fileName: "schema", // Set name of the schema file when downloaded
       },
     },
   },
@@ -238,6 +239,8 @@ Available options:
 - `schemaDownload`: Enable schema download functionality. When enabled, displays a button allowing
   users to download the OpenAPI schema, copy it to clipboard, or open in a new tab.
   - `enabled`: Enable or disable the schema download button
+  - `fileName`: Set name of the schema file when downloaded (default: `schema`). Note: Do not
+    include a file extension, as that is added automatically based on the input file type.
 - `transformExamples`: Function to transform request/response examples before rendering. See
   [Transforming Examples](../guides/transforming-examples.md) for detailed usage
 - `generateCodeSnippet`: Function to generate custom code snippets for the API playground. See
@@ -261,6 +264,7 @@ const config = {
       showInfoPage: true, // Show API information page as the index route
       schemaDownload: {
         enabled: true, // Enable schema download button
+        fileName: "schema", // Set name of the schema file when downloaded
       },
     },
   },

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -375,6 +375,7 @@ const config: ZudokuConfig = {
       examplesLanguage: "js",
       schemaDownload: {
         enabled: true,
+        fileName: "openapi",
       },
     },
   },

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -94,7 +94,15 @@ const ApiOptionsSchema = z
     showVersionSelect: z.enum(["always", "if-available", "hide"]),
     expandAllTags: z.boolean(),
     showInfoPage: z.boolean(),
-    schemaDownload: z.object({ enabled: z.boolean() }).partial(),
+    schemaDownload: z
+      .object({
+        enabled: z.boolean(),
+        fileName: z
+          .string()
+          .regex(/^[A-Za-z0-9_-]+$/)
+          .optional(),
+      })
+      .partial(),
     transformExamples: z.custom<TransformExamplesFn>(
       (val) => typeof val === "function",
     ),
@@ -103,6 +111,8 @@ const ApiOptionsSchema = z
     ),
   })
   .partial();
+
+export type ApiOptionsConfig = z.infer<typeof ApiOptionsSchema>;
 
 const ApiConfigSchema = z
   .object({

--- a/packages/zudoku/src/vite/api/SchemaManager.test.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.test.ts
@@ -136,6 +136,36 @@ describe("SchemaManager", () => {
     expect(schemas?.[1]?.downloadUrl).toBe("/test-api/1.0.0/schema.json");
   });
 
+  it("should handle overridden fileName", async () => {
+    const schemaPath = path.join(tempDir, "openapi.json");
+
+    await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
+
+    const config: ConfigWithMeta = {
+      __meta,
+      apis: [
+        {
+          type: "file",
+          path: "test-api",
+          input: [schemaPath],
+          options: {
+            schemaDownload: {
+              fileName: "openapi",
+            },
+          },
+        },
+      ],
+    };
+
+    const manager = new SchemaManager({ storeDir, config, processors: [] });
+
+    await manager.processAllSchemas();
+
+    const schemas = manager.getSchemasForPath("test-api");
+    expect(schemas).toHaveLength(1);
+    expect(schemas?.[0]?.downloadUrl).toBe("/test-api/1.0.0/openapi.json");
+  });
+
   it("should track processed files", async () => {
     const schemaPath = path.join(tempDir, "openapi.json");
     await fs.writeFile(schemaPath, JSON.stringify(mockSchema));

--- a/packages/zudoku/src/vite/api/SchemaManager.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.ts
@@ -8,7 +8,10 @@ import { upgrade, validate } from "@scalar/openapi-parser";
 import { deepEqual } from "fast-equals";
 import type { LoadedConfig } from "../../config/config.js";
 import type { Processor } from "../../config/validators/BuildSchema.js";
-import type { VersionConfig } from "../../config/validators/ZudokuConfig.js";
+import type {
+  ApiOptionsConfig,
+  VersionConfig,
+} from "../../config/validators/ZudokuConfig.js";
 import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
 import { ensureArray } from "../../lib/util/ensureArray.js";
 import { flattenAllOfProcessor } from "../../lib/util/flattenAllOfProcessor.js";
@@ -201,6 +204,10 @@ export class SchemaManager {
         ? existingSchema.path
         : paramsPath(params) || schemaVersion;
 
+    const config = ensureArray(this.config.apis ?? []).find(
+      (c) => c.path === configuredPath,
+    );
+
     const processed = {
       schema: processedSchema,
       version: schemaVersion,
@@ -218,6 +225,7 @@ export class SchemaManager {
         versionPath,
         configuredPath,
         params,
+        config?.options,
       ),
       processedJsonPath,
       processedTime,
@@ -340,15 +348,21 @@ export class SchemaManager {
     versionPath: string,
     apiPath: string,
     params: Record<string, string>,
+    config: ApiOptionsConfig | undefined,
   ) => {
     const suffix = paramsSuffix(params);
     const extension = suffix ? ".json" : path.extname(inputPath);
+
+    const fileName =
+      config?.schemaDownload?.fileName ??
+      this.config.defaults?.apis?.schemaDownload?.fileName ??
+      "schema";
 
     return joinUrl(
       this.config.basePath,
       apiPath,
       versionPath,
-      `schema${suffix}${extension}`,
+      `${fileName}${suffix}${extension}`,
     );
   };
 


### PR DESCRIPTION
Add new config option for open apis: `schemaDownload.fileName`. Makes it possible to override the name of the file where the raw OpenAPI specification is served for download. The default value is `"schema"`, which is backwards compatible, see for example on cosmocargo: https://www.cosmocargo.dev/api-shipments/1.0.0/schema.json

Setting this value will override the name, so you can set it to for example `"openapi"`: https://www.cosmocargo.dev/api-shipments/1.0.0/openapi.json (which is recommended in the oas: https://spec.openapis.org/oas/v3.1.0.html#document-structure)

It is possible to override this name both in the `default` section, for all apis, or for individual specifications.