### PR TITLE
Add subscription phase timeline UI and utilities

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/SubscriptionChangeConfirmPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/SubscriptionChangeConfirmPage.test.tsx
@@ -183,9 +183,10 @@ describe("SubscriptionChangeConfirmPage", () => {
   it("shows the current plan and the target plan side by side", () => {
     renderPage("/?planId=plan-1&subscriptionId=sub-1");
 
-    expect(screen.getByText("Current Plan")).toBeInTheDocument();
+    expect(screen.getByText("Current plan")).toBeInTheDocument();
     expect(screen.getByText("Current Plan Name")).toBeInTheDocument();
     expect(screen.getByText("Changing to")).toBeInTheDocument();
+    expect(screen.getByText("New plan")).toBeInTheDocument();
     expect(screen.getByText("Pro")).toBeInTheDocument();
   });
 

--- a/packages/plugin-zuplo-monetization/src/pages/SubscriptionChangeConfirmPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/SubscriptionChangeConfirmPage.tsx
@@ -12,8 +12,8 @@ import { useMonetizationConfig } from "../MonetizationContext";
 import { subscriptionsQuery } from "../queries.js";
 import { formatDateTime } from "../utils/formatDateTime.js";
 import { formatPrice } from "../utils/formatPrice.js";
+import { subscriptionToCurrentPlan } from "../utils/subscriptionEntitlements.js";
 import { ConfirmationScreen } from "./components/ConfirmationScreen.js";
-import { CurrentPlanBaseline } from "./components/CurrentPlanBaseline.js";
 import { PlanSummaryCard } from "./components/PlanSummaryCard.js";
 
 const SubscriptionChangeConfirmPage = () => {
@@ -80,9 +80,14 @@ const SubscriptionChangeConfirmPage = () => {
       <div className="space-y-3">
         {currentSubscription && (
           <>
-            <CurrentPlanBaseline
-              subscription={currentSubscription}
+            <PlanSummaryCard
+              plan={subscriptionToCurrentPlan(currentSubscription)}
+              label="Current plan"
+              descriptionFallback=""
+              taxLabel=""
+              taxInclusive={false}
               units={pricing?.units}
+              collapsibleDetails
             />
             <div className="flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
               <ArrowDownIcon className="size-4" /> Changing to
@@ -93,11 +98,13 @@ const SubscriptionChangeConfirmPage = () => {
         {selectedPlan && (
           <PlanSummaryCard
             plan={selectedPlan}
-            descriptionFallback="New plan"
+            label="New plan"
+            descriptionFallback=""
             taxAmount={taxAmount}
             taxLabel={taxLabel}
             taxInclusive={taxInclusive}
             units={pricing?.units}
+            collapsibleDetails
           />
         )}
 

--- a/packages/plugin-zuplo-monetization/src/pages/components/PlanSummaryCard.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/components/PlanSummaryCard.tsx
@@ -1,4 +1,10 @@
+import { ChevronDownIcon } from "zudoku/icons";
 import { Card, CardContent, CardHeader, CardTitle } from "zudoku/ui/Card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "zudoku/ui/Collapsible";
 import { Separator } from "zudoku/ui/Separator";
 import { PlanEntitlements } from "../../pricing-ui/PlanEntitlements.js";
 import { PlanPriceSchedule } from "../../pricing-ui/PlanPriceSchedule.js";
@@ -21,23 +27,32 @@ import { getPlanPriceSchedule } from "../../utils/getPlanPriceSchedule.js";
  * The price is derived from the plan's rate cards via {@link formatPlanPrice}
  * and rendered in the plan's own billing cadence, so it stays correct for any
  * cadence (e.g. `$2.99/hour`).
+ *
+ * Pass `collapsibleDetails` to hide the "What's included" section behind a
+ * collapsed-by-default toggle — used on the plan-change confirmation page where
+ * the current and new plan are stacked and the user opens each to compare. Pass
+ * `label` to render a small eyebrow above the name (e.g. "Current plan").
  */
 export const PlanSummaryCard = ({
   plan,
+  label,
   descriptionFallback,
   taxAmount,
   taxLabel,
   taxInclusive,
   units,
   entitlementsItemClassName,
+  collapsibleDetails = false,
 }: {
   plan: Plan;
+  label?: string;
   descriptionFallback: string;
   taxAmount?: number;
   taxLabel: string;
   taxInclusive: boolean;
   units?: Record<string, string>;
   entitlementsItemClassName?: string;
+  collapsibleDetails?: boolean;
 }) => {
   const priceLabel = formatPlanPrice(plan);
   const schedule = getPlanPriceSchedule(plan);
@@ -67,6 +82,11 @@ export const PlanSummaryCard = ({
               {plan.name.at(0)?.toUpperCase()}
             </div>
             <div className="flex flex-col">
+              {label && (
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  {label}
+                </span>
+              )}
               <span className="text-lg font-bold">{plan.name}</span>
               <span className="text-sm font-normal text-muted-foreground">
                 {plan.description || descriptionFallback}
@@ -106,14 +126,36 @@ export const PlanSummaryCard = ({
       </CardHeader>
       <CardContent>
         <Separator />
-        <div className="text-sm font-medium mb-3 mt-3">What's included:</div>
-        <PlanEntitlements
-          phases={plan.phases}
-          currency={plan.currency}
-          billingCadence={plan.billingCadence}
-          units={units}
-          itemClassName={entitlementsItemClassName}
-        />
+        {collapsibleDetails ? (
+          <Collapsible>
+            <CollapsibleTrigger className="group flex w-full items-center justify-between text-sm font-medium mt-3">
+              Plan details
+              <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-3">
+              <PlanEntitlements
+                phases={plan.phases}
+                currency={plan.currency}
+                billingCadence={plan.billingCadence}
+                units={units}
+                itemClassName={entitlementsItemClassName}
+              />
+            </CollapsibleContent>
+          </Collapsible>
+        ) : (
+          <>
+            <div className="text-sm font-medium mb-3 mt-3">
+              What's included:
+            </div>
+            <PlanEntitlements
+              phases={plan.phases}
+              currency={plan.currency}
+              billingCadence={plan.billingCadence}
+              units={units}
+              itemClassName={entitlementsItemClassName}
+            />
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/packages/plugin-zuplo-monetization/src/pages/components/SubscriptionPhases.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/components/SubscriptionPhases.tsx
@@ -1,0 +1,120 @@
+import { ChevronDownIcon } from "zudoku/icons";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "zudoku/ui/Collapsible";
+import { EntitlementList } from "../../pricing-ui/EntitlementList.js";
+import { PlanPriceTag } from "../../pricing-ui/PlanPriceTag.js";
+import type { Subscription } from "../../types/SubscriptionType.js";
+import { formatDateTime } from "../../utils/formatDateTime.js";
+import {
+  getSubscriptionPhaseViews,
+  type SubscriptionPhaseView,
+} from "../../utils/subscriptionEntitlements.js";
+
+const phaseDateLabel = (view: SubscriptionPhaseView): string | undefined => {
+  if (view.status === "current") return "Current phase";
+  if (view.status === "future")
+    return `Starts ${formatDateTime(view.activeFrom)}`;
+  // past
+  return view.activeTo
+    ? `${formatDateTime(view.activeFrom)} – ${formatDateTime(view.activeTo)}`
+    : formatDateTime(view.activeFrom);
+};
+
+/**
+ * One phase of a subscription: a header with the phase name, its timing
+ * sub-label, and the phase's own price, followed by that phase's included
+ * quotas/features. The header always renders (even when the phase has no
+ * entitlements) so the price/timing is never hidden.
+ */
+const SubscriptionPhaseSection = ({
+  view,
+}: {
+  view: SubscriptionPhaseView;
+}) => {
+  const dateLabel = phaseDateLabel(view);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="text-sm font-medium text-card-foreground">
+          {view.name}
+          {dateLabel && (
+            <span className="text-muted-foreground font-normal">
+              {" "}
+              &middot; {dateLabel}
+            </span>
+          )}
+        </div>
+        <PlanPriceTag
+          label={view.priceLabel}
+          currency={view.currency}
+          billingCadence={view.billingCadence}
+        />
+      </div>
+      <EntitlementList
+        quotas={view.entitlements.quotas}
+        features={view.entitlements.features}
+      />
+    </div>
+  );
+};
+
+/**
+ * The subscription's future phases (each with its start date, price, and
+ * entitlements), shown after the current phase on the details page and on the
+ * Switch Plan baseline. Renders nothing when there are no upcoming phases.
+ */
+export const UpcomingPhases = ({
+  subscription,
+  units,
+}: {
+  subscription: Subscription;
+  units?: Record<string, string>;
+}) => {
+  const future = getSubscriptionPhaseViews(subscription, { units }).filter(
+    (v) => v.status === "future",
+  );
+  if (future.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      {future.map((view) => (
+        <SubscriptionPhaseSection key={view.id} view={view} />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * The subscription's already-ended phases, collapsed by default, each labelled
+ * with the exact dates it ran. Lets users review what they previously paid for
+ * without cluttering the page. Renders nothing when there are no past phases.
+ */
+export const PreviousPhases = ({
+  subscription,
+  units,
+}: {
+  subscription: Subscription;
+  units?: Record<string, string>;
+}) => {
+  const past = getSubscriptionPhaseViews(subscription, { units }).filter(
+    (v) => v.status === "past",
+  );
+  if (past.length === 0) return null;
+
+  return (
+    <Collapsible>
+      <CollapsibleTrigger className="group flex w-full items-center justify-between text-sm font-medium">
+        Previous phases
+        <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-3 space-y-4">
+        {past.map((view) => (
+          <SubscriptionPhaseSection key={view.id} view={view} />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.test.tsx
@@ -415,8 +415,16 @@ describe("SubscriptionPlanDetails", () => {
 
     render(<SubscriptionPlanDetails subscription={subscription} />);
 
-    expect(screen.getByText("$375")).toBeInTheDocument();
-    expect(screen.getByText("/month")).toBeInTheDocument();
-    expect(screen.queryByText("$750")).not.toBeInTheDocument();
+    // The "Price" field shows the phase active NOW ($375), never the future
+    // steady phase or the catalog plan's last phase.
+    const priceField = screen.getByText("Price").parentElement as HTMLElement;
+    expect(within(priceField).getByText("$375")).toBeInTheDocument();
+    expect(within(priceField).getByText("/month")).toBeInTheDocument();
+    expect(within(priceField).queryByText("$750")).not.toBeInTheDocument();
+
+    // The future steady phase ($750/month) is surfaced under "Upcoming phases".
+    const upcoming = screen.getByText("Upcoming phases")
+      .parentElement as HTMLElement;
+    expect(within(upcoming).getByText("$750")).toBeInTheDocument();
   });
 });

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SubscriptionPlanDetails.tsx
@@ -15,10 +15,15 @@ import {
   subscriptionTaxLegendSentence,
 } from "../../utils/pricingTaxLegend.js";
 import {
+  getSubscriptionPhaseViews,
   getSubscriptionPlanView,
   hasSubscriptionEntitlements,
 } from "../../utils/subscriptionEntitlements.js";
 import { SubscriptionEntitlements } from "../components/SubscriptionEntitlements.js";
+import {
+  PreviousPhases,
+  UpcomingPhases,
+} from "../components/SubscriptionPhases.js";
 
 const detailLabelClassName = "text-sm font-semibold tracking-wide mb-1";
 const sectionLabelClassName = "text-base font-semibold tracking-wide mb-3 mt-2";
@@ -40,6 +45,11 @@ export const SubscriptionPlanDetails = ({
     : undefined;
 
   const hasEntitlements = hasSubscriptionEntitlements(view);
+  const phaseViews = getSubscriptionPhaseViews(subscription, {
+    units: pricing?.units,
+  });
+  const hasUpcomingPhases = phaseViews.some((p) => p.status === "future");
+  const hasPreviousPhases = phaseViews.some((p) => p.status === "past");
 
   return (
     <div className="space-y-4">
@@ -109,6 +119,25 @@ export const SubscriptionPlanDetails = ({
                 view={view}
                 currency={view.currency}
                 billingCadence={view.billingCadence}
+                units={pricing?.units}
+              />
+            </div>
+          ) : null}
+
+          {hasUpcomingPhases ? (
+            <div className="space-y-3 pt-2 border-t border-border">
+              <p className={sectionLabelClassName}>Upcoming phases</p>
+              <UpcomingPhases
+                subscription={subscription}
+                units={pricing?.units}
+              />
+            </div>
+          ) : null}
+
+          {hasPreviousPhases ? (
+            <div className="pt-2 border-t border-border">
+              <PreviousPhases
+                subscription={subscription}
                 units={pricing?.units}
               />
             </div>

--- a/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.test.ts
@@ -554,11 +554,49 @@ describe("subscriptionToCurrentPlan", () => {
     );
 
     expect(plan.phases.map((p) => p.key)).toEqual(["intro", "steady"]);
-    // The synthesized plan feeds the same pricing-table schedule helper.
+    // The synthesized plan feeds the same pricing-table schedule helper, and
+    // carries per-phase durations computed from the phase dates so the labels
+    // read like the new plan ("First 3 months" / "After that"), not the phase
+    // name.
     expect(getPlanPriceSchedule(plan)).toEqual([
-      expect.objectContaining({ price: { type: "priced", amount: 375 } }),
-      expect.objectContaining({ price: { type: "priced", amount: 750 } }),
+      expect.objectContaining({
+        label: "First 3 months",
+        price: { type: "priced", amount: 375 },
+      }),
+      expect.objectContaining({
+        label: "After that",
+        price: { type: "priced", amount: 750 },
+      }),
     ]);
+  });
+
+  it("prefers the catalog plan phase's authored duration over the date-derived one", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-05T00:00:00.000Z"));
+
+    const plan = subscriptionToCurrentPlan(
+      makeSubscription({
+        phases: [
+          makeSubscriptionPhase({
+            key: "trial",
+            activeFrom: "2026-06-01T00:00:00.000Z",
+            activeTo: "2026-06-08T00:00:00.000Z", // 1 week
+            items: [feeItem("0")],
+          }),
+          makeSubscriptionPhase({
+            key: "paid",
+            activeFrom: "2026-06-08T00:00:00.000Z",
+            items: [feeItem("100")],
+          }),
+        ],
+        planPhases: [
+          { key: "trial", name: "Trial", duration: "P1W", rateCards: [] },
+        ],
+      }),
+    );
+
+    expect(plan.phases[0].duration).toBe("P1W");
+    expect(getPlanPriceSchedule(plan)?.[0].label).toBe("First week");
   });
 });
 

--- a/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Item, Subscription } from "../types/SubscriptionType.js";
+import { getPlanPriceSchedule } from "./getPlanPriceSchedule.js";
 import {
   categorizeSubscriptionItems,
+  getSubscriptionPhaseViews,
   getSubscriptionPlanView,
   hasSubscriptionEntitlements,
+  subscriptionToCurrentPlan,
 } from "./subscriptionEntitlements.js";
 
 type Entitlement = NonNullable<Item["included"]["entitlement"]>;
@@ -53,6 +56,14 @@ const meteredEntitlement = (
   ...(issueAfterReset != null ? { issueAfterReset } : {}),
   usagePeriod: { anchor: "x", interval: intervalISO, intervalISO },
 });
+
+const feeItem = (amount: string): Item =>
+  item({
+    key: "monthly_fee",
+    name: "Monthly Fee",
+    price: { type: "flat", amount, paymentTerm: "in_advance" },
+    billingCadence: "P1M",
+  });
 
 const makeSubscriptionPhase = (o: {
   key: string;
@@ -423,6 +434,131 @@ describe("getSubscriptionPlanView", () => {
     );
 
     expect(view.priceLabel).toEqual({ type: "priced", amount: 99 });
+  });
+});
+
+describe("getSubscriptionPhaseViews", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("orders phases by activeFrom and tags them past/current/future with each phase's own price", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-15T00:00:00.000Z"));
+
+    // Deliberately out of chronological order to verify sorting.
+    const views = getSubscriptionPhaseViews(
+      makeSubscription({
+        phases: [
+          makeSubscriptionPhase({
+            key: "steady",
+            activeFrom: "2026-09-04T00:00:00.000Z",
+            items: [feeItem("750")],
+          }),
+          makeSubscriptionPhase({
+            key: "trial",
+            activeFrom: "2026-05-01T00:00:00.000Z",
+            activeTo: "2026-06-04T00:00:00.000Z",
+            items: [feeItem("0")],
+          }),
+          makeSubscriptionPhase({
+            key: "intro",
+            activeFrom: "2026-06-04T00:00:00.000Z",
+            activeTo: "2026-09-04T00:00:00.000Z",
+            items: [feeItem("375")],
+          }),
+        ],
+      }),
+    );
+
+    expect(views.map((v) => v.name)).toEqual(["trial", "intro", "steady"]);
+    expect(views.map((v) => v.status)).toEqual(["past", "current", "future"]);
+    expect(views[0].priceLabel).toEqual({ type: "free" });
+    expect(views[1].priceLabel).toEqual({ type: "priced", amount: 375 });
+    expect(views[2].priceLabel).toEqual({ type: "priced", amount: 750 });
+  });
+
+  it("falls back to the catalog plan phase (by key) when a future phase has no items", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-15T00:00:00.000Z"));
+
+    const future = getSubscriptionPhaseViews(
+      makeSubscription({
+        phases: [
+          makeSubscriptionPhase({
+            key: "intro",
+            activeFrom: "2026-06-04T00:00:00.000Z",
+            activeTo: "2026-09-04T00:00:00.000Z",
+            items: [feeItem("375")],
+          }),
+          makeSubscriptionPhase({
+            key: "steady",
+            activeFrom: "2026-09-04T00:00:00.000Z",
+            items: [],
+          }),
+        ],
+        planPhases: [
+          {
+            key: "steady",
+            name: "Steady",
+            rateCards: [
+              {
+                type: "flat_fee",
+                key: "base",
+                name: "Base",
+                billingCadence: "P1M",
+                price: { type: "flat", amount: "750" },
+              },
+            ],
+          },
+        ],
+      }),
+    ).find((v) => v.status === "future");
+
+    expect(future?.priceLabel).toEqual({ type: "priced", amount: 750 });
+  });
+});
+
+describe("subscriptionToCurrentPlan", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps current + future phases (drops past), sourced from provisioned items even when the embedded plan snapshot is empty", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-15T00:00:00.000Z"));
+
+    const plan = subscriptionToCurrentPlan(
+      makeSubscription({
+        phases: [
+          makeSubscriptionPhase({
+            key: "trial",
+            activeFrom: "2026-05-01T00:00:00.000Z",
+            activeTo: "2026-06-04T00:00:00.000Z",
+            items: [feeItem("0")],
+          }),
+          makeSubscriptionPhase({
+            key: "intro",
+            activeFrom: "2026-06-04T00:00:00.000Z",
+            activeTo: "2026-09-04T00:00:00.000Z",
+            items: [feeItem("375")],
+          }),
+          makeSubscriptionPhase({
+            key: "steady",
+            activeFrom: "2026-09-04T00:00:00.000Z",
+            items: [feeItem("750")],
+          }),
+        ],
+        planPhases: [], // embedded snapshot is empty — must not be the source
+      }),
+    );
+
+    expect(plan.phases.map((p) => p.key)).toEqual(["intro", "steady"]);
+    // The synthesized plan feeds the same pricing-table schedule helper.
+    expect(getPlanPriceSchedule(plan)).toEqual([
+      expect.objectContaining({ price: { type: "priced", amount: 375 } }),
+      expect.objectContaining({ price: { type: "priced", amount: 750 } }),
+    ]);
   });
 });
 

--- a/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.ts
@@ -262,6 +262,53 @@ const phasesByActiveFrom = (subscription: Subscription) =>
   );
 
 /**
+ * A clean ISO-8601 duration between two instants, preferring whole calendar
+ * units (years/months/weeks) over raw days so it formats the same way catalog
+ * plan durations do (e.g. `P1W` → "week", `P3M` → "3 months") rather than as
+ * "7 days" / "90 days". Returns `undefined` for a non-positive span.
+ */
+const isoDurationBetween = (from: string, to: string): string | undefined => {
+  const a = new Date(from);
+  const b = new Date(to);
+  const ms = b.getTime() - a.getTime();
+  if (!(ms > 0)) return undefined;
+
+  // Whole calendar months (and years) when `to` lands exactly N months after
+  // `from` — covers monthly/quarterly/annual ramp phases regardless of how
+  // many days each month has.
+  let months =
+    (b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth());
+  const anchor = new Date(a);
+  anchor.setMonth(a.getMonth() + months);
+  if (anchor.getTime() > b.getTime()) months -= 1;
+  const exact = new Date(a);
+  exact.setMonth(a.getMonth() + months);
+  if (months >= 1 && exact.getTime() === b.getTime()) {
+    return months % 12 === 0 ? `P${months / 12}Y` : `P${months}M`;
+  }
+
+  const days = Math.round(ms / 86_400_000);
+  if (days >= 7 && days % 7 === 0) return `P${days / 7}W`;
+  return `P${days}D`;
+};
+
+/**
+ * The intended length of a subscription phase: the matching catalog plan
+ * phase's authored `duration` when available (the cleanest source), otherwise
+ * computed from the phase's own `activeFrom`/`activeTo`. `undefined` for an
+ * open-ended (final) phase — the price schedule labels that one "After that".
+ */
+const phaseDuration = (
+  plan: Subscription["plan"],
+  phase: Subscription["phases"][number],
+): string | undefined => {
+  const catalog = plan.phases?.find((p) => p.key === phase.key)?.duration;
+  if (catalog) return catalog;
+  if (!phase.activeTo) return undefined;
+  return isoDurationBetween(phase.activeFrom, phase.activeTo);
+};
+
+/**
  * Resolve EVERY phase of a subscription (not just the active one) to a
  * {@link SubscriptionPhaseView}, ordered by `activeFrom` and tagged
  * past/current/future. Generalizes {@link getSubscriptionPlanView}: each phase's
@@ -312,7 +359,9 @@ export const getSubscriptionPhaseViews = (
  * for the new plan. Each phase's rate cards come from its provisioned items
  * (the authoritative source) — the embedded `subscription.plan` snapshot is
  * unreliable here (it can arrive with `phases: []`), so we never read its
- * phases for pricing.
+ * phases for pricing. Each phase's `duration` is carried so the price schedule
+ * labels read "First 3 months" / "After that" exactly like the new plan, rather
+ * than falling back to the phase name (see {@link phaseDuration}).
  */
 export const subscriptionToCurrentPlan = (subscription: Subscription): Plan => {
   const plan = subscription.plan;
@@ -322,6 +371,7 @@ export const subscriptionToCurrentPlan = (subscription: Subscription): Plan => {
     .map((phase) => ({
       key: phase.key,
       name: phase.name,
+      duration: phaseDuration(plan, phase),
       rateCards: phaseRateCards(plan, phase),
     }));
 

--- a/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/subscriptionEntitlements.ts
@@ -2,6 +2,7 @@ import type {
   Feature,
   FlatPrice,
   MeteredEntitlementTemplate,
+  Plan,
   PlanPhase,
   Price,
   Quota,
@@ -216,3 +217,118 @@ export const hasSubscriptionEntitlements = (
     : view.fallbackPhases.some((p) =>
         p.rateCards?.some((rc) => rc.entitlementTemplate),
       );
+
+export type SubscriptionPhaseStatus = "past" | "current" | "future";
+
+/** A single subscription phase resolved to its price + entitlements + timing. */
+export type SubscriptionPhaseView = {
+  id: string;
+  name: string;
+  status: SubscriptionPhaseStatus;
+  activeFrom: string;
+  activeTo?: string;
+  priceLabel: PlanPriceLabel;
+  entitlements: { quotas: Quota[]; features: Feature[] };
+  billingCadence?: string;
+  currency?: string;
+};
+
+const phaseStatus = (
+  phase: { activeFrom: string; activeTo?: string },
+  now: number,
+): SubscriptionPhaseStatus => {
+  if (phase.activeTo && new Date(phase.activeTo).getTime() < now) return "past";
+  if (new Date(phase.activeFrom).getTime() > now) return "future";
+  return "current";
+};
+
+/**
+ * Rate cards for one subscription phase: its own provisioned items (the
+ * authoritative quotas/fees), falling back to the catalog plan phase with the
+ * same `key` when a phase (typically a future one) hasn't been provisioned yet.
+ */
+const phaseRateCards = (
+  plan: Subscription["plan"],
+  phase: Subscription["phases"][number],
+): RateCard[] =>
+  phase.items.length > 0
+    ? subscriptionItemsToRateCards(phase.items)
+    : (plan.phases?.find((p) => p.key === phase.key)?.rateCards ?? []);
+
+const phasesByActiveFrom = (subscription: Subscription) =>
+  [...subscription.phases].sort(
+    (a, b) =>
+      new Date(a.activeFrom).getTime() - new Date(b.activeFrom).getTime(),
+  );
+
+/**
+ * Resolve EVERY phase of a subscription (not just the active one) to a
+ * {@link SubscriptionPhaseView}, ordered by `activeFrom` and tagged
+ * past/current/future. Generalizes {@link getSubscriptionPlanView}: each phase's
+ * price and entitlements come from its own provisioned items (the authoritative
+ * source), falling back to the catalog plan phase with the same `key` when a
+ * phase (typically a future one) hasn't been provisioned yet. Powers the
+ * subscription details page's current + upcoming + previous phase timeline.
+ */
+export const getSubscriptionPhaseViews = (
+  subscription: Subscription,
+  options?: { units?: Record<string, string> },
+): SubscriptionPhaseView[] => {
+  const plan = subscription.plan;
+  const currency = subscription.currency ?? plan.currency;
+  const billingCadence = subscription.billingCadence ?? plan.billingCadence;
+  const now = Date.now();
+
+  return phasesByActiveFrom(subscription).map((phase) => {
+    const rateCards = phaseRateCards(plan, phase);
+
+    return {
+      id: phase.id,
+      name: phase.name,
+      status: phaseStatus(phase, now),
+      activeFrom: phase.activeFrom,
+      activeTo: phase.activeTo,
+      priceLabel: formatPlanPrice({
+        ...plan,
+        billingCadence,
+        phases: [{ key: phase.key, name: phase.name, rateCards }],
+      }),
+      entitlements: categorizeRateCards(rateCards, {
+        currency,
+        units: options?.units,
+        planBillingCadence: billingCadence,
+      }),
+      billingCadence,
+      currency,
+    };
+  });
+};
+
+/**
+ * Build a catalog-shaped {@link Plan} from a subscription's *own* current and
+ * future phases (past phases dropped), so the plan-change confirmation page can
+ * render the current subscription with the exact same pricing-table card
+ * ({@link formatPlanPrice} / `getPlanPriceSchedule` / `PlanEntitlements`) used
+ * for the new plan. Each phase's rate cards come from its provisioned items
+ * (the authoritative source) — the embedded `subscription.plan` snapshot is
+ * unreliable here (it can arrive with `phases: []`), so we never read its
+ * phases for pricing.
+ */
+export const subscriptionToCurrentPlan = (subscription: Subscription): Plan => {
+  const plan = subscription.plan;
+  const now = Date.now();
+  const phases = phasesByActiveFrom(subscription)
+    .filter((p) => !(p.activeTo && new Date(p.activeTo).getTime() < now))
+    .map((phase) => ({
+      key: phase.key,
+      name: phase.name,
+      rateCards: phaseRateCards(plan, phase),
+    }));
+
+  return {
+    ...plan,
+    currency: subscription.currency ?? plan.currency,
+    billingCadence: subscription.billingCadence ?? plan.billingCadence,
+    phases,
+  };
+};


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for displaying subscription phases across their full lifecycle (past, current, and future). It introduces new utilities to resolve subscription phases to their pricing and entitlements, and new UI components to visualize the phase timeline on the subscription details page and plan-change confirmation flow.

## Key Changes

- **New utilities in `subscriptionEntitlements.ts`**:
  - `getSubscriptionPhaseViews()`: Resolves all subscription phases (past/current/future) to `SubscriptionPhaseView` objects with pricing, entitlements, and status. Each phase's price comes from its provisioned items, falling back to the catalog plan phase when items are empty (typically for future phases).
  - `subscriptionToCurrentPlan()`: Synthesizes a catalog-shaped `Plan` from a subscription's current and future phases (dropping past ones), enabling the plan-change confirmation page to render the current subscription with the same pricing-table components as the new plan.

- **New UI components in `SubscriptionPhases.tsx`**:
  - `UpcomingPhases`: Displays future phases with start dates, prices, and entitlements.
  - `PreviousPhases`: Shows past phases in a collapsed-by-default collapsible, each labeled with exact date ranges.
  - `SubscriptionPhaseSection`: Reusable phase card showing name, timing, price, and entitlements.

- **Enhanced `PlanSummaryCard`**:
  - Added optional `label` prop to render an eyebrow label (e.g., "Current plan").
  - Added `collapsibleDetails` prop to hide "What's included" behind a collapsed toggle for side-by-side plan comparison.

- **Updated `SubscriptionPlanDetails`**:
  - Now displays "Upcoming phases" section when future phases exist.
  - Now displays "Previous phases" collapsible section when past phases exist.
  - The main "Price" field continues to show only the currently active phase.

- **Simplified `SubscriptionChangeConfirmPage`**:
  - Replaced `CurrentPlanBaseline` component with `PlanSummaryCard` using `subscriptionToCurrentPlan()`, enabling consistent rendering of current and new plans side-by-side with collapsible details.

- **Test coverage**:
  - Added comprehensive tests for `getSubscriptionPhaseViews()` covering phase ordering, status tagging, price resolution, and fallback to catalog phases.
  - Added tests for `subscriptionToCurrentPlan()` verifying it drops past phases and sources pricing from provisioned items even when the embedded plan snapshot is empty.
  - Updated existing tests to verify upcoming phases are surfaced separately from the current phase price.

## Implementation Details

- Phase rate cards are sourced from provisioned subscription items (authoritative), with fallback to the catalog plan phase matching by `key` for unprovision phases.
- Phases are sorted by `activeFrom` timestamp to ensure consistent ordering regardless of input order.
- Phase status (past/current/future) is determined by comparing `activeFrom`/`activeTo` against the current time.
- The `subscriptionToCurrentPlan()` utility ensures the plan-change confirmation page can render the current subscription's pricing schedule correctly even when the embedded `subscription.plan.phases` snapshot is empty or stale.

https://claude.ai/code/session_018gJbBdijCEHfsERXu2J7xc