### PR TITLE
Warn when config uses deprecated UNSAFE_ options

### DIFF
--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -388,4 +388,41 @@ describe("validateConfig", () => {
 
     expect(() => validateConfig(config)).toThrow();
   });
+
+  it("should warn when a config option uses the UNSTABLE_ prefix", () => {
+    const config = {
+      UNSTABLE_experimentalFeature: true,
+    };
+
+    validateConfig(config);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "the `UNSTABLE_` prefix and will be removed soon: UNSTABLE_experimentalFeature",
+      ),
+    );
+  });
+
+  it("should list all config options that use the UNSTABLE_ prefix", () => {
+    const config = {
+      UNSTABLE_first: true,
+      UNSTABLE_second: "value",
+    };
+
+    validateConfig(config);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("UNSTABLE_first, UNSTABLE_second"),
+    );
+  });
+
+  it("should not warn about UNSTABLE_ when no such option is used", () => {
+    const config = {
+      aiAssistants: ["claude"],
+    };
+
+    validateConfig(config);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
 });

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -390,6 +390,8 @@ describe("validateConfig", () => {
   });
 
   it("should warn when the deprecated UNSAFE_slotlets option is used", () => {
+    process.env.NODE_ENV = "development";
+
     const config = {
       UNSAFE_slotlets: {},
     };
@@ -404,6 +406,8 @@ describe("validateConfig", () => {
   });
 
   it("should not warn about UNSAFE_ options that are not whitelisted", () => {
+    process.env.NODE_ENV = "development";
+
     const config = {
       UNSAFE_somethingElse: true,
     };
@@ -414,6 +418,8 @@ describe("validateConfig", () => {
   });
 
   it("should not warn when no deprecated option is used", () => {
+    process.env.NODE_ENV = "development";
+
     const config = {
       aiAssistants: ["claude"],
     };

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -389,34 +389,31 @@ describe("validateConfig", () => {
     expect(() => validateConfig(config)).toThrow();
   });
 
-  it("should warn when a config option uses the UNSTABLE_ prefix", () => {
+  it("should warn when the deprecated UNSAFE_slotlets option is used", () => {
     const config = {
-      UNSTABLE_experimentalFeature: true,
+      UNSAFE_slotlets: {},
     };
 
     validateConfig(config);
 
     expect(mockConsoleLog).toHaveBeenCalledWith(
       expect.stringContaining(
-        "the `UNSTABLE_` prefix and will be removed soon: UNSTABLE_experimentalFeature",
+        "deprecated and will be removed soon: UNSAFE_slotlets",
       ),
     );
   });
 
-  it("should list all config options that use the UNSTABLE_ prefix", () => {
+  it("should not warn about UNSAFE_ options that are not whitelisted", () => {
     const config = {
-      UNSTABLE_first: true,
-      UNSTABLE_second: "value",
+      UNSAFE_somethingElse: true,
     };
 
     validateConfig(config);
 
-    expect(mockConsoleLog).toHaveBeenCalledWith(
-      expect.stringContaining("UNSTABLE_first, UNSTABLE_second"),
-    );
+    expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
-  it("should not warn about UNSTABLE_ when no such option is used", () => {
+  it("should not warn when no deprecated option is used", () => {
     const config = {
       aiAssistants: ["claude"],
     };

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -799,7 +799,9 @@ const DEPRECATED_UNSAFE_KEYS = ["UNSAFE_slotlets"] as const;
 function warnUnsafeConfigKeys(config: unknown) {
   if (typeof config !== "object" || config === null) return;
 
-  const usedKeys = DEPRECATED_UNSAFE_KEYS.filter((key) => key in config);
+  const usedKeys = DEPRECATED_UNSAFE_KEYS.filter((key) =>
+    Object.hasOwn(config, key),
+  );
 
   if (usedKeys.length === 0) return;
 

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -769,7 +769,7 @@ export type ZudokuConfig = Omit<
 };
 
 export function validateConfig(config: unknown, configPath?: string) {
-  warnUnstableConfigKeys(config);
+  warnUnsafeConfigKeys(config);
 
   const validationResult = ZudokuConfig.safeParse(config);
 
@@ -789,23 +789,24 @@ export function validateConfig(config: unknown, configPath?: string) {
   }
 }
 
+// `UNSAFE_` prefixed config options that are deprecated and will be removed soon.
+const DEPRECATED_UNSAFE_KEYS = ["UNSAFE_slotlets"] as const;
+
 /**
- * Warns when config keys use the `UNSTABLE_` prefix, signalling that they are
- * experimental and will be removed soon.
+ * Warns when config uses a deprecated `UNSAFE_` prefixed option, signalling
+ * that it will be removed soon.
  */
-function warnUnstableConfigKeys(config: unknown) {
+function warnUnsafeConfigKeys(config: unknown) {
   if (typeof config !== "object" || config === null) return;
 
-  const unstableKeys = Object.keys(config).filter((key) =>
-    key.startsWith("UNSTABLE_"),
-  );
+  const usedKeys = DEPRECATED_UNSAFE_KEYS.filter((key) => key in config);
 
-  if (unstableKeys.length === 0) return;
+  if (usedKeys.length === 0) return;
 
   // biome-ignore lint/suspicious/noConsole: Logging allowed here
   console.log(
     colors.yellow(
-      `Warning: The following config ${unstableKeys.length === 1 ? "option uses" : "options use"} the \`UNSTABLE_\` prefix and will be removed soon: ${unstableKeys.join(", ")}`,
+      `Warning: The following config ${usedKeys.length === 1 ? "option is" : "options are"} deprecated and will be removed soon: ${usedKeys.join(", ")}`,
     ),
   );
 }

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -769,6 +769,8 @@ export type ZudokuConfig = Omit<
 };
 
 export function validateConfig(config: unknown, configPath?: string) {
+  warnUnstableConfigKeys(config);
+
   const validationResult = ZudokuConfig.safeParse(config);
 
   if (!validationResult.success) {
@@ -785,4 +787,25 @@ export function validateConfig(config: unknown, configPath?: string) {
     // biome-ignore lint/suspicious/noConsole: Logging allowed here
     console.log(colors.yellow(z.prettifyError(validationResult.error)));
   }
+}
+
+/**
+ * Warns when config keys use the `UNSTABLE_` prefix, signalling that they are
+ * experimental and will be removed soon.
+ */
+function warnUnstableConfigKeys(config: unknown) {
+  if (typeof config !== "object" || config === null) return;
+
+  const unstableKeys = Object.keys(config).filter((key) =>
+    key.startsWith("UNSTABLE_"),
+  );
+
+  if (unstableKeys.length === 0) return;
+
+  // biome-ignore lint/suspicious/noConsole: Logging allowed here
+  console.log(
+    colors.yellow(
+      `Warning: The following config ${unstableKeys.length === 1 ? "option uses" : "options use"} the \`UNSTABLE_\` prefix and will be removed soon: ${unstableKeys.join(", ")}`,
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
Add a validation warning for deprecated `UNSAFE_` prefixed config options, signaling to users that they will be removed soon. The warning targets an explicit whitelist of known deprecated options (currently `UNSAFE_slotlets`) rather than any arbitrary prefix.

## Changes
- Added `warnUnsafeConfigKeys()` which checks the config against a `DEPRECATED_UNSAFE_KEYS` whitelist and warns about any present keys
- Integrated the warning into `validateConfig()` so it runs before schema validation
- Warning message uses proper pluralization and lists all matched keys
- Added test coverage:
  - `UNSAFE_slotlets` triggers the warning
  - Non-whitelisted `UNSAFE_` keys do not warn
  - Clean configs stay silent

## Implementation Details
- The warning function verifies config is a non-null object before processing
- Uses `Object.hasOwn` to avoid matching prototype-chain properties
- Uses `console.log` with yellow color formatting, consistent with existing validation warnings
- To deprecate more options later, add them to the `DEPRECATED_UNSAFE_KEYS` array

https://claude.ai/code/session_019Zedmx8t3zrUy7pz81HhEV