### PR TITLE
fix(ssr): render protected pages after first login

### DIFF
--- a/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
+++ b/packages/zudoku/src/lib/authentication/components/CallbackHandler.tsx
@@ -1,9 +1,11 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Navigate } from "react-router";
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
 import { useZudoku } from "zudoku/components";
 import { joinUrl } from "../../util/joinUrl.js";
 import { normalizeRedirectUrl } from "../../util/url.js";
 import { OAuthAuthorizationError, type OAuthErrorType } from "../errors.js";
+import { redirectAfterAuth } from "../utils/redirectAfterAuth.js";
 
 export function CallbackHandler({
   handleCallback,
@@ -11,6 +13,7 @@ export function CallbackHandler({
   handleCallback: () => Promise<string>;
 }) {
   const { options } = useZudoku();
+  const navigate = useNavigate();
   const executeCallback = useSuspenseQuery({
     retry: false,
     queryKey: ["oauth-callback", window.location.search],
@@ -41,5 +44,9 @@ export function CallbackHandler({
     },
   });
 
-  return <Navigate to={executeCallback.data} replace />;
+  useEffect(() => {
+    void redirectAfterAuth(navigate, executeCallback.data, { replace: true });
+  }, [navigate, executeCallback.data]);
+
+  return null;
 }

--- a/packages/zudoku/src/lib/authentication/cookie-sync.test.ts
+++ b/packages/zudoku/src/lib/authentication/cookie-sync.test.ts
@@ -1,8 +1,10 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { createStore } from "zustand";
-import { setupCookieSync } from "./cookie-sync.js";
+import { setupCookieSync, waitForSessionSync } from "./cookie-sync.js";
 import type { UserProfile } from "./state.js";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 // cookie-sync is intentionally provider-agnostic: it reads top-level
 // access/refresh tokens off providerData. Use a loose shape so tests can
@@ -193,5 +195,117 @@ describe("setupCookieSync", () => {
     });
     await vi.waitFor(() => expect(errSpy).toHaveBeenCalled());
     errSpy.mockRestore();
+  });
+
+  test("waitForSessionSync resolves only after the in-flight POST settles", async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const store = createSlice();
+    setup(store);
+    store.setState({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+
+    let settled = false;
+    const wait = waitForSessionSync().then(() => {
+      settled = true;
+    });
+    await flush();
+    expect(settled).toBe(false); // POST still in flight
+
+    resolveFetch(new Response(null, { status: 200 }));
+    await wait;
+    expect(settled).toBe(true);
+  });
+
+  test("waitForSessionSync resolves (never rejects) when the sync fails", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 502 }));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createSlice();
+    setup(store);
+    store.setState({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+
+    await expect(waitForSessionSync()).resolves.toBeUndefined();
+    errSpy.mockRestore();
+  });
+
+  test("waitForSessionSync awaits a superseding sync, not the superseded one", async () => {
+    const resolvers: Array<(r: Response) => void> = [];
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const store = createSlice();
+    setup(store);
+    store.setState({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "a" },
+    });
+
+    let settled = false;
+    const wait = waitForSessionSync().then(() => {
+      settled = true;
+    });
+
+    // A token refresh supersedes the first POST before it settles.
+    store.setState({ providerData: { accessToken: "b" } });
+    await flush();
+
+    // Settling only the first (superseded) POST must NOT open the gate.
+    resolvers[0]?.(new Response(null, { status: 200 }));
+    await flush();
+    expect(settled).toBe(false);
+
+    // Settling the superseding POST does.
+    resolvers[1]?.(new Response(null, { status: 200 }));
+    await wait;
+    expect(settled).toBe(true);
+  });
+
+  test("waitForSessionSync tracks the DELETE on logout", async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const store = createSlice({
+      isAuthenticated: true,
+      profile: PROFILE,
+      providerData: { accessToken: "t" },
+    });
+    (window as { ZUDOKU_SSR_AUTH?: unknown }).ZUDOKU_SSR_AUTH = {
+      profile: PROFILE,
+    };
+    setup(store);
+    store.setState({
+      isAuthenticated: false,
+      profile: null,
+      providerData: null,
+    });
+
+    let settled = false;
+    const wait = waitForSessionSync().then(() => {
+      settled = true;
+    });
+    await flush();
+    expect(settled).toBe(false); // DELETE still in flight
+
+    resolveFetch(new Response(null, { status: 200 }));
+    await wait;
+    expect(settled).toBe(true);
   });
 });

