### PR TITLE
ci(release-monetization): sync to npm latest + rebase/retry push

### DIFF
--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -97,12 +97,18 @@ jobs:
       - name: Push Git Changes
         env:
           ZUDOKU_RELEASE_TOKEN: ${{ steps.zudoku-release-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "::add-mask::${ZUDOKU_RELEASE_TOKEN}"
           REMOTE="https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git"
+          TAG="monetization-v${VERSION}"
           for i in 1 2 3; do
-            git pull --rebase "$REMOTE" main && \
-            git push "$REMOTE" main --follow-tags && exit 0
+            if git pull --rebase "$REMOTE" main; then
+              git tag -f -a "$TAG" -m "Release monetization v${VERSION}"
+              git push "$REMOTE" main --follow-tags && exit 0
+            else
+              git rebase --abort || true
+            fi
             sleep $((i * 5))
           done
           exit 1

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -52,6 +52,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Sync to npm latest
+        working-directory: packages/plugin-zuplo-monetization
+        run: |
+          PUBLISHED=$(npm view @zuplo/zudoku-plugin-monetization version)
+          npm version "$PUBLISHED" --allow-same-version --no-git-tag-version
+
       - name: Typecheck
         run: pnpm --filter @zuplo/zudoku-plugin-monetization run typecheck
 
@@ -93,7 +99,13 @@ jobs:
           ZUDOKU_RELEASE_TOKEN: ${{ steps.zudoku-release-token.outputs.token }}
         run: |
           echo "::add-mask::${ZUDOKU_RELEASE_TOKEN}"
-          git push "https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git" main --follow-tags
+          REMOTE="https://x-access-token:${ZUDOKU_RELEASE_TOKEN}@github.com/zuplo/zudoku.git"
+          for i in 1 2 3; do
+            git pull --rebase "$REMOTE" main && \
+            git push "$REMOTE" main --follow-tags && exit 0
+            sleep $((i * 5))
+          done
+          exit 1
 
       - name: Generate a token
         id: app-token


### PR DESCRIPTION
Fix desync where `git push main` race left npm published but package.json on main stale, causing reruns to bump to an already-published version.

- Sync local package.json to npm latest before bump (auto-corrects drift)
- Rebase + retry (3x) on push to tolerate main moving mid-run