### PR TITLE
Tighten PricingTable grid sizing and gap

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pricing-ui/PricingTable.tsx
+++ b/packages/plugin-zuplo-monetization/src/pricing-ui/PricingTable.tsx
@@ -81,7 +81,7 @@ export const PricingTable = ({
     <>
       <div
         className={cn(
-          "w-full grid grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(300px,max-content))] justify-center gap-6",
+          "w-full grid grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] justify-center gap-2",
           className,
         )}
       >


### PR DESCRIPTION
## Summary

- Reduce the minimum card width in the PricingTable grid from `300px` to `200px`.
- Switch the second `minmax` arg from `max-content` to `1fr` so columns fill the row evenly instead of shrinking to content.
- Drop the inter-card `gap` from `6` to `2` for a denser layout.
- Bump `@zuplo/zudoku-plugin-monetization` to `0.0.36-pre.2`.

## Why

The previous `300px` / `max-content` / `gap-6` combination left a lot of whitespace and could collapse into a single column on mid-width viewports. The new values pack more plans per row and keep the columns equal width.

## Test plan

- [ ] Visually verify the PricingTable in a consumer (e.g. monetization plugin demo) at narrow, medium, and wide widths.
- [ ] Confirm `renderCard` overrides still receive the expected `defaultCard`.