### PR TITLE
fix: prevent dev server crash on schema reprocess errors, fix config error overlay

### DIFF
--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import http from "node:http";
 import https from "node:https";
 import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { createHttpTerminator, type HttpTerminator } from "http-terminator";
 import {
   createServer as createViteServer,
@@ -316,11 +317,15 @@ export class DevServer {
         const html = `<!DOCTYPE html><html><body><script type="module">
           import { ErrorOverlay } from '/@vite/client';
           document.body.appendChild(new ErrorOverlay(${JSON.stringify({
-            message: e instanceof Error ? e.message : String(e),
-            stack: e instanceof Error ? e.stack : "",
+            message: stripVTControlCharacters(
+              e instanceof Error ? e.message : String(e),
+            ),
+            stack: stripVTControlCharacters(
+              e instanceof Error ? (e.stack ?? "") : "",
+            ),
           })}));
         </script></body></html>`;
-        res.writeHead(500, { "Content-Type": "text/html" });
+        res.writeHead(500, { "Content-Type": "text/html; charset=utf-8" });
         res.end(html);
       }
     });

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -94,8 +94,24 @@ const viteApiPlugin = async (): Promise<Plugin> => {
         // biome-ignore lint/suspicious/noConsole: Logging allowed here
         console.log(`Re-processing schema ${id}`);
 
-        for (const inputConfig of mainFiles) {
-          await schemaManager.processSchema(inputConfig);
+        try {
+          for (const inputConfig of mainFiles) {
+            await schemaManager.processSchema(inputConfig);
+          }
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          server.config.logger.error(
+            `Failed to re-process schema ${id}. Fix the error and save again.`,
+            { error: err },
+          );
+          server.ws.send({
+            type: "error",
+            err: {
+              message: `Failed to re-process schema ${id}: ${err.message}`,
+              stack: err.stack ?? "",
+            },
+          });
+          return;
         }
         schemaManager
           .getAllTrackedFiles()


### PR DESCRIPTION
Big schema edits could kill the dev server for good: a mid-edit save with a dangling `$ref` threw a `MissingPointerError` that crashed the process, so even refreshing didn't help. Reprocessing now catches the error and surfaces it in the browser overlay, and the next valid save recovers.

Also fixes the config error overlay, which showed scrambled ANSI codes and mojibake instead of the actual parse error. Now strips ANSI and serves UTF-8 so the code frame is readable.