### PR TITLE
chore(release): publish 0.78.2 [skip ci]

### DIFF
--- a/packages/create-zudoku/package.json
+++ b/packages/create-zudoku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-zudoku",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "keywords": [
     "react",
     "zudoku"

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zudoku",
-  "version": "0.78.1",
+  "version": "0.78.2",
   "type": "module",
   "sideEffects": [
     "**/*.css",


### PR DESCRIPTION
Manual version bump to recover from failed release workflow on #2495. npm already has 0.78.2 published; this catches main up.

After merge, push the v0.78.2 tag manually.