### PR TITLE
fix: placeholder auth header in code snippets

### DIFF
--- a/examples/cosmo-cargo/schema/label-v3.json
+++ b/examples/cosmo-cargo/schema/label-v3.json
@@ -40,10 +40,10 @@
   ],
   "security": [
     {
-      "ApiKeyAuth": []
+      "BearerAuth": []
     },
     {
-      "BearerAuth": []
+      "ApiKeyAuth": []
     },
     {
       "OAuth2": ["read:labels", "write:labels"]

--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -84,10 +84,10 @@
   ],
   "security": [
     {
-      "ApiKeyAuth": []
+      "BearerAuth": []
     },
     {
-      "BearerAuth": []
+      "ApiKeyAuth": []
     }
   ],
   "components": {
@@ -743,7 +743,7 @@
             "source": "import requests\n\nresponse = requests.post(\n    'https://api.cosmocargo.com/v1/shipments',\n    headers={\n        'Content-Type': 'application/json',\n        'X-API-Key': 'YOUR_API_KEY',\n    },\n    json={\n        'recipientAddress': {\n            'name': 'Zara Nebula',\n            'planet': 'Mars',\n            'station': 'Olympus Mons Hub',\n        },\n        'packages': [{'weight': 2.5, 'dimensions': '30x20x15'}],\n    },\n)\n\nshipment = response.json()"
           }
         ],
