### PR TITLE
perf(cli): lazy-load command modules to slash startup time

### DIFF
--- a/docs/pages/docs/configuration/overview.md
+++ b/docs/pages/docs/configuration/overview.md
@@ -297,12 +297,15 @@ passed to the CLI as `--port`, or set via the `PORT` environment variable.
 
 If the port is already in use, the next available port will be used.
 
-Resolution order (highest precedence first):
+Resolution order for `dev` (highest precedence first):
 
 1. `--port` CLI flag
 2. `PORT` environment variable
 3. `port` in the config file
-4. Default (`3000` for `dev`, `4000` for `preview`)
+4. Default (`3000`)
+
+`zudoku preview` uses the same flag and env-var precedence but does not read `port` from the config
+file. It defaults to `4000`.
 
 See [Named local URLs](../guides/named-local-urls.md) for how to swap the port-based URL for
 something like `feature-branch.localhost`.

--- a/docs/pages/docs/configuration/overview.md
+++ b/docs/pages/docs/configuration/overview.md
@@ -287,7 +287,7 @@ URL.
 ### `port`
 
 The port on which the development server will run. Defaults to `3000`. This option can also be
-passed to the CLI as `--port' (which takes precedence).
+passed to the CLI as `--port`, or set via the `PORT` environment variable.
 
 ```ts
 {
@@ -296,6 +296,16 @@ passed to the CLI as `--port' (which takes precedence).
 ```
 
 If the port is already in use, the next available port will be used.
+
+Resolution order (highest precedence first):
+
+1. `--port` CLI flag
+2. `PORT` environment variable
+3. `port` in the config file
+4. Default (`3000` for `dev`, `4000` for `preview`)
+
+See [Named local URLs](../guides/named-local-urls.md) for how to swap the port-based URL for
+something like `feature-branch.localhost`.
 
 ### `basePath`
 

--- a/docs/pages/docs/guides/named-local-urls.md
+++ b/docs/pages/docs/guides/named-local-urls.md
@@ -1,0 +1,50 @@
+---
+title: Named local URLs
+sidebar_icon: globe
+---
+
+By default the dev server is reachable at a port-based URL like `http://localhost:3000`. For
+multiple projects, feature branches, or anything that needs a stable URL (cookies, OAuth redirects,
+CORS allowlists), you can put a reverse proxy in front that maps a name like
+`feature-branch.localhost` to the dev server's port.
+
+Zudoku's dev server honors the `PORT` environment variable, so any wrapper that picks a port and
+spawns the dev server works without extra configuration.
+
+## With [portless](https://portless.sh)
+
+[portless](https://portless.sh) is a zero-config local proxy that assigns a free port, sets `PORT`
+when it spawns your script, and exposes the server under `https://<name>.localhost`.
+
+**Zero config** — runs the `dev` script from `package.json` and uses its `name` field as the
+subdomain:
+
+```sh
+portless
+```
+
+**Wrap an arbitrary command** without any config file:
+
+```sh
+portless feature-branch pnpm dev
+```
+
+Opens the dev server at `https://feature-branch.localhost`.
+
+**Config file** for more control — add `portless.json` at the project root, or a `"portless"` key in
+`package.json`:
+
+```json title=portless.json
+{
+  "name": "feature-branch",
+  "script": "dev"
+}
+```
+
+In every mode, Portless picks a free port, exports `PORT=<that port>`, and spawns the command.
+Zudoku reads `PORT` and binds there; Portless proxies traffic to it.
+
+## With other proxies
+
+Any reverse proxy that fronts the dev server works the same way — point it at the Zudoku port (set
+`PORT`, pass `--port`, or use the config file) and route traffic from whatever hostname you want.

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -116,6 +116,7 @@ export const docs: Navigation = [
     items: [
       "docs/guides/static-files",
       "docs/guides/environment-variables",
+      "docs/guides/named-local-urls",
       "docs/guides/custom-pages",
       "docs/guides/mermaid",
       "docs/guides/using-multiple-apis",

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -66,7 +66,7 @@
     "./testing": "./src/lib/testing/index.tsx"
   },
   "scripts": {
-    "build": "esbuild src/cli/cli.ts src/vite/prerender/worker.ts --outdir=dist/cli --entry-names=[name] --bundle --format=esm --packages=external --target=node20 --platform=node --log-level=error",
+    "build": "tsx scripts/build-cli.ts",
     "postbuild": "tsx scripts/check-external-deps.ts",
     "typecheck": "tsc --project tsconfig.app.json --noEmit",
     "generate:types": "tsx scripts/generate-types.js && tsx scripts/generate-flat-config.js",

--- a/packages/zudoku/scripts/build-cli.ts
+++ b/packages/zudoku/scripts/build-cli.ts
@@ -1,0 +1,16 @@
+import * as esbuild from "esbuild";
+
+await esbuild.build({
+  entryPoints: ["src/cli/cli.ts", "src/vite/prerender/worker.ts"],
+  outdir: "dist/cli",
+  entryNames: "[name]",
+  // Enable code-splitting so dynamic imports in cli.ts are chunked
+  chunkNames: "chunks/[name]-[hash]",
+  splitting: true,
+  bundle: true,
+  format: "esm",
+  packages: "external",
+  target: "node20",
+  platform: "node",
+  logLevel: "error",
+});

--- a/packages/zudoku/scripts/build-cli.ts
+++ b/packages/zudoku/scripts/build-cli.ts
@@ -4,8 +4,10 @@ await esbuild.build({
   entryPoints: ["src/cli/cli.ts", "src/vite/prerender/worker.ts"],
   outdir: "dist/cli",
   entryNames: "[name]",
-  // Enable code-splitting so dynamic imports in cli.ts are chunked
-  chunkNames: "chunks/[name]-[hash]",
+  // Code-splitting so dynamic imports in cli.ts get separate chunks.
+  // Chunks must live next to entries (no subdir) because prerender.ts uses
+  // `new URL("./worker.js", import.meta.url)` from a chunk to find worker.js.
+  chunkNames: "[name]-[hash]",
   splitting: true,
   bundle: true,
   format: "esm",

--- a/packages/zudoku/src/cli/cli.ts
+++ b/packages/zudoku/src/cli/cli.ts
@@ -1,9 +1,9 @@
-import * as Sentry from "@sentry/node";
+// Keep this file's static imports small. Heavy deps (vite, graphql, sentry,
+// mdx, shiki, …) must only be reachable via dynamic import inside a cmd.
+
+import type { Argv, CommandModule } from "yargs";
 import { hideBin } from "yargs/helpers";
 import yargs from "yargs/yargs";
-import build from "./cmds/build.js";
-import dev from "./cmds/dev.js";
-import preview from "./cmds/preview.js";
 import { shutdownAnalytics } from "./common/analytics/lib.js";
 import { MAX_WAIT_PENDING_TIME_MS, SENTRY_DSN } from "./common/constants.js";
 import { warnIfOutdatedVersion } from "./common/outdated.js";
@@ -11,18 +11,30 @@ import { printDiagnosticsToConsole } from "./common/output.js";
 import { getZudokuPackageJson } from "./common/package-json.js";
 import { warnPackageVersionMismatch } from "./common/version-check.js";
 
+type LazyCmd = {
+  command: string;
+  desc: string;
+  builder: (y: Argv) => Argv;
+  // biome-ignore lint/suspicious/noExplicitAny: argv shape varies per command
+  handler: (argv: any) => Promise<void> | void;
+};
+
+const lazyCommand = (
+  command: string,
+  describe: string,
+  load: () => Promise<{ default: LazyCmd }>,
+): CommandModule => ({
+  command,
+  describe,
+  builder: (y) => load().then(({ default: cmd }) => cmd.builder(y)),
+  handler: (argv) => load().then(({ default: cmd }) => cmd.handler(argv)),
+});
+
 process.env.ZUDOKU_ENV = process.env.ZUDOKU_INTERNAL_DEV
   ? "internal"
   : "module";
 
 const packageJson = getZudokuPackageJson();
-
-if (SENTRY_DSN) {
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    release: packageJson?.version,
-  });
-}
 
 const cli = yargs(hideBin(process.argv))
   .option("zuplo", {
@@ -30,16 +42,22 @@ const cli = yargs(hideBin(process.argv))
     description: "Enable Zuplo mode",
     global: true,
   })
-  .middleware((argv) => {
-    if (argv.zuplo) {
+  .middleware((args) => {
+    if (args.zuplo) {
       process.env.ZUPLO = "1";
       printDiagnosticsToConsole("Running in Zuplo mode");
     }
   })
   .middleware(warnPackageVersionMismatch)
-  .command(build)
-  .command(dev)
-  .command(preview)
+  .command(lazyCommand("build", "Build", () => import("./cmds/build.js")))
+  .command(lazyCommand("dev", "Runs locally", () => import("./cmds/dev.js")))
+  .command(
+    lazyCommand(
+      "preview",
+      "Preview production build",
+      () => import("./cmds/preview.js"),
+    ),
+  )
   .demandCommand()
   .strictCommands()
   .version(packageJson?.version)
@@ -47,16 +65,21 @@ const cli = yargs(hideBin(process.argv))
   .help();
 
 try {
-  // Don't block
   void warnIfOutdatedVersion(packageJson?.version);
 
   await cli.argv;
 
-  void Sentry.close(MAX_WAIT_PENDING_TIME_MS).then(() => {
+  if (SENTRY_DSN) {
+    const Sentry = await import("@sentry/node");
+    void Sentry.close(MAX_WAIT_PENDING_TIME_MS).then(() => {
+      process.exit(0);
+    });
+  } else {
     process.exit(0);
-  });
+  }
 } catch (err) {
-  if (err instanceof Error) {
+  if (SENTRY_DSN && err instanceof Error) {
+    const Sentry = await import("@sentry/node");
     Sentry.captureException(err);
   }
   throw err;

--- a/packages/zudoku/src/cli/cli.ts
+++ b/packages/zudoku/src/cli/cli.ts
@@ -66,17 +66,7 @@ const cli = yargs(hideBin(process.argv))
 
 try {
   void warnIfOutdatedVersion(packageJson?.version);
-
   await cli.argv;
-
-  if (SENTRY_DSN) {
-    const Sentry = await import("@sentry/node");
-    void Sentry.close(MAX_WAIT_PENDING_TIME_MS).then(() => {
-      process.exit(0);
-    });
-  } else {
-    process.exit(0);
-  }
 } catch (err) {
   if (SENTRY_DSN && err instanceof Error) {
     const Sentry = await import("@sentry/node");
@@ -86,3 +76,9 @@ try {
 } finally {
   await shutdownAnalytics();
 }
+
+if (SENTRY_DSN) {
+  const Sentry = await import("@sentry/node");
+  await Sentry.close(MAX_WAIT_PENDING_TIME_MS);
+}
+process.exit(0);

--- a/packages/zudoku/src/cli/cmds/build.ts
+++ b/packages/zudoku/src/cli/cmds/build.ts
@@ -1,7 +1,7 @@
 import type { Argv } from "yargs";
 import { build } from "../build/handler.js";
 import { captureEvent } from "../common/analytics/lib.js";
-import { DEFAULT_PREVIEW_PORT } from "../preview/handler.js";
+import { DEFAULT_PREVIEW_PORT } from "../common/constants.js";
 
 export type Arguments = {
   dir: string;

--- a/packages/zudoku/src/cli/common/constants.ts
+++ b/packages/zudoku/src/cli/common/constants.ts
@@ -8,3 +8,6 @@ export const MAX_WAIT_PENDING_TIME_MS = 1000;
 
 // PostHog
 export const POST_HOG_CAPTURE_KEY = undefined;
+
+// Defaults
+export const DEFAULT_PREVIEW_PORT = 4000;

--- a/packages/zudoku/src/cli/common/output.ts
+++ b/packages/zudoku/src/cli/common/output.ts
@@ -1,84 +1,13 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: Allow any type
 
-import * as Sentry from "@sentry/node";
 import colors from "picocolors";
-import { MAX_WAIT_PENDING_TIME_MS } from "./constants.js";
 
-// We standardize printing to the terminal with this module
-
-// According to https://unix.stackexchange.com/questions/331611/do-progress-reports-logging-information-belong-on-stderr-or-stdout
-// any diagnostic information should go to stderr, and only the actual output goes to stdout
+// Diagnostic info goes to stderr; stdout is reserved for command output.
+// https://unix.stackexchange.com/questions/331611/do-progress-reports-logging-information-belong-on-stderr-or-stdout
 export function printDiagnosticsToConsole(message?: any) {
   console.error(colors.bold(colors.blue(message)));
 }
 
 export function printWarningToConsole(message?: any) {
   console.error(message);
-}
-
-// This information is displayed to the user, so it should be actionable.
-export async function printCriticalFailureToConsoleAndExit(message?: any) {
-  console.error(colors.bold(colors.red(message)));
-  await Sentry.close(MAX_WAIT_PENDING_TIME_MS).then(() => {
-    process.exit(1);
-  });
-}
-
-// Only use this to output the actual result of a command
-// This outputs to STDOUT, which is reserved for the actual result of a command
-export function printResultToConsole(message?: any) {
-  console.log(colors.bold(colors.green(message)));
-}
-
-// Only use this to output the actual result of a command
-// This outputs to STDOUT, which is reserved for the actual result of a command
-export function printTableToConsole(table: any) {
-  console.table(table);
-}
-
-export async function printResultToConsoleAndExitGracefully(message?: any) {
-  printResultToConsole(message);
-  await Sentry.close(MAX_WAIT_PENDING_TIME_MS).then(() => {
-    process.exit(0);
-  });
-}
-
-export async function printTableToConsoleAndExitGracefully(table: any) {
-  printTableToConsole(table);
-  await Sentry.close(MAX_WAIT_PENDING_TIME_MS).then(() => {
-    process.exit(0);
-  });
-}
-
-// See https://nodejs.org/docs/latest-v18.x/api/process.html#a-note-on-process-io
-// We want to deliberately have STDOUT flush synchronously, so we can pipe the output to another command
-
-interface WriteStreamWithHandle {
-  _handle: {
-    setBlocking: (blocking: boolean) => void;
-  };
-  isTTY: boolean;
-}
-
-export default function setBlocking() {
-  // Deno and browser have no process object:
-  if (typeof process === "undefined") return;
-  [process.stdout, process.stderr].forEach((_stream) => {
-    const stream = _stream as any as WriteStreamWithHandle;
-    if (
-      stream._handle &&
-      stream.isTTY &&
-      typeof stream._handle.setBlocking === "function"
-    ) {
-      stream._handle.setBlocking(true);
-    }
-  });
-}
-
-export function textOrJson(text: string) {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
 }

--- a/packages/zudoku/src/cli/dev/handler.ts
+++ b/packages/zudoku/src/cli/dev/handler.ts
@@ -15,9 +15,12 @@ export async function dev(argv: Arguments) {
   const packageJson = getZudokuPackageJson();
   process.env.NODE_ENV = "development";
   const dir = path.resolve(process.cwd(), argv.dir);
+  const port =
+    argv.port ?? (process.env.PORT ? Number(process.env.PORT) : undefined);
+
   const server = new DevServer({
     dir,
-    argPort: argv.port,
+    argPort: port,
     ssr: argv.ssr,
     open: argv.open,
   });

--- a/packages/zudoku/src/cli/preview/handler.ts
+++ b/packages/zudoku/src/cli/preview/handler.ts
@@ -2,9 +2,8 @@ import path from "node:path";
 import { preview as vitePreview } from "vite";
 import { getViteConfig } from "../../vite/config.js";
 import type { Arguments } from "../cmds/preview.js";
+import { DEFAULT_PREVIEW_PORT } from "../common/constants.js";
 import { printDiagnosticsToConsole } from "../common/output.js";
-
-export const DEFAULT_PREVIEW_PORT = 4000;
 
 export async function preview(argv: Arguments) {
   const dir = path.resolve(process.cwd(), argv.dir);
@@ -15,12 +14,15 @@ export async function preview(argv: Arguments) {
     isPreview: true,
   });
 
+  const port =
+    argv.port ??
+    (process.env.PORT ? Number(process.env.PORT) : undefined) ??
+    DEFAULT_PREVIEW_PORT;
+
   const server = await vitePreview({
     ...viteConfig,
     appType: "mpa", // to serve the static generated files
-    preview: {
-      port: argv.port ?? DEFAULT_PREVIEW_PORT,
-    },
+    preview: { port },
   });
 
   printDiagnosticsToConsole("");


### PR DESCRIPTION
The CLI was eagerly loading the full build+dev+preview dep graph on every invocation. 175 static imports, ~285 KB just to print `--version`. Defender real-time-scanning every JS file Node opens made cold starts crawl.

Fix: dispatcher only loads the matched command's module.