### PR TITLE
Add responsive tab navigation to MCPEndpoint component

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -5,6 +5,13 @@ import { Typography } from "../../components/Typography.js";
 import { Button } from "../../ui/Button.js";
 import { Callout } from "../../ui/Callout.js";
 import { Card } from "../../ui/Card.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../ui/Select.js";
 import { SyntaxHighlight } from "../../ui/SyntaxHighlight.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/Tabs.js";
 import {
@@ -67,6 +74,7 @@ export const MCPEndpoint = ({
   const vscodeConfig = getVscodeConfig(name, mcpUrl, auth);
 
   const defaultTab = visibleApps[0]?.id ?? "generic";
+  const [activeTab, setActiveTab] = useState(defaultTab);
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(mcpUrl).then(() => {
@@ -345,9 +353,25 @@ export const MCPEndpoint = ({
 
           <hr className="my-4" />
 
-          <Tabs defaultValue={defaultTab} className="w-full">
+          <Tabs
+            value={activeTab}
+            onValueChange={setActiveTab}
+            className="w-full"
+          >
+            <Select value={activeTab} onValueChange={setActiveTab}>
+              <SelectTrigger className="w-full sm:hidden">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {visibleApps.map((app) => (
+                  <SelectItem key={app.id} value={app.id}>
+                    {app.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <TabsList
-              className="grid w-full"
+              className="hidden sm:grid w-full"
               style={{
                 gridTemplateColumns: `repeat(${visibleApps.length}, minmax(0, 1fr))`,
               }}


### PR DESCRIPTION
## Summary
Adds responsive tab navigation to the MCPEndpoint component by introducing a mobile-friendly Select dropdown that replaces the TabsList on smaller screens, while maintaining the full TabsList on desktop viewports.

<img width="1158" height="700" alt="CleanShot 2026-05-18 at 09 46 42@2x" src="https://github.com/user-attachments/assets/9cbda375-4380-4099-a8d7-8600e5922ad7" />


## Key Changes
- Imported Select UI components (`Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`) from the UI module
- Added `activeTab` state using `useState` to manage the currently selected tab, replacing the static `defaultValue` approach
- Converted the Tabs component from uncontrolled to controlled by binding `value` and `onValueChange` props to the `activeTab` state
- Added a responsive Select dropdown that displays only on mobile (`sm:hidden`) to allow tab selection
- Updated TabsList to hide on mobile (`hidden sm:grid`) and display only on desktop viewports
- Both Select and TabsList are synchronized through the shared `activeTab` state

## Implementation Details
The responsive design uses Tailwind's responsive prefixes to toggle between the Select (mobile) and TabsList (desktop) components. The Select dropdown mirrors the TabsList functionality by mapping over `visibleApps` to generate SelectItem options, ensuring feature parity across both navigation methods.

https://claude.ai/code/session_017WPtWrqWaSNtmyxTN1QBt8