### PR TITLE
Pricing UI test coverage + correct ProRatingConfig.mode

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pricing-ui/PricingCard.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pricing-ui/PricingCard.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Plan, PlanPhase } from "../types/PlanType.js";
+import { PricingCard } from "./PricingCard.js";
+
+const phase = (overrides: Partial<PlanPhase> = {}): PlanPhase => ({
+  key: "default",
+  name: "Default",
+  rateCards: [],
+  ...overrides,
+});
+
+const plan = (overrides: Partial<Plan> = {}): Plan => ({
+  id: "plan_1",
+  key: "p",
+  name: "Pro",
+  billingCadence: "P1M",
+  currency: "USD",
+  phases: [phase()],
+  monthlyPrice: null,
+  yearlyPrice: null,
+  ...overrides,
+});
+
+describe("PricingCard", () => {
+  it("renders nothing when the plan has no phases", () => {
+    const { container } = render(<PricingCard plan={plan({ phases: [] })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the plan name as the card header", () => {
+    render(<PricingCard plan={plan({ name: "Scale" })} />);
+    expect(screen.getByRole("heading", { name: "Scale" })).toBeInTheDocument();
+  });
+
+  it("renders 'Free' when the plan has no priced rate cards", () => {
+    render(<PricingCard plan={plan()} />);
+    expect(screen.getByText("Free")).toBeInTheDocument();
+  });
+
+  it("renders the monthly price and billing interval for a priced plan", () => {
+    render(
+      <PricingCard plan={plan({ monthlyPrice: "29", yearlyPrice: "348" })} />,
+    );
+    expect(screen.getByText("$29")).toBeInTheDocument();
+    expect(screen.getByText("/month")).toBeInTheDocument();
+  });
+
+  it("renders the yearly price when showYearlyPrice is true (default)", () => {
+    render(
+      <PricingCard plan={plan({ monthlyPrice: "29", yearlyPrice: "348" })} />,
+    );
+    expect(screen.getByText("$348/year")).toBeInTheDocument();
+  });
+
+  it("hides the yearly price line when showYearlyPrice is false", () => {
+    render(
+      <PricingCard
+        plan={plan({ monthlyPrice: "29", yearlyPrice: "348" })}
+        showYearlyPrice={false}
+      />,
+    );
+    expect(screen.queryByText("$348/year")).not.toBeInTheDocument();
+  });
+
+  it("hides the yearly price line when yearly is 0", () => {
+    render(
+      <PricingCard plan={plan({ monthlyPrice: "29", yearlyPrice: "0" })} />,
+    );
+    expect(screen.queryByText(/\$0\/year/)).not.toBeInTheDocument();
+  });
+
+  it("renders 'Pay as you go / Usage-based pricing' for a PAYG plan", () => {
+    const paygPlan = plan({
+      monthlyPrice: null,
+      yearlyPrice: null,
+      phases: [
+        phase({
+          rateCards: [
+            {
+              type: "usage_based",
+              key: "api",
+              name: "API",
+              billingCadence: "P1M",
+              price: { type: "unit", amount: "0.10" },
+              entitlementTemplate: { type: "metered", isSoftLimit: true },
+            },
+          ],
+        }),
+      ],
+    });
+    render(<PricingCard plan={paygPlan} />);
+    expect(screen.getByText("Pay as you go")).toBeInTheDocument();
+    expect(screen.getByText("Usage-based pricing")).toBeInTheDocument();
+  });
+
+  it("renders 'Custom / Contact Sales' when metadata.isCustom is true", () => {
+    render(<PricingCard plan={plan({ metadata: { isCustom: true } })} />);
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+    expect(screen.getByText("Contact Sales")).toBeInTheDocument();
+  });
+
+  it("renders the 'Most Popular' badge when isPopular is true", () => {
+    render(<PricingCard plan={plan()} isPopular />);
+    expect(screen.getByText("Most Popular")).toBeInTheDocument();
+  });
+
+  it("does not render the 'Most Popular' badge by default", () => {
+    render(<PricingCard plan={plan()} />);
+    expect(screen.queryByText("Most Popular")).not.toBeInTheDocument();
+  });
+
+  it("renders 'No CC required' when paymentRequired is explicitly false", () => {
+    render(<PricingCard plan={plan({ paymentRequired: false })} />);
+    expect(screen.getByText("No CC required")).toBeInTheDocument();
+  });
+
+  it("does not render 'No CC required' when paymentRequired is unset or true", () => {
+    const { rerender } = render(<PricingCard plan={plan()} />);
+    expect(screen.queryByText("No CC required")).not.toBeInTheDocument();
+    rerender(<PricingCard plan={plan({ paymentRequired: true })} />);
+    expect(screen.queryByText("No CC required")).not.toBeInTheDocument();
+  });
+
+  it("renders the action slot at the bottom of the card", () => {
+    render(
+      <PricingCard
+        plan={plan()}
+        action={<button type="button">Subscribe</button>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Subscribe" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders entitlements from each rate card on the steady-state phase", () => {
+    const planWithFeatures = plan({
+      phases: [
+        phase({
+          rateCards: [
+            {
+              type: "flat_fee",
+              key: "support",
+              name: "Priority Support",
+              billingCadence: null,
+              price: null,
+              entitlementTemplate: { type: "boolean" },
+            },
+            {
+              type: "usage_based",
+              key: "api",
+              name: "API Calls",
+              billingCadence: "P1M",
+              price: null,
+              entitlementTemplate: {
+                type: "metered",
+                issueAfterReset: 10000,
+              },
+            },
+          ],
+        }),
+      ],
+    });
+    render(<PricingCard plan={planWithFeatures} />);
+    expect(screen.getByText("Priority Support")).toBeInTheDocument();
+    expect(screen.getByText("API Calls:")).toBeInTheDocument();
+    expect(screen.getByText(/10,000/)).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/pricing-ui/PricingTable.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pricing-ui/PricingTable.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Plan, PlanPhase } from "../types/PlanType.js";
+import { PricingTable } from "./PricingTable.js";
+
+const phase = (overrides: Partial<PlanPhase> = {}): PlanPhase => ({
+  key: "default",
+  name: "Default",
+  rateCards: [],
+  ...overrides,
+});
+
+const plan = (overrides: Partial<Plan> = {}): Plan => ({
+  id: "plan_1",
+  key: "p",
+  name: "Plan",
+  billingCadence: "P1M",
+  currency: "USD",
+  phases: [phase()],
+  monthlyPrice: null,
+  yearlyPrice: null,
+  ...overrides,
+});
+
+describe("PricingTable", () => {
+  it("renders the default empty state when there are no plans", () => {
+    render(<PricingTable plans={[]} />);
+    expect(
+      screen.getByText("No plans are currently available."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a custom emptyState when provided", () => {
+    render(<PricingTable plans={[]} emptyState={<div>Coming soon!</div>} />);
+    expect(screen.getByText("Coming soon!")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No plans are currently available."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a card per plan", () => {
+    render(
+      <PricingTable
+        plans={[
+          plan({ id: "a", name: "Free" }),
+          plan({ id: "b", name: "Pro", monthlyPrice: "29" }),
+          plan({ id: "c", name: "Enterprise", monthlyPrice: "199" }),
+        ]}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "Free" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Pro" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Enterprise" }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the default isPopular predicate (metadata.zuplo_most_popular === 'true')", () => {
+    render(
+      <PricingTable
+        plans={[
+          plan({ id: "a", name: "Free" }),
+          plan({
+            id: "b",
+            name: "Pro",
+            metadata: { zuplo_most_popular: "true" },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Most Popular")).toBeInTheDocument();
+  });
+
+  it("honours a custom isPopular predicate", () => {
+    render(
+      <PricingTable
+        plans={[
+          plan({ id: "a", name: "Free" }),
+          plan({ id: "b", name: "Pro" }),
+        ]}
+        isPopular={(p) => p.name === "Pro"}
+      />,
+    );
+    expect(screen.getByText("Most Popular")).toBeInTheDocument();
+  });
+
+  it("renders the action per plan via renderAction", () => {
+    const renderAction = vi.fn((p: Plan) => (
+      <button type="button">Subscribe to {p.name}</button>
+    ));
+    render(
+      <PricingTable
+        plans={[
+          plan({ id: "a", name: "Free" }),
+          plan({ id: "b", name: "Pro" }),
+        ]}
+        renderAction={renderAction}
+      />,
+    );
+    expect(renderAction).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole("button", { name: "Subscribe to Free" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Subscribe to Pro" }),
+    ).toBeInTheDocument();
+  });
+
+  it("wraps each card via renderCard when provided", () => {
+    render(
+      <PricingTable
+        plans={[plan({ id: "a", name: "Free" })]}
+        renderCard={(p, { defaultCard }) => (
+          <div data-testid={`wrap-${p.id}`}>{defaultCard}</div>
+        )}
+      />,
+    );
+    const wrapper = screen.getByTestId("wrap-a");
+    expect(wrapper).toBeInTheDocument();
+    expect(
+      within(wrapper).getByRole("heading", { name: "Free" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the tax legend when the first plan has a default tax behavior", () => {
+    render(
+      <PricingTable
+        plans={[
+          plan({
+            id: "a",
+            name: "Pro",
+            defaultTaxConfig: { behavior: "exclusive" },
+          }),
+        ]}
+      />,
+    );
+    expect(
+      screen.getByText(
+        "Prices exclude tax; taxes may be added at checkout if applicable.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the tax legend when showTaxLegend is false", () => {
+    render(
+      <PricingTable
+        plans={[
+          plan({
+            id: "a",
+            name: "Pro",
+            defaultTaxConfig: { behavior: "exclusive" },
+          }),
+        ]}
+        showTaxLegend={false}
+      />,
+    );
+    expect(screen.queryByText(/Prices exclude tax/)).not.toBeInTheDocument();
+  });
+
+  it("does not render the tax legend when no plan has a tax behavior", () => {
+    render(<PricingTable plans={[plan({ id: "a" })]} />);
+    expect(
+      screen.queryByText(/Prices (include|exclude)/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("passes showYearlyPrice and units through to each card", () => {
+    const planWithUsage: Plan = plan({
+      id: "a",
+      monthlyPrice: "29",
+      yearlyPrice: "348",
+      phases: [
+        phase({
+          rateCards: [
+            {
+              type: "usage_based",
+              key: "api",
+              name: "API Calls",
+              billingCadence: "P1M",
+              price: { type: "unit", amount: "0.10" },
+              entitlementTemplate: { type: "metered", isSoftLimit: true },
+            },
+          ],
+        }),
+      ],
+    });
+    render(
+      <PricingTable
+        plans={[planWithUsage]}
+        showYearlyPrice
+        units={{ api: "request" }}
+      />,
+    );
+    // Yearly price comes from showYearlyPrice on PricingCard.
+    expect(screen.getByText("$348/year")).toBeInTheDocument();
+    // Custom unit label comes from the `units` map.
+    expect(screen.getByText(/\$0\.10\/request/)).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/types/PlanType.ts
+++ b/packages/plugin-zuplo-monetization/src/types/PlanType.ts
@@ -119,7 +119,7 @@ export interface Alignment {
 
 export interface ProRatingConfig {
   enabled: boolean; // defaults to true
-  mode: "prorate_prices" | "prorate_quantities"; // defaults to "prorate_prices"
+  mode: "max_consumption_based"; // currently the only supported mode
 }
 
 export interface ValidationError {

--- a/packages/plugin-zuplo-monetization/src/utils/formatDuration.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatDuration.test.ts
@@ -62,6 +62,29 @@ describe("formatDuration", () => {
     expect(formatDuration("PT30S")).toBe("30 seconds");
   });
 
+  // Portal models billing cadences using these less-common ISO 8601 forms,
+  // so the renderer must format them sensibly when the plan flows through
+  // the monetization plugin.
+  it("returns '14 days' for P14D", () => {
+    expect(formatDuration("P14D")).toBe("14 days");
+  });
+
+  it("returns '30 days' for P30D", () => {
+    expect(formatDuration("P30D")).toBe("30 days");
+  });
+
+  it("returns '4 weeks' for P4W", () => {
+    expect(formatDuration("P4W")).toBe("4 weeks");
+  });
+
+  it("returns '6 months' for P6M", () => {
+    expect(formatDuration("P6M")).toBe("6 months");
+  });
+
+  it("returns '12 months' for P12M", () => {
+    expect(formatDuration("P12M")).toBe("12 months");
+  });
+
   it("returns raw string for invalid input", () => {
     expect(formatDuration("not-a-duration")).toBe("not-a-duration");
   });

--- a/packages/plugin-zuplo-monetization/src/utils/formatStaticEntitlementConfig.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatStaticEntitlementConfig.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatStaticEntitlementConfig } from "./formatStaticEntitlementConfig.js";
+
+describe("formatStaticEntitlementConfig", () => {
+  it("returns undefined for empty or missing config", () => {
+    expect(formatStaticEntitlementConfig(undefined)).toBeUndefined();
+    expect(formatStaticEntitlementConfig("")).toBeUndefined();
+  });
+
+  it("unwraps the .value field on an object config", () => {
+    expect(formatStaticEntitlementConfig(JSON.stringify({ value: 5 }))).toBe(
+      "5",
+    );
+    expect(
+      formatStaticEntitlementConfig(JSON.stringify({ value: "Gold" })),
+    ).toBe("Gold");
+    expect(formatStaticEntitlementConfig(JSON.stringify({ value: true }))).toBe(
+      "true",
+    );
+  });
+
+  it("renders boolean / number / string primitives directly", () => {
+    expect(formatStaticEntitlementConfig(JSON.stringify(42))).toBe("42");
+    expect(formatStaticEntitlementConfig(JSON.stringify("Premium"))).toBe(
+      "Premium",
+    );
+    expect(formatStaticEntitlementConfig(JSON.stringify(true))).toBe("true");
+    expect(formatStaticEntitlementConfig(JSON.stringify(false))).toBe("false");
+  });
+
+  it("falls back to JSON.stringify for objects without a .value field", () => {
+    const config = JSON.stringify({ mode: "strict", limit: 3 });
+    expect(formatStaticEntitlementConfig(config)).toBe(config);
+  });
+
+  it("falls back to JSON.stringify for arrays", () => {
+    const config = JSON.stringify(["jobs", "exports"]);
+    expect(formatStaticEntitlementConfig(config)).toBe(config);
+  });
+
+  it("renders null literal as 'null'", () => {
+    expect(formatStaticEntitlementConfig(JSON.stringify(null))).toBe("null");
+  });
+
+  it("returns undefined for malformed JSON", () => {
+    expect(formatStaticEntitlementConfig("{not-json}")).toBeUndefined();
+    expect(formatStaticEntitlementConfig("[")).toBeUndefined();
+  });
+
+  it("preserves empty-string config value as an empty string", () => {
+    expect(formatStaticEntitlementConfig(JSON.stringify(""))).toBe("");
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/utils/pricingTaxLegend.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/pricingTaxLegend.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { Plan } from "../types/PlanType.js";
+import {
+  collectDefaultTaxBehaviors,
+  planHasDefaultTaxBehavior,
+  subscriptionTaxLegendSentence,
+  taxBehaviorLegendSentence,
+} from "./pricingTaxLegend.js";
+
+const plan = (overrides: Partial<Plan> = {}): Plan => ({
+  id: "plan_1",
+  key: "p",
+  name: "Plan",
+  billingCadence: "P1M",
+  phases: [],
+  monthlyPrice: null,
+  yearlyPrice: null,
+  ...overrides,
+});
+
+describe("planHasDefaultTaxBehavior", () => {
+  it("returns false when no tax config is set", () => {
+    expect(planHasDefaultTaxBehavior(plan())).toBe(false);
+  });
+
+  it("returns false when behavior is missing or whitespace", () => {
+    expect(planHasDefaultTaxBehavior(plan({ defaultTaxConfig: {} }))).toBe(
+      false,
+    );
+    expect(
+      planHasDefaultTaxBehavior(plan({ defaultTaxConfig: { behavior: "  " } })),
+    ).toBe(false);
+  });
+
+  it("returns true when behavior is a non-empty string", () => {
+    expect(
+      planHasDefaultTaxBehavior(
+        plan({ defaultTaxConfig: { behavior: "exclusive" } }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("collectDefaultTaxBehaviors", () => {
+  it("returns 'unspecified' when no behavior is set", () => {
+    expect(collectDefaultTaxBehaviors(plan())).toBe("unspecified");
+  });
+
+  it("normalizes 'exclusive' and 'tax_exclusive' to 'exclusive'", () => {
+    expect(
+      collectDefaultTaxBehaviors(
+        plan({ defaultTaxConfig: { behavior: "exclusive" } }),
+      ),
+    ).toBe("exclusive");
+    expect(
+      collectDefaultTaxBehaviors(
+        plan({ defaultTaxConfig: { behavior: "tax_exclusive" } }),
+      ),
+    ).toBe("exclusive");
+  });
+
+  it("normalizes 'inclusive' and 'tax_inclusive' to 'inclusive'", () => {
+    expect(
+      collectDefaultTaxBehaviors(
+        plan({ defaultTaxConfig: { behavior: "inclusive" } }),
+      ),
+    ).toBe("inclusive");
+    expect(
+      collectDefaultTaxBehaviors(
+        plan({ defaultTaxConfig: { behavior: "tax_inclusive" } }),
+      ),
+    ).toBe("inclusive");
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(
+      collectDefaultTaxBehaviors(
+        plan({ defaultTaxConfig: { behavior: "  EXCLUSIVE  " } }),
+      ),
+    ).toBe("exclusive");
+  });
+
+  it("returns 'unspecified' for an unrecognised behavior", () => {
+    expect(
+      collectDefaultTaxBehaviors(
+        plan({ defaultTaxConfig: { behavior: "custom" } }),
+      ),
+    ).toBe("unspecified");
+  });
+});
+
+describe("taxBehaviorLegendSentence", () => {
+  it("returns the exclusive sentence", () => {
+    expect(taxBehaviorLegendSentence("exclusive")).toBe(
+      "Prices exclude tax; taxes may be added at checkout if applicable.",
+    );
+    expect(taxBehaviorLegendSentence("tax_exclusive")).toBe(
+      "Prices exclude tax; taxes may be added at checkout if applicable.",
+    );
+  });
+
+  it("returns the inclusive sentence", () => {
+    expect(taxBehaviorLegendSentence("inclusive")).toBe(
+      "Prices include tax where applicable.",
+    );
+    expect(taxBehaviorLegendSentence("tax_inclusive")).toBe(
+      "Prices include tax where applicable.",
+    );
+  });
+
+  it("returns undefined for unspecified behavior", () => {
+    expect(taxBehaviorLegendSentence("unspecified")).toBeUndefined();
+    expect(taxBehaviorLegendSentence("")).toBeUndefined();
+    expect(taxBehaviorLegendSentence("custom")).toBeUndefined();
+  });
+});
+
+describe("subscriptionTaxLegendSentence", () => {
+  it("returns the exclusive sentence framed for subscriptions", () => {
+    expect(subscriptionTaxLegendSentence("exclusive")).toBe(
+      "Price excludes tax; taxes may be added on invoice if applicable.",
+    );
+  });
+
+  it("returns the inclusive sentence", () => {
+    expect(subscriptionTaxLegendSentence("inclusive")).toBe(
+      "Price includes tax where applicable.",
+    );
+  });
+
+  it("returns undefined for unspecified behavior", () => {
+    expect(subscriptionTaxLegendSentence("custom")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Squares up the monetization plugin's test coverage with portal — the pricing-UI
components and helpers that portal renders plan tiles through — and corrects one
type that didn't match the real API.

This is the zudoku half of a cross-repo change; the portal half is
[zuplo/portal#4875](https://github.com/zuplo/portal/pull/4875), which routes
portal's plan-editor preview and pricing-table view through these same
components so the admin preview matches the live pricing page 1:1.

## Changes

### Fix
- **`ProRatingConfig.mode`** — was typed `"prorate_prices" | "prorate_quantities"`,
  neither of which the API actually emits. The only supported mode is
  `max_consumption_based` (what portal writes when building plans). The fictional
  union is what forced portal's pricing-UI adapter to drop `proRatingConfig`
  entirely, since the real value isn't assignable to it. Type-only change: nothing
  in the plugin reads `proRatingConfig` for rendering, and the subscription
  fixtures use the looser `Subscription.proRatingConfig.mode` (`string`), so no
  tests change.

### New tests
- **`PricingCard.test.tsx`** — free / priced / PAYG / custom price branches, the
  "Most Popular" badge, the `paymentRequired === false` ("No CC required") line,
  the yearly-price toggle, the `action` slot, empty-phases null render, and
  entitlement rendering on the steady-state phase.
- **`PricingTable.test.tsx`** — default and custom empty state, `isPopular`
  default and override, the `renderAction` / `renderCard` slots, the tax-legend
  toggle, and `units` / `showYearlyPrice` forwarding to each card.
- **`formatStaticEntitlementConfig.test.ts`** — `.value` unwrapping, primitive
  rendering, object/array fallthrough to `JSON.stringify`, malformed JSON, and
  empty input.
- **`pricingTaxLegend.test.ts`** — behavior detection/normalization plus legend
  sentences for both the checkout and subscription contexts.

### Extended tests
- **`formatDuration.test.ts`** — cover the less-common ISO 8601 cadences portal
  models plans with (P14D, P30D, P4W, P6M, P12M).

All 276 plugin tests pass; `tsc` typecheck clean.