### PR TITLE
Make Auth0 audience optional for sign-in-only flows

### DIFF
--- a/docs/pages/docs/configuration/authentication-auth0.md
+++ b/docs/pages/docs/configuration/authentication-auth0.md
@@ -50,21 +50,7 @@ If you don't have an Auth0 account, you can sign up for a
 
    Keep the default **Refresh Token Expiration** settings unless you have specific requirements.
 
-3. Create an Auth0 API:
-   - Navigate to the [APIs section](https://manage.auth0.com/#/apis) in the Auth0 dashboard
-   - Click **Create API**
-   - Set a name (e.g., "Zudoku API") and an identifier (e.g., `https://your-domain.com/api`)
-   - Choose **RS256** as the signing algorithm
-   - Save the API
-
-   :::warning
-
-   This step is important. If you skip creating an API, Zudoku will not be able to validate the
-   tokens issued by Auth0, leading to authentication failures.
-
-   :::
-
-4. **Configure Zudoku**
+3. **Configure Zudoku**
 
    Add the Auth0 configuration to your [Zudoku configuration file](./overview.md):
 
@@ -76,7 +62,6 @@ If you don't have an Auth0 account, you can sign up for a
        type: "auth0",
        domain: "your-domain.us.auth0.com",
        clientId: "<your-auth0-client-id>",
-       audience: "https://your-domain.com/api", // Your Auth0 API identifier
      },
      // ... other configuration
    };
