### PR TITLE
Add balance source breakdown for metered entitlements

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/CancelSubscriptionDialog.tsx
@@ -126,6 +126,16 @@ export const CancelSubscriptionDialog = ({
             )}
           </Alert>
 
+          <Alert variant="warning">
+            <InfoIcon className="size-4" />
+            <AlertTitle>Any bonus top-ups will be canceled</AlertTitle>
+            <AlertDescription>
+              If you have received additional top-up entitlements on this
+              subscription, they are canceled when the subscription is canceled
+              and any unused balance is removed.
+            </AlertDescription>
+          </Alert>
+
           <div className="space-y-2">
             <label
               className="text-sm text-foreground"

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
@@ -631,6 +631,13 @@ export const SwitchPlanModal = ({
                 </AlertDescription>
               </Alert>
             )}
+            <Alert variant="warning">
+              <AlertDescription>
+                Changing your plan replaces your current subscription. Any
+                active bonus top-ups on your current plan are canceled when you
+                upgrade or downgrade.
+              </AlertDescription>
+            </Alert>
             <Item variant="outline">
               <ItemContent>
                 <ItemTitle>Current Plan</ItemTitle>

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/Usage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/Usage.tsx
@@ -44,10 +44,22 @@ export type Entitlement = {
   config?: string;
 };
 
+// A single balance source contributing to a metered entitlement: either the
+// plan's own allowance or a bonus top-up. Surfaced when the backend provides a
+// per-source breakdown so customers can see where their balance comes from and
+// which source is used first.
+export type BalanceSource = {
+  source: "manual" | "subscription";
+  remaining: number;
+  amount?: number;
+  expiresAt?: string;
+};
+
 export type MeteredEntitlement = Entitlement & {
   balance: number;
   usage: number;
   overage: number;
+  sources?: BalanceSource[];
 };
 
 const isMeteredEntitlement = (
@@ -152,6 +164,33 @@ const UsageItem = ({
         <p className="text-xs text-muted-foreground">
           {meter.balance.toLocaleString()} remaining this billing period
         </p>
+        {meter.sources && meter.sources.length > 0 && (
+          <div className="mt-3 border-t pt-3 space-y-1">
+            <p className="text-xs font-medium text-foreground">
+              Where this balance comes from
+            </p>
+            {meter.sources.map((source, index) => (
+              <div
+                key={`${source.source}-${index}`}
+                className="flex items-center justify-between text-xs text-muted-foreground"
+              >
+                <span>
+                  {source.source === "manual"
+                    ? "Bonus top-up"
+                    : "Plan allowance"}
+                  {source.expiresAt
+                    ? ` · expires ${new Date(source.expiresAt).toLocaleDateString()}`
+                    : ""}
+                </span>
+                <span>{source.remaining.toLocaleString()} remaining</span>
+              </div>
+            ))}
+            <p className="text-[11px] text-muted-foreground pt-1">
+              Balances are drawn down in priority order. A time-limited bonus
+              top-up is typically used before your plan allowance.
+            </p>
+          </div>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary

This PR adds support for displaying a detailed breakdown of balance sources in metered entitlements, allowing customers to see where their balance comes from (plan allowance vs. bonus top-ups) and understand the priority order in which balances are consumed.

## Key Changes

- **New `BalanceSource` type**: Added to represent individual balance sources with source type, remaining amount, optional total amount, and expiration date
- **Enhanced `MeteredEntitlement` type**: Added optional `sources` field to support per-source balance breakdown
- **Usage display enhancement**: Updated `UsageItem` component to render balance source details when available, showing:
  - Source type (bonus top-up or plan allowance)
  - Expiration date if applicable
  - Remaining balance per source
  - Explanatory text about balance draw-down priority
- **Subscription cancellation warning**: Added alert in `CancelSubscriptionDialog` to inform users that bonus top-ups will be canceled when the subscription is canceled
- **Plan switch warning**: Added alert in `SwitchPlanModal` to inform users that active bonus top-ups are canceled when upgrading or downgrading plans

## Implementation Details

- Balance sources are rendered conditionally only when the backend provides the `sources` array
- Source labels distinguish between "Bonus top-up" (manual) and "Plan allowance" (subscription) types
- Expiration dates are formatted using `toLocaleDateString()` for user-friendly display
- The UI includes explanatory text about balance draw-down priority to help customers understand which balance is used first
- New warnings provide clear communication about the impact of subscription changes on bonus top-ups

https://claude.ai/code/session_01VCfACMq8knZTRbBmXrmJdM