### PR TITLE
fix: clearer config error messages and don't swallow reload failures

### DIFF
--- a/packages/zudoku/src/config/loader.test.ts
+++ b/packages/zudoku/src/config/loader.test.ts
@@ -78,6 +78,20 @@ describe("loadZudokuConfig", () => {
     );
   });
 
+  it("does not treat a present-but-falsy default export as missing", async () => {
+    vi.mocked(fileExists).mockResolvedValue(true);
+    vi.mocked(runnerImport).mockResolvedValue({
+      module: { default: null },
+      dependencies: [],
+    } as never);
+
+    // `export default null` is a real (if invalid) export, so it must fall
+    // through to validateConfig rather than the "missing default export" path.
+    await expect(
+      loadZudokuConfig(configEnv, "/project"),
+    ).resolves.toBeDefined();
+  });
+
   it("still reports a genuinely missing config file", async () => {
     vi.mocked(fileExists).mockResolvedValue(false);
 
@@ -89,11 +103,13 @@ describe("loadZudokuConfig", () => {
   it("logs the error and keeps the last valid config on a failed reload", async () => {
     const cached = {
       __meta: {
-        rootDir: "/project",
+        rootDir: "/reload-project",
         moduleDir: "/zudoku-root",
         mode: undefined,
         dependencies: [],
-        configPath: "/project/zudoku.config.js",
+        // A path no other test has cached an mtime for, so change-detection
+        // reliably forces a reload regardless of test ordering.
+        configPath: "/reload-project/zudoku.config.js",
       },
     };
     configStore.__zudokuConfig = cached;

--- a/packages/zudoku/src/config/loader.test.ts
+++ b/packages/zudoku/src/config/loader.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  stat: vi.fn(() => Promise.resolve({ mtimeMs: 1 })),
+}));
+
+vi.mock("vite", () => ({
+  runnerImport: vi.fn(),
+  loadEnv: vi.fn(() => ({})),
+}));
+
+vi.mock("../cli/common/logger.js", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("../cli/common/package-json.js", () => ({
+  getZudokuRootDir: () => "/zudoku-root",
+}));
+
+vi.mock("../lib/core/transform-config.js", () => ({
+  runPluginTransformConfig: vi.fn((config) => config),
+}));
+
+vi.mock("./file-exists.js", () => ({
+  fileExists: vi.fn(),
+}));
+
+import { runnerImport } from "vite";
+import { logger } from "../cli/common/logger.js";
+import { fileExists } from "./file-exists.js";
+import { loadZudokuConfig } from "./loader.js";
+
+const configEnv = { mode: "development", command: "serve" } as const;
+
+const configStore = globalThis as { __zudokuConfig?: unknown };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset the cached config that lives on globalThis between loads.
+  configStore.__zudokuConfig = undefined;
+});
+
+describe("loadZudokuConfig", () => {
+  it("surfaces the underlying error for a failed import instead of 'no config file found'", async () => {
+    vi.mocked(fileExists).mockResolvedValue(true);
+    vi.mocked(runnerImport).mockRejectedValue(
+      new Error("Failed to resolve import './does-not-exist'"),
+    );
+
+    await expect(loadZudokuConfig(configEnv, "/project")).rejects.toThrow(
+      /Invalid Zudoku configuration at/,
+    );
+    // The actual cause is inlined so the user doesn't have to hunt the logs.
+    await expect(loadZudokuConfig(configEnv, "/project")).rejects.toThrow(
+      /Failed to resolve import '\.\/does-not-exist'/,
+    );
+  });
+
+  it("preserves the original error as `cause`", async () => {
+    const original = new Error("boom");
+    vi.mocked(fileExists).mockResolvedValue(true);
+    vi.mocked(runnerImport).mockRejectedValue(original);
+
+    await expect(loadZudokuConfig(configEnv, "/project")).rejects.toMatchObject(
+      { cause: original },
+    );
+  });
+
+  it("throws a clear error when the config has no default export", async () => {
+    vi.mocked(fileExists).mockResolvedValue(true);
+    vi.mocked(runnerImport).mockResolvedValue({
+      module: {},
+      dependencies: [],
+    } as never);
+
+    await expect(loadZudokuConfig(configEnv, "/project")).rejects.toThrow(
+      /must have a default export/,
+    );
+  });
+
+  it("still reports a genuinely missing config file", async () => {
+    vi.mocked(fileExists).mockResolvedValue(false);
+
+    await expect(loadZudokuConfig(configEnv, "/project")).rejects.toThrow(
+      "No zudoku config file found in project root.",
+    );
+  });
+
+  it("logs the error and keeps the last valid config on a failed reload", async () => {
+    const cached = {
+      __meta: {
+        rootDir: "/project",
+        moduleDir: "/zudoku-root",
+        mode: undefined,
+        dependencies: [],
+        configPath: "/project/zudoku.config.js",
+      },
+    };
+    configStore.__zudokuConfig = cached;
+
+    vi.mocked(fileExists).mockResolvedValue(true);
+    vi.mocked(runnerImport).mockRejectedValue(new Error("syntax error"));
+
+    const result = await loadZudokuConfig(configEnv, "/project");
+
+    expect(result.config).toBe(cached);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("using last valid config"),
+      expect.objectContaining({ timestamp: true }),
+    );
+  });
+});

--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -110,7 +110,10 @@ async function loadZudokuConfigWithMeta(
     );
   }
 