@@ -85,7 +70,36 @@ If you don't have an Auth0 account, you can sign up for a
    Where:
    - **domain**: Your Auth0 domain (found in your application's Basic Information)
    - **clientId**: The Client ID from your Auth0 application settings
-   - **audience**: The identifier of the Auth0 API you created (e.g., `https://your-domain.com/api`)
+
+4. **(Optional) Configure an audience for API access**
+
+   Only configure an `audience` if you need the access token to call a specific API (for example,
+   when using the API playground to send authenticated requests to your backend). Without an
+   audience, Auth0 issues an opaque token that can be used to identify the user via `/userinfo` —
+   which is all Zudoku needs for sign-in and protected routes.
+
+   :::tip
+
+   Avoid setting an audience when you don't need it. Issuing an access token scoped to an API when
+   it isn't going to call that API gives the token broader privileges than necessary.
+
+   :::
+
+   If you do need API access:
+   - Navigate to the [APIs section](https://manage.auth0.com/#/apis) in the Auth0 dashboard
+   - Click **Create API**, set a name (e.g., "Zudoku API") and an identifier (e.g.,
+     `https://your-domain.com/api`)
+   - Choose **RS256** as the signing algorithm and save the API
+   - Add the identifier to your Zudoku configuration:
+
+   ```typescript
+   authentication: {
+     type: "auth0",
+     domain: "your-domain.us.auth0.com",
+     clientId: "<your-auth0-client-id>",
+     audience: "https://your-domain.com/api", // Your Auth0 API identifier
+   }
+   ```
 
 </Stepper>
 
@@ -188,8 +202,9 @@ authentication: {
 3. **Authentication Loop**: Check that your Auth0 domain is a plain hostname only (e.g.,
    `your-domain.us.auth0.com`) without a protocol prefix (`https://`) or trailing slash.
 
-4. **Token Validation Errors**: Ensure the audience in your Zudoku configuration matches the
-   identifier of the Auth0 API you created.
+4. **Token Validation Errors**: If you've configured an `audience`, make sure it matches the
+   identifier of the Auth0 API you created. If you don't need to call an API, remove `audience` from
+   your configuration — Auth0 will issue an opaque token suitable for `/userinfo`.
 
 ## Next Steps
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -154,8 +154,13 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       expect(useAuthState.getState().profile?.emailVerified).toBe(true);
     });
 
-    test("throws OAuthAuthorizationError for opaque access tokens", async () => {
-      const provider = createProvider();
+    test("throws OAuthAuthorizationError for opaque access tokens when audience is configured", async () => {
+      const provider = new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        audience: "https://api.example.com",
+      });
 
       Object.defineProperty(window, "location", {
         configurable: true,
@@ -182,6 +187,44 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       await expect(provider.handleCallback()).rejects.toThrow(
         OAuthAuthorizationError,
       );
+    });
+
+    test("accepts opaque access tokens when no audience is configured", async () => {
+      const provider = createProvider();
+
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL(
+          "http://localhost/oauth/callback?state=test-state&code=test-code",
+        ),
+      });
+
+      sessionStorage.setItem("oauth-state", "test-state");
+      sessionStorage.setItem("code-verifier", "test-verifier");
+
+      vi.mocked(oauth.validateAuthResponse).mockReturnValue(
+        new URLSearchParams({ code: "test-code" }),
+      );
+      vi.mocked(oauth.authorizationCodeGrantRequest).mockResolvedValue(
+        new Response(),
+      );
+      vi.mocked(oauth.processAuthorizationCodeResponse).mockResolvedValue({
+        access_token: "opaque-token-without-dots",
+        token_type: "bearer",
+        expires_in: 3600,
+      } as oauth.TokenEndpointResponse);
+      vi.mocked(oauth.userInfoRequest).mockImplementation(() =>
+        Promise.resolve(
+          Response.json({ sub: "user-1", email: "u@e.com", name: "U" }),
+        ),
+      );
+
+      await expect(provider.handleCallback()).resolves.toBeDefined();
+      const providerData = useAuthState.getState().providerData;
+      expect(providerData?.type).toBe("openid");
+      if (providerData?.type === "openid") {
+        expect(providerData.accessToken).toBe("opaque-token-without-dots");
+      }
     });
 
     test("emailVerified defaults to false when absent everywhere", async () => {

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -145,14 +145,18 @@ export class OpenIDAuthenticationProvider
     }
 
     const accessToken = response.access_token;
-    if (accessToken.split(".").length !== 3) {
+    // Only require a JWT-shaped access token when an audience was explicitly
+    // configured. Without an audience, providers like Auth0 issue opaque
+    // tokens intended for the /userinfo endpoint, which is fine when the
+    // token isn't used to call an API.
+    if (this.audience && accessToken.split(".").length !== 3) {
       throw new OAuthAuthorizationError(
         "The access token received is not a valid JWT.",
         {
           error: "configuration_error",
           error_description:
             "The authentication provider is issuing opaque tokens instead of JWTs. " +
-            "Ensure you have configured the correct `audience` in your authentication settings.",
+            "Ensure the configured `audience` matches an API registered with your authentication provider.",
         },
       );
     }


### PR DESCRIPTION
## Summary

This change makes the `audience` configuration optional for Auth0 authentication, allowing Zudoku to work with opaque tokens issued by Auth0 when no API access is needed. Previously, an `audience` was required, which forced Auth0 to issue JWT-shaped access tokens even when they weren't being used.

## Key Changes

- **Documentation updates** (`authentication-auth0.md`):
  - Removed the mandatory "Create an Auth0 API" step from the main setup flow
  - Made API creation optional and moved it to a new step 4 with clear guidance on when it's needed
  - Removed the `audience` field from the basic configuration example
  - Added explanation that opaque tokens are sufficient for sign-in and protected routes via `/userinfo`
  - Updated troubleshooting section to clarify that `audience` is only needed when calling an API

- **OpenID provider implementation** (`openid.tsx`):
  - Modified JWT validation to only require a JWT-shaped access token when `audience` is explicitly configured
  - Updated error message to clarify that the issue is a mismatch between configured audience and provider setup
  - Allows opaque tokens to be accepted and stored when no audience is configured

- **Test coverage** (`openid.test.ts`):
  - Updated existing test to explicitly configure `audience` when testing JWT validation
  - Added new test case verifying that opaque tokens are accepted when no audience is configured
  - Both test cases now clearly document the expected behavior for each scenario

## Implementation Details

The key insight is that Auth0 issues different token types based on whether an `audience` is requested:
- **With audience**: JWT-shaped access token (three dot-separated parts) intended for API calls
- **Without audience**: Opaque token suitable only for the `/userinfo` endpoint

Since Zudoku only needs to identify the user via `/userinfo` for sign-in and route protection, the opaque token is sufficient. The JWT validation now only enforces the three-part structure when an audience is explicitly configured, making the feature optional and following the principle of least privilege.

https://claude.ai/code/session_01ABYqK3w9ZzADkgxHDksqYy