--- a/packages/zudoku/src/lib/authentication/cookie-sync.ts
+++ b/packages/zudoku/src/lib/authentication/cookie-sync.ts
@@ -94,7 +94,15 @@ export const setupCookieSync = (
 
   store.subscribe((next, prev) => {
     if (next.isAuthenticated && next.profile) {
-      if (!prev.isAuthenticated || next.providerData !== prev.providerData) {
+      // Compare tokens, not object identity: Supabase sets state both directly
+      // and via its listener with fresh objects but identical tokens.
+      const a = readTokens(next.providerData);
+      const b = readTokens(prev.providerData);
+      if (
+        !prev.isAuthenticated ||
+        a.accessToken !== b.accessToken ||
+        a.refreshToken !== b.refreshToken
+      ) {
         pendingSessionSync = postSession(next.providerData);
       }
     } else if (!next.isAuthenticated && prev.isAuthenticated) {

--- a/packages/zudoku/src/lib/authentication/cookie-sync.ts
+++ b/packages/zudoku/src/lib/authentication/cookie-sync.ts
@@ -3,6 +3,23 @@ import type { AuthState } from "./state.js";
 
 type TokenBearer = { accessToken?: string; refreshToken?: string };
 
+// Latest in-flight cookie sync, so a post-login redirect can await the cookie
+// write before navigating. Resolved by default. See redirectAfterAuth.
+let pendingSessionSync: Promise<unknown> = Promise.resolve();
+
+// Cap a single sync so a stalled endpoint can't make waitForSessionSync hang.
+const SESSION_SYNC_TIMEOUT_MS = 10_000;
+
+// Resolve once the sync settles and none newer started meanwhile (a refresh can
+// supersede a login's POST mid-flight). Never rejects.
+export const waitForSessionSync = async (): Promise<void> => {
+  let awaited: Promise<unknown>;
+  do {
+    awaited = pendingSessionSync;
+    await awaited;
+  } while (awaited !== pendingSessionSync);
+};
+
 const readTokens = (providerData: unknown): TokenBearer => {
   if (!providerData || typeof providerData !== "object") return {};
   const data = providerData as Record<string, unknown>;
@@ -31,8 +48,16 @@ export const setupCookieSync = (
 
   const send = (init: RequestInit) => {
     inflight?.abort();
-    inflight = new AbortController();
-    return fetch(sessionEndpoint, { ...init, signal: inflight.signal });
+    const controller = new AbortController();
+    inflight = controller;
+    const timeout = setTimeout(
+      () => controller.abort(),
+      SESSION_SYNC_TIMEOUT_MS,
+    );
+    return fetch(sessionEndpoint, {
+      ...init,
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeout));
   };
 
   const postSession = async (providerData: unknown) => {
@@ -70,10 +95,10 @@ export const setupCookieSync = (
   store.subscribe((next, prev) => {
     if (next.isAuthenticated && next.profile) {
       if (!prev.isAuthenticated || next.providerData !== prev.providerData) {
-        void postSession(next.providerData);
+        pendingSessionSync = postSession(next.providerData);
       }
     } else if (!next.isAuthenticated && prev.isAuthenticated) {
-      void clearSession();
+      pendingSessionSync = clearSession();
     }
   });
 
@@ -85,6 +110,6 @@ export const setupCookieSync = (
     state.profile &&
     !window.ZUDOKU_SSR_AUTH?.profile
   ) {
-    void postSession(state.providerData);
+    pendingSessionSync = postSession(state.providerData);
   }
 };

--- a/packages/zudoku/src/lib/authentication/providers/supabase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/supabase.tsx
@@ -194,13 +194,19 @@ class SupabaseAuthenticationProvider
     password: string,
   ) => {
     useAuthState.setState({ isPending: true });
-    const { error } = await this.client.auth.signInWithPassword({
+    const { data, error } = await this.client.auth.signInWithPassword({
       email,
       password,
     });
     useAuthState.setState({ isPending: false });
     if (error) {
       throw Error(getSupabaseErrorMessage(error), { cause: error });
+    }
+    // Set state synchronously (triggering the cookie sync) instead of waiting on
+    // the async onAuthStateChange listener, so a post-login redirect can await
+    // it. Mirrors sign-up below.
+    if (data.session) {
+      await this.updateUserState(data.session);
     }
   };
 

--- a/packages/zudoku/src/lib/authentication/ui/EmailLinkCallbackUi.tsx
+++ b/packages/zudoku/src/lib/authentication/ui/EmailLinkCallbackUi.tsx
@@ -12,6 +12,7 @@ import {
 } from "zudoku/ui/Card.js";
 import { Input } from "zudoku/ui/Input.js";
 import { EMAIL_LINK_STORAGE_KEY } from "../constants.js";
+import { redirectAfterAuth } from "../utils/redirectAfterAuth.js";
 import { getRelativeRedirectUrl } from "../utils/relativeRedirectUrl.js";
 import { AuthCard } from "./AuthCard.js";
 
@@ -33,7 +34,7 @@ export const EmailLinkCallbackUi = ({
     mutationFn: (email: string) => onCompleteSignIn(email),
     onSuccess: () => {
       localStorage.removeItem(EMAIL_LINK_STORAGE_KEY);
-      void navigate(relativeRedirectTo, { replace: true });
+      void redirectAfterAuth(navigate, relativeRedirectTo, { replace: true });
     },
   });
 

--- a/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
+++ b/packages/zudoku/src/lib/authentication/ui/ZudokuAuthUi.tsx
@@ -21,6 +21,7 @@ import {
   FormMessage,
 } from "../../ui/Form.js";
 import { cn } from "../../util/cn.js";
+import { redirectAfterAuth } from "../utils/redirectAfterAuth.js";
 import { getRelativeRedirectUrl } from "../utils/relativeRedirectUrl.js";
 import { AuthCard } from "./AuthCard.js";
 import AppleIcon from "./icons/Apple.js";
@@ -172,14 +173,14 @@ export const ZudokuSignInUi = ({
     mutationFn: ({ email, password }: FormFields) =>
       onUsernamePasswordSignIn(email, password),
     onSuccess: () => {
-      void navigate(relativeRedirectTo);
+      void redirectAfterAuth(navigate, relativeRedirectTo);
     },
   });
   const signInByProviderMutation = useMutation({
     mutationFn: ({ providerId }: { providerId: string }) =>
       onOAuthSignIn(providerId),
     onSuccess: () => {
-      void navigate(relativeRedirectTo);
+      void redirectAfterAuth(navigate, relativeRedirectTo);
     },
   });
   const form = useForm<FormFields>({
@@ -318,7 +319,7 @@ export const ZudokuSignUpUi = ({
       await onUsernamePasswordSignUp(email, password);
     },
     onSuccess: () => {
-      void navigate(relativeRedirectTo);
+      void redirectAfterAuth(navigate, relativeRedirectTo);
     },
   });
 
@@ -327,7 +328,7 @@ export const ZudokuSignUpUi = ({
       await onOAuthSignUp(providerId);
     },
     onSuccess: () => {
-      void navigate(relativeRedirectTo);
+      void redirectAfterAuth(navigate, relativeRedirectTo);
     },
   });
 

--- a/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.test.ts
+++ b/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { NavigateFunction } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { waitForSessionSync } = vi.hoisted(() => ({
+  waitForSessionSync: vi.fn(() => Promise.resolve<unknown>(undefined)),
+}));
+vi.mock("../cookie-sync.js", () => ({ waitForSessionSync }));
+
+const { redirectAfterAuth } = await import("./redirectAfterAuth.js");
+
+describe("redirectAfterAuth", () => {
+  let assign: ReturnType<typeof vi.fn>;
+  let replace: ReturnType<typeof vi.fn>;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    waitForSessionSync.mockReturnValue(Promise.resolve(undefined));
+    assign = vi.fn();
+    replace = vi.fn();
+    originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign, replace },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("navigates client-side without touching window.location in SSG mode", async () => {
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "");
+    const navigate = vi.fn() as unknown as NavigateFunction;
+
+    await redirectAfterAuth(navigate, "/target", { replace: true });
+
+    expect(navigate).toHaveBeenCalledWith("/target", { replace: true });
+    expect(assign).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("hard-navigates after the cookie sync in SSR mode", async () => {
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
+    const navigate = vi.fn() as unknown as NavigateFunction;
+
+    await redirectAfterAuth(navigate, "/target");
+
+    expect(waitForSessionSync).toHaveBeenCalled();
+    expect(assign).toHaveBeenCalledWith("/target");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("uses location.replace when replace is requested in SSR mode", async () => {
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
+
+    await redirectAfterAuth(vi.fn() as unknown as NavigateFunction, "/target", {
+      replace: true,
+    });
+
+    expect(replace).toHaveBeenCalledWith("/target");
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("prepends the app base so a hard nav stays inside basePath", async () => {
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
+    vi.stubEnv("BASE_URL", "/docs/");
+
+    await redirectAfterAuth(
+      vi.fn() as unknown as NavigateFunction,
+      "/protected",
+    );
+
+    expect(assign).toHaveBeenCalledWith("/docs/protected");
+  });
+
+  it("waits for the cookie sync before navigating", async () => {
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
+    let resolveSync: () => void = () => {};
+    waitForSessionSync.mockReturnValue(
+      new Promise<unknown>((resolve) => {
+        resolveSync = () => resolve(undefined);
+      }),
+    );
+
+    const pending = redirectAfterAuth(
+      vi.fn() as unknown as NavigateFunction,
+      "/target",
+    );
+    await Promise.resolve();
+    expect(assign).not.toHaveBeenCalled();
+
+    resolveSync();
+    await pending;
+    expect(assign).toHaveBeenCalledWith("/target");
+  });
+});

--- a/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.test.ts
+++ b/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.test.ts
@@ -24,7 +24,7 @@ describe("redirectAfterAuth", () => {
     originalLocation = window.location;
     Object.defineProperty(window, "location", {
       configurable: true,
-      value: { ...window.location, assign, replace },
+      value: { origin: window.location.origin, assign, replace },
     });
   });
 
@@ -72,6 +72,18 @@ describe("redirectAfterAuth", () => {
   it("prepends the app base so a hard nav stays inside basePath", async () => {
     vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
     vi.stubEnv("BASE_URL", "/docs/");
+
+    await redirectAfterAuth(
+      vi.fn() as unknown as NavigateFunction,
+      "/protected",
+    );
+
+    expect(assign).toHaveBeenCalledWith("/docs/protected");
+  });
+
+  it("stays same-origin when BASE_URL is an absolute CDN url", async () => {
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
+    vi.stubEnv("BASE_URL", "https://cdn.example.com/docs/");
 
     await redirectAfterAuth(
       vi.fn() as unknown as NavigateFunction,

--- a/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.ts
+++ b/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.ts
@@ -2,10 +2,9 @@ import type { NavigateFunction } from "react-router";
 import { joinUrl } from "../../util/joinUrl.js";
 import { waitForSessionSync } from "../cookie-sync.js";
 
-// Send the user to the post-login target. In SSR the protected route's chunk is
-// server-gated by the auth cookie, so hard-navigate (once the cookie sync
-// settles) for a fresh authed render; prepend the base since a hard nav ignores
-// the router basename. SSG navigates client-side.
+// Send the user to the post-login target. SSR hard-navigates (after the cookie
+// sync) for a fresh authed render; BASE_URL is resolved to a same-origin path
+// first since it can be an absolute CDN URL. SSG navigates client-side.
 export const redirectAfterAuth = async (
   navigate: NavigateFunction,
   url: string,
@@ -13,7 +12,11 @@ export const redirectAfterAuth = async (
 ): Promise<void> => {
   if (import.meta.env.ZUDOKU_HAS_SERVER) {
     await waitForSessionSync();
-    const target = joinUrl(import.meta.env.BASE_URL, url);
+    const { pathname } = new URL(
+      import.meta.env.BASE_URL,
+      window.location.origin,
+    );
+    const target = joinUrl(pathname, url);
     if (replace) window.location.replace(target);
     else window.location.assign(target);
     return;

--- a/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.ts
+++ b/packages/zudoku/src/lib/authentication/utils/redirectAfterAuth.ts
@@ -1,0 +1,22 @@
+import type { NavigateFunction } from "react-router";
+import { joinUrl } from "../../util/joinUrl.js";
+import { waitForSessionSync } from "../cookie-sync.js";
+
+// Send the user to the post-login target. In SSR the protected route's chunk is
+// server-gated by the auth cookie, so hard-navigate (once the cookie sync
+// settles) for a fresh authed render; prepend the base since a hard nav ignores
+// the router basename. SSG navigates client-side.
+export const redirectAfterAuth = async (
+  navigate: NavigateFunction,
+  url: string,
+  { replace = false }: { replace?: boolean } = {},
+): Promise<void> => {
+  if (import.meta.env.ZUDOKU_HAS_SERVER) {
+    await waitForSessionSync();
+    const target = joinUrl(import.meta.env.BASE_URL, url);
+    if (replace) window.location.replace(target);
+    else window.location.assign(target);
+    return;
+  }
+  void navigate(url, { replace });
+};

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -69,7 +69,9 @@ export class DevServer {
       mode: "development",
       command: "serve",
     };
-    const viteConfig = await getViteConfig(this.#options.dir, configEnv);
+    const viteConfig = await getViteConfig(this.#options.dir, configEnv, {
+      ssr: this.#options.ssr,
+    });
     const { config } = await loadZudokuConfig(configEnv, this.#options.dir);
 
     this.resolvedPort = await findAvailablePort(


### PR DESCRIPTION
Protected pages rendered blank after signing in for the first time in SSR mode.

- Cause: the client router is built once at boot. While signed out it stubs protected routes, so a client-side post-login navigation lands on that stale router and renders nothing.
- Fix: in SSR mode the post-login redirect now does a full navigation (after the auth cookie is written), so the server re-renders the target signed in and serves the gated chunk. Applied via a shared `redirectAfterAuth` helper across OAuth, in-place, and email-link sign in.
- Dev: `zudoku dev` now honors `--ssr` when setting `ZUDOKU_HAS_SERVER` (it was hardcoded false), so SSR auth actually runs in dev. Side effect: the header no longer flashes "Login" before hydrating.
- Cookie sync: `waitForSessionSync` waits until the latest sync settles, with a timeout so a stalled session endpoint can't hang the redirect.