### PR TITLE
fix: tolerate incompatible anyOf branches when flattening allOf

### DIFF
--- a/examples/cosmo-cargo/schema/interplanetary.json
+++ b/examples/cosmo-cargo/schema/interplanetary.json
@@ -1024,6 +1024,57 @@
             "description": "Current fuel availability percentage"
           }
         }
+      },
+      "QuantumContext": {
+        "anyOf": [
+          {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        ]
+      },
+      "QuantumManifestBase": {
+        "type": "object",
+        "required": ["manifestId", "quantumContext"],
+        "properties": {
+          "manifestId": {
+            "type": "string",
+            "description": "Unique manifest identifier"
+          },
+          "quantumContext": { "$ref": "#/components/schemas/QuantumContext" }
+        }
+      },
+      "QuantumManifest": {
+        "allOf": [
+          { "$ref": "#/components/schemas/QuantumManifestBase" },
+          {
+            "type": "object",
+            "required": ["entries"],
+            "properties": {
+              "quantumContext": {
+                "$ref": "#/components/schemas/QuantumContext"
+              },
+              "entries": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["entryId", "mass"],
+                  "properties": {
+                    "entryId": { "type": "string" },
+                    "mass": {
+                      "type": "number",
+                      "description": "Cargo mass in metric tons"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
       }
     }
   },
@@ -1273,6 +1324,33 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/interplanetary/quantum-manifests/{manifestId}": {
+      "get": {
+        "tags": ["Interplanetary"],
+        "summary": "Get quantum manifest",
+        "description": "Returns a quantum cargo manifest.",
+        "operationId": "getQuantumManifest",
+        "parameters": [
+          {
+            "name": "manifestId",
+            "in": "path",
+            "required": true,
+            "description": "Manifest identifier",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quantum manifest",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/QuantumManifest" }
               }
             }
           }

--- a/packages/zudoku/src/lib/util/flattenAllOf.test.ts
+++ b/packages/zudoku/src/lib/util/flattenAllOf.test.ts
@@ -243,6 +243,36 @@ describe("flattenAllOf", () => {
     expect(flattenAllOf(objectSchema)).toEqual(objectSchema);
   });
 
+  it("should not throw when allOf branches share an anyOf with incompatible types", () => {
+    const JsonLdContext = {
+      anyOf: [{ type: "array", items: {} }, { type: "object" }],
+    };
+    const schema = {
+      allOf: [
+        { type: "object", properties: { ctx: JsonLdContext } },
+        { type: "object", properties: { ctx: JsonLdContext } },
+      ],
+    } as JSONSchema7;
+
+    expect(() => flattenAllOf(schema)).not.toThrow();
+    const result = flattenAllOf(schema) as JSONSchema7;
+    expect(result).not.toHaveProperty("allOf");
+    expect(result).toHaveProperty("properties.ctx");
+  });
+
+  it("should not throw on incompatible enums", () => {
+    const schema = {
+      allOf: [
+        { type: "string", enum: ["a", "b"] },
+        { type: "string", enum: ["c", "d"] },
+      ],
+    } as JSONSchema7;
+
+    expect(() => flattenAllOf(schema)).not.toThrow();
+    const result = flattenAllOf(schema) as JSONSchema7;
+    expect(result.enum).toEqual(expect.arrayContaining(["a", "b", "c", "d"]));
+  });
+
   it("should convert boolean true to empty object", () => {
     // Empty objects merge to boolean true, should convert back to {}
     const schema = { allOf: [{}] } as JSONSchema7;

--- a/packages/zudoku/src/lib/util/flattenAllOf.ts
+++ b/packages/zudoku/src/lib/util/flattenAllOf.ts
@@ -13,6 +13,19 @@ const { compareSchemaDefinitions, compareSchemaValues } = createComparator();
 const { mergeArrayOfSchemaDefinitions } = createMerger({
   intersectJson: createIntersector(compareSchemaValues),
   deduplicateJsonSchemaDef: createDeduplicator(compareSchemaDefinitions),
+  // Default mergers throw on incompatible type/enum pairs, which aborts the
+  // whole flatten even when the bad pair is one branch of a pairwise `anyOf`
+  // combination. Union instead.
+  mergers: {
+    type: (a, b) => {
+      if (a === b) return a;
+      const aArr = Array.isArray(a) ? a : [a];
+      const bArr = Array.isArray(b) ? b : [b];
+      const set = new Set([...aArr, ...bArr]);
+      return set.size === 1 ? [...set][0]! : ([...set] as typeof a);
+    },
+    enum: (a, b) => Array.from(new Set([...a, ...b])),
+  },
 });
 
 const shallowAllOfMerge = createShallowAllOfMerge(


### PR DESCRIPTION
Schemas where two `allOf` branches both reference an `anyOf` of incompatible types (e.g. JSON-LD `@context: array | object`) crash flattening with `It is not possible to create an intersection of the following incompatible types`. The default `type` and `enum` mergers in `@x0k/json-schema-merge` throw on empty intersections, so a single impossible pair from a pairwise `anyOf` combination aborts the whole merge. Override both to union instead.

Reproducible via `cosmo-cargo`: `GET /interplanetary/quantum-manifests/{manifestId}` exercises the pattern.