### PR TITLE
feat: apply zudoku theme to GraphiQL panel

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/playground/GraphiQL.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/GraphiQL.tsx
@@ -3,6 +3,7 @@ import { GraphiQL } from "graphiql";
 import { useMemo } from "react";
 import { useTheme } from "../../../hooks/index.js";
 import "graphiql/style.css";
+import "./graphiql-theme.css";
 
 export type GraphiQLPanelProps = {
   endpoint: string;

--- a/packages/zudoku/src/lib/plugins/openapi/playground/graphiql-theme.css
+++ b/packages/zudoku/src/lib/plugins/openapi/playground/graphiql-theme.css
@@ -1,0 +1,76 @@
+/**
+ * Zudoku theme overrides for GraphiQL.
+ *
+ * GraphiQL exposes its palette as raw HSL components (e.g. `220, 14%, 96%`)
+ * via CSS variables, so we approximate Zudoku's default Zinc theme here and
+ * route the most prominent surfaces (buttons, accents, dialog backdrop) to
+ * Zudoku's own variables so custom themes still bleed through.
+ */
+
+.graphiql-container,
+.graphiql-dialog,
+.graphiql-dialog-overlay,
+.graphiql-tooltip,
+[data-radix-popper-content-wrapper] {
+  --font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  --font-family-mono: var(--font-mono, ui-monospace, monospace);
+
+  --border-radius-2: 2px;
+  --border-radius-4: calc(var(--radius) - 4px);
+  --border-radius-8: calc(var(--radius) - 2px);
+  --border-radius-12: var(--radius);
+
+  /* HSL approximations of Zudoku's default zinc palette (light) */
+  --color-base: 0, 0%, 100%;
+  --color-neutral: 240, 6%, 10%;
+  --color-primary: 240, 6%, 12%;
+}
+
+.dark .graphiql-container,
+.dark .graphiql-dialog,
+.dark .graphiql-dialog-overlay,
+.dark .graphiql-tooltip,
+.dark [data-radix-popper-content-wrapper],
+body.graphiql-dark .graphiql-container,
+body.graphiql-dark .graphiql-dialog,
+body.graphiql-dark .graphiql-dialog-overlay,
+body.graphiql-dark .graphiql-tooltip,
+body.graphiql-dark [data-radix-popper-content-wrapper] {
+  --color-base: 240, 10%, 4%;
+  --color-neutral: 0, 0%, 98%;
+  --color-primary: 240, 6%, 90%;
+}
+
+/* Honour the user's primary on the surfaces that matter most. */
+.graphiql-container .graphiql-execute-button,
+.graphiql-container .graphiql-execute-button:hover,
+.graphiql-container .graphiql-execute-button:focus {
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.graphiql-container .graphiql-sidebar button.active,
+.graphiql-container .graphiql-tab.graphiql-tab-active,
+.graphiql-container .graphiql-doc-explorer-back,
+.graphiql-container a {
+  color: var(--primary);
+}
+
+/* Match Zudoku's radius on common controls */
+.graphiql-container .graphiql-button,
+.graphiql-container .graphiql-execute-button,
+.graphiql-container .graphiql-sidebar > button,
+.graphiql-container .graphiql-toolbar > button,
+.graphiql-dialog {
+  border-radius: var(--radius);
+}
+
+/* Reset the GraphiQL dialog chrome — we render inside Zudoku's Dialog. */
+.graphiql-container {
+  border-radius: inherit;
+}
+
+/* Subtle: align hover ring color with Zudoku */
+.graphiql-container *:focus-visible {
+  outline-color: var(--ring);
+}


### PR DESCRIPTION
Follow-up to #2499.

Themes the GraphiQL panel so it blends with the surrounding Zudoku docs instead of falling back to GraphiQL's stock pink/magenta accent.

## What changes

- Adds `playground/graphiql-theme.css` which overrides GraphiQL's HSL color variables (`--color-base`, `--color-neutral`, `--color-primary`, …) with values that match Zudoku's default zinc palette in both light and dark mode.
- Routes the most visible surfaces — execute button, active tab/sidebar, links, focus ring — through Zudoku's own CSS variables (`--primary`, `--ring`, …) so custom themes still bleed through.
- Maps `--font-family`/`--font-family-mono` to Zudoku's `--font-sans`/`--font-mono` and aligns `--border-radius-*` with Zudoku's `--radius`.

The Monaco editor inside GraphiQL keeps its built-in `vs` / `vs-dark` syntax theme; the existing `forcedTheme` plumbing in `GraphiQL.tsx` already swaps it in sync with `useTheme()`.

## Test plan

- [x] `pnpm -F zudoku typecheck`
- [x] `pnpm check`
- [x] Open `/api-shipments/shipment-management#graphql-endpoint` in the cosmo-cargo example, click **Test**, verify the panel chrome matches the rest of the page in both light and dark mode.

https://claude.ai/code/session_01MrYuYsNxqpWH2hg5QDoCoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrYuYsNxqpWH2hg5QDoCoD)_