### PR TITLE
fix: reset sidebar filter when switching nav sections

### DIFF
--- a/packages/zudoku/src/lib/components/Main.tsx
+++ b/packages/zudoku/src/lib/components/Main.tsx
@@ -9,7 +9,7 @@ import { Slot } from "./Slot.js";
 
 export const Main = ({ children }: PropsWithChildren) => {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
-  const { navigation } = useCurrentNavigation();
+  const { navigation, topNavItem } = useCurrentNavigation();
   const hasNavigation = navigation.length > 0;
   const isNavigating = useNavigation().state === "loading";
   const { options } = useZudoku();
@@ -24,6 +24,7 @@ export const Main = ({ children }: PropsWithChildren) => {
         <Navigation
           onRequestClose={() => setDrawerOpen(false)}
           navigation={navigation}
+          topNavItem={topNavItem}
         />
       )}
       {hasNavigation && (

--- a/packages/zudoku/src/lib/components/navigation/Navigation.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Navigation.tsx
@@ -5,15 +5,20 @@ import { Slot } from "../Slot.js";
 import { NavigationFilterProvider } from "./NavigationFilterContext.js";
 import { NavigationItem } from "./NavigationItem.js";
 import { NavigationWrapper } from "./NavigationWrapper.js";
+import { getItemPath } from "./utils.js";
 
 export const Navigation = ({
   onRequestClose,
   navigation,
+  topNavItem,
 }: {
   onRequestClose?: () => void;
   navigation: NavigationItemType[];
+  topNavItem?: NavigationItemType;
 }) => (
-  <NavigationFilterProvider>
+  <NavigationFilterProvider
+    key={topNavItem ? (getItemPath(topNavItem) ?? topNavItem.label) : undefined}
+  >
     <NavigationWrapper>
       <Slot.Target name="navigation-before" />
       {navigation.map((item) => (


### PR DESCRIPTION
Sidebar filter query carried over when navigating to a different top-level section, leaving the new sidebar filtered with no way to clear it. Resets filter state when the active top nav section changes. Fixes #2515.