### PR TITLE
feat(callout): modernize admonitions and add new types

### DIFF
--- a/docs/pages/docs/components/callout.mdx
+++ b/docs/pages/docs/components/callout.mdx
@@ -185,7 +185,7 @@ Or pass any React node as the `icon` to override the default for the chosen `typ
   Or have neither title nor icon
 </Callout>
 
-<Callout type="tip" icon={<HeartIcon />} title="Made with love">
+<Callout type="tip" icon={<FileHeartIcon />} title="Made with love">
   The icon inherits the type's accent color.
 </Callout>
 ```

--- a/docs/pages/docs/components/callout.mdx
+++ b/docs/pages/docs/components/callout.mdx
@@ -5,8 +5,12 @@ sidebar_icon: circle-alert
 
 import { Callout } from "zudoku/ui/Callout";
 import { ReactComponentDoc } from "zudoku/ui/ReactComponentDoc";
+import { FileHeartIcon } from "zudoku/icons";
 
-This is a callout component that can be used to draw attention to important information.
+A callout component to draw attention to important information.
+
+Writing Markdown? Use the [admonitions](../markdown/admonitions) shorthand (`:::tip`) instead of the
+component directly.
 
 ## Import
 
@@ -15,13 +19,6 @@ import { Callout } from "zudoku/ui/Callout";
 ```
 
 <ReactComponentDoc component={Callout} />
-
-:::tip{title="Hot tip"}
-
-There's a shortcut to use callout components in Markdown files:
-[Admonitions](../markdown/admonitions).
-
-:::
 
 ## Note
 
@@ -83,6 +80,78 @@ There's a shortcut to use callout components in Markdown files:
 </Callout>
 ```
 
+## Sparkles
+
+<Callout type="sparkles" title="What's new">
+  Highlight new features or AI-powered functionality.
+</Callout>
+
+```tsx
+<Callout type="sparkles" title="What's new">
+  Highlight new features or AI-powered functionality.
+</Callout>
+```
+
+## Rocket
+
+<Callout type="rocket" title="Getting started">
+  Spin up your first project in minutes.
+</Callout>
+
+```tsx
+<Callout type="rocket" title="Getting started">
+  Spin up your first project in minutes.
+</Callout>
+```
+
+## Settings
+
+<Callout type="settings" title="Configuration">
+  Tweak these options to match your workflow.
+</Callout>
+
+```tsx
+<Callout type="settings" title="Configuration">
+  Tweak these options to match your workflow.
+</Callout>
+```
+
+## Zap
+
+<Callout type="zap" title="Performance">
+  Use this pattern when latency matters.
+</Callout>
+
+```tsx
+<Callout type="zap" title="Performance">
+  Use this pattern when latency matters.
+</Callout>
+```
+
+## Lock
+
+<Callout type="lock" title="Authentication required">
+  This endpoint needs a valid API key.
+</Callout>
+
+```tsx
+<Callout type="lock" title="Authentication required">
+  This endpoint needs a valid API key.
+</Callout>
+```
+
+## Megaphone
+
+<Callout type="megaphone" title="Announcement">
+  We've just shipped a breaking change to the v2 API.
+</Callout>
+
+```tsx
+<Callout type="megaphone" title="Announcement">
+  We've just shipped a breaking change to the v2 API.
+</Callout>
+```
+
 ## Variations
 
 Callouts can be customized by omitting the title or icon:
@@ -97,6 +166,12 @@ Callouts can be customized by omitting the title or icon:
   Or have neither title nor icon
 </Callout>
 
+Or pass any React node as the `icon` to override the default for the chosen `type`:
+
+<Callout type="tip" icon={<FileHeartIcon />} title="Made with love">
+  The icon inherits the type's accent color.
+</Callout>
+
 ```tsx
 <Callout type="note">
   Without a title
@@ -109,4 +184,47 @@ Callouts can be customized by omitting the title or icon:
 <Callout type="note" icon={false}>
   Or have neither title nor icon
 </Callout>
+
+<Callout type="tip" icon={<HeartIcon />} title="Made with love">
+  The icon inherits the type's accent color.
+</Callout>
+```
+
+## Customize colors
+
+Each callout type is driven by a single CSS variable that determines the icon, border tint, and
+background tint via `color-mix`. Override any of them in your theme's `customCss` to recolor a type
+globally:
+
+```ts title="zudoku.config.ts"
+export default {
+  theme: {
+    customCss: `
+      :root {
+        --callout-tip: oklch(0.65 0.18 160);
+        --callout-sparkles: oklch(0.6 0.22 320);
+      }
+      .dark {
+        --callout-tip: oklch(0.78 0.18 160);
+        --callout-sparkles: oklch(0.75 0.2 320);
+      }
+    `,
+  },
+};
+```
+
+All available variables:
+
+```css
+--callout-note
+--callout-tip
+--callout-info
+--callout-caution
+--callout-danger
+--callout-sparkles
+--callout-rocket
+--callout-settings
+--callout-zap
+--callout-lock
+--callout-megaphone
 ```

