### PR TITLE
feat: stacked sub-navigation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -102,6 +102,11 @@ When adding new components that depend on these, either lazy-load them or place 
 plugin code. A static import chain from `MdxComponents.tsx` or similar always-loaded modules will
 pull the heavy dependency into `entry.client`.
 
+`motion`/`motion/react`: The core (`m`, `LazyMotion`, `AnimatePresence`, ~5kb) can be statically
+imported, but `domAnimation` (~37kb) must load via `LazyMotion`'s async `features` prop using a
+separate module (see `navigation/motionFeatures.ts`). Always use `m.*` (not `motion.*`) inside
+`<LazyMotion strict features={...}>`.
+
 ## Plugin Architecture
 
 - Plugins live in packages/zudoku/lib/plugins/

--- a/docs/pages/docs/configuration/navigation.mdx
+++ b/docs/pages/docs/configuration/navigation.mdx
@@ -93,6 +93,7 @@ type NavigationLink = {
   label: string;
   icon?: string; // Lucide icon name
   target?: "_self" | "_blank";
+  stack?: boolean; // open the destination as a stacked sub-nav
   badge?: {
     label: string;
     color: "green" | "blue" | "yellow" | "red" | "purple" | "indigo" | "gray" | "outline";
@@ -141,6 +142,7 @@ type NavigationCategory = {
   label: string;
   collapsible?: boolean;
   collapsed?: boolean;
+  stack?: boolean; // open the category's items as a stacked sub-nav
   link?: string | { type: "doc"; file: string; label?: string; path?: string };
   display?:
     | "auth"
@@ -460,6 +462,67 @@ type NavigationFilter = {
 
 </details>
 
+## Stacked navigation
+
+By default a category expands inline when clicked. Set `stack: true` and it opens as a full panel
+that slides in over the current menu, with a **Back** button to return. Use it for deep sections
+that would otherwise crowd the sidebar.
+
+`stack` works on categories and links. The panel content comes from the item itself:
+
+- A **category** with `stack: true` shows its own `items`.
+- A **link** with `stack: true` opens the navigation at its destination, such as the sidebar a
+  plugin generates at that path.
+
+```tsx title="Stack a category's items"
+{
+  type: "category",
+  label: "Shipping Guides",
+  stack: true,
+  items: ["guides/interstellar", "guides/intergalactic"],
+}
+```
+
+```tsx title="Stack a linked section (e.g. a GraphQL plugin)"
+{
+  type: "link",
+  label: "Developer API",
+  to: "/graphql/dev",
+  stack: true,
+}
+```
+
+The **Back** button points to the section the stacked item belongs to (for example "Back to Our
+APIs"), so the page still works when someone opens it directly from a search result or a shared
+link.
+
+:::note
+
+A stacked link drills into wherever its `to` points, so the destination should be a section with its
+own navigation, such as a plugin route or a category landing page. The slide animation respects the
+user's reduced-motion setting and falls back to an instant swap.
+
+:::
+
+### Stacking generated navigation
+
+Plugin-generated sidebars (e.g. OpenAPI) can be stacked too, with a
+[navigation rule](#navigation-rules). This is useful for large APIs: instead of one long scroll,
+make each tag drill into its own panel.
+
+```tsx title="Stack an OpenAPI tag"
+navigationRules: [
+  {
+    type: "modify",
+    match: "Shipments/Shipment/Shipment Management",
+    set: { stack: true },
+  },
+],
+```
+
+The `match` targets a generated category by label (here, the `Shipment Management` tag under the
+`Shipments` API). See [Navigation Rules](#navigation-rules) for the matching syntax.
+
 ## Display Control
 
 All navigation items support a `display` property that controls when the item should be visible:
@@ -671,13 +734,13 @@ For a practical walkthrough with more examples, see the
 
 Each rule has a `type` and a `match` property that targets a navigation item.
 
-| Type     | Description                                                               |
-| -------- | ------------------------------------------------------------------------- |
-| `insert` | Add items `before` or `after` a matched item                              |
-| `modify` | Change `label`, `icon`, `badge`, `collapsed`, `collapsible`, or `display` |
-| `remove` | Remove a matched item from the sidebar                                    |
-| `sort`   | Sort children of a matched category using a custom comparator             |
-| `move`   | Relocate a matched item `before` or `after` another item                  |
+| Type     | Description                                                                        |
+| -------- | ---------------------------------------------------------------------------------- |
+| `insert` | Add items `before` or `after` a matched item                                       |
+| `modify` | Change `label`, `icon`, `badge`, `collapsed`, `collapsible`, `display`, or `stack` |
+| `remove` | Remove a matched item from the sidebar                                             |
+| `sort`   | Sort children of a matched category using a custom comparator                      |
+| `move`   | Relocate a matched item `before` or `after` another item                           |
 
 ### Match Syntax
 

--- a/examples/cosmo-cargo/pages/cargo-handbook/anomalous.mdx
+++ b/examples/cosmo-cargo/pages/cargo-handbook/anomalous.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_label: Oversized & Anomalous
+sidebar_icon: shapes
+---
+
+# Oversized & Anomalous Freight
+
+When cargo won't fit through a standard airlock — or doesn't obey standard geometry — it's routed
+here. Anomalous freight is rare, billed by the exception, and always hand-flown by a senior pilot.
+
+## Handling Categories
+
+| Category      | Example                   | Special Handling            |
+| ------------- | ------------------------- | --------------------------- |
+| Oversized     | Orbital ring segments     | External tow rig            |
+| Non-Euclidean | Folded-space artifacts    | Dimensional anchor required |
+| Living-Vessel | Bio-engineered transports | Negotiated route            |
+| Temporal      | Chrono-sealed containers  | Do not open before arrival  |
+
+Anomalous shipments are quoted individually — start a manifest and our dispatch AI will assign a
+specialist.

--- a/examples/cosmo-cargo/pages/cargo-handbook/cryo.mdx
+++ b/examples/cosmo-cargo/pages/cargo-handbook/cryo.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_label: Cryogenic Freight
+sidebar_icon: snowflake
+---
+
+# Cryogenic & Temperature-Controlled Freight
+
+From vaccine vials to gas-giant ice cores, temperature-sensitive cargo travels in our cryo-rated
+holds. Pick the tier that matches your payload's tolerance.
+
+## Temperature Tiers
+
+| Tier     | Range            | Typical Cargo               |
+| -------- | ---------------- | --------------------------- |
+| Chilled  | 0 °C to 8 °C     | Biologics, fresh provisions |
+| Frozen   | −40 °C to −18 °C | Tissue samples, rations     |
+| Deep     | −150 °C          | Quantum substrates          |
+| Absolute | Near 0 K         | Superconductor cores        |
+
+Cryo holds report their internal temperature to the tracking API every 30 seconds, so a thermal
+excursion raises an alert long before your cargo ever notices.

--- a/examples/cosmo-cargo/pages/cargo-handbook/hazardous.mdx
+++ b/examples/cosmo-cargo/pages/cargo-handbook/hazardous.mdx
@@ -1,0 +1,30 @@
+---
+sidebar_label: Hazardous & Volatile
+sidebar_icon: flame
+---
+
+# Hazardous & Volatile Cargo
+
+Some cargo doesn't just need a box — it needs a containment field. This section covers the handling,
+labeling, and routing rules for freight that could otherwise vent, ignite, or annihilate a cargo
+bay.
+
+<SpaceWarning sector="7-G">
+  Antimatter and exotic isotopes require a certified containment manifest before a shipping label
+  can be issued. Uncertified volatiles are automatically rejected at the dock.
+</SpaceWarning>
+
+## Hazard Classes
+
+| Class | Cargo Type          | Containment      | Max per Hauler |
+| ----- | ------------------- | ---------------- | -------------- |
+| H1    | Compressed plasma   | Magnetic bottle  | 12 units       |
+| H2    | Ion cells           | Faraday crate    | 240 units      |
+| H3    | Antimatter capsules | Suspension field | 2 units        |
+| H4    | Unstable isotopes   | Lead-lined pod   | 40 units       |
+
+## Routing Rules
+
+- Volatile cargo never shares a bay with **Living & Biological** freight.
+- H3 and H4 shipments avoid populated lanes and route through designated void corridors.
+- Every hazard manifest is double-signed by the dispatch AI and the vessel captain.

--- a/examples/cosmo-cargo/pages/cargo-handbook/living.mdx
+++ b/examples/cosmo-cargo/pages/cargo-handbook/living.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_label: Living & Biological
+sidebar_icon: leaf
+---
+
+# Living & Biological Cargo
+
+Transporting anything that breathes, photosynthesizes, or reproduces comes with extra duty of care.
+Living cargo rides in life-support holds with their own atmosphere, gravity, and feeding schedule.
+
+## Requirements
+
+- A valid **bio-transit permit** for both the origin and destination systems.
+- Declared atmosphere mix (O₂/N₂/other) and gravity preference.
+- An emergency revival contact for any cryo-suspended specimens.
+
+<SpaceWarning>
+  Sentient passengers are not "cargo" and must be booked through Passenger Services. This handbook
+  covers livestock, flora, and non-sentient specimens only.
+</SpaceWarning>

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -5,6 +5,7 @@ import type {
   ZudokuConfig,
   ZudokuContext,
 } from "zudoku";
+import { Callout } from "zudoku/components";
 import { generateWebhookCodeSnippet } from "./src/CodeSnippetGenerator";
 import { Landingpage } from "./src/Landingpage";
 import { MembersOnly } from "./src/MembersOnly";
@@ -223,12 +224,12 @@ const config: ZudokuConfig = {
         children: ReactNode;
         sector?: string;
       }) => (
-        <div className="my-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
-          <div className="flex items-center gap-2 font-semibold text-yellow-600 dark:text-yellow-400">
-            ⚠️ {sector ? `Sector ${sector} Advisory` : "Space Advisory"}
-          </div>
-          <div className="mt-1 text-sm">{children}</div>
-        </div>
+        <Callout
+          type="danger"
+          title={sector ? `Sector ${sector} Advisory` : "Space Advisory"}
+        >
+          {children}
+        </Callout>
       ),
     },
   },
@@ -270,7 +271,6 @@ const config: ZudokuConfig = {
       items: [
         { type: "filter", placeholder: "Filter documentation" },
         "documentation",
-        { type: "section", label: "Operations" },
         {
           type: "category",
           icon: "telescope",
@@ -283,15 +283,25 @@ const config: ZudokuConfig = {
             "ship-states",
           ],
         },
-        "global",
-        { type: "separator" },
-        { type: "section", label: "Guides" },
         {
           type: "category",
           icon: "library-big",
           label: "Shipping Guides",
-          items: ["interstellar", "intergalactic"],
+          items: ["global", "interstellar", "intergalactic"],
         },
+        {
+          type: "category",
+          icon: "book-marked",
+          label: "Cargo Handbook",
+          stack: true,
+          items: [
+            "cargo-handbook/hazardous",
+            "cargo-handbook/cryo",
+            "cargo-handbook/living",
+            "cargo-handbook/anomalous",
+          ],
+        },
+        { type: "separator" },
         {
           type: "link",
           label: "See Shipment API",

--- a/examples/graphql/zudoku.config.ts
+++ b/examples/graphql/zudoku.config.ts
@@ -29,8 +29,18 @@ const config: ZudokuConfig = {
           label: "GraphQL",
           collapsed: false,
           items: [
-            { label: "Developer API", type: "link", to: "/graphql/dev" },
-            { label: "Analytics API", type: "link", to: "/graphql/analytics" },
+            {
+              label: "Developer API",
+              type: "link",
+              to: "/graphql/dev",
+              stack: true,
+            },
+            {
+              label: "Analytics API",
+              type: "link",
+              to: "/graphql/analytics",
+              stack: true,
+            },
           ],
         },
         {
@@ -47,7 +57,6 @@ const config: ZudokuConfig = {
         },
       ],
     },
-    { label: "GraphQL API", type: "link", to: "/graphql/default" },
     { label: "REST API", type: "link", to: "/api" },
     { label: "GraphQL OAS", type: "link", to: "/graphql-api" },
   ],

--- a/packages/zudoku/src/config/validators/InputNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.ts
@@ -48,6 +48,9 @@ const NavigationModifyRuleSchema = z.object({
     collapsed: z.boolean().optional(),
     collapsible: z.boolean().optional(),
     display: DisplaySchema,
+    // Turn a (plugin-generated) category into a stacked sub-nav
+    // E.g. make each OpenAPI tag drill into its own panel. See `stack` above.
+    stack: z.boolean().optional(),
   }),
 });
 
@@ -117,6 +120,7 @@ const InputNavigationLinkSchema = z.object({
   icon: IconSchema.optional(),
   badge: BadgeSchema.optional(),
   display: DisplaySchema,
+  stack: z.boolean().optional(),
 });
 
 const InputNavigationCustomPageSchema = z.object({
@@ -156,6 +160,7 @@ const BaseInputNavigationCategorySchema = z.object({
   collapsed: z.boolean().optional(),
   link: InputNavigationCategoryLinkDocSchema.optional(),
   display: DisplaySchema,
+  stack: z.boolean().optional(),
 });
 
 export type InputNavigationItem =

--- a/packages/zudoku/src/lib/components/navigation/Navigation.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Navigation.tsx
@@ -3,8 +3,9 @@ import type { NavigationItem as NavigationItemType } from "../../../config/valid
 import { DrawerContent, DrawerTitle } from "../../ui/Drawer.js";
 import { Slot } from "../Slot.js";
 import { NavigationFilterProvider } from "./NavigationFilterContext.js";
-import { NavigationItem } from "./NavigationItem.js";
+import { NavigationFrames } from "./NavigationFrames.js";
 import { NavigationWrapper } from "./NavigationWrapper.js";
+import { useNavigationFrame } from "./useNavigationFrame.js";
 import { getItemPath } from "./utils.js";
 
 export const Navigation = ({
@@ -15,43 +16,31 @@ export const Navigation = ({
   onRequestClose?: () => void;
   navigation: NavigationItemType[];
   topNavItem?: NavigationItemType;
-}) => (
-  <NavigationFilterProvider
-    key={topNavItem ? (getItemPath(topNavItem) ?? topNavItem.label) : undefined}
-  >
-    <NavigationWrapper>
-      <Slot.Target name="navigation-before" />
-      {navigation.map((item) => (
-        <NavigationItem
-          key={
-            item.type +
-            (item.label ?? "") +
-            ("path" in item ? item.path : "") +
-            ("file" in item ? item.file : "") +
-            ("to" in item ? item.to : "")
-          }
-          item={item}
-        />
-      ))}
-      <Slot.Target name="navigation-after" />
-    </NavigationWrapper>
-    <DrawerContent
-      className="lg:hidden h-dvh inset-s-0 w-[320px] rounded-none"
-      aria-describedby={undefined}
-      onCloseAutoFocus={(e) => e.preventDefault()}
-    >
-      <div className="p-4 overflow-y-auto overscroll-none">
-        <VisuallyHidden>
-          <DrawerTitle>Navigation</DrawerTitle>
-        </VisuallyHidden>
-        {navigation.map((item) => (
-          <NavigationItem
-            key={item.label}
-            item={item}
-            onRequestClose={onRequestClose}
-          />
-        ))}
-      </div>
-    </DrawerContent>
-  </NavigationFilterProvider>
-);
+}) => {
+  const frame = useNavigationFrame(navigation, topNavItem);
+  const section = topNavItem
+    ? (getItemPath(topNavItem) ?? topNavItem.label)
+    : "";
+
+  return (
+    <NavigationFilterProvider resetKey={`${section}\n${frame.id}`}>
+      <NavigationWrapper>
+        <Slot.Target name="navigation-before" />
+        <NavigationFrames frame={frame} />
+        <Slot.Target name="navigation-after" />
+      </NavigationWrapper>
+      <DrawerContent
+        className="lg:hidden h-dvh inset-s-0 w-[320px] rounded-none"
+        aria-describedby={undefined}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="p-4 overflow-y-auto overscroll-none">
+          <VisuallyHidden>
+            <DrawerTitle>Navigation</DrawerTitle>
+          </VisuallyHidden>
+          <NavigationFrames frame={frame} onRequestClose={onRequestClose} />
+        </div>
+      </DrawerContent>
+    </NavigationFilterProvider>
+  );
+};

--- a/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
@@ -9,7 +9,11 @@ import { cn } from "../../util/cn.js";
 import { joinUrl } from "../../util/joinUrl.js";
 import { useNavigationFilter } from "./NavigationFilterContext.js";
 import { NavigationItem } from "./NavigationItem.js";
-import { navigationListItem, useIsCategoryOpen } from "./utils.js";
+import {
+  navigationItemKey,
+  navigationListItem,
+  useIsCategoryOpen,
+} from "./utils.js";
 
 const NavigationCategoryInner = ({
   category,
@@ -152,13 +156,7 @@ const NavigationCategoryInner = ({
         <ul className="relative after:absolute after:-inset-s-(--padding-nav-item) after:translate-x-[1.5px] after:top-0 after:bottom-0 after:w-px after:bg-border">
           {category.items.map((item) => (
             <NavigationItem
-              key={
-                item.type +
-                (item.label ?? "") +
-                ("path" in item ? item.path : "") +
-                ("file" in item ? item.file : "") +
-                ("to" in item ? item.to : "")
-              }
+              key={navigationItemKey(item)}
               onRequestClose={onRequestClose}
               item={item}
             />

--- a/packages/zudoku/src/lib/components/navigation/NavigationFilterContext.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationFilterContext.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   type PropsWithChildren,
   useContext,
+  useRef,
   useState,
 } from "react";
 
@@ -15,8 +16,20 @@ const NavigationFilterContext = createContext<NavigationFilterContextType>({
   setQuery: () => {},
 });
 
-export const NavigationFilterProvider = ({ children }: PropsWithChildren) => {
+// `resetKey` changes when the active section changes. We reset the filter query
+// during render (instead of remounting via a `key`) so the surrounding
+// navigation subtree — and its slide animation — survives section changes.
+export const NavigationFilterProvider = ({
+  resetKey,
+  children,
+}: PropsWithChildren<{ resetKey?: string }>) => {
   const [query, setQuery] = useState("");
+  const prevResetKey = useRef(resetKey);
+
+  if (prevResetKey.current !== resetKey) {
+    prevResetKey.current = resetKey;
+    if (query !== "") setQuery("");
+  }
 
   return (
     <NavigationFilterContext.Provider value={{ query, setQuery }}>

--- a/packages/zudoku/src/lib/components/navigation/NavigationFilterContext.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationFilterContext.tsx
@@ -2,7 +2,6 @@ import {
   createContext,
   type PropsWithChildren,
   useContext,
-  useRef,
   useState,
 } from "react";
 
@@ -16,18 +15,20 @@ const NavigationFilterContext = createContext<NavigationFilterContextType>({
   setQuery: () => {},
 });
 
-// `resetKey` changes when the active section changes. We reset the filter query
-// during render (instead of remounting via a `key`) so the surrounding
-// navigation subtree — and its slide animation — survives section changes.
+// Clear the filter when the active section or frame changes (`resetKey`). This
+// is React's "adjust state during render" pattern: the previous key lives in
+// state (not a ref) so it's concurrent-safe, and the reset runs in render rather
+// than an effect so results never lag a frame and the nav subtree isn't
+// remounted, which would kill the slide animation.
 export const NavigationFilterProvider = ({
   resetKey,
   children,
 }: PropsWithChildren<{ resetKey?: string }>) => {
   const [query, setQuery] = useState("");
-  const prevResetKey = useRef(resetKey);
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
 
-  if (prevResetKey.current !== resetKey) {
-    prevResetKey.current = resetKey;
+  if (prevResetKey !== resetKey) {
+    setPrevResetKey(resetKey);
     if (query !== "") setQuery("");
   }
 

--- a/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
@@ -1,7 +1,7 @@
 import { UndoIcon } from "lucide-react";
 import { AnimatePresence, LazyMotion, useReducedMotion } from "motion/react";
 import * as m from "motion/react-m";
-import { useRef } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
 import { cn } from "../../util/cn.js";
 import { NavigationItem } from "./NavigationItem.js";
@@ -34,22 +34,22 @@ export const NavigationFrames = ({
 }) => {
   const reduceMotion = useReducedMotion();
 
-  // Track visited frames to determine slide direction (forward/backward)
-  const visited = useRef<string[]>([frame.id]);
-  const prevId = useRef(frame.id);
-  const directionRef = useRef(1);
+  // Slide direction, tracked in state via React's "adjust state during render"
+  // pattern rather than ref mutation, so it stays concurrent-safe. A frame
+  // already in the history slides back and trims the stack to it; a new frame
+  // slides forward.
+  const [visited, setVisited] = useState<string[]>([frame.id]);
+  const [prevId, setPrevId] = useState(frame.id);
+  const [direction, setDirection] = useState(1);
 
-  if (prevId.current !== frame.id) {
-    const existing = visited.current.indexOf(frame.id);
-    directionRef.current = existing >= 0 ? -1 : 1;
-    visited.current =
-      existing >= 0
-        ? visited.current.slice(0, existing + 1)
-        : [...visited.current, frame.id];
-    prevId.current = frame.id;
+  if (prevId !== frame.id) {
+    const existing = visited.indexOf(frame.id);
+    setDirection(existing >= 0 ? -1 : 1);
+    setVisited(
+      existing >= 0 ? visited.slice(0, existing + 1) : [...visited, frame.id],
+    );
+    setPrevId(frame.id);
   }
-
-  const direction = directionRef.current;
 
   return (
     <LazyMotion features={loadFeatures} strict>

--- a/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
@@ -1,0 +1,104 @@
+import { UndoIcon } from "lucide-react";
+import { AnimatePresence, LazyMotion, useReducedMotion } from "motion/react";
+import * as m from "motion/react-m";
+import { useRef } from "react";
+import { Link } from "react-router";
+import { cn } from "../../util/cn.js";
+import { NavigationItem } from "./NavigationItem.js";
+import type { NavigationFrame } from "./useNavigationFrame.js";
+import { navigationItemKey, navigationListItem } from "./utils.js";
+
+const loadFeatures = () =>
+  import("./motionFeatures.js").then((mod) => mod.default);
+
+const variants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? "100%" : "-100%",
+    opacity: 0,
+  }),
+  center: { x: 0, opacity: 1 },
+  exit: (direction: number) => ({
+    x: direction > 0 ? "-100%" : "100%",
+    opacity: 0,
+  }),
+};
+
+export const NavigationFrames = ({
+  frame,
+  onRequestClose,
+  className,
+}: {
+  frame: NavigationFrame;
+  onRequestClose?: () => void;
+  className?: string;
+}) => {
+  const reduceMotion = useReducedMotion();
+
+  // Track visited frames to determine slide direction (forward/backward)
+  const visited = useRef<string[]>([frame.id]);
+  const prevId = useRef(frame.id);
+  const directionRef = useRef(1);
+
+  if (prevId.current !== frame.id) {
+    const existing = visited.current.indexOf(frame.id);
+    directionRef.current = existing >= 0 ? -1 : 1;
+    visited.current =
+      existing >= 0
+        ? visited.current.slice(0, existing + 1)
+        : [...visited.current, frame.id];
+    prevId.current = frame.id;
+  }
+
+  const direction = directionRef.current;
+
+  return (
+    <LazyMotion features={loadFeatures} strict>
+      <div
+        className={cn(
+          "relative overflow-clip [overflow-clip-margin:0.5rem]",
+          className,
+        )}
+      >
+        <AnimatePresence initial={false} custom={direction} mode="popLayout">
+          <m.div
+            key={frame.id}
+            custom={direction}
+            variants={variants}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={
+              reduceMotion
+                ? { duration: 0 }
+                : { type: "tween", duration: 0.25, ease: "easeInOut" }
+            }
+            className="flex flex-col"
+          >
+            {frame.back && (
+              <Link
+                viewTransition
+                to={frame.back.to}
+                onClick={onRequestClose}
+                className={navigationListItem({
+                  className: "",
+                })}
+              >
+                <UndoIcon size={16} className="shrink-0" />
+                <span className="truncate">
+                  {frame.back.label ? `Back to ${frame.back.label}` : "Back"}
+                </span>
+              </Link>
+            )}
+            {frame.items.map((item) => (
+              <NavigationItem
+                key={navigationItemKey(item)}
+                item={item}
+                onRequestClose={onRequestClose}
+              />
+            ))}
+          </m.div>
+        </AnimatePresence>
+      </div>
+    </LazyMotion>
+  );
+};

--- a/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationItem.tsx
@@ -1,6 +1,6 @@
 import { ExternalLinkIcon } from "lucide-react";
 import { Suspense, lazy, useEffect, useRef, useState } from "react";
-import { NavLink, useLocation } from "react-router";
+import { NavLink, useLocation, useNavigation } from "react-router";
 import { Separator } from "zudoku/ui/Separator.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "zudoku/ui/Tooltip.js";
 import type { NavigationItem as NavigationItemType } from "../../../config/validators/NavigationSchema.js";
@@ -14,7 +14,12 @@ import { NavigationBadge } from "./NavigationBadge.js";
 import { NavigationCategory } from "./NavigationCategory.js";
 import { useNavigationFilter } from "./NavigationFilterContext.js";
 import { NavigationFilterInput } from "./NavigationFilterInput.js";
-import { navigationListItem, shouldShowItem } from "./utils.js";
+import { StackCategoryRow, StackDrillRow } from "./StackRows.js";
+import {
+  getNavLinkState,
+  navigationListItem,
+  shouldShowItem,
+} from "./utils.js";
 
 const HastRichText = lazy(() => import("../../util/hastToJsx.js"));
 
@@ -67,6 +72,7 @@ export const NavigationItem = ({
   onRequestClose?: () => void;
 }) => {
   const location = useLocation();
+  const navigation = useNavigation();
   const { activeAnchor } = useViewportAnchor();
   const auth = useAuth();
   const context = useZudoku();
@@ -78,7 +84,9 @@ export const NavigationItem = ({
 
   switch (item.type) {
     case "category":
-      return (
+      return item.stack && !query.trim() ? (
+        <StackCategoryRow category={item} onRequestClose={onRequestClose} />
+      ) : (
         <NavigationCategory category={item} onRequestClose={onRequestClose} />
       );
     case "separator":
@@ -122,7 +130,24 @@ export const NavigationItem = ({
     case "link":
     case "custom-page": {
       const href = item.type === "link" ? item.to : joinUrl(item.path);
-      const hasAnchor = href.includes("#");
+
+      if (item.type === "link" && item.stack) {
+        return (
+          <StackDrillRow to={joinUrl(item.to)} onRequestClose={onRequestClose}>
+            {item.icon && (
+              <item.icon size={16} className="align-[-0.125em] shrink-0" />
+            )}
+            <TruncatedLabel label={item.label} />
+            {item.badge && <NavigationBadge {...item.badge} />}
+          </StackDrillRow>
+        );
+      }
+
+      const linkState = getNavLinkState(
+        href,
+        { pathname: location.pathname, activeAnchor },
+        navigation.location,
+      );
       return !href.startsWith("http") ? (
         <AnchorLink
           end
@@ -132,18 +157,7 @@ export const NavigationItem = ({
             search: location.search,
           }}
           {...{ [DATA_ANCHOR_ATTR]: href.split("#")[1] }}
-          className={({ isPending }) =>
-            navigationListItem({
-              isActive:
-                href ===
-                (hasAnchor
-                  ? [joinUrl(location.pathname), activeAnchor]
-                      .filter(Boolean)
-                      .join("#")
-                  : joinUrl(location.pathname)),
-              isPending,
-            })
-          }
+          className={() => navigationListItem(linkState)}
           onClick={onRequestClose}
         >
           {item.icon && (

--- a/packages/zudoku/src/lib/components/navigation/StackRows.tsx
+++ b/packages/zudoku/src/lib/components/navigation/StackRows.tsx
@@ -1,0 +1,65 @@
+import { ChevronRightIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import type { NavigationCategory as NavigationCategoryType } from "../../../config/validators/NavigationSchema.js";
+import { cn } from "../../util/cn.js";
+import { NavigationCategory } from "./NavigationCategory.js";
+import { navigationListItem, stackCategoryTarget } from "./utils.js";
+
+export const StackDrillRow = ({
+  to,
+  onRequestClose,
+  className,
+  children,
+}: {
+  to: string;
+  onRequestClose?: () => void;
+  className?: string;
+  children: ReactNode;
+}) => (
+  <Link
+    viewTransition
+    to={to}
+    onClick={onRequestClose}
+    className={cn(navigationListItem(), "group justify-between", className)}
+  >
+    <span className="flex items-center gap-2 truncate">{children}</span>
+    <span className="grid size-6 shrink-0 place-items-center">
+      <ChevronRightIcon size={16} />
+    </span>
+  </Link>
+);
+
+// Renders a drill-in row that navigates to a stacked sub-panel.
+// Falls back to an inline category if there's no navigable target.
+export const StackCategoryRow = ({
+  category,
+  onRequestClose,
+}: {
+  category: NavigationCategoryType;
+  onRequestClose?: () => void;
+}) => {
+  const target = stackCategoryTarget(category);
+  if (!target) {
+    // biome-ignore lint/suspicious/noConsole: Dev-only stacked navigation misconfiguration warning
+    console.warn(
+      `[Zudoku] Stacked category "${category.label}" has no navigable items; rendering inline.`,
+    );
+    return (
+      <NavigationCategory category={category} onRequestClose={onRequestClose} />
+    );
+  }
+
+  return (
+    <StackDrillRow
+      to={target}
+      onRequestClose={onRequestClose}
+      className="font-medium"
+    >
+      {category.icon && (
+        <category.icon size={16} className="shrink-0 align-[-0.125em]" />
+      )}
+      <span className="truncate">{category.label}</span>
+    </StackDrillRow>
+  );
+};

--- a/packages/zudoku/src/lib/components/navigation/motionFeatures.ts
+++ b/packages/zudoku/src/lib/components/navigation/motionFeatures.ts
@@ -1,0 +1,2 @@
+// Lazy-loaded animation features for LazyMotion (keeps the main bundle small).
+export { domAnimation as default } from "motion/react";

--- a/packages/zudoku/src/lib/components/navigation/useNavigationFrame.test.ts
+++ b/packages/zudoku/src/lib/components/navigation/useNavigationFrame.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NavigationItem } from "../../../config/validators/NavigationSchema.js";
+import {
+  findStackCategory,
+  resolveNavigationFrame,
+  resolveStackOwner,
+} from "./useNavigationFrame.js";
+import { cleanPath } from "./utils.js";
+
+const stackCategory: NavigationItem = {
+  type: "category",
+  label: "Handbook",
+  stack: true,
+  items: [
+    { type: "link", label: "Hazardous", to: "/handbook/hazardous" },
+    { type: "link", label: "Cryo", to: "/handbook/cryo" },
+  ],
+};
+
+const plainCategory: NavigationItem = {
+  type: "category",
+  label: "Guides",
+  items: [{ type: "link", label: "Intro", to: "/guides/intro" }],
+};
+
+const section: NavigationItem = {
+  type: "category",
+  label: "Our APIs",
+  link: { type: "link", to: "/apis" },
+  items: [{ type: "link", label: "Dev API", to: "/graphql/dev", stack: true }],
+};
+
+describe("cleanPath", () => {
+  it("strips query and hash and normalizes", () => {
+    expect(cleanPath("/foo?ref=1")).toBe("/foo");
+    expect(cleanPath("/foo#section")).toBe("/foo");
+    expect(cleanPath("/foo/?a=1#b")).toBe("/foo");
+  });
+});
+
+describe("findStackCategory", () => {
+  it("returns a stack category that owns the path", () => {
+    expect(findStackCategory([stackCategory], "/handbook/cryo")).toBe(
+      stackCategory,
+    );
+  });
+
+  it("matches paths nested deep in the sub-tree", () => {
+    const nested: NavigationItem = {
+      type: "category",
+      label: "Outer",
+      stack: true,
+      items: [
+        {
+          type: "category",
+          label: "Inner",
+          items: [{ type: "link", label: "Leaf", to: "/outer/inner/leaf" }],
+        },
+      ],
+    };
+    expect(findStackCategory([nested], "/outer/inner/leaf")).toBe(nested);
+  });
+
+  it("ignores non-stack categories", () => {
+    expect(findStackCategory([plainCategory], "/guides/intro")).toBeUndefined();
+  });
+
+  it("returns undefined when no stack category owns the path", () => {
+    expect(findStackCategory([stackCategory], "/elsewhere")).toBeUndefined();
+  });
+});
+
+describe("resolveStackOwner", () => {
+  it("resolves the owning section's landing for an exact match", () => {
+    expect(resolveStackOwner([section], "/graphql/dev")).toEqual({
+      to: "/apis",
+      label: "Our APIs",
+    });
+  });
+
+  it("resolves for a child path", () => {
+    expect(resolveStackOwner([section], "/graphql/dev/queries")).toEqual({
+      to: "/apis",
+      label: "Our APIs",
+    });
+  });
+
+  it("does not match a sibling whose path is a string prefix", () => {
+    // `/graphql/dev` must not match `/graphql/development`.
+    expect(
+      resolveStackOwner([section], "/graphql/development"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no stack link owns the path", () => {
+    expect(resolveStackOwner([section], "/unrelated")).toBeUndefined();
+  });
+});
+
+describe("resolveNavigationFrame", () => {
+  const topNavItem: NavigationItem = {
+    type: "category",
+    label: "Docs",
+    link: { type: "link", to: "/handbook" },
+    items: [stackCategory],
+  };
+
+  it("prefers an intra-section stack frame and derives back from the section", () => {
+    const frame = resolveNavigationFrame(
+      [stackCategory],
+      [topNavItem],
+      "/handbook/cryo",
+      topNavItem,
+    );
+    expect(frame.id).toBe("stack:/handbook/hazardous");
+    expect(frame.items).toBe(stackCategory.items);
+    expect(frame.back).toEqual({ to: "/handbook", label: "Docs" });
+  });
+
+  it("falls back to a root frame with no back link", () => {
+    const frame = resolveNavigationFrame(
+      [plainCategory],
+      [plainCategory],
+      "/guides/intro",
+      undefined,
+    );
+    expect(frame.id).toBe("root");
+    expect(frame.back).toBeUndefined();
+  });
+
+  it("resolves a cross-section stack frame from the site navigation", () => {
+    const frame = resolveNavigationFrame(
+      [{ type: "link", label: "Dev API", to: "/graphql/dev" }],
+      [section],
+      "/graphql/dev",
+      undefined,
+    );
+    expect(frame.id).toBe("ref:/apis");
+    expect(frame.back).toEqual({ to: "/apis", label: "Our APIs" });
+  });
+
+  it("warns and falls back to / when a section landing cannot resolve", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const emptySection: NavigationItem = {
+      type: "category",
+      label: "Empty",
+      items: [],
+    };
+    const frame = resolveNavigationFrame(
+      [stackCategory],
+      [emptySection],
+      "/handbook/cryo",
+      emptySection,
+    );
+    expect(frame.back?.to).toBe("/");
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});

--- a/packages/zudoku/src/lib/components/navigation/useNavigationFrame.ts
+++ b/packages/zudoku/src/lib/components/navigation/useNavigationFrame.ts
@@ -1,0 +1,107 @@
+import { useLocation } from "react-router";
+import type {
+  NavigationCategory,
+  NavigationItem,
+} from "../../../config/validators/NavigationSchema.js";
+import { joinUrl } from "../../util/joinUrl.js";
+import { useZudoku } from "../context/ZudokuContext.js";
+import {
+  cleanPath,
+  getItemPath,
+  sectionLanding,
+  stackCategoryTarget,
+  traverseNavigation,
+  traverseNavigationItem,
+} from "./utils.js";
+
+type BackLink = { to: string; label?: string };
+
+// What the sidebar currently shows. Normally the section's own items ("root"),
+// but when you drill into a `stack` it becomes that panel's items plus a `back`
+// link. `id` identifies the frame so the panel can slide on change.
+export type NavigationFrame = {
+  id: string;
+  items: NavigationItem[];
+  back?: BackLink;
+};
+
+const containsPath = (
+  category: NavigationCategory,
+  pathname: string,
+): boolean =>
+  traverseNavigationItem(category, (item) => {
+    const itemPath = getItemPath(item);
+    return itemPath && cleanPath(itemPath) === pathname ? true : undefined;
+  }) ?? false;
+
+// An intra-section stack: a `stack` category whose own sub-tree owns the current path.
+export const findStackCategory = (
+  navigation: NavigationItem[],
+  pathname: string,
+): NavigationCategory | undefined =>
+  traverseNavigation(navigation, (item) =>
+    item.type === "category" && item.stack && containsPath(item, pathname)
+      ? item
+      : undefined,
+  );
+
+// Resolve a back link to a section's landing page, falling back to "/".
+const resolveBack = (item: NavigationItem): BackLink => {
+  const to = sectionLanding(item);
+  if (to) return { to, label: item.label };
+  // biome-ignore lint/suspicious/noConsole: Dev-only stacked navigation misconfiguration warning
+  console.warn(
+    `[Zudoku] Stacked navigation: no landing path for section "${item.label}"; falling back to "/".`,
+  );
+  return { to: "/", label: item.label };
+};
+
+// Cross-section stack: derive the back link from the ancestor that owns the `stack` link.
+export const resolveStackOwner = (
+  siteNavigation: NavigationItem[],
+  pathname: string,
+): BackLink | undefined =>
+  traverseNavigation(siteNavigation, (item, parents) => {
+    if (item.type !== "link" || !item.stack) return;
+    const base = cleanPath(item.to);
+    if (pathname !== base && !pathname.startsWith(`${base}/`)) return;
+    return resolveBack(parents.at(0) ?? item);
+  });
+
+export const resolveNavigationFrame = (
+  navigation: NavigationItem[],
+  siteNavigation: NavigationItem[],
+  pathname: string,
+  topNavItem?: NavigationItem,
+): NavigationFrame => {
+  const stack = findStackCategory(navigation, pathname);
+  if (stack) {
+    return {
+      id: `stack:${stackCategoryTarget(stack) || stack.label}`,
+      items: stack.items,
+      back: topNavItem ? resolveBack(topNavItem) : { to: "/" },
+    };
+  }
+
+  const owner = resolveStackOwner(siteNavigation, pathname);
+  if (owner) {
+    return { id: `ref:${owner.to}`, items: navigation, back: owner };
+  }
+
+  return { id: "root", items: navigation };
+};
+
+export const useNavigationFrame = (
+  navigation: NavigationItem[],
+  topNavItem?: NavigationItem,
+): NavigationFrame => {
+  const pathname = joinUrl(useLocation().pathname);
+  const { navigation: siteNavigation } = useZudoku();
+
+  return resolveNavigationFrame(
+    navigation,
+    siteNavigation,
+    pathname,
+    topNavItem,
+  );
+};

--- a/packages/zudoku/src/lib/components/navigation/utils.ts
+++ b/packages/zudoku/src/lib/components/navigation/utils.ts
@@ -44,10 +44,10 @@ export const traverseNavigationItem = <T>(
   }
 };
 
-export const getCategoryLinkHref = (link: NavigationCategoryLink): string =>
+export const getCategoryLinkHref = (link: NavigationCategoryLink) =>
   link.type === "doc" ? link.path : link.to;
 
-export const getItemPath = (item: NavigationItem): string | undefined => {
+export const getItemPath = (item: NavigationItem) => {
   switch (item.type) {
     case "doc":
     case "custom-page":
@@ -88,6 +88,52 @@ export const getFirstMatchingPath = (item: NavigationItem): string => {
     default:
       return "";
   }
+};
+
+export const cleanPath = (path: string) =>
+  joinUrl(path.split("?").at(0)?.split("#").at(0) ?? "");
+
+// Returns the item's path or its first navigable descendant's path.
+export const sectionLanding = (item: NavigationItem) =>
+  getItemPath(item) ?? getFirstMatchingPath(item);
+
+// Where a `stack` category drills to: its link target, else its first page.
+export const stackCategoryTarget = (category: NavigationCategory) =>
+  category.link
+    ? joinUrl(getCategoryLinkHref(category.link))
+    : getFirstMatchingPath(category);
+
+export const navigationItemKey = (item: NavigationItem) =>
+  item.type +
+  (item.label ?? "") +
+  ("path" in item ? item.path : "") +
+  ("file" in item ? item.file : "") +
+  ("to" in item ? item.to : "");
+
+// Build a link's comparable href: `/path`, or `/path#fragment` when a fragment
+// is present.
+const hrefWithFragment = (pathname: string, fragment?: string) =>
+  [joinUrl(pathname), fragment].filter(Boolean).join("#");
+
+// Resolve a nav link's active/pending state by comparing the full href
+// (incl. hash) so anchor links on the same page don't all highlight together.
+export const getNavLinkState = (
+  href: string,
+  current: { pathname: string; activeAnchor?: string },
+  pending?: { pathname: string; hash: string },
+): { isActive: boolean; isPending: boolean } => {
+  const hasAnchor = href.includes("#");
+  return {
+    isActive:
+      href ===
+      hrefWithFragment(
+        current.pathname,
+        hasAnchor ? current.activeAnchor : undefined,
+      ),
+    isPending: pending
+      ? href === hrefWithFragment(pending.pathname, pending.hash.slice(1))
+      : false,
+  };
 };
 
 export const useCurrentItem = () => {

--- a/packages/zudoku/src/lib/navigation/applyRules.test.ts
+++ b/packages/zudoku/src/lib/navigation/applyRules.test.ts
@@ -59,6 +59,17 @@ describe("applyRules", () => {
       expect(result[0]).toHaveProperty("collapsible", false);
       expect(result[0]).toHaveProperty("collapsed", true);
     });
+
+    it("should turn a category into a stacked sub-nav", () => {
+      const nav = createMockNavigation();
+      const rules: ResolvedNavigationRule[] = [
+        { type: "modify", match: "Shipments", set: { stack: true } },
+      ];
+
+      const { result } = applyRules(nav, rules);
+
+      expect(result[0]).toHaveProperty("stack", true);
+    });
   });
 
   describe("insert rules", () => {


### PR DESCRIPTION
Adds stacked sub-navigation. Categories and links can set `stack: true` to open as a sliding panel with a Back button instead of expanding inline, which keeps deep sections and large API references from crowding the sidebar.

It also works on plugin-generated navigation: a `modify` navigation rule can set `stack` on generated items like OpenAPI tags, so a big API can be split into panels without hand-authoring the tree.