### PR TITLE
refactor: switch to unhead

### DIFF
--- a/docs/pages/docs/components/head.mdx
+++ b/docs/pages/docs/components/head.mdx
@@ -3,9 +3,8 @@ title: Head
 sidebar_icon: circle-fading-plus
 ---
 
-The Head component (alias for Helmet) allows you to manage document head elements like title, meta
-tags, and links from anywhere in your component tree. It uses
-[`react-helmet-async`](https://github.com/staylor/react-helmet-async) under the hood.
+The Head component allows you to manage document head elements like title, meta tags, and links from
+anywhere in your component tree. It uses [Unhead](https://unhead.unjs.io/) under the hood.
 
 ## Import
 
@@ -175,15 +174,6 @@ The Layout component automatically provides:
 - Canonical URLs when `canonicalUrlOrigin` is configured
 - Description meta tags from page meta
 - Favicon links from meta configuration
-
-## Notes
-
-:::tip
-
-The Head component is an alias for the Helmet component from React Helmet Async. You can use either
-`<Head>` or `<Helmet>` - they're identical.
-
-:::
 
 :::info
 

--- a/e2e/cosmo-cargo.spec.ts
+++ b/e2e/cosmo-cargo.spec.ts
@@ -78,6 +78,30 @@ test("plugin head injection works (SSR)", async ({ page }) => {
   expect(html).toContain("__COSMO_HEAD_TEST");
 });
 
+test("SSR emits page title and meta description on landing", async ({
+  page,
+}) => {
+  const res = await page.goto("/");
+  const html = (await res?.text()) ?? "";
+  expect(html).toMatch(/<title[^>]*>[^<]*Cosmo Cargo Inc\.[^<]*<\/title>/);
+  expect(html).toMatch(
+    /<meta[^>]*name="description"[^>]*content="Interstellar shipping API documentation"/,
+  );
+});
+
+test("SSR emits per-page title on API operation page", async ({ page }) => {
+  const res = await page.goto("/api-shipments/shipment-management");
+  const html = (await res?.text()) ?? "";
+  expect(html).toMatch(/<title[^>]*>[^<]*Cosmo Cargo Inc\.[^<]*<\/title>/);
+});
+
+test("document.title updates on SPA navigation", async ({ page }) => {
+  await page.goto("/documentation", { waitUntil: "networkidle" });
+  await page.locator('a[href*="/api-shipments"]').first().click();
+  await page.waitForURL("**/api-shipments**");
+  await expect.poll(() => page.title()).toContain("Shipment API");
+});
+
 test("client-side navigation between sections", async ({ page }) => {
   await page.goto("/documentation", { waitUntil: "networkidle" });
   await expect(page.locator("main")).toBeVisible();

--- a/e2e/cosmo-cargo.spec.ts
+++ b/e2e/cosmo-cargo.spec.ts
@@ -92,7 +92,10 @@ test("SSR emits page title and meta description on landing", async ({
 test("SSR emits per-page title on API operation page", async ({ page }) => {
   const res = await page.goto("/api-shipments/shipment-management");
   const html = (await res?.text()) ?? "";
-  expect(html).toMatch(/<title[^>]*>[^<]*Cosmo Cargo Inc\.[^<]*<\/title>/);
+  // Asserts both the per-page fragment and the title template suffix render
+  expect(html).toMatch(
+    /<title[^>]*>[^<]*Shipment Management[^<]*Cosmo Cargo Inc\.[^<]*<\/title>/,
+  );
 });
 
 test("document.title updates on SPA navigation", async ({ page }) => {

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -36,7 +36,8 @@ export class CosmoCargoApiIdentityPlugin implements ApiIdentityPlugin {
 
 const config: ZudokuConfig = {
   metadata: {
-    title: "Cosmo Cargo Inc.",
+    title: "%s | Cosmo Cargo Inc.",
+    defaultTitle: "Cosmo Cargo Inc.",
   },
   header: {
     navigation: [

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -38,6 +38,7 @@ const config: ZudokuConfig = {
   metadata: {
     title: "%s | Cosmo Cargo Inc.",
     defaultTitle: "Cosmo Cargo Inc.",
+    description: "Interstellar shipping API documentation",
   },
   header: {
     navigation: [

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -130,7 +130,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "6.0.1",
     "@x0k/json-schema-merge": "1.0.2",
-    "@zudoku/react-helmet-async": "2.0.5",
+    "@unhead/react": "3.0.5",
     "@zuplo/mcp": "0.0.32",
     "bs58": "6.0.0",
     "class-variance-authority": "0.7.1",

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -130,7 +130,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "6.0.1",
     "@x0k/json-schema-merge": "1.0.2",
-    "@unhead/react": "3.0.5",
+    "@unhead/react": "3.1.0",
     "@zuplo/mcp": "0.0.32",
     "bs58": "6.0.0",
     "class-variance-authority": "0.7.1",

--- a/packages/zudoku/src/app/demo.tsx
+++ b/packages/zudoku/src/app/demo.tsx
@@ -1,3 +1,4 @@
+import { createHead } from "@unhead/react/client";
 import logger from "loglevel";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router";
@@ -74,4 +75,6 @@ const routes = getRoutesByConfig(config);
 const router = createBrowserRouter(routes, {
   basename: window.location.pathname,
 });
-createRoot(root).render(<BootstrapClient router={router} />);
+createRoot(root).render(
+  <BootstrapClient router={router} head={createHead()} />,
+);

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -1,4 +1,5 @@
 import type { DehydratedState } from "@tanstack/react-query";
+import { createHead } from "@unhead/react/client";
 import { createRoot, hydrateRoot } from "react-dom/client";
 import {
   createBrowserRouter,
@@ -20,6 +21,7 @@ if (import.meta.env.ZUDOKU_HAS_SERVER) {
 const routes = getRoutesByConfig(config);
 // biome-ignore lint/style/noNonNullAssertion: We know the root element exists
 const root = document.getElementById("root")!;
+const head = createHead();
 
 declare global {
   interface Window {
@@ -105,7 +107,7 @@ function render(routes: RouteObject[]) {
   const router = createBrowserRouter(routes, {
     basename: config.basePath,
   });
-  createRoot(root).render(<BootstrapClient router={router} />);
+  createRoot(root).render(<BootstrapClient router={router} head={head} />);
 }
 
 async function hydrate(routes: RouteObject[]) {
@@ -115,7 +117,7 @@ async function hydrate(routes: RouteObject[]) {
     basename: config.basePath,
   });
 
-  hydrateRoot(root, <BootstrapClient hydrate router={router} />);
+  hydrateRoot(root, <BootstrapClient hydrate router={router} head={head} />);
 }
 
 // Reload on chunk preload failures to recover from version skew.

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -1,5 +1,5 @@
 import { dehydrate, QueryClient } from "@tanstack/react-query";
-import type { HelmetData } from "@zudoku/react-helmet-async";
+import { createHead, transformHtmlTemplate } from "@unhead/react/server";
 import { Hono } from "hono";
 import { compress } from "hono/compress";
 import logger from "loglevel";
@@ -137,7 +137,7 @@ export const handleRequest = async ({
   }
 
   const router = createStaticRouter(dataRoutes, context);
-  const helmetContext = {} as HelmetData["context"];
+  const head = createHead();
   const renderContext = {
     status: 200,
     bypassProtection: bypassProtection ?? false,
@@ -149,7 +149,7 @@ export const handleRequest = async ({
       router={router}
       context={context}
       queryClient={queryClient}
-      helmetContext={helmetContext}
+      head={head}
       bypassProtection={bypassProtection}
       renderContext={renderContext}
     />
@@ -170,22 +170,14 @@ export const handleRequest = async ({
       throw new Error("No <!--app-html--> found in template");
     }
 
+    const headHtml = await transformHtmlTemplate(head, htmlStart);
+
     const encoder = new TextEncoder();
     const reader = reactStream.getReader();
 
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
-        const helmetHtml = [
-          helmetContext.helmet?.title?.toString() ?? "",
-          helmetContext.helmet?.meta?.toString() ?? "",
-          helmetContext.helmet?.link?.toString() ?? "",
-          helmetContext.helmet?.style?.toString() ?? "",
-          helmetContext.helmet?.script?.toString() ?? "",
-        ].join("\n");
-
-        controller.enqueue(
-          encoder.encode(htmlStart.replace("<!--app-helmet-->", helmetHtml)),
-        );
+        controller.enqueue(encoder.encode(headHtml));
 
         while (true) {
           const { done, value } = await reader.read();

--- a/packages/zudoku/src/app/standalone.tsx
+++ b/packages/zudoku/src/app/standalone.tsx
@@ -1,3 +1,4 @@
+import { createHead } from "@unhead/react/client";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router";
 import type { ZudokuConfig } from "../config/validators/ZudokuConfig.js";
@@ -57,4 +58,6 @@ const routes = getRoutesByConfig(config);
 const router = createBrowserRouter(routes, {
   basename: window.location.pathname,
 });
-createRoot(root).render(<BootstrapClient router={router} />);
+createRoot(root).render(
+  <BootstrapClient router={router} head={createHead()} />,
+);

--- a/packages/zudoku/src/lib/components/Bootstrap.tsx
+++ b/packages/zudoku/src/lib/components/Bootstrap.tsx
@@ -3,7 +3,8 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
-import { type HelmetData, HelmetProvider } from "@zudoku/react-helmet-async";
+import { type Unhead, UnheadProvider } from "@unhead/react/client";
+import { UnheadProvider as UnheadServerProvider } from "@unhead/react/server";
 import { StrictMode } from "react";
 import {
   type createBrowserRouter,
@@ -27,19 +28,21 @@ const queryClient = new QueryClient({
 
 export const BootstrapClient = ({
   router,
+  head,
   hydrate = false,
 }: {
   hydrate?: boolean;
+  head: Unhead;
   router: ReturnType<typeof createBrowserRouter>;
 }) => (
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <HydrationBoundary state={hydrate ? window.ZUDOKU_DATA : undefined}>
-        <HelmetProvider>
+        <UnheadProvider head={head}>
           <RenderContext value={{ status: 200, bypassProtection: false }}>
             <RouterProvider router={router} />
           </RenderContext>
-        </HelmetProvider>
+        </UnheadProvider>
       </HydrationBoundary>
     </QueryClientProvider>
   </StrictMode>
@@ -49,11 +52,11 @@ const BootstrapStatic = ({
   router,
   context,
   queryClient,
-  helmetContext,
+  head,
   bypassProtection = false,
   renderContext,
 }: {
-  helmetContext: HelmetData["context"];
+  head: Unhead;
   context: StaticHandlerContext;
   queryClient: QueryClient;
   router: ReturnType<typeof createStaticRouter>;
@@ -63,7 +66,7 @@ const BootstrapStatic = ({
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <HydrationBoundary state={undefined}>
-        <HelmetProvider context={helmetContext}>
+        <UnheadServerProvider value={head}>
           <RenderContext
             value={
               renderContext ?? {
@@ -74,7 +77,7 @@ const BootstrapStatic = ({
           >
             <StaticRouterProvider router={router} context={context} />
           </RenderContext>
-        </HelmetProvider>
+        </UnheadServerProvider>
       </HydrationBoundary>
     </QueryClientProvider>
   </StrictMode>

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
 import { LogOutIcon } from "lucide-react";
 import { memo } from "react";
 import { Link } from "react-router";
@@ -168,10 +168,10 @@ export const Header = memo(function HeaderInner() {
               <div className="flex items-center gap-3.5">
                 {site?.logo ? (
                   <>
-                    <Helmet>
+                    <Head>
                       <link rel="preload" as="image" href={logoLightSrc} />
                       <link rel="preload" as="image" href={logoDarkSrc} />
-                    </Helmet>
+                    </Head>
                     <img
                       src={logoLightSrc}
                       alt={site.logo.alt ?? site.title}

--- a/packages/zudoku/src/lib/components/Meta.tsx
+++ b/packages/zudoku/src/lib/components/Meta.tsx
@@ -1,4 +1,4 @@
-import { Helmet } from "@zudoku/react-helmet-async";
+import { useHead } from "@unhead/react";
 import type { PropsWithChildren } from "react";
 import { useLocation } from "react-router";
 import { joinUrl } from "../util/joinUrl.js";
@@ -9,48 +9,54 @@ export const Meta = ({ children }: PropsWithChildren) => {
   const { metadata: meta } = options;
   const location = useLocation();
 
-  return (
-    <>
-      <Helmet titleTemplate={meta?.title} defaultTitle={meta?.defaultTitle}>
-        {options.canonicalUrlOrigin && (
-          <link
-            rel="canonical"
-            href={joinUrl(
-              options.canonicalUrlOrigin,
-              options.basePath,
-              location.pathname,
-            )}
-          />
-        )}
-        {meta?.description && (
-          <meta name="description" content={meta.description} />
-        )}
-        {meta?.favicon && (
-          <link
-            rel="icon"
-            href={
-              /^https?:\/\//.test(meta.favicon)
-                ? meta.favicon
-                : joinUrl(options.basePath, meta.favicon)
-            }
-          />
-        )}
-        {meta?.generator && <meta name="generator" content={meta.generator} />}
-        {meta?.applicationName && (
-          <meta name="application-name" content={meta.applicationName} />
-        )}
-        {meta?.referrer && <meta name="referrer" content={meta.referrer} />}
-        {meta?.keywords && meta.keywords.length > 0 && (
-          <meta name="keywords" content={meta.keywords.join(", ")} />
-        )}
-        {meta?.authors?.map((author) => (
-          <meta key={author} name="author" content={author} />
-        ))}
-        {meta?.creator && <meta name="creator" content={meta.creator} />}
-        {meta?.publisher && <meta name="publisher" content={meta.publisher} />}
-        {meta?.robots && <meta name="robots" content={meta.robots} />}
-      </Helmet>
-      {children}
-    </>
-  );
+  const favicon = meta?.favicon
+    ? /^https?:\/\//.test(meta.favicon)
+      ? meta.favicon
+      : joinUrl(options.basePath, meta.favicon)
+    : undefined;
+
+  useHead({
+    titleTemplate: (title) => (title ? meta?.title : meta?.defaultTitle) ?? "",
+    link: [
+      ...(options.canonicalUrlOrigin
+        ? [
+            {
+              rel: "canonical" as const,
+              href: joinUrl(
+                options.canonicalUrlOrigin,
+                options.basePath,
+                location.pathname,
+              ),
+            },
+          ]
+        : []),
+      ...(favicon ? [{ rel: "icon" as const, href: favicon }] : []),
+    ],
+    meta: [
+      ...(meta?.description
+        ? [{ name: "description", content: meta.description }]
+        : []),
+      ...(meta?.generator
+        ? [{ name: "generator", content: meta.generator }]
+        : []),
+      ...(meta?.applicationName
+        ? [{ name: "application-name", content: meta.applicationName }]
+        : []),
+      ...(meta?.referrer ? [{ name: "referrer", content: meta.referrer }] : []),
+      ...(meta?.keywords && meta.keywords.length > 0
+        ? [{ name: "keywords", content: meta.keywords.join(", ") }]
+        : []),
+      ...(meta?.authors?.map((author) => ({
+        name: "author",
+        content: author,
+      })) ?? []),
+      ...(meta?.creator ? [{ name: "creator", content: meta.creator }] : []),
+      ...(meta?.publisher
+        ? [{ name: "publisher", content: meta.publisher }]
+        : []),
+      ...(meta?.robots ? [{ name: "robots", content: meta.robots }] : []),
+    ],
+  });
+
+  return children;
 };

--- a/packages/zudoku/src/lib/components/PluginHeads.test.tsx
+++ b/packages/zudoku/src/lib/components/PluginHeads.test.tsx
@@ -1,4 +1,8 @@
-import { type HelmetData, HelmetProvider } from "@zudoku/react-helmet-async";
+import {
+  createHead,
+  renderSSRHead,
+  UnheadProvider,
+} from "@unhead/react/server";
 import { renderToString } from "react-dom/server";
 import type { Location } from "react-router";
 import { describe, expect, it } from "vitest";
@@ -13,28 +17,28 @@ const loc = {
   key: "default",
 } as Location;
 
-const renderHeadSSR = (plugins: ZudokuPlugin[]) => {
-  const ctx = {} as HelmetData["context"];
+const renderHeadSSR = async (plugins: ZudokuPlugin[]) => {
+  const head = createHead();
 
   renderToString(
-    <HelmetProvider context={ctx}>
+    <UnheadProvider value={head}>
       <PluginHeads plugins={plugins} location={loc} />
-    </HelmetProvider>,
+    </UnheadProvider>,
   );
 
-  return ctx.helmet;
+  return renderSSRHead(head);
 };
 
 describe("PluginHeads SSR injection", () => {
-  it("single meta element", () => {
-    const helmet = renderHeadSSR([
+  it("single meta element", async () => {
+    const { headTags } = await renderHeadSSR([
       { getHead: () => <meta name="test-single" content="val" /> },
     ]);
-    expect(helmet?.meta?.toString()).toContain('name="test-single"');
+    expect(headTags).toContain('name="test-single"');
   });
 
-  it("array of elements", () => {
-    const helmet = renderHeadSSR([
+  it("array of elements", async () => {
+    const { headTags } = await renderHeadSSR([
       {
         getHead: () => [
           <meta key="a" name="arr-a" content="a" />,
@@ -42,13 +46,12 @@ describe("PluginHeads SSR injection", () => {
         ],
       },
     ]);
-    const meta = helmet?.meta?.toString() ?? "";
-    expect(meta).toContain('name="arr-a"');
-    expect(meta).toContain('name="arr-b"');
+    expect(headTags).toContain('name="arr-a"');
+    expect(headTags).toContain('name="arr-b"');
   });
 
-  it("fragment with scripts (PostHog pattern)", () => {
-    const helmet = renderHeadSSR([
+  it("fragment with scripts (PostHog pattern)", async () => {
+    const { headTags } = await renderHeadSSR([
       {
         getHead: () => (
           <>
@@ -58,12 +61,12 @@ describe("PluginHeads SSR injection", () => {
         ),
       },
     ]);
-    expect(helmet?.script?.toString()).toContain("__PH");
-    expect(helmet?.meta?.toString()).toContain("ph-verify");
+    expect(headTags).toContain("__PH");
+    expect(headTags).toContain("ph-verify");
   });
 
-  it("multiple plugins", () => {
-    const helmet = renderHeadSSR([
+  it("multiple plugins", async () => {
+    const { headTags } = await renderHeadSSR([
       { getHead: () => <meta name="plugin-a" content="a" /> },
       {
         getHead: () => (
@@ -73,8 +76,7 @@ describe("PluginHeads SSR injection", () => {
         ),
       },
     ]);
-    const meta = helmet?.meta?.toString() ?? "";
-    expect(meta).toContain('name="plugin-a"');
-    expect(meta).toContain('name="plugin-b"');
+    expect(headTags).toContain('name="plugin-a"');
+    expect(headTags).toContain('name="plugin-b"');
   });
 });

--- a/packages/zudoku/src/lib/components/PluginHeads.tsx
+++ b/packages/zudoku/src/lib/components/PluginHeads.tsx
@@ -1,6 +1,14 @@
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
+import { Children, Fragment, isValidElement, type ReactNode } from "react";
 import type { Location } from "react-router";
 import { hasHead, type ZudokuPlugin } from "../core/plugins.js";
+
+const flattenFragments = (node: ReactNode): ReactNode[] =>
+  Children.toArray(node).flatMap((child) =>
+    isValidElement(child) && child.type === Fragment
+      ? flattenFragments((child.props as { children?: ReactNode }).children)
+      : [child],
+  );
 
 export const PluginHeads = ({
   plugins,
@@ -8,10 +16,10 @@ export const PluginHeads = ({
 }: {
   plugins: ZudokuPlugin[];
   location: Location;
-}) =>
-  plugins
-    .flatMap((plugin) =>
-      hasHead(plugin) ? (plugin.getHead?.({ location }) ?? []) : [],
-    )
-    // biome-ignore lint/suspicious/noArrayIndexKey: No stable key available
-    .map((entry, i) => <Helmet key={i}>{entry}</Helmet>);
+}) => {
+  const entries = plugins.flatMap((plugin) =>
+    hasHead(plugin) ? (plugin.getHead?.({ location }) ?? []) : [],
+  );
+
+  return <Head>{flattenFragments(entries)}</Head>;
+};

--- a/packages/zudoku/src/lib/components/index.ts
+++ b/packages/zudoku/src/lib/components/index.ts
@@ -1,4 +1,4 @@
-export { Helmet as Head } from "@zudoku/react-helmet-async";
+export { Head } from "@unhead/react";
 export { Link } from "react-router";
 export { Button } from "../ui/Button.js";
 export { Callout } from "../ui/Callout.js";

--- a/packages/zudoku/src/lib/core/RouteGuard.test.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.test.tsx
@@ -12,7 +12,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { HelmetProvider } from "@zudoku/react-helmet-async";
+import { createHead, UnheadProvider } from "@unhead/react/client";
 import type { PropsWithChildren } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -118,7 +118,7 @@ const render = async (
     createWrapper(options);
 
   const Providers = () => (
-    <HelmetProvider>
+    <UnheadProvider head={createHead()}>
       <QueryClientProvider client={queryClient}>
         <ZudokuProvider context={context}>
           <RenderContext
@@ -128,7 +128,7 @@ const render = async (
           </RenderContext>
         </ZudokuProvider>
       </QueryClientProvider>
-    </HelmetProvider>
+    </UnheadProvider>
   );
 
   const routes = ensureArray(routeObject);
@@ -164,6 +164,10 @@ const render = async (
 describe("RouteGuard", () => {
   beforeEach(() => {
     cleanup();
+    // Clean up meta elements injected by unhead into the DOM
+    document
+      .querySelectorAll('head meta[name="pagefind"]')
+      .forEach((el) => el.remove());
     vi.clearAllMocks();
     useAuthState.setState({
       isAuthenticated: false,
@@ -186,7 +190,7 @@ describe("RouteGuard", () => {
 
       expect(screen.getByText("Protected")).toBeInTheDocument();
 
-      // Check for Helmet meta tag
+      // Check for unhead meta tag
       await waitFor(() => {
         const metaTags = document.querySelectorAll('meta[name="pagefind"]');
         expect(metaTags.length).toBeGreaterThan(0);
@@ -214,7 +218,7 @@ describe("RouteGuard", () => {
       });
 
       const Wrapper = ({ children }: PropsWithChildren) => (
-        <HelmetProvider>
+        <UnheadProvider head={createHead()}>
           <QueryClientProvider client={queryClient}>
             <ZudokuProvider context={context}>
               <RenderContext value={{ status: 200, bypassProtection: false }}>
@@ -222,7 +226,7 @@ describe("RouteGuard", () => {
               </RenderContext>
             </ZudokuProvider>
           </QueryClientProvider>
-        </HelmetProvider>
+        </UnheadProvider>
       );
 
       const TestComponent = () => (

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -1,4 +1,4 @@
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
 import { use, useCallback, useEffect, useMemo } from "react";
 import { Outlet, useBlocker, useLocation } from "react-router";
 import { Button } from "zudoku/ui/Button.js";
@@ -60,13 +60,13 @@ export const LoginDialog = ({
 const BypassRoute = ({ isProtectedRoute }: { isProtectedRoute: boolean }) => (
   <>
     {isProtectedRoute && (
-      <Helmet>
+      <Head>
         <meta
           name="pagefind"
           data-pagefind-filter={`section:${SEARCH_PROTECTED_SECTION}`}
           content="true"
         />
-      </Helmet>
+      </Head>
     )}
     <Outlet />
   </>

--- a/packages/zudoku/src/lib/plugins/api-catalog/Catalog.tsx
+++ b/packages/zudoku/src/lib/plugins/api-catalog/Catalog.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
 import { SearchIcon, XIcon } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { Link } from "zudoku/components";
@@ -103,9 +103,9 @@ export const Catalog = ({
 
   return (
     <section className="pt-(--padding-content-top) pb-12">
-      <Helmet>
+      <Head>
         <title>{label}</title>
-      </Helmet>
+      </Head>
       <div className="flex flex-col gap-6">
         <header className="flex flex-col gap-2">
           <Heading level={1} className="text-4xl font-bold tracking-tight">

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -1,5 +1,5 @@
 import { useMDXComponents } from "@mdx-js/react";
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
 import {
   ArrowUpIcon,
   CheckIcon,
@@ -252,13 +252,13 @@ export const MdxPage = ({
       data-pagefind-filter="section:markdown"
       data-pagefind-meta="section:markdown"
     >
-      <Helmet>
+      <Head>
         <title>{pageTitle}</title>
         {description && <meta name="description" content={description} />}
         {publishMarkdown && (
           <link rel="alternate" type="text/markdown" href={markdownUrl} />
         )}
-      </Helmet>
+      </Head>
 
       <Typography
         className={cn(

--- a/packages/zudoku/src/lib/plugins/openapi/OperationList.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/OperationList.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
 import { Navigate, useParams } from "react-router";
 import { useApiIdentities } from "../../components/context/ZudokuContext.js";
 import { Markdown } from "../../components/Markdown.js";
@@ -278,12 +278,12 @@ export const OperationList = ({
       data-pagefind-meta="section:openapi"
     >
       <PagefindSearchMeta name="category">{title}</PagefindSearchMeta>
-      <Helmet>
+      <Head>
         {helmetTitle && <title>{helmetTitle}</title>}
         {metaDescription && (
           <meta name="description" content={metaDescription} />
         )}
-      </Helmet>
+      </Head>
 
       <div className="mb-8">
         <ApiHeader

--- a/packages/zudoku/src/lib/plugins/openapi/SchemaInfo.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SchemaInfo.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
 import {
   GlobeIcon,
   InfoIcon,
@@ -288,10 +288,10 @@ export const SchemaInfo = () => {
       data-pagefind-meta="section:openapi"
     >
       <PagefindSearchMeta name="category">{title}</PagefindSearchMeta>
-      <Helmet>
+      <Head>
         {title && <title>{title}</title>}
         {description && <meta name="description" content={description} />}
-      </Helmet>
+      </Head>
 
       <div className="mb-8 flex flex-col gap-4">
         <ApiHeader heading={title} headingId="description" />

--- a/packages/zudoku/src/lib/plugins/openapi/SchemaList.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SchemaList.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Helmet } from "@zudoku/react-helmet-async";
+import { Head } from "@unhead/react";
 import { ChevronRightIcon } from "lucide-react";
 import { Button } from "zudoku/ui/Button.js";
 import {
@@ -52,10 +52,10 @@ export function SchemaList() {
   if (!schemas.length) {
     return (
       <div>
-        <Helmet>
+        <Head>
           <title>Schemas {showVersions ? version : ""}</title>
           <meta name="description" content="List of schemas used by the API." />
-        </Helmet>
+        </Head>
         No schemas found
       </div>
     );
@@ -68,10 +68,10 @@ export function SchemaList() {
       data-pagefind-meta="section:openapi"
     >
       <PagefindSearchMeta name="category">{title}</PagefindSearchMeta>
-      <Helmet>
+      <Head>
         <title>Schemas {showVersions ? version : ""}</title>
         <meta name="description" content="List of schemas used by the API." />
-      </Helmet>
+      </Head>
       <div className="pt-(--padding-content-top) pb-(--padding-content-bottom)">
         <ApiHeader title={title} heading="Schemas" headingId="schemas" />
         <hr className="my-8" />

--- a/packages/zudoku/src/lib/testing/index.tsx
+++ b/packages/zudoku/src/lib/testing/index.tsx
@@ -3,7 +3,7 @@ import {
   QueryClientProvider,
   type QueryKey,
 } from "@tanstack/react-query";
-import { HelmetProvider } from "@zudoku/react-helmet-async";
+import { createHead, UnheadProvider } from "@unhead/react/client";
 import { Suspense } from "react";
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
 import { createRedirectRoutes } from "../../app/utils/createRedirectRoutes.js";
@@ -99,6 +99,7 @@ const StaticZudoku = ({
     queryClient.setQueryData(queryKey, data);
   }
 
+  const head = createHead();
   const routes = getRoutesByOptions(options);
   const router = createMemoryRouter(
     [
@@ -130,11 +131,11 @@ const StaticZudoku = ({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <HelmetProvider>
+      <UnheadProvider head={head}>
         <RenderContext value={{ status: 200, bypassProtection: false }}>
           <RouterProvider router={router} />
         </RenderContext>
-      </HelmetProvider>
+      </UnheadProvider>
     </QueryClientProvider>
   );
 };

--- a/packages/zudoku/src/vite/html.ts
+++ b/packages/zudoku/src/vite/html.ts
@@ -11,7 +11,6 @@ export function getDevHtml({
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-    <!--app-helmet-->
     <link rel="preconnect" href="https://cdn.zudoku.dev/">
   </head>
   <body>
@@ -43,7 +42,6 @@ export function getBuildHtml({
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <script type="module" crossorigin src="${jsEntry}"></script>
 ${cssLinks}
-    <!--app-helmet-->
     <link rel="preconnect" href="https://cdn.zudoku.dev/">
   </head>
   <body>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,8 +714,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       '@unhead/react':
-        specifier: 3.0.5
-        version: 3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(oxc-parser@0.126.0)(react@19.2.5)(rolldown@1.0.1)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: 3.1.0
+        version: 3.1.0(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(oxc-parser@0.126.0)(react@19.2.5)(rolldown@1.0.1)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
@@ -5561,28 +5561,40 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@unhead/bundler@3.0.5':
-    resolution: {integrity: sha512-NByETf7g0PQ3msif6HAgtkDGpjfjJfWfJwB4m2fHgW6+BpXRqQQxCscLi3UILhZ06XZVVxx5oCUA8SGfGE7j8A==}
+  '@unhead/bundler@3.1.0':
+    resolution: {integrity: sha512-PzIa26mo1fk2t3KJ6ACJXTi1MD1nDJXb4hl/P8+UTMmdK0EWyDo3LMttePsIgKKR5PTnrtSeyhd43Pdoym4z2g==}
     peerDependencies:
+      '@unhead/cli': ^3.1.0
       esbuild: '>=0.17.0'
       lightningcss: '>=1.20.0'
       rolldown: '>=1.0.0-beta.0'
-      unhead: ^3.0.5
+      unhead: ^3.1.0
+      vite: '>=6.4.2'
+      webpack: '>=5.0.0'
     peerDependenciesMeta:
+      '@unhead/cli':
+        optional: true
       esbuild:
         optional: true
       lightningcss:
         optional: true
       rolldown:
         optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
-  '@unhead/react@3.0.5':
-    resolution: {integrity: sha512-+Mv6YfUmw714P/mceG5FD8FopotiQusBsDRJWeZ86Kj0OoBTJGzv9jJLgChj/0ODzAQl+pxWMGlPhFjXg0Z+3Q==}
+  '@unhead/react@3.1.0':
+    resolution: {integrity: sha512-qOBA80ECsk5+OWNVPXmMAGLdvivSlodU57HWqF4vu5ZNddoVWBMKJXFkYKc45bdXytewNoErThT515rmXcrPWg==}
     peerDependencies:
       react: '>=19.2.4'
       vite: '>=6.4.2'
+      webpack: '>=5.0.0'
     peerDependenciesMeta:
       vite:
+        optional: true
+      webpack:
         optional: true
 
   '@upsetjs/venn.js@2.0.0':
@@ -8968,8 +8980,8 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  unhead@3.0.5:
-    resolution: {integrity: sha512-CJldelG14jlsUYq4S6e4RevzcuGRnsyelZ4WrPWcbivHn4COtT7ECTbvY5TVrpUVC+VQH506LRHWyflgC6w+qA==}
+  unhead@3.1.0:
+    resolution: {integrity: sha512-SH1PAjAMspLIoBjAjE/R8hty2NYo7YcIrdu5I+PVfiW4QmmwEG4pgoiKG0MCs6WRSwiatzeha+4lqSqvHW9PEg==}
     peerDependencies:
       vite: '>=6.4.2'
     peerDependenciesMeta:
@@ -14001,38 +14013,40 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@unhead/bundler@3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.1)(typescript@6.0.3)(unhead@3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@unhead/bundler@3.1.0(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.1)(typescript@6.0.3)(unhead@3.1.0(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitejs/devtools-kit': 0.1.24(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       magic-string: 0.30.21
       oxc-parser: 0.127.0
       oxc-walker: 0.7.0(oxc-parser@0.127.0)
       ufo: 1.6.4
-      unhead: 3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      unhead: 3.1.0(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       unplugin: 3.0.0
     optionalDependencies:
       esbuild: 0.28.0
       lightningcss: 1.32.0
       rolldown: 1.0.1
+      vite: 8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
       - crossws
       - typescript
       - utf-8-validate
-      - vite
 
-  '@unhead/react@3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(oxc-parser@0.126.0)(react@19.2.5)(rolldown@1.0.1)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@unhead/react@3.1.0(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(oxc-parser@0.126.0)(react@19.2.5)(rolldown@1.0.1)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@unhead/bundler': 3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.1)(typescript@6.0.3)(unhead@3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@unhead/bundler': 3.1.0(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.1)(typescript@6.0.3)(unhead@3.1.0(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       magic-string: 0.30.21
       oxc-walker: 0.7.0(oxc-parser@0.126.0)
       react: 19.2.5
-      unhead: 3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      unhead: 3.1.0(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      unplugin: 3.0.0
     optionalDependencies:
       vite: 8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
+      - '@unhead/cli'
       - bufferutil
       - crossws
       - esbuild
@@ -18072,9 +18086,10 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  unhead@3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
+  unhead@3.1.0(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       hookable: 6.1.1
+      unplugin: 3.0.0
     optionalDependencies:
       vite: 8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,15 +713,15 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
+      '@unhead/react':
+        specifier: 3.0.5
+        version: 3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(oxc-parser@0.126.0)(react@19.2.5)(rolldown@1.0.1)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       '@x0k/json-schema-merge':
         specifier: 1.0.2
         version: 1.0.2
-      '@zudoku/react-helmet-async':
-        specifier: 2.0.5
-        version: 2.0.5(react@19.2.5)
       '@zuplo/mcp':
         specifier: 0.0.32
         version: 0.0.32
@@ -3647,8 +3647,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm64@0.126.0':
     resolution: {integrity: sha512-hPEBRKgplp1mG9GkINFsr4JVMDNrGJLOqfDaadTWpAoTnzYR5Rmv8RMvB3hJZpiNvbk1aacopdHUP1pggMQ/cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -3659,8 +3671,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-x64@0.126.0':
     resolution: {integrity: sha512-CHB4zVjNSKqx8Fw9pHowzQQnjjuq04i4Ng0Avj+DixlwhwAoMYqlFbocYIlbg+q3zOLGlm7vEHm83jqEMitnyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -3671,8 +3695,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.126.0':
     resolution: {integrity: sha512-onipc2wCDA7Bauzb4KK1mab0GsEDf4ujiIfWECdnmY/2LlzAoX3xdQRLAUyEDB1kn3yilHBrkmXDdHluyHXxiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -3683,8 +3719,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.126.0':
     resolution: {integrity: sha512-r2KApRgm2pOJaduRm6GOT8x0whcr67AyejNkSdzPt34GJ+Y3axcXN2mwlTs+8lfO/SSmpO5ZJGYiHYnxEE0jkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -3697,8 +3746,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.126.0':
     resolution: {integrity: sha512-Wv/T8C98hRQhGTlx2XFyLn5raRMp9U1lOQD+YnXNgAr7wHbJJpZ8mDBU7Rw+M3WytGcGTFcr6kqgfyQeHVtLbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -3711,8 +3774,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-riscv64-musl@0.126.0':
     resolution: {integrity: sha512-umDc2mTShH0U2zcEYf8mIJ163seLJNn54ZUZYeI5jD4qlg9izPwoLrC2aNPKlMJTu6u/ysmQWiEvIiaAG+INkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -3725,8 +3802,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-x64-gnu@0.126.0':
     resolution: {integrity: sha512-wzocjxm34TbB3bFlqG65JiLtvf6ZDg2ZxRkLLbgXwDQUNU+0MPjQN8zy/0jBKNA5fnPLk3XeVdZ7Uin+7+CVkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3739,8 +3830,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-openharmony-arm64@0.126.0':
     resolution: {integrity: sha512-4WiOILHnPrTDY2/L4mE6PZCYwLN1d3ghma6BuTJ452CCgzRMt3uFplCtR+o3r9zdUWJYb370UizpI9CUcWXr1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -3750,8 +3854,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.126.0':
     resolution: {integrity: sha512-Znug1u1iRvT4VC3jANz6nhGBHsFwEFMxuimYpJFwMtsB6H5FcEoZRMmH26tHkSTD03JvDmG+gB65W3ajLjPcSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -3762,14 +3877,29 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.126.0':
     resolution: {integrity: sha512-ibB1s+mPUFXvS7MFJO2jpw/aCNs/P6ifnWlRyTYB+WYBpniOiCcHQQskZneJtwcjQMDRol3RGG3ihoYnzXSY4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
@@ -5431,12 +5561,46 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@unhead/bundler@3.0.5':
+    resolution: {integrity: sha512-NByETf7g0PQ3msif6HAgtkDGpjfjJfWfJwB4m2fHgW6+BpXRqQQxCscLi3UILhZ06XZVVxx5oCUA8SGfGE7j8A==}
+    peerDependencies:
+      esbuild: '>=0.17.0'
+      lightningcss: '>=1.20.0'
+      rolldown: '>=1.0.0-beta.0'
+      unhead: ^3.0.5
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      lightningcss:
+        optional: true
+      rolldown:
+        optional: true
+
+  '@unhead/react@3.0.5':
+    resolution: {integrity: sha512-+Mv6YfUmw714P/mceG5FD8FopotiQusBsDRJWeZ86Kj0OoBTJGzv9jJLgChj/0ODzAQl+pxWMGlPhFjXg0Z+3Q==}
+    peerDependencies:
+      react: '>=19.2.4'
+      vite: '>=6.4.2'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@valibot/to-json-schema@1.7.0':
+    resolution: {integrity: sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vercel/ncc@0.38.4':
     resolution: {integrity: sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==}
     hasBin: true
+
+  '@vitejs/devtools-kit@0.1.24':
+    resolution: {integrity: sha512-sHM4i80Rrx4HTv/c2d28pQpeMz99GQe/2lVvJvna9t/YcoVouqpsms8oKiF/NcX8474A5gx3TtJHXWvqbov1dg==}
+    peerDependencies:
+      vite: '*'
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -5526,11 +5690,6 @@ packages:
   '@zkochan/js-yaml@0.0.7':
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
     hasBin: true
-
-  '@zudoku/react-helmet-async@2.0.5':
-    resolution: {integrity: sha512-wDakXPJEiQb4JmacSqPyAiJPdOBFqp6e3VUbm1BtTEkXo6FrC2nN+GmIniQ2OimBEC042rSZ9JdQBX+wou/MKw==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
 
   '@zuplo/mcp@0.0.32':
     resolution: {integrity: sha512-rpLTpwL+g1sXtylu2gZwCTXdNIV2L0LPOcCdwogpP5hdyp/JMLSAVtd7H5fs5Wt2cq3jTm6nn7ZZvsBAECdl3A==}
@@ -5924,6 +6083,9 @@ packages:
     resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
     engines: {node: '>=20'}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
     engines: {node: '>=12'}
@@ -6238,6 +6400,14 @@ packages:
     resolution: {integrity: sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==}
     engines: {node: '>= 4.0.0'}
     hasBin: true
+
+  devframe@0.2.2:
+    resolution: {integrity: sha512-nB5xJR0XREJSVD7Me7j9UUY1NIpPlBGYI/b6EMigeoVPaUv7/RwKf/uyc/94P00yMMxQzSMy/94NzWemDd70SQ==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -6710,6 +6880,16 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  h3@2.0.1-rc.22:
+    resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
@@ -7309,6 +7489,9 @@ packages:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
 
+  logs-sdk@0.0.6:
+    resolution: {integrity: sha512-G4M1C9aLLBOIWpmw/Lqk4zrap/T2IJsoUOuUDjRcVSLy6lHQqxr3wCqIT1FvvpYTUYpEwvu4utsMY42jTNvx8Q==}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -7337,6 +7520,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-regexp@0.10.0:
+    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -7630,6 +7816,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
@@ -7656,6 +7845,10 @@ packages:
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -7772,6 +7965,15 @@ packages:
     resolution: {integrity: sha512-FktCvLby/mOHyuijZt22+nOt10dS24gGUZE3XwIbUg7Kf4+rer3/5T7RgwzazlNuVsCjPloZ3p8E+4ONT3A8Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-walker@0.7.0:
+    resolution: {integrity: sha512-54B4KUhrzbzc4sKvKwVYm7E2PgeROpGba0/2nlNZMqfDyca+yOor5IMb4WLGBatGDT0nkzYdYuzylg7n3YfB7A==}
+    peerDependencies:
+      oxc-parser: '>=0.98.0'
+
   oxfmt@0.36.0:
     resolution: {integrity: sha512-/ejJ+KoSW6J9bcNT9a9UtJSJNWhJ3yOLSBLbkoFHJs/8CZjmaZVZAJe4YgO1KMJlKpNQasrn/G9JQUEZI3p0EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -7861,6 +8063,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -7882,6 +8087,9 @@ packages:
   piscina@5.1.4:
     resolution: {integrity: sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==}
     engines: {node: '>=20.x'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -8004,9 +8212,6 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
-  react-fast-compare@3.2.2:
-    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-
   react-hook-form@7.75.0:
     resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
     engines: {node: '>=18.0.0'}
@@ -8110,6 +8315,10 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
 
   regexpu-core@6.4.0:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
@@ -8299,6 +8508,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -8359,9 +8571,6 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
-
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -8466,6 +8675,11 @@ packages:
 
   sponge-case@2.0.3:
     resolution: {integrity: sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==}
+
+  srvx@0.11.15:
+    resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -8716,10 +8930,16 @@ packages:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
     engines: {node: '>=20'}
 
+  type-level-regexp@0.1.17:
+    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
@@ -8747,6 +8967,14 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unhead@3.0.5:
+    resolution: {integrity: sha512-CJldelG14jlsUYq4S6e4RevzcuGRnsyelZ4WrPWcbivHn4COtT7ECTbvY5TVrpUVC+VQH506LRHWyflgC6w+qA==}
+    peerDependencies:
+      vite: '>=6.4.2'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -8805,6 +9033,14 @@ packages:
     resolution: {integrity: sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==}
     engines: {node: '>=0.10.0'}
 
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
+  unplugin@3.0.0:
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -8855,6 +9091,14 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  valibot@1.4.0:
+    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
@@ -9007,6 +9251,9 @@ packages:
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   websocket-driver@0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
@@ -12073,49 +12320,97 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-x64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-musl@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.126.0':
@@ -12125,16 +12420,34 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.126.0':
     optional: true
 
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
   '@oxc-project/types@0.126.0': {}
+
+  '@oxc-project/types@0.127.0': {}
 
   '@oxc-project/types@0.130.0': {}
 
@@ -13688,12 +14001,74 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@unhead/bundler@3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.1)(typescript@6.0.3)(unhead@3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@vitejs/devtools-kit': 0.1.24(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      magic-string: 0.30.21
+      oxc-parser: 0.127.0
+      oxc-walker: 0.7.0(oxc-parser@0.127.0)
+      ufo: 1.6.4
+      unhead: 3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      unplugin: 3.0.0
+    optionalDependencies:
+      esbuild: 0.28.0
+      lightningcss: 1.32.0
+      rolldown: 1.0.1
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - crossws
+      - typescript
+      - utf-8-validate
+      - vite
+
+  '@unhead/react@3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(oxc-parser@0.126.0)(react@19.2.5)(rolldown@1.0.1)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@unhead/bundler': 3.0.5(bufferutil@4.1.0)(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.1)(typescript@6.0.3)(unhead@3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      magic-string: 0.30.21
+      oxc-walker: 0.7.0(oxc-parser@0.126.0)
+      react: 19.2.5
+      unhead: 3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+    optionalDependencies:
+      vite: 8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - crossws
+      - esbuild
+      - lightningcss
+      - oxc-parser
+      - rolldown
+      - typescript
+      - utf-8-validate
+
   '@upsetjs/venn.js@2.0.0':
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.0(typescript@6.0.3)
+
   '@vercel/ncc@0.38.4': {}
+
+  '@vitejs/devtools-kit@0.1.24(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      birpc: 4.0.0
+      devframe: 0.2.2(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      logs-sdk: 0.0.6
+      mlly: 1.8.2
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      tinyexec: 1.1.2
+      vite: 8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - crossws
+      - typescript
+      - utf-8-validate
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -13822,13 +14197,6 @@ snapshots:
   '@zkochan/js-yaml@0.0.7':
     dependencies:
       argparse: 2.0.1
-
-  '@zudoku/react-helmet-async@2.0.5(react@19.2.5)':
-    dependencies:
-      invariant: 2.2.4
-      react: 19.2.5
-      react-fast-compare: 3.2.2
-      shallowequal: 1.1.0
 
   '@zuplo/mcp@0.0.32':
     dependencies:
@@ -14215,6 +14583,8 @@ snapshots:
       semver: 7.8.0
       uint8array-extras: 1.5.0
 
+  confbox@0.1.8: {}
+
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
@@ -14527,6 +14897,23 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  devframe@0.2.2(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6):
+    dependencies:
+      '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@6.0.3))
+      birpc: 4.0.0
+      cac: 7.0.0
+      h3: 2.0.1-rc.22
+      logs-sdk: 0.0.6
+      mrmime: 2.0.1
+      pathe: 2.0.3
+      valibot: 1.4.0(typescript@6.0.3)
+      ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - crossws
+      - typescript
+      - utf-8-validate
 
   devlop@1.1.0:
     dependencies:
@@ -15069,6 +15456,11 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  h3@2.0.1-rc.22:
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.15
 
   hachure-fill@0.5.2: {}
 
@@ -15684,6 +16076,12 @@ snapshots:
 
   loglevel@1.9.2: {}
 
+  logs-sdk@0.0.6:
+    dependencies:
+      magic-string: 0.30.21
+      oxc-parser: 0.126.0
+      unplugin: 3.0.0
+
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
@@ -15705,6 +16103,16 @@ snapshots:
       react: 19.2.5
 
   lz-string@1.5.0: {}
+
+  magic-regexp@0.10.0:
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      ufo: 1.6.4
+      unplugin: 2.3.11
 
   magic-string@0.30.21:
     dependencies:
@@ -16305,6 +16713,13 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   module-details-from-path@1.0.4: {}
 
   motion-dom@12.38.0:
@@ -16323,6 +16738,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   mri@1.2.0: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
@@ -16497,6 +16914,41 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.126.0
       '@oxc-parser/binding-win32-x64-msvc': 0.126.0
 
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-walker@0.7.0(oxc-parser@0.126.0):
+    dependencies:
+      magic-regexp: 0.10.0
+      oxc-parser: 0.126.0
+
+  oxc-walker@0.7.0(oxc-parser@0.127.0):
+    dependencies:
+      magic-regexp: 0.10.0
+      oxc-parser: 0.127.0
+
   oxfmt@0.36.0:
     dependencies:
       tinypool: 2.1.0
@@ -16609,6 +17061,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  perfect-debounce@2.1.0: {}
+
   pg-int8@1.0.1: {}
 
   pg-protocol@1.13.0: {}
@@ -16628,6 +17082,12 @@ snapshots:
   piscina@5.1.4:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   playwright-core@1.59.1: {}
 
@@ -16753,8 +17213,6 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-fast-compare@3.2.2: {}
-
   react-hook-form@7.75.0(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -16878,6 +17336,8 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexp-tree@0.1.27: {}
 
   regexpu-core@6.4.0:
     dependencies:
@@ -17167,6 +17627,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  rou3@0.8.1: {}
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -17214,8 +17676,6 @@ snapshots:
   semver@7.8.0: {}
 
   set-cookie-parser@2.7.2: {}
-
-  shallowequal@1.1.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -17354,6 +17814,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   sponge-case@2.0.3: {}
+
+  srvx@0.11.15: {}
 
   stackback@0.0.2: {}
 
@@ -17583,7 +18045,11 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-level-regexp@0.1.17: {}
+
   typescript@6.0.3: {}
+
+  ufo@1.6.4: {}
 
   uint8array-extras@1.5.0: {}
 
@@ -17605,6 +18071,12 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unhead@3.0.5(vite@8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
+    dependencies:
+      hookable: 6.1.1
+    optionalDependencies:
+      vite: 8.0.13(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -17686,6 +18158,19 @@ snapshots:
     dependencies:
       normalize-path: 2.1.1
 
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@3.0.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -17728,6 +18213,10 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.0: {}
+
+  valibot@1.4.0(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   validate-npm-package-name@7.0.2: {}
 
@@ -17910,6 +18399,8 @@ snapshots:
   web-vitals@4.2.4: {}
 
   web-worker@1.5.0: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   websocket-driver@0.7.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,8 @@ minimumReleaseAge: 4320
 
 minimumReleaseAgeExclude:
   - zudoku
+  - unhead
+  - "@unhead/*"
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
Moves us off our `react-helmet-async` fork onto [`@unhead/react`](https://unhead.unjs.io/) v3. No more fork to maintain, and we get a library built for React 19 with SSR and streaming out of the box.

Also adds e2e checks for SSR title, meta description, and SPA title updates.