### PR TITLE
feat: default publishMarkdown to true

### DIFF
--- a/docs/pages/docs/configuration/docs.md
+++ b/docs/pages/docs/configuration/docs.md
@@ -228,7 +228,7 @@ The copy button provides:
 
 ### `publishMarkdown`
 
-**Type:** `boolean` **Default:** `false`
+**Type:** `boolean` **Default:** `true`
 
 When enabled, generates `.md` files for each documentation page during build. Pages can then be
 accessed at their URL path with the `.md` extension appended (e.g., `/docs/quickstart.md`).

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -317,7 +317,7 @@ export const DocsConfigSchema = z.object({
     .default([DEFAULT_DOCS_FILES]),
   publishMarkdown: z
     .boolean()
-    .default(false)
+    .default(true)
     .describe(
       "When enabled, generates .md files for each document during build. Access documents at their URL path with .md extension (e.g., /foo/hello.md). Markdown files are generated without frontmatter.",
     ),

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -200,7 +200,9 @@ export const MdxPage = ({
   const editText = editConfig ? editConfig.text || "Edit this page" : null;
 
   const copyMarkdownConfig =
-    frontmatter.copyPage !== false && defaultOptions?.copyPage !== false;
+    publishMarkdown === true &&
+    frontmatter.copyPage !== false &&
+    defaultOptions?.copyPage !== false;
 
   const markdownUrl = joinUrl(
     basePath,


### PR DESCRIPTION
Default for `publishMarkdown` is now `true`, so every doc page gets a `.md` artifact and the copy button by default. Set it to `false` to opt out.

Copy button now also checks `publishMarkdown === true` so it doesn't render when the files aren't being generated.