### PR TITLE
fix: SSG auth on page refresh

### DIFF
--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -13,7 +13,9 @@ import { BootstrapClient } from "../lib/components/Bootstrap.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { getRoutesByConfig, shikiReady } from "./main.js";
 
-setupCookieSync(authState, joinUrl(config.basePath, "/__z/auth/session"));
+if (import.meta.env.ZUDOKU_HAS_SERVER) {
+  setupCookieSync(authState, joinUrl(config.basePath, "/__z/auth/session"));
+}
 
 const routes = getRoutesByConfig(config);
 // biome-ignore lint/style/noNonNullAssertion: We know the root element exists

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -54,6 +54,31 @@ const safeSerialize = (data: unknown) =>
     .replace(/\u2028/g, "\\u2028")
     .replace(/\u2029/g, "\\u2029");
 
+// Profile must come from the verifier so a forged cookie can't render
+// protected HTML. SSG has no runtime cookie and short-circuits.
+const resolveSsrAuth = async (
+  request: Request,
+): Promise<SSRAuthState | undefined> => {
+  if (!import.meta.env.ZUDOKU_HAS_SERVER || !configuredAuthProvider) return;
+
+  const { accessToken } = parseCookies(request);
+  if (!accessToken || !verifier)
+    return { accessToken: undefined, profile: null };
+
+  try {
+    const verified = await verifier(accessToken);
+    return verified
+      ? { accessToken, profile: verified.profile }
+      : { accessToken: undefined, profile: null };
+  } catch (error) {
+    logger.error(
+      `SSR auth verifier error (${request.method} ${request.url}):`,
+      error,
+    );
+    return { accessToken: undefined, profile: null };
+  }
+};
+
 // Statically importing shiki.ts here ensures it's in the SSR bundle.
 // main.tsx dynamically imports it instead to enable lazy loading on the client.
 await import("virtual:zudoku-shiki-register").then(
@@ -75,27 +100,7 @@ export const handleRequest = async ({
   basePath?: string;
   bypassProtection?: boolean;
 }): Promise<Response> => {
-  const { accessToken } = parseCookies(request);
-  // Always derive profile from the verifier, never trust the client cookie.
-  // An unverified profile would let a stale/forged cookie render protected HTML.
-  let verifiedProfile: SSRAuthState["profile"] = null;
-  if (accessToken && verifier) {
-    try {
-      const verified = await verifier(accessToken);
-      if (verified) verifiedProfile = verified.profile;
-    } catch (error) {
-      logger.error(
-        `SSR auth verifier error (${request.method} ${request.url}):`,
-        error,
-      );
-    }
-  }
-  const ssrAuth: SSRAuthState | undefined = configuredAuthProvider
-    ? {
-        accessToken: verifiedProfile ? accessToken : undefined,
-        profile: verifiedProfile,
-      }
-    : undefined;
+  const ssrAuth = await resolveSsrAuth(request);
 
   // No-op lazy() on protected subtrees for unauthed requests so loaders
   // don't run for a 401 render.

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -151,8 +151,9 @@ export const getRoutesByConfig = (config: ZudokuConfig): RouteObject[] => {
             </Meta>
           ),
           errorElement: <RouterError />,
+          // Chunk-gate protected routes only in SSR; SSG has no 401 to avoid.
           children:
-            typeof window === "undefined"
+            typeof window === "undefined" || !import.meta.env.ZUDOKU_HAS_SERVER
               ? processRoutes(routes)
               : wrapProtectedRoutes(
                   processRoutes(routes),

--- a/packages/zudoku/src/lib/authentication/state.test.ts
+++ b/packages/zudoku/src/lib/authentication/state.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { UserProfile } from "./state.js";
+
+const STORAGE_KEY = "auth-state";
+
+const PROFILE: UserProfile = {
+  sub: "u1",
+  email: "u@example.com",
+  emailVerified: true,
+  name: "U",
+  pictureUrl: undefined,
+};
+
+const loadState = async () => {
+  vi.resetModules();
+  const mod = await import("./state.js");
+  return mod.authState;
+};
+
+describe("authState — SSG (ZUDOKU_HAS_SERVER unset)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH;
+  });
+
+  test("persists login to localStorage so refresh keeps the session", async () => {
+    const store = await loadState();
+    store.getState().setLoggedIn({ profile: PROFILE, providerData: null });
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null");
+    expect(persisted?.state?.isAuthenticated).toBe(true);
+    expect(persisted?.state?.profile?.sub).toBe("u1");
+  });
+
+  test("rehydrates a persisted session on next load", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          isAuthenticated: true,
+          isPending: false,
+          profile: PROFILE,
+          providerData: null,
+        },
+        version: 0,
+      }),
+    );
+
+    const store = await loadState();
+    expect(store.getState().isAuthenticated).toBe(true);
+    expect(store.getState().profile?.sub).toBe("u1");
+  });
+
+  test("ignores a stale ZUDOKU_SSR_AUTH signal — localStorage still wins", async () => {
+    // Prerendered HTML from an older build may still carry this script;
+    // SSG must not flip into cookie-as-source-of-truth mode.
+    (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH = {
+      profile: null,
+    };
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          isAuthenticated: true,
+          isPending: false,
+          profile: PROFILE,
+          providerData: null,
+        },
+        version: 0,
+      }),
+    );
+
+    const store = await loadState();
+    expect(store.getState().isAuthenticated).toBe(true);
+  });
+});
+
+describe("authState — SSR (ZUDOKU_HAS_SERVER=true)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH;
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("does not write to localStorage; cookies are the source of truth", async () => {
+    const store = await loadState();
+    store.getState().setLoggedIn({ profile: PROFILE, providerData: null });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/packages/zudoku/src/lib/authentication/state.test.ts
+++ b/packages/zudoku/src/lib/authentication/state.test.ts
@@ -26,7 +26,11 @@ describe("authState — SSG (ZUDOKU_HAS_SERVER unset)", () => {
 
   test("persists login to localStorage so refresh keeps the session", async () => {
     const store = await loadState();
-    store.getState().setLoggedIn({ profile: PROFILE, providerData: null });
+    store.setState({
+      isAuthenticated: true,
+      isPending: false,
+      profile: PROFILE,
+    });
 
     const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null");
     expect(persisted?.state?.isAuthenticated).toBe(true);
@@ -89,7 +93,11 @@ describe("authState — SSR (ZUDOKU_HAS_SERVER=true)", () => {
 
   test("does not write to localStorage; cookies are the source of truth", async () => {
     const store = await loadState();
-    store.getState().setLoggedIn({ profile: PROFILE, providerData: null });
+    store.setState({
+      isAuthenticated: true,
+      isPending: false,
+      profile: PROFILE,
+    });
 
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -50,7 +50,10 @@ const ssrAuthInitial =
   typeof window !== "undefined" ? window.ZUDOKU_SSR_AUTH : undefined;
 
 // SSR builds use cookies as the source of truth; SSG uses localStorage.
-const ssrMode = import.meta.env.ZUDOKU_HAS_SERVER;
+// `import.meta.env` is missing when this module is loaded outside a Vite
+// build (e.g. esbuild bundling a vite.*.config.ts), so guard the access.
+const ssrMode =
+  typeof import.meta.env !== "undefined" && import.meta.env.ZUDOKU_HAS_SERVER;
 
 export const authState = create<AuthState>()(
   persist(

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -49,11 +49,8 @@ const noopStorage: StateStorage = {
 const ssrAuthInitial =
   typeof window !== "undefined" ? window.ZUDOKU_SSR_AUTH : undefined;
 
-// When the server injected ZUDOKU_SSR_AUTH, cookies are the single source of
-// truth. Persisting would let stale localStorage contradict the SSR signal
-// (ghost login after cookies expire). SSG has no SSR signal, so persist the
-// full snapshot for reload continuity.
-const ssrMode = ssrAuthInitial !== undefined;
+// SSR builds use cookies as the source of truth; SSG uses localStorage.
+const ssrMode = import.meta.env.ZUDOKU_HAS_SERVER;
 
 export const authState = create<AuthState>()(
   persist(

--- a/packages/zudoku/src/vite-env.d.ts
+++ b/packages/zudoku/src/vite-env.d.ts
@@ -5,4 +5,5 @@ declare module "vite/modulepreload-polyfill" {}
 interface ImportMetaEnv {
   readonly IS_ZUPLO: boolean;
   readonly ZUPLO_BUILD_ID?: string;
+  readonly ZUDOKU_HAS_SERVER: boolean;
 }

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -123,6 +123,7 @@ export async function getViteConfig(
       "process.env.ZUDOKU_VERSION": JSON.stringify(packageJson.version),
       "process.env.IS_ZUPLO": ZuploEnv.isZuplo,
       "import.meta.env.IS_ZUPLO": ZuploEnv.isZuplo,
+      "import.meta.env.ZUDOKU_HAS_SERVER": JSON.stringify(options.ssr === true),
       "import.meta.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME":
         JSON.stringify(deploymentName),
       ...defineEnvVars([


### PR DESCRIPTION
SSG builds were embedding `window.ZUDOKU_SSR_AUTH` into prerendered HTML, which flipped the client store into SSR mode and disabled localStorage persistence. Since SSG has no runtime server to set or verify the auth cookie, every refresh wiped the session and bounced the user back to sign-in.

Gates the SSR auth pipeline behind a new build-time `import.meta.env.ZUDOKU_HAS_SERVER` flag derived from `options.ssr`. SSG keeps the pre-0.78.1 localStorage behavior; SSR builds and `--experimental-ssr` are unchanged.

Repro: log in on the `zuplo-monetization` example, refresh.