-  if (!module.default) {
+  // Only treat a genuinely absent default export as missing. A present-but-falsy
+  // export (e.g. `export default null`) falls through to validateConfig so it's
+  // reported as an invalid configuration rather than a missing one.
+  if (module.default === undefined) {
     throw new Error(
       `Invalid Zudoku configuration at ${colors.dim(configPath)}:\n\nConfig file must have a default export.`,
     );
@@ -239,11 +242,15 @@ export async function loadZudokuConfig(
       // Keep serving the last valid config (e.g. during dev reload), but log
       // the error instead of silently swallowing it so the user knows why
       // their latest changes haven't taken effect.
+      // Pass the error object via `options.error` so the logger prints the full
+      // stack/location of the import or syntax failure, not just the message.
       logger.error(
         colors.red("Failed to reload config, using last valid config."),
-        { timestamp: true },
+        {
+          timestamp: true,
+          error: error instanceof Error ? error : new Error(String(error)),
+        },
       );
-      logger.error(error instanceof Error ? error.message : String(error));
       return { config: lastValid, envPrefix, publicEnv };
     }
 

--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -74,27 +74,47 @@ async function loadZudokuConfigWithMeta(
 ): Promise<ConfigWithMeta> {
   const configPath = await getConfigFilePath(rootDir);
 
-  const { module, dependencies } = await runnerImport<{
-    default: ZudokuConfig;
-  }>(configPath, {
-    plugins: [virtualModuleStubPlugin],
-    environments: {
-      inline: {
-        resolve: {
-          // Prevent Node.js from trying to load zudoku's raw .ts source
-          // directly, which fails with ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING
-          // when --experimental-strip-types is enabled. Uses regex to also
-          // catch plugins that re-export from zudoku (e.g. @zuplo/zudoku-plugin-*).
-          noExternal: [/zudoku/],
+  let module: { default: ZudokuConfig };
+  let dependencies: string[];
+
+  try {
+    ({ module, dependencies } = await runnerImport<{
+      default: ZudokuConfig;
+    }>(configPath, {
+      plugins: [virtualModuleStubPlugin],
+      environments: {
+        inline: {
+          resolve: {
+            // Prevent Node.js from trying to load zudoku's raw .ts source
+            // directly, which fails with ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING
+            // when --experimental-strip-types is enabled. Uses regex to also
+            // catch plugins that re-export from zudoku (e.g. @zuplo/zudoku-plugin-*).
+            noExternal: [/zudoku/],
+          },
         },
       },
-    },
-    server: {
-      // this allows us to 'load' CSS files in the config
-      // see https://github.com/vitejs/vite/pull/19577
-      perEnvironmentStartEndDuringDev: true,
-    },
-  });
+      server: {
+        // this allows us to 'load' CSS files in the config
+        // see https://github.com/vitejs/vite/pull/19577
+        perEnvironmentStartEndDuringDev: true,
+      },
+    }));
+  } catch (error) {
+    // A failed import (bad/missing import, syntax error, throwing top-level
+    // code) is not a "missing config file". Surface the underlying cause inline
+    // so the user doesn't have to hunt through earlier logs to find it.
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid Zudoku configuration at ${colors.dim(configPath)}:\n\n${detail}`,
+      { cause: error },
+    );
+  }
+
+  if (!module.default) {
+    throw new Error(
+      `Invalid Zudoku configuration at ${colors.dim(configPath)}:\n\nConfig file must have a default export.`,
+    );
+  }
 
   const config = module.default;
 
@@ -214,15 +234,22 @@ export async function loadZudokuConfig(
 
     return { config, envPrefix, publicEnv };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-
     const lastValid = getConfig();
     if (lastValid) {
-      // return the last valid config if it exists
+      // Keep serving the last valid config (e.g. during dev reload), but log
+      // the error instead of silently swallowing it so the user knows why
+      // their latest changes haven't taken effect.
+      logger.error(
+        colors.red("Failed to reload config, using last valid config."),
+        { timestamp: true },
+      );
+      logger.error(error instanceof Error ? error.message : String(error));
       return { config: lastValid, envPrefix, publicEnv };
     }
 
-    throw new Error(errorMessage, { cause: error });
+    // Preserve the original error (and its `cause`) so the branded
+    // "Invalid Zudoku configuration" message and stack survive.
+    throw error;
   } finally {
     await updateModifiedTimes();
   }

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -41,7 +41,7 @@ describe("validateConfig", () => {
 
     expect(() => validateConfig(configWithValidAuth0))
       .toThrowErrorMatchingInlineSnapshot(`
-      [Error: Whoops, looks like there's an issue with your config:
+      [Error: Invalid Zudoku configuration:
       ✖ Clerk public key invalid, must start with pk_test or pk_live
         → at authentication.clerkPubKey]
     `);
@@ -172,7 +172,7 @@ describe("validateConfig", () => {
       validateConfig(configWithInvalidAuth0Domain),
     ).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: Whoops, looks like there's an issue with your config:
+      [Error: Invalid Zudoku configuration:
       ✖ Domain must be a host only (e.g., 'example.com') without protocol or slashes
         → at authentication.domain]
     `,
@@ -194,7 +194,29 @@ describe("validateConfig", () => {
       validateConfig(configWithInvalidAuth0Domain),
     ).toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: Whoops, looks like there's an issue with your config:
+      [Error: Invalid Zudoku configuration:
+      ✖ Domain must be a host only (e.g., 'example.com') without protocol or slashes
+        → at authentication.domain]
+    `,
+    );
+  });
+
+  it("should include the config path in the error when provided", () => {
+    process.env.NODE_ENV = "production";
+
+    const configWithInvalidAuth0Domain = {
+      authentication: {
+        type: "auth0" as const,
+        clientId: "client123",
+        domain: "https://example.auth0.com",
+      },
+    };
+
+    expect(() =>
+      validateConfig(configWithInvalidAuth0Domain, "zudoku.config.ts"),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `
+      [Error: Invalid Zudoku configuration at zudoku.config.ts:
       ✖ Domain must be a host only (e.g., 'example.com') without protocol or slashes
         → at authentication.domain]
     `,

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -772,17 +772,20 @@ export function validateConfig(config: unknown, configPath?: string) {
   const validationResult = ZudokuConfig.safeParse(config);
 
   if (!validationResult.success) {
+    const prettyErrors = z.prettifyError(validationResult.error);
+    const location = configPath ? ` at ${configPath}` : "";
+
     // In production (build mode), throw an error to fail the build
     if (process.env.NODE_ENV === "production") {
       throw new Error(
-        `Whoops, looks like there's an issue with your ${configPath ?? "config"}:\n${z.prettifyError(validationResult.error)}`,
+        `Invalid Zudoku configuration${location}:\n${prettyErrors}`,
       );
     }
 
     // In development mode, log warnings but don't fail
     // biome-ignore lint/suspicious/noConsole: Logging allowed here
-    console.log(colors.yellow("Validation errors:"));
+    console.log(colors.yellow(`Invalid Zudoku configuration${location}:`));
     // biome-ignore lint/suspicious/noConsole: Logging allowed here
-    console.log(colors.yellow(z.prettifyError(validationResult.error)));
+    console.log(colors.yellow(prettyErrors));
   }
 }


### PR DESCRIPTION
Closes #894. Supersedes #2313 (rebased on current `main`, drops the contradictory "check the logs above" wording, and adds the test coverage #2313 was missing).

## Background

Issue #894 reports that a config failure caused by a **bad import** logs the misleading `"no zudoku config file found in project root."`, forcing the user to scroll back through earlier logs to find the real cause. The ask was: say "invalid configuration", and surface the actual error inline.

On current `main` the literal symptom is mostly gone (finding the file and importing it are now separate steps), but the rough edges remain:
- A failed import propagates as a raw, unbranded error.
- A failed **dev reload** silently swallows the error and keeps serving the stale config, so the user has no idea why their edits aren't taking effect.
- A missing `default` export produces an opaque failure.

## Changes

- **Brand import failures.** Wrap the config import so failures throw `Invalid Zudoku configuration at <path>:` with the underlying cause **inlined** (and attached as `cause`), instead of conflating them with a missing file. Deliberately does **not** tell the user to "check the logs above" — issue #894 explicitly asked to remove that.
- **Validate the default export** and give a clear message when it's missing.
- **Stop swallowing reload errors.** On a failed dev reload, log the error before falling back to the last valid config.
- **Consistent wording.** `validateConfig` now uses the same `Invalid Zudoku configuration` phrasing (production throw + dev warning).
- **Tests.** `loader.ts` previously had **zero** tests — added a suite covering: failed import → branded message, `cause` preservation, missing default export, genuinely-missing file (regression guard), and the dev-reload-logs-and-keeps-cached-config path. Plus a `configPath` location test for `validateConfig`.

## Validation

- `vitest run` for `loader.test.ts` + `ZudokuConfig.test.ts` — 31 passing.
- `pnpm biome ci` / `pnpm fmt` clean; `pnpm -F zudoku typecheck` clean.

Manual repro (in `examples/cosmo-cargo`, `nx run cosmo-cargo:dev`):
- add `import { x } from "./nope"` → error names the config path with the resolve failure inline, on both cold start and hot reload;
- remove `export default` → "Config file must have a default export";
- delete the config file entirely → still "No zudoku config file found in project root."

## Why a new PR instead of pushing to #2313

#2313 was stale (merge-conflicting with `main`, built on the pre-`globalThis` loader) and its message re-added the "check the logs above" line that #894 asked to remove, with no loader tests. This PR is a clean, rebased version. Closing #2313 in favor of this.

https://claude.ai/code/session_01VDfpnoWd7epbnb5TQEpmBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDfpnoWd7epbnb5TQEpmBp)_