--- a/docs/pages/docs/markdown/admonitions.md
+++ b/docs/pages/docs/markdown/admonitions.md
@@ -80,6 +80,85 @@ Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
 
 :::
 
+## Additional types
+
+Beyond the standard severity types, the following themed variants are available with their own color
+and icon:
+
+```markdown
+:::sparkles
+
+For new features or AI-powered functionality.
+
+:::
+
+:::rocket
+
+For getting-started or launch-related content.
+
+:::
+
+:::settings
+
+For configuration sections.
+
+:::
+
+:::zap
+
+For performance tips.
+
+:::
+
+:::lock
+
+For authentication and security notes.
+
+:::
+
+:::megaphone
+
+For announcements.
+
+:::
+```
+
+:::sparkles
+
+For new features or AI-powered functionality.
+
+:::
+
+:::rocket
+
+For getting-started or launch-related content.
+
+:::
+
+:::settings
+
+For configuration sections.
+
+:::
+
+:::zap
+
+For performance tips.
+
+:::
+
+:::lock
+
+For authentication and security notes.
+
+:::
+
+:::megaphone
+
+For announcements.
+
+:::
+
 ## With title
 
 You can also add a title to the admonition by adding it after the type:

--- a/packages/zudoku/src/app/defaultTheme.css
+++ b/packages/zudoku/src/app/defaultTheme.css
@@ -38,6 +38,17 @@
   --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
   --sidebar-border: oklch(0.92 0.004 286.32);
   --sidebar-ring: oklch(0.705 0.015 286.067);
+  --callout-note: oklch(0.55 0.02 280);
+  --callout-tip: oklch(0.62 0.17 145);
+  --callout-info: oklch(0.58 0.16 250);
+  --callout-caution: oklch(0.7 0.16 75);
+  --callout-danger: oklch(0.6 0.22 25);
+  --callout-sparkles: oklch(0.6 0.2 300);
+  --callout-rocket: oklch(0.55 0.2 270);
+  --callout-settings: oklch(0.5 0.015 285);
+  --callout-zap: oklch(0.68 0.17 95);
+  --callout-lock: oklch(0.52 0.06 230);
+  --callout-megaphone: oklch(0.62 0.15 220);
 }
 
 .dark {
@@ -74,4 +85,15 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.552 0.016 285.938);
+  --callout-note: oklch(0.72 0.02 280);
+  --callout-tip: oklch(0.75 0.17 145);
+  --callout-info: oklch(0.72 0.16 250);
+  --callout-caution: oklch(0.8 0.16 75);
+  --callout-danger: oklch(0.7 0.2 25);
+  --callout-sparkles: oklch(0.72 0.18 300);
+  --callout-rocket: oklch(0.7 0.18 270);
+  --callout-settings: oklch(0.72 0.015 285);
+  --callout-zap: oklch(0.85 0.16 90);
+  --callout-lock: oklch(0.7 0.06 230);
+  --callout-megaphone: oklch(0.75 0.14 220);
 }

--- a/packages/zudoku/src/lib/ui/Callout.tsx
+++ b/packages/zudoku/src/lib/ui/Callout.tsx
@@ -2,66 +2,56 @@ import {
   AlertTriangleIcon,
   InfoIcon,
   LightbulbIcon,
+  LockIcon,
   type LucideIcon,
+  MegaphoneIcon,
+  RocketIcon,
+  SettingsIcon,
   ShieldAlertIcon,
+  SparklesIcon,
+  ZapIcon,
 } from "lucide-react";
-import { type ReactNode, useId } from "react";
+import { type CSSProperties, type ReactNode, useId } from "react";
 import { cn } from "../util/cn.js";
 
