### PR TITLE
feat(ssr): emit Cache-Control on anonymous successful renders

### DIFF
--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -25,6 +25,7 @@ import { highlighterPromise } from "../lib/shiki.js";
 import type { Adapter } from "./adapter.js";
 import { getRoutesByConfig } from "./main.js";
 import { protectChunks as rawProtectChunks } from "./protectChunks.js";
+import { getSsrCacheControl } from "./ssrCacheControl.js";
 import { wrapProtectedRoutes } from "./wrapProtectedRoutes.js";
 
 export { getRoutesByConfig };
@@ -217,14 +218,15 @@ export const handleRequest = async ({
     const headers: HeadersInit = {
       "Content-Type": "text/html; charset=utf-8",
     };
-    // Only suppress caching for pages that embed a per-user profile.
-    // Anonymous renders (auth configured but no session) stay cacheable.
-    if (ssrAuth?.profile) {
-      headers["Cache-Control"] = "private, no-store";
+    const finalStatus =
+      renderContext.status !== 200 ? renderContext.status : status;
+    const cacheControl = getSsrCacheControl(finalStatus, !!ssrAuth?.profile);
+    if (cacheControl) {
+      headers["Cache-Control"] = cacheControl;
     }
 
     return new Response(stream, {
-      status: renderContext.status !== 200 ? renderContext.status : status,
+      status: finalStatus,
       headers,
     });
   } catch (error) {

--- a/packages/zudoku/src/app/ssrCacheControl.test.ts
+++ b/packages/zudoku/src/app/ssrCacheControl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getSsrCacheControl } from "./ssrCacheControl.js";
+
+describe("getSsrCacheControl", () => {
+  it("forces private, no-store on authed renders regardless of status", () => {
+    expect(getSsrCacheControl(200, true)).toBe("private, no-store");
+    expect(getSsrCacheControl(404, true)).toBe("private, no-store");
+    expect(getSsrCacheControl(500, true)).toBe("private, no-store");
+  });
+
+  it("emits the cacheable two-tier header on anon 200 renders", () => {
+    expect(getSsrCacheControl(200, false)).toBe(
+      "public, max-age=0, s-maxage=60, must-revalidate",
+    );
+  });
+
+  it("emits nothing on anon non-200 renders so the caller can decide", () => {
+    expect(getSsrCacheControl(301, false)).toBeUndefined();
+    expect(getSsrCacheControl(404, false)).toBeUndefined();
+    expect(getSsrCacheControl(500, false)).toBeUndefined();
+  });
+});

--- a/packages/zudoku/src/app/ssrCacheControl.ts
+++ b/packages/zudoku/src/app/ssrCacheControl.ts
@@ -1,0 +1,20 @@
+/**
+ * Decide the Cache-Control header for an SSR response.
+ *
+ * - Authed renders embed the user's profile in HTML, so they must never be
+ *   shared-cached. Always `private, no-store`.
+ * - Anonymous successful (200) renders use the standard two-tier SSR cache
+ *   pattern: `max-age=0, must-revalidate` keeps browsers from caching
+ *   navigations, `s-maxage=60` lets shared caches (CDNs) absorb concurrent
+ *   load.
+ * - Non-200 responses get no Cache-Control here — error/redirect handling
+ *   is delegated to the calling layer.
+ */
+export const getSsrCacheControl = (
+  status: number,
+  isAuthed: boolean,
+): string | undefined => {
+  if (isAuthed) return "private, no-store";
+  if (status === 200) return "public, max-age=0, s-maxage=60, must-revalidate";
+  return undefined;
+};


### PR DESCRIPTION
## What

The SSR handler now emits `Cache-Control` on every response:

| Render | Cache-Control |
|---|---|
| Authed (`ssrAuth.profile` set) | `private, no-store` (unchanged) |
| Anonymous 200 | **`public, max-age=0, s-maxage=60, must-revalidate`** (new) |
| Anonymous non-200 | (no header — caller decides) |

## Why

Anonymous SSR pages have no reason to be uncacheable. Previously, only authed responses got a `Cache-Control` header; everything else fell through with no directive, which left the choice to whatever CDN/proxy sits in front. Many CDNs default to "don't cache" when origin says nothing, so the SSR runtime ended up rendering every request even though anonymous output is identical across visitors.

The new default uses the standard two-tier SSR cache pattern:

- **`max-age=0, must-revalidate`** → browsers always revalidate on navigation, so a deploy is visible to all users immediately. No stale HTML on the client.
- **`s-maxage=60`** → shared caches (CDNs, reverse proxies) may serve a stored response for 60s, absorbing concurrent reads of the same URL. The SSR runtime only renders once per window per edge location.

`private, no-store` is preserved for authed renders because the HTML embeds the user's profile.

## Diagram

```
                 ┌──────────────────────────────────────────────────┐
                 │              Cache-Control: public,              │
                 │        max-age=0, s-maxage=60, must-revalidate   │
                 └──────────────────────────────────────────────────┘
                          │                                │
            max-age=0  ───┘                                └───  s-maxage=60
            (browser                                              (CDN / shared
            does NOT cache)                                       cache DOES)
                  │                                                   │
                  ▼                                                   ▼
            ┌───────────┐         ┌────────────────────────────────────┐
            │  Browser  │ ──────► │  Shared cache (e.g. CDN edge POP)  │
            │           │         │                                    │
            │  Always   │ ◄────── │  Stores response for up to 60s     │
            │  revali-  │         │  Subsequent identical requests     │
            │  dates    │         │  served from store, do NOT reach   │
            └───────────┘         │  the SSR origin                    │
                                  └────────────────┬───────────────────┘
                                                   │ (on miss / expiry)
                                                   ▼
                                            ┌────────────┐
                                            │  SSR       │
                                            │  origin    │
                                            └────────────┘
```

## Implementation

- New small helper `packages/zudoku/src/app/ssrCacheControl.ts` containing the header-decision logic (3-branch pure function).
- `entry.server.tsx` imports the helper and uses it where the inline `if (ssrAuth?.profile)` block used to live.
- Unit tests `packages/zudoku/src/app/ssrCacheControl.test.ts` cover all three branches (authed, anon-200, anon-non-200).

## Test plan

- [x] `pnpm vitest run packages/zudoku/src/app/ssrCacheControl.test.ts` — 3/3 pass.
- [x] `pnpm biome ci` on the three touched files — clean.
- [x] `pnpm fmt:check` — clean (oxfmt agreed).
- [x] Verified end-to-end against a live SSR deployment (curl shows the new header passing through to clients; subsequent hits to the same URL return `X-Cache: Hit` from the CDN with no SSR origin invocation).

## Out of scope

- Per-route override (e.g. opt-in long-TTL for blog posts, opt-out for status-page-style updates). Worth a follow-up if a customer asks.
- Different default for protected routes that 401 without a session. The current "no header on non-200" leaves that to the caller, which is the safe default.