### PR TITLE
fix: read zudoku version at runtime to avoid drift in published bundle

### DIFF
--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -9,10 +9,12 @@ import {
   loadConfigFromFile,
   mergeConfig,
 } from "vite";
-import packageJson from "../../package.json" with { type: "json" };
 import { ZuploEnv } from "../app/env.js";
 import { logger } from "../cli/common/logger.js";
-import { getZudokuRootDir } from "../cli/common/package-json.js";
+import {
+  getZudokuPackageJson,
+  getZudokuRootDir,
+} from "../cli/common/package-json.js";
 import { loadZudokuConfig } from "../config/loader.js";
 import { CdnUrlSchema } from "../config/validators/ZudokuConfig.js";
 import { PROTECTED_CHUNK_DIR } from "../lib/manifest.js";
@@ -120,7 +122,9 @@ export async function getViteConfig(
       },
     },
     define: {
-      "process.env.ZUDOKU_VERSION": JSON.stringify(packageJson.version),
+      "process.env.ZUDOKU_VERSION": JSON.stringify(
+        getZudokuPackageJson().version,
+      ),
       "process.env.IS_ZUPLO": ZuploEnv.isZuplo,
       "import.meta.env.IS_ZUPLO": ZuploEnv.isZuplo,
       "import.meta.env.ZUDOKU_HAS_SERVER": JSON.stringify(options.ssr === true),


### PR DESCRIPTION
The browser console logged the previous zudoku version (0.78.1) while the CLI printed the correct one (0.79.0).

Cause: `vite/config.ts` statically imported `package.json`, inlining the version into the published cli bundle. The release pipeline then bumps the version and publishes, leaving `ZUDOKU_VERSION` defined as the previous version.

Fix: read the version at runtime via `getZudokuPackageJson()`, matching what `cli/dev/handler.ts` already does.