-const stylesMap = {
-  note: {
-    border: "border-gray-300 dark:border-zinc-800",
-    bg: "bg-gray-100 dark:bg-zinc-800/50",
-    iconColor: "text-gray-600 dark:text-zinc-300",
-    titleColor: "text-gray-600 dark:text-zinc-300",
-    textColor:
-      "text-gray-600 dark:text-zinc-300 [&_a]:hover:text-gray-700 [&_a]:dark:hover:text-zinc-400",
-    Icon: InfoIcon as LucideIcon,
-  },
-  tip: {
-    border: "border-green-500 dark:border-green-800",
-    bg: "bg-green-200/25 dark:bg-green-950/70",
-    iconColor: "text-green-600 dark:text-green-200",
-    titleColor: "text-green-700 dark:text-green-200",
-    textColor:
-      "text-green-600 dark:text-green-50 [&_a]:hover:text-green-700 [&_a]:dark:hover:text-green-300",
-    Icon: LightbulbIcon as LucideIcon,
-  },
-  info: {
-    border: "border-blue-400 dark:border-blue-900/60",
-    bg: "bg-blue-50 dark:bg-blue-950/40",
-    iconColor: "text-blue-400 dark:text-blue-200",
-    titleColor: "text-blue-700 dark:text-blue-200",
-    textColor:
-      "text-blue-600 dark:text-blue-100 [&_a]:hover:text-blue-800 [&_a]:dark:hover:text-blue-300",
-    Icon: InfoIcon as LucideIcon,
-  },
+const typeMap = {
+  note: { color: "var(--callout-note)", Icon: InfoIcon as LucideIcon },
+  tip: { color: "var(--callout-tip)", Icon: LightbulbIcon as LucideIcon },
+  info: { color: "var(--callout-info)", Icon: InfoIcon as LucideIcon },
   caution: {
-    border: "border-yellow-500 dark:border-yellow-400/25",
-    bg: "bg-yellow-100/60 dark:bg-yellow-400/10",
-    iconColor: "text-yellow-700 dark:text-yellow-300",
-    titleColor: "text-yellow-800 dark:text-yellow-300",
-    textColor:
-      "text-amber-800 dark:text-yellow-200 [&_a]:hover:text-amber-900 [&_a]:dark:hover:text-yellow-300",
+    color: "var(--callout-caution)",
     Icon: AlertTriangleIcon as LucideIcon,
   },
   danger: {
-    border: "border-rose-400 dark:border-rose-800",
-    bg: "bg-rose-50 dark:bg-rose-950/40",
-    iconColor: "text-rose-400 dark:text-rose-300",
-    titleColor: "text-rose-800 dark:text-rose-300",
-    textColor:
-      "text-rose-700 dark:text-rose-100 [&_a]:hover:text-rose-800 [&_a]:dark:hover:text-rose-300",
+    color: "var(--callout-danger)",
     Icon: ShieldAlertIcon as LucideIcon,
+  },
+  sparkles: {
+    color: "var(--callout-sparkles)",
+    Icon: SparklesIcon as LucideIcon,
+  },
+  rocket: {
+    color: "var(--callout-rocket)",
+    Icon: RocketIcon as LucideIcon,
+  },
+  settings: {
+    color: "var(--callout-settings)",
+    Icon: SettingsIcon as LucideIcon,
+  },
+  zap: { color: "var(--callout-zap)", Icon: ZapIcon as LucideIcon },
+  lock: { color: "var(--callout-lock)", Icon: LockIcon as LucideIcon },
+  megaphone: {
+    color: "var(--callout-megaphone)",
+    Icon: MegaphoneIcon as LucideIcon,
   },
 } as const;
 
 type CalloutProps = {
-  type: keyof typeof stylesMap;
+  type: keyof typeof typeMap;
   title?: string;
   children: ReactNode;
   className?: string;
-  icon?: boolean;
+  icon?: boolean | ReactNode;
 };
 
 export const Callout = ({
@@ -71,49 +61,59 @@ export const Callout = ({
   className,
   icon = true,
 }: CalloutProps) => {
-  const { border, bg, iconColor, titleColor, textColor, Icon } =
-    stylesMap[type];
+  const { color, Icon } = typeMap[type];
   const titleId = useId();
+
+  const style = {
+    "--callout-color": color,
+    backgroundColor:
+      "color-mix(in oklab, var(--callout-color) 6%, var(--background))",
+    borderColor: "color-mix(in oklab, var(--callout-color) 25%, transparent)",
+  } as CSSProperties;
+
+  const headingColor =
+    "color-mix(in oklab, var(--callout-color) 70%, var(--foreground))";
 
   return (
     <div
       role="note"
       aria-labelledby={title ? titleId : undefined}
+      style={style}
       className={cn(
-        "not-prose rounded-md border p-4 text-md my-2",
-        icon &&
-          "grid grid-cols-[min-content_1fr] items-baseline grid-rows-[fit-content_1fr] gap-x-4 gap-y-2",
-        !icon && title && "flex flex-col gap-2",
+        "not-prose rounded-xl border px-4 py-3 flex gap-3 text-sm my-3 text-foreground",
         "[&_a]:underline [&_a]:decoration-current [&_a]:decoration-from-font [&_a]:underline-offset-4 hover:[&_a]:decoration-1",
         "[&_.code-block-wrapper]:border",
         "[&_ul]:list-disc [&_ol]:list-decimal [&_ul]:ps-4 [&_ul>li]:ps-1 [&_ul>li]:my-1",
-        icon && title && "items-center",
-        border,
-        bg,
         className,
       )}
     >
-      {icon && (
+      {icon === true ? (
         <Icon
-          className={cn(!title ? "translate-y-1" : "align-middle", iconColor)}
-          size={20}
+          className="shrink-0 mt-0.5"
+          style={{ color: "var(--callout-color)" }}
+          size={18}
           aria-hidden="true"
         />
+      ) : icon === false ? null : (
+        <span
+          aria-hidden="true"
+          className="shrink-0 mt-0.5 inline-flex items-center justify-center size-[18px] [&_svg]:size-full"
+          style={{ color: "var(--callout-color)" }}
+        >
+          {icon}
+        </span>
       )}
-      {title && (
-        <p id={titleId} className={cn("font-medium", titleColor)}>
-          {title}
-        </p>
-      )}
-      <div
-        className={cn(
-          icon && "col-start-2",
-          !title && icon && "row-start-1",
-          textColor,
-          "overflow-x-auto",
+      <div className="flex-1 min-w-0 flex flex-col gap-1">
+        {title && (
+          <p
+            id={titleId}
+            className="font-medium leading-snug"
+            style={{ color: headingColor }}
+          >
+            {title}
+          </p>
         )}
-      >
-        {children}
+        <div className="overflow-x-auto leading-relaxed">{children}</div>
       </div>
     </div>
   );

--- a/packages/zudoku/src/lib/ui/Callout.tsx
+++ b/packages/zudoku/src/lib/ui/Callout.tsx
@@ -87,14 +87,14 @@ export const Callout = ({
         className,
       )}
     >
-      {icon === true ? (
+      {!icon ? null : icon === true ? (
         <Icon
           className="shrink-0 mt-0.5"
           style={{ color: "var(--callout-color)" }}
           size={18}
           aria-hidden="true"
         />
-      ) : icon === false ? null : (
+      ) : (
         <span
           aria-hidden="true"
           className="shrink-0 mt-0.5 inline-flex items-center justify-center size-[18px] [&_svg]:size-full"

--- a/packages/zudoku/src/lib/util/MdxComponents.tsx
+++ b/packages/zudoku/src/lib/util/MdxComponents.tsx
@@ -106,6 +106,12 @@ export const MdxComponents = {
   caution: (props) => <Callout type="caution" {...props} />,
   warning: (props) => <Callout type="caution" {...props} />,
   danger: (props) => <Callout type="danger" {...props} />,
+  sparkles: (props) => <Callout type="sparkles" {...props} />,
+  rocket: (props) => <Callout type="rocket" {...props} />,
+  settings: (props) => <Callout type="settings" {...props} />,
+  zap: (props) => <Callout type="zap" {...props} />,
+  lock: (props) => <Callout type="lock" {...props} />,
+  megaphone: (props) => <Callout type="megaphone" {...props} />,
   CodeTabs: (props) => (
     <Suspense>
       <CodeTabs {...props} />


### PR DESCRIPTION
Reworks the callout/admonition look and fixes a WCAG contrast issue on the old defaults (tip, info, and danger all failed AA).

What changed:
- Cleaner layout: rounded card, subtle accent-tinted background, body text uses `--foreground` so contrast is always safe
- Six new types: `sparkles`, `rocket`, `settings`, `zap`, `lock`, `megaphone`, each with its own icon and color
- `icon` prop now accepts a `ReactNode`, so you can swap the icon while keeping the type's color
- Per-type colors are driven by `--callout-{type}` CSS vars and can be overridden via `theme.customCss`

Docs updated for the new types, the customization story, and the markdown directives (`:::sparkles`, etc).

Preview at: https://zudoku-dev-git-feat-admonition-colors.zuplosite.com/docs/components/callout