### PR TITLE
docs: Add Categories and Tags section to API Catalog documentation

### DIFF
--- a/docs/pages/docs/configuration/api-catalog.md
+++ b/docs/pages/docs/configuration/api-catalog.md
@@ -6,6 +6,22 @@ sidebar_icon: book-open
 If you're dealing with multiple APIs and multiple OpenAPI files, the API Catalog comes in handy. It
 creates an overview of all your APIs and lets you organize them into categories and tags.
 
+## Categories and Tags
+
+Each entry in an API's `categories` array has two fields, `label` and `tags`, which serve different
+purposes:
+
+- **`label`** is the primary grouping. The catalog page renders one filter chip per unique label, so
+  this is what users click to narrow the list. An API can belong to multiple categories by adding
+  multiple entries to the array.
+- **`tags`** are secondary descriptors attached to that category. They do _not_ get their own filter
+  chip. Instead, they are matched against the search input and rendered as additional badges on the
+  API card (alongside the label). Use them for finer-grained keywords that should help users
+  discover an API without cluttering the top-level filters.
+
+For example, `{ label: "Payments", tags: ["billing", "subscriptions"] }` puts the API under the
+"Payments" filter chip and adds "billing" and "subscriptions" as searchable badges on its card.
+
 ## Enable API Catalog
 
 The first step to enable the API Catalog, you need to add a `catalogs` object to your Zudoku


### PR DESCRIPTION
## Summary

Added a new "Categories and Tags" section to the API Catalog documentation that explains the distinction between `label` and `tags` fields in the `categories` array, how they function in the UI, and provides a practical example.

## Changes

- Added comprehensive documentation explaining the purpose and behavior of `label` and `tags` fields
- Clarified that `label` is the primary grouping mechanism that creates filter chips
- Explained that `tags` are secondary descriptors used for search matching and rendered as badges
- Included a concrete example showing how to structure a category entry with both label and tags

## Details

The new section is positioned early in the API Catalog documentation (after the introductory paragraph and before the "Enable API Catalog" section) to help users understand the core concepts before implementing the feature. The explanation uses clear language and formatting to distinguish between the two concepts and their respective roles in the UI.

https://claude.ai/code/session_01ByEFHH7udUHs9T4GgGYDY7