### PR TITLE
fix: disable ligatures in code blocks

### DIFF
--- a/docs/pages/docs/customization/colors-theme.mdx
+++ b/docs/pages/docs/customization/colors-theme.mdx
@@ -214,6 +214,25 @@ const config = {
 };
 ```
 
+### Enabling Code Ligatures
+
+Zudoku disables ligatures in code blocks by default to avoid unwanted glyph joining in fonts like
+Geist Mono (e.g. `---`, `###`, `|--|`). If you're using a coding font designed around ligatures
+(Fira Code, JetBrains Mono, etc.), re-enable them via `customCss`:
+
+```ts title=zudoku.config.ts
+const config = {
+  theme: {
+    customCss: `
+      code, pre, kbd, samp, .shiki, .shiki span {
+        font-variant-ligatures: normal;
+        font-feature-settings: normal;
+      }
+    `,
+  },
+};
+```
+
 ## Default Theme
 
 Zudoku comes with a built-in default theme based on

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -218,6 +218,18 @@
       "calt" 1;
   }
 
+  code,
+  pre,
+  kbd,
+  samp,
+  .shiki,
+  .shiki span {
+    font-variant-ligatures: none;
+    font-feature-settings:
+      "liga" 0,
+      "calt" 0;
+  }
+
   ::selection {
     background: var(--color-primary);
     color: var(--color-primary-foreground);


### PR DESCRIPTION
Geist Mono's contextual alternates (`calt`) were being forced on globally via `body { font-feature-settings: "rlig" 1, "calt" 1 }`, joining glyphs in code blocks (e.g. `---` → connected stroke, `###` → joined, `{...props}` → respaced, `|---|` table borders fused).

Disable `liga`/`calt` on `code, pre, kbd, samp, .shiki` so code renders literally. Users who want ligature-aware fonts (Fira Code, JetBrains Mono) can re-enable via `customCss` — documented in `colors-theme.mdx`.

<table>
<tr>
<td><img width="324" height="143" alt="image" src="https://github.com/user-attachments/assets/20f511b2-4d77-4759-81f9-968a082a7658" />

<td><img width="324" src="https://github.com/user-attachments/assets/ff547503-3e3a-4356-a709-673e256bb944" />

<td><img width="334" height="39" alt="image" src="https://github.com/user-attachments/assets/1551fc76-5384-48fc-85dc-9ab2dbad1ba4" />
