### PR TITLE
Match PricingPageSkeleton grid to PricingTable

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/PricingPageSkeleton.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPageSkeleton.tsx
@@ -7,9 +7,9 @@ export const PricingPageSkeleton = () => (
       <Skeleton className="h-9 w-48 mx-auto" />
       <Skeleton className="h-5 w-96 mx-auto" />
     </div>
-    <div className="w-full grid grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(300px,max-content))] justify-center gap-6">
+    <div className="w-full grid grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] justify-center gap-2">
       {[1, 2, 3].map((i) => (
-        <Card key={i} className="w-[300px]">
+        <Card key={i}>
           <CardHeader className="space-y-3">
             <Skeleton className="h-6 w-24" />
             <Skeleton className="h-8 w-32" />


### PR DESCRIPTION
## Summary

Follow-up to [#2468](https://github.com/zuplo/zudoku/pull/2468). The live `PricingTable` was tightened (`minmax(200px,1fr)` / `gap-2`), but `PricingPageSkeleton` still rendered with the old `minmax(300px,max-content)` / `gap-6` grid and a fixed `w-[300px]` card, so the page reflowed when plans loaded.

- Switch the skeleton grid to `minmax(200px,1fr)` and `gap-2` to match `PricingTable`.
- Drop the fixed `w-[300px]` on the skeleton card so it fills its column under the new `1fr` sizing.

## Test plan

- [ ] Load a pricing page with slow plan data and confirm the skeleton occupies the same footprint as the rendered table.