-        "security": [{ "ApiKeyAuth": [] }, { "BearerAuth": [] }],
+        "security": [{ "BearerAuth": [] }, { "ApiKeyAuth": [] }],
         "parameters": [
           {
             "$ref": "#/components/parameters/CorrelationId"
@@ -1234,7 +1234,7 @@
         "summary": "Cancel shipment",
         "description": "Cancel a shipment that hasn't been picked up yet.",
         "operationId": "cancelShipment",
-        "security": [{ "ApiKeyAuth": [] }, { "BearerAuth": [] }],
+        "security": [{ "BearerAuth": [] }, { "ApiKeyAuth": [] }],
         "parameters": [
           {
             "name": "trackingNumber",

--- a/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.test.ts
@@ -142,6 +142,97 @@ describe("createHttpSnippet body encoding", () => {
   });
 });
 
+const opWithSecurity = (
+  schemes: Array<{
+    name: string;
+    type: "apiKey" | "http" | "oauth2" | "openIdConnect";
+    in?: "header" | "query";
+    paramName?: string;
+    scheme?: string;
+  }>,
+): OperationsFragmentFragment =>
+  ({
+    method: "GET",
+    path: "/things",
+    parameters: [],
+    security: [{ schemes: schemes.map((s) => ({ scopes: [], scheme: s })) }],
+  }) as any;
+
+describe("createHttpSnippet placeholder auth", () => {
+  it("adds Bearer placeholder for http bearer when no resolved auth", () => {
+    const out = shell(
+      opWithSecurity([{ name: "B", type: "http", scheme: "bearer" }]),
+    );
+    expect(out).toContain("Authorization: Bearer <token>");
+  });
+
+  it("adds Basic placeholder for http basic", () => {
+    const out = shell(
+      opWithSecurity([{ name: "B", type: "http", scheme: "basic" }]),
+    );
+    expect(out).toContain("Authorization: Basic <credentials>");
+  });
+
+  it("adds generic capitalized scheme for non-basic/bearer http auth", () => {
+    const out = shell(
+      opWithSecurity([{ name: "D", type: "http", scheme: "digest" }]),
+    );
+    expect(out).toContain("Authorization: Digest <token>");
+  });
+
+  it("adds apiKey header placeholder", () => {
+    const out = shell(
+      opWithSecurity([
+        { name: "K", type: "apiKey", in: "header", paramName: "X-Api-Key" },
+      ]),
+    );
+    expect(out).toContain("X-Api-Key: <api-key>");
+  });
+
+  it("adds apiKey query placeholder", () => {
+    const out = shell(
+      opWithSecurity([
+        { name: "K", type: "apiKey", in: "query", paramName: "api_key" },
+      ]),
+    );
+    expect(out).toContain("api_key=<api-key>");
+  });
+
+  it.each(["oauth2", "openIdConnect"] as const)(
+    "adds Bearer placeholder for %s",
+    (type) => {
+      const out = shell(opWithSecurity([{ name: "O", type }]));
+      expect(out).toContain("Authorization: Bearer <token>");
+    },
+  );
+
+  it("emits no auth headers when operation has no security", () => {
+    const out = shell(makeOp());
+    expect(out).not.toContain("Authorization");
+    expect(out).not.toContain("<api-key>");
+  });
+
+  it("falls back to placeholder when resolvedAuth is empty but defined", () => {
+    const out = shell(
+      opWithSecurity([{ name: "B", type: "http", scheme: "bearer" }]),
+      { headers: [], queryString: [] },
+    );
+    expect(out).toContain("Authorization: Bearer <token>");
+  });
+
+  it("prefers resolved auth over placeholders", () => {
+    const out = shell(
+      opWithSecurity([{ name: "B", type: "http", scheme: "bearer" }]),
+      {
+        headers: [{ name: "authorization", value: "Bearer real-token" }],
+        queryString: [],
+      },
+    );
+    expect(out).toContain("Bearer real-token");
+    expect(out).not.toContain("<token>");
+  });
+});
+
 describe("getConverted plugin selection", () => {
   it("falls back to shell/curl for an unknown language", () => {
     const req = createHttpSnippet({

--- a/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/util/createHttpSnippet.ts
@@ -47,6 +47,52 @@ export const EMPTY_RESOLVED_AUTH: ResolvedAuth = {
   queryString: [],
 };
 
+const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+// Picks the first non-empty security requirement. OpenAPI requirements are OR'd
+// (any one satisfies); we only show one alternative as a placeholder.
+const getPlaceholderAuth = (
+  operation: OperationsFragmentFragment,
+): ResolvedAuth => {
+  const requirement = operation.security?.find((r) => r.schemes.length > 0);
+  if (!requirement) return EMPTY_RESOLVED_AUTH;
+
+  const headers: Array<{ name: string; value: string }> = [];
+  const queryString: Array<{ name: string; value: string }> = [];
+
+  for (const { scheme } of requirement.schemes) {
+    switch (scheme.type) {
+      case "apiKey": {
+        if (!scheme.paramName) break;
+        const entry = { name: scheme.paramName, value: "<api-key>" };
+        if (scheme.in === "header") headers.push(entry);
+        else if (scheme.in === "query") queryString.push(entry);
+        break;
+      }
+      case "http": {
+        const httpScheme = scheme.scheme?.toLowerCase();
+        if (httpScheme === "basic") {
+          headers.push({ name: "Authorization", value: "Basic <credentials>" });
+        } else if (httpScheme === "bearer" || !scheme.scheme) {
+          headers.push({ name: "Authorization", value: "Bearer <token>" });
+        } else {
+          headers.push({
+            name: "Authorization",
+            value: `${capitalize(scheme.scheme)} <token>`,
+          });
+        }
+        break;
+      }
+      case "oauth2":
+      case "openIdConnect":
+        headers.push({ name: "Authorization", value: "Bearer <token>" });
+        break;
+    }
+  }
+
+  return { headers, queryString };
+};
+
 export const createHttpSnippet = ({
   operation,
   selectedServer,
@@ -113,12 +159,16 @@ export const createHttpSnippet = ({
                 : "<value>"),
       })) ?? [];
 
+  const effectiveAuth =
+    resolvedAuth &&
+    (resolvedAuth.headers.length > 0 || resolvedAuth.queryString.length > 0)
+      ? resolvedAuth
+      : getPlaceholderAuth(operation);
+
   const authHeaderNames = new Set(
-    resolvedAuth?.headers.map((h) => h.name.toLowerCase()) ?? [],
+    effectiveAuth.headers.map((h) => h.name.toLowerCase()),
   );
-  const authQueryNames = new Set(
-    resolvedAuth?.queryString.map((q) => q.name) ?? [],
-  );
+  const authQueryNames = new Set(effectiveAuth.queryString.map((q) => q.name));
 
   return {
     method: operation.method.toUpperCase(),
@@ -129,11 +179,11 @@ export const createHttpSnippet = ({
     postData,
     headers: [
       ...baseHeaders.filter((h) => !authHeaderNames.has(h.name.toLowerCase())),
-      ...(resolvedAuth?.headers ?? []),
+      ...effectiveAuth.headers,
     ],
     queryString: [
       ...baseQueryString.filter((q) => !authQueryNames.has(q.name)),
-      ...(resolvedAuth?.queryString ?? []),
+      ...effectiveAuth.queryString,
     ],
   } satisfies Partial<HarRequest>;
 };


### PR DESCRIPTION
Snippets had no auth header when no credential was configured, so copy-pasting curl from the docs hit 401. Now we render a placeholder derived from the operation's first security requirement:

- apiKey (header/query): `<paramName>: <api-key>`
- http basic: `Authorization: Basic <credentials>`
- http bearer or missing scheme: `Authorization: Bearer <token>`
- http other (e.g. digest): `Authorization: <Scheme> <token>`
- oauth2 / openIdConnect: `Authorization: Bearer <token>`

Real credentials still take precedence.

Also reordered global security in label-v3 and shipments cosmo-cargo schemas so the Bearer placeholder shows up in the demo.