### PR TITLE
fix(monetization): always derive plan headline price from rate cards

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pricing-ui/PricingCard.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pricing-ui/PricingCard.test.tsx
@@ -22,6 +22,23 @@ const plan = (overrides: Partial<Plan> = {}): Plan => ({
   ...overrides,
 });
 
+// A priced plan: the headline is derived from the rate cards (the server
+// monthlyPrice/yearlyPrice are ignored), so a $29 P1M flat fee yields a $29
+// monthly headline and a $348 (29 * 12) annualized yearly figure.
+const flatFeePhase = (amount: string): PlanPhase => ({
+  key: "default",
+  name: "Default",
+  rateCards: [
+    {
+      type: "flat_fee",
+      key: "base",
+      name: "Monthly Fee",
+      billingCadence: "P1M",
+      price: { type: "flat", amount },
+    },
+  ],
+});
+
 describe("PricingCard", () => {
   it("renders nothing when the plan has no phases", () => {
     const { container } = render(<PricingCard plan={plan({ phases: [] })} />);
@@ -39,35 +56,24 @@ describe("PricingCard", () => {
   });
 
   it("renders the monthly price and billing interval for a priced plan", () => {
-    render(
-      <PricingCard plan={plan({ monthlyPrice: "29", yearlyPrice: "348" })} />,
-    );
+    render(<PricingCard plan={plan({ phases: [flatFeePhase("29")] })} />);
     expect(screen.getByText("$29")).toBeInTheDocument();
     expect(screen.getByText("/month")).toBeInTheDocument();
   });
 
   it("renders the yearly price when showYearlyPrice is true (default)", () => {
-    render(
-      <PricingCard plan={plan({ monthlyPrice: "29", yearlyPrice: "348" })} />,
-    );
+    render(<PricingCard plan={plan({ phases: [flatFeePhase("29")] })} />);
     expect(screen.getByText("$348/year")).toBeInTheDocument();
   });
 
   it("hides the yearly price line when showYearlyPrice is false", () => {
     render(
       <PricingCard
-        plan={plan({ monthlyPrice: "29", yearlyPrice: "348" })}
+        plan={plan({ phases: [flatFeePhase("29")] })}
         showYearlyPrice={false}
       />,
     );
     expect(screen.queryByText("$348/year")).not.toBeInTheDocument();
-  });
-
-  it("hides the yearly price line when yearly is 0", () => {
-    render(
-      <PricingCard plan={plan({ monthlyPrice: "29", yearlyPrice: "0" })} />,
-    );
-    expect(screen.queryByText(/\$0\/year/)).not.toBeInTheDocument();
   });
 
   it("renders 'Pay as you go / Usage-based pricing' for a PAYG plan", () => {

--- a/packages/plugin-zuplo-monetization/src/pricing-ui/PricingTable.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pricing-ui/PricingTable.test.tsx
@@ -165,13 +165,20 @@ describe("PricingTable", () => {
   });
 
   it("passes showYearlyPrice and units through to each card", () => {
+    // $29 P1M flat fee → derived $29/mo headline and $348 (29 * 12) yearly;
+    // the usage card supplies the per-unit entitlement for the units check.
     const planWithUsage: Plan = plan({
       id: "a",
-      monthlyPrice: "29",
-      yearlyPrice: "348",
       phases: [
         phase({
           rateCards: [
+            {
+              type: "flat_fee",
+              key: "base",
+              name: "Monthly Fee",
+              billingCadence: "P1M",
+              price: { type: "flat", amount: "29" },
+            },
             {
               type: "usage_based",
               key: "api",

--- a/packages/plugin-zuplo-monetization/src/utils/formatPlanPrice.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatPlanPrice.test.ts
@@ -46,16 +46,19 @@ describe("formatPlanPrice", () => {
     });
   });
 
-  it("returns free for a flat plan with monthlyPrice 0", () => {
+  it("returns free for a flat plan with a zero flat fee", () => {
     expect(formatPlanPrice(makePlan([flatFee("0")]))).toEqual({ type: "free" });
   });
 
-  it("returns priced for a flat plan with monthlyPrice > 0", () => {
-    const plan = makePlan([flatFee("49")], { monthlyPrice: "49" });
+  it("returns priced for a flat plan with a positive flat fee (yearly annualized)", () => {
+    // Price is derived from the rate cards, not the server aggregate, so the
+    // yearly figure is the annualized monthly (49 * 12), matching the admin
+    // preview in portal.
+    const plan = makePlan([flatFee("49")]);
     expect(formatPlanPrice(plan)).toEqual({
       type: "priced",
       monthly: 49,
-      yearly: 0,
+      yearly: 588,
     });
   });
 
@@ -63,17 +66,15 @@ describe("formatPlanPrice", () => {
     // Hybrid plans (flat fee + usage) classify as "priced" because their
     // monthly base is positive. Usage on top of the base is communicated
     // by the per-feature tier breakdown, not a separate label.
-    const plan = makePlan([flatFee("49"), unitUsage("0.01")], {
-      monthlyPrice: "49",
-    });
+    const plan = makePlan([flatFee("49"), unitUsage("0.01")]);
     expect(formatPlanPrice(plan)).toEqual({
       type: "priced",
       monthly: 49,
-      yearly: 0,
+      yearly: 588,
     });
   });
 
-  it("returns payg for a usage-only plan with monthlyPrice 0", () => {
+  it("returns payg for a usage-only plan with no flat fee", () => {
     expect(formatPlanPrice(makePlan([unitUsage("0.05")]))).toEqual({
       type: "payg",
       main: "Pay as you go",

--- a/packages/plugin-zuplo-monetization/src/utils/getPriceFromPlan.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/getPriceFromPlan.test.ts
@@ -21,10 +21,46 @@ const plan = (overrides: Partial<Plan> = {}): Plan => ({
 });
 
 describe("getPriceFromPlan", () => {
-  it("prefers explicit monthlyPrice / yearlyPrice when set", () => {
+  it("ignores server-provided monthlyPrice/yearlyPrice and derives from rate cards", () => {
+    // The server aggregate can disagree with the rate cards (e.g. it omits a
+    // priced feature flat-fee). We always derive so every surface — including
+    // the portal admin preview, which gets no server aggregate — matches.
+    expect(
+      getPriceFromPlan(
+        plan({
+          monthlyPrice: "999",
+          yearlyPrice: "9999",
+          billingCadence: "P1M",
+          phases: [
+            phase({
+              rateCards: [
+                {
+                  type: "flat_fee",
+                  key: "base",
+                  name: "Base",
+                  billingCadence: "P1M",
+                  price: { type: "flat", amount: "20" },
+                },
+                {
+                  type: "flat_fee",
+                  key: "support",
+                  name: "Priority Support",
+                  billingCadence: "P1M",
+                  price: { type: "flat", amount: "1" },
+                  entitlementTemplate: { type: "boolean" },
+                },
+              ],
+            }),
+          ],
+        }),
+      ),
+    ).toEqual({ monthly: 21, yearly: 252 });
+  });
+
+  it("treats a plan with no phases as Free, even when the server sends a price", () => {
     expect(
       getPriceFromPlan(plan({ monthlyPrice: "19.50", yearlyPrice: "200" })),
-    ).toEqual({ monthly: 19.5, yearly: 200 });
+    ).toEqual({ monthly: 0, yearly: 0 });
   });
 
   it("treats null monthlyPrice/yearlyPrice with no phases as Free", () => {

--- a/packages/plugin-zuplo-monetization/src/utils/getPriceFromPlan.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/getPriceFromPlan.ts
@@ -63,20 +63,18 @@ export const derivePriceFromPlan = (
 };
 
 /**
- * Returns the monthly and yearly headline price for a plan. Prefers the
- * server-provided `monthlyPrice` / `yearlyPrice` strings when present;
- * otherwise falls back to {@link derivePriceFromPlan}. Values that can't
- * be resolved are reported as `0`, which the pricing card renders as
- * "Free".
+ * Returns the monthly and yearly headline price for a plan, always derived
+ * from the plan's rate cards via {@link derivePriceFromPlan}.
+ *
+ * The server may also send pre-computed `monthlyPrice` / `yearlyPrice` on the
+ * plan, but we deliberately ignore them and derive client-side so the headline
+ * is computed the same way everywhere it's shown. In particular the admin
+ * preview (Zuplo portal) builds plans from an API that carries no aggregate,
+ * so it can only derive — deriving here too keeps the two surfaces identical
+ * and avoids drift when the server aggregate disagrees with the rate cards.
+ * Values that can't be resolved are reported as `0`, which renders as "Free".
  */
 export const getPriceFromPlan = (plan: Plan) => {
-  if (plan.monthlyPrice != null || plan.yearlyPrice != null) {
-    return {
-      monthly: plan.monthlyPrice != null ? parseFloat(plan.monthlyPrice) : 0,
-      yearly: plan.yearlyPrice != null ? parseFloat(plan.yearlyPrice) : 0,
-    };
-  }
-
   const derived = derivePriceFromPlan(plan);
   return {
     monthly: derived.monthly ?? 0,


### PR DESCRIPTION
## Problem

For the same plan, the public Zudoku pricing page shows a different monthly headline than the Zuplo portal admin preview. Example "Pro Plan": Zudoku renders **$99/month**, portal renders **$100/month** (the correct figure).

## Root cause

Both surfaces use the same `PricingCard` / `getPriceFromPlan`, but `getPriceFromPlan` had a two-tier strategy:

```ts
if (plan.monthlyPrice != null) return …use the server value…  // trust precomputed
return derivePriceFromPlan(plan);                              // else derive from rate cards
```

- **Zudoku** fetches `/v3/zudoku-metering/{deployment}/pricing-page`, which returns a server-precomputed `monthlyPrice: "99"` → trusted as-is → **$99**.
- **Portal** builds plans from the management API, which carries **no** aggregate → derives from rate cards: `monthly_fee $99 + priority_support $1 = $100`.

The `$1` "Priority Support" is a `flat_fee` rate card with a `boolean` entitlement (rendered as a `✓ Priority Support` feature). The metering `/pricing-page` backend omits it from `monthlyPrice`, producing the wrong `$99`. The headline should count it (it's a real recurring charge), so **$100** is correct.

## Fix

Make `getPriceFromPlan` **always derive** from the plan's rate cards and ignore the server-provided `monthlyPrice`/`yearlyPrice`, so every surface computes the headline the same way and can't drift from the portal admin preview (which has no server aggregate and already derives correctly).

```ts
export const getPriceFromPlan = (plan: Plan) => {
  const derived = derivePriceFromPlan(plan);
  return { monthly: derived.monthly ?? 0, yearly: derived.yearly ?? 0 };
};
```

`derivePriceFromPlan` already sums every `flat_fee` rate card on the steady-state phase and projects onto the billing cadence.

## Scope

This touches every `getPriceFromPlan` caller — the pricing card/table **and** checkout, plan-switch, and the subscription detail/confirm pages — so the headline is consistent across all of them. The server aggregate is no longer consulted anywhere.

## Tests

- `getPriceFromPlan` now asserts it **ignores** the server value and derives (incl. counting an entitlement-bearing flat fee: `20 + 1 = 21`).
- `formatPlanPrice` priced cases expect the annualized yearly (`monthly * 12`).
- `PricingCard` / `PricingTable` priced fixtures are backed by real flat-fee rate cards instead of bare `monthlyPrice`/`yearlyPrice`.
- All 276 plugin tests pass; `tsc` typecheck + biome/oxfmt clean.

## Notes

- This corrects the **Zudoku live** site; the portal admin preview already shows the correct `$100` (it derives). Once this ships in a plugin release, both match.
- Alternative root-cause fix (out of scope for this repo): correct the metering `/pricing-page` endpoint's `monthlyPrice` computation to include all flat fees.

https://claude.ai/code/session_012GtfeaJjEPZBpdnbvLnpkL

---
_Generated by [Claude Code](https://claude.ai/code/session_012GtfeaJjEPZBpdnbvLnpkL)_