### PR TITLE
fix: keep doc route when navigation file includes a `.md` extension

### DIFF
--- a/packages/zudoku/src/vite/plugin-docs.test.ts
+++ b/packages/zudoku/src/vite/plugin-docs.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ConfigWithMeta } from "../config/loader.js";
+import { isNavigationPlugin } from "../lib/core/plugins.js";
+import {
+  type MarkdownPluginOptions,
+  markdownPlugin,
+} from "../lib/plugins/markdown/index.js";
+import {
+  globMarkdownFiles,
+  resolveCustomNavigationPaths,
+} from "./plugin-docs.js";
+import { routesToPaths } from "./prerender/utils.js";
+
+describe("resolveCustomNavigationPaths", () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let __meta: ConfigWithMeta["__meta"];
+
+  const writeDoc = async (relativePath: string) => {
+    const absolute = path.join(tempDir, relativePath);
+    await fs.mkdir(path.dirname(absolute), { recursive: true });
+    await fs.writeFile(absolute, "# Page\n");
+  };
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    // glob resolves relative patterns against cwd, so the file lookups in
+    // NavigationResolver and globMarkdownFiles need cwd to be the fixture dir.
+    tempDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "zudoku-docs-test-")),
+    );
+    process.chdir(tempDir);
+    __meta = {
+      rootDir: tempDir,
+      moduleDir: path.join(tempDir, "node_modules"),
+      mode: "module",
+      dependencies: [],
+      configPath: path.join(tempDir, "zudoku.config.ts"),
+    };
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const resolve = async (navigation: ConfigWithMeta["navigation"]) => {
+    const config: ConfigWithMeta = {
+      __meta,
+      docs: { files: "pages/**/*.{md,mdx}" },
+      navigation,
+    };
+    return resolveCustomNavigationPaths(
+      config,
+      await globMarkdownFiles(config),
+    );
+  };
+
+  it("keeps the route when the navigation file includes a .md extension", async () => {
+    await writeDoc("pages/resources/page_1.md");
+
+    const mapping = await resolve([
+      { type: "doc", file: "/resources/page_1.md", label: "Page One" },
+    ]);
+
+    expect(mapping["/resources/page_1"]).toBe("pages/resources/page_1.md");
+  });
+
+  it("keeps the route when the navigation file omits the extension", async () => {
+    await writeDoc("pages/dev_guide/page_1.md");
+
+    const mapping = await resolve([
+      { type: "doc", file: "/dev_guide/page_1", label: "First Page" },
+    ]);
+
+    expect(mapping["/dev_guide/page_1"]).toBe("pages/dev_guide/page_1.md");
+  });
+
+  it("still remaps when a genuine custom path is set", async () => {
+    await writeDoc("pages/resources/page_1.md");
+
+    const mapping = await resolve([
+      { type: "doc", file: "/resources/page_1", path: "/custom/path" },
+    ]);
+
+    expect(mapping["/custom/path"]).toBe("pages/resources/page_1.md");
+    expect(mapping["/resources/page_1"]).toBeUndefined();
+  });
+
+  it("keeps the route for a category link doc with a .md extension", async () => {
+    await writeDoc("pages/resources/overview.md");
+
+    const mapping = await resolve([
+      {
+        type: "category",
+        label: "Resources",
+        items: [],
+        link: { type: "doc", file: "/resources/overview.md" },
+      },
+    ]);
+
+    expect(mapping["/resources/overview"]).toBe("pages/resources/overview.md");
+  });
+
+  it("collects the route as a prerender path for an extension-suffixed nav file", async () => {
+    await writeDoc("pages/resources/page_1.md");
+
+    const mapping = await resolve([
+      { type: "doc", file: "/resources/page_1.md", label: "Page One" },
+    ]);
+
+    const fileImports: MarkdownPluginOptions["fileImports"] =
+      Object.fromEntries(
+        Object.keys(mapping).map((routePath) => [
+          routePath,
+          () => Promise.resolve({} as never),
+        ]),
+      );
+
+    const plugin = markdownPlugin({
+      basePath: "",
+      fileImports,
+      files: ["pages/**/*.{md,mdx}"],
+      publishMarkdown: false,
+    });
+    const routes = isNavigationPlugin(plugin) ? plugin.getRoutes() : [];
+
+    expect(routesToPaths(routes)).toContain("/resources/page_1");
+  });
+});

--- a/packages/zudoku/src/vite/plugin-docs.ts
+++ b/packages/zudoku/src/vite/plugin-docs.ts
@@ -101,7 +101,8 @@ export const resolveCustomNavigationPaths = async (
 
     const customPath = ensureLeadingSlash(doc.path);
     mapping[customPath] = filePath;
-    delete mapping[fileRoutePath];
+
+    if (customPath !== fileRoutePath) delete mapping[fileRoutePath];
   };
 
   if (config.navigation) {


### PR DESCRIPTION
Issue was [reported in Discord](https://discord.com/channels/848913990360629268/1511417662578757642)

Doc pages referenced in navigation with a file path that includes the `.md` or `.mdx` extension (like `/resources/page_1.md`) were silently dropped from the build and never written to `dist`. Paths without the extension worked fine.

The cause was in `resolveCustomNavigationPaths`: when the file path carried an extension, the custom path and the file route path both collapsed to the same key once the extension was stripped, so the code set the entry then immediately deleted it under that same key. Now the delete only runs when the keys actually differ, so both forms produce the route.

Added tests for the extension and non-extension forms, the category link variant, and a check that the route makes it through to the prerendered path list.