### PR TITLE
fix(openapi): generate response examples per status code

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/ResponsesSidecarBox.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/ResponsesSidecarBox.tsx
@@ -13,22 +13,25 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "zudoku/ui/Tooltip.js";
-import type { ResponseItem } from "./graphql/graphql.js";
+import type { MediaTypeObject, ResponseItem } from "./graphql/graphql.js";
 import * as SidecarBox from "./SidecarBox.js";
 import { SidecarExamples } from "./SidecarExamples.js";
+
+type SidecarMediaTypeObject = MediaTypeObject & { isGenerated?: boolean };
+type SidecarResponseItem = Omit<ResponseItem, "content"> & {
+  content?: SidecarMediaTypeObject[] | null;
+};
 
 export const ResponsesSidecarBox = ({
   responses,
   selectedResponse,
   isOnScreen,
   shouldLazyHighlight,
-  isGenerated,
 }: {
-  responses: ResponseItem[];
+  responses: SidecarResponseItem[];
   selectedResponse?: string;
   isOnScreen: boolean;
   shouldLazyHighlight?: boolean;
-  isGenerated?: boolean;
 }) => {
   const [internalSelectedResponse, setInternalSelectedResponse] = useState(
     selectedResponse ?? responses[0]?.statusCode,
@@ -48,6 +51,11 @@ export const ResponsesSidecarBox = ({
     setSelectedContentIndex(0);
     setSelectedExampleIndex(0);
   }, [internalSelectedResponse]);
+
+  const selectedContent =
+    responses.find((r) => r.statusCode === internalSelectedResponse)?.content ??
+    [];
+  const isGenerated = selectedContent[selectedContentIndex]?.isGenerated;
 
   return (
     <Collapsible className="group/collapsible" defaultOpen>
@@ -103,10 +111,7 @@ export const ResponsesSidecarBox = ({
               setSelectedContentIndex(selected.contentTypeIndex);
               setSelectedExampleIndex(selected.exampleIndex);
             }}
-            content={
-              responses.find((r) => r.statusCode === internalSelectedResponse)
-                ?.content ?? []
-            }
+            content={selectedContent}
             isOnScreen={isOnScreen}
             shouldLazyHighlight={shouldLazyHighlight}
           />

--- a/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/Sidecar.tsx
@@ -401,7 +401,7 @@ export const Sidecar = ({
               embedded
               language={selectedLang}
               showLanguageIndicator={false}
-              className="[--scrollbar-color:gray] rounded-none text-xs max-h-[200px]"
+              className="[--scrollbar-color:gray] rounded-none text-xs max-h-50"
               // biome-ignore lint/style/noNonNullAssertion: code is guaranteed to be defined
               code={httpSnippetCode!}
             />
@@ -523,43 +523,42 @@ export const Sidecar = ({
         />
       ) : null}
 
-      {(hasResponseExamples || !isGraphQLEndpoint) &&
-        (hasResponseExamples ? (
-          <ResponsesSidecarBox
-            isOnScreen={isOnScreen}
-            shouldLazyHighlight={shouldLazyHighlight}
-            selectedResponse={selectedResponse}
-            responses={operation.responses.map((response) => ({
+      {(hasResponseExamples || !isGraphQLEndpoint) && (
+        <ResponsesSidecarBox
+          isOnScreen={isOnScreen}
+          shouldLazyHighlight={shouldLazyHighlight}
+          selectedResponse={selectedResponse}
+          responses={operation.responses.map((response) => {
+            const content =
+              response.content && options?.transformExamples
+                ? options.transformExamples({
+                    auth,
+                    type: "response",
+                    context,
+                    operation,
+                    content: response.content,
+                  })
+                : response.content;
+
+            return {
               ...response,
-              content:
-                response.content && options?.transformExamples
-                  ? options.transformExamples({
-                      auth,
-                      type: "response",
-                      context,
-                      operation,
-                      content: response.content,
-                    })
-                  : response.content,
-            }))}
-          />
-        ) : (
-          <ResponsesSidecarBox
-            isGenerated
-            isOnScreen={isOnScreen}
-            shouldLazyHighlight={shouldLazyHighlight}
-            selectedResponse={selectedResponse}
-            responses={operation.responses.map((response) => ({
-              ...response,
-              content: response.content?.map((content) => ({
-                ...content,
-                examples: content.schema
-                  ? [{ name: "", value: generateSchemaExample(content.schema) }]
-                  : content.examples,
-              })),
-            }))}
-          />
-        ))}
+              // Generate an example per status only when none is provided, so
+              // an example on one status doesn't suppress generation on others.
+              content: content?.map((c) => {
+                if ((c.examples?.length ?? 0) > 0) return c;
+                if (isGraphQLEndpoint || !c.schema) return c;
+                return {
+                  ...c,
+                  examples: [
+                    { name: "", value: generateSchemaExample(c.schema) },
+                  ],
+                  isGenerated: true,
+                };
+              }),
+            };
+          })}
+        />
+      )}
     </aside>
   );
 };


### PR DESCRIPTION
Providing an example response for one HTTP status removed the auto-generated examples for all the others. The sidecar used a single global flag, so as soon as any status had a user-supplied example the whole box rendered provided examples only and skipped schema generation for the rest.

Now each response decides on its own: use the provided example if present, otherwise generate one from the schema. The "auto-generated from schema" hint moved to track the selected status instead of the whole box. GraphQL endpoints keep their existing no-generation behavior.