### PR TITLE
fix: don't re-scroll sidebar nav when toggling a category

### DIFF
--- a/examples/cosmo-cargo/pages/billing/galactic-credits.mdx
+++ b/examples/cosmo-cargo/pages/billing/galactic-credits.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_label: Galactic Credits
+sidebar_icon: coins
+---
+
+# Galactic Credits
+
+Galactic credits are the settlement currency across the Cosmo Cargo network. Balances sync in real
+time with the central ledger.
+
+## Topping up
+
+Add credits from any member station or through the billing API. Transfers clear within one orbital
+period.

--- a/examples/cosmo-cargo/pages/billing/invoices.mdx
+++ b/examples/cosmo-cargo/pages/billing/invoices.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_label: Invoices
+sidebar_icon: file-text
+---
+
+# Invoices
+
+Cosmo Cargo bills per parsec hauled. Invoices generate at the end of each delivery cycle and settle
+in galactic credits.
+
+## Reading an invoice
+
+Each line item lists the route, mass, and warp surcharge. Disputed charges open a review ticket
+automatically.

--- a/examples/cosmo-cargo/pages/billing/refunds.mdx
+++ b/examples/cosmo-cargo/pages/billing/refunds.mdx
@@ -1,0 +1,13 @@
+---
+sidebar_label: Refunds
+sidebar_icon: receipt
+---
+
+# Refunds
+
+When a shipment is lost to a wormhole or seized at customs, you can file for a credit refund.
+
+## Eligibility
+
+Refunds cover the haul fee and declared cargo value. Warp surcharges are non-refundable once the
+drive has fired.

--- a/examples/cosmo-cargo/pages/compliance/customs.mdx
+++ b/examples/cosmo-cargo/pages/compliance/customs.mdx
@@ -1,0 +1,13 @@
+---
+sidebar_label: Customs
+sidebar_icon: stamp
+---
+
+# Customs
+
+Every border crossing between systems requires a customs manifest. File it before entering a
+controlled lane to avoid impound.
+
+## Manifest fields
+
+List origin, destination, mass, and any restricted materials. Incomplete manifests trigger a hold.

--- a/examples/cosmo-cargo/pages/compliance/quarantine.mdx
+++ b/examples/cosmo-cargo/pages/compliance/quarantine.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_label: Quarantine
+sidebar_icon: biohazard
+---
+
+# Quarantine
+
+Living and biological cargo passes through quarantine at the destination station before release.
+
+## Hold periods
+
+Standard hold is one cycle. Anomalous lifeforms may be held indefinitely pending a science review.

--- a/examples/cosmo-cargo/pages/compliance/treaties.mdx
+++ b/examples/cosmo-cargo/pages/compliance/treaties.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_label: Treaties
+sidebar_icon: scroll
+---
+
+# Treaties
+
+Cosmo Cargo operates under the interstellar transit treaties. These agreements set the lanes and
+tariffs between member systems.
+
+## Key provisions
+
+- Free passage through neutral jump points.
+- Shared liability for lane hazards.

--- a/examples/cosmo-cargo/pages/fleet/crew.mdx
+++ b/examples/cosmo-cargo/pages/fleet/crew.mdx
@@ -1,0 +1,15 @@
+---
+sidebar_label: Crew Roster
+sidebar_icon: users
+---
+
+# Crew Roster
+
+A long-haul freighter needs a balanced crew. This page describes the minimum roster for a certified
+interstellar run.
+
+## Required posts
+
+- Pilot and relief pilot.
+- Warp engineer.
+- Cargo master for hazardous manifests.

--- a/examples/cosmo-cargo/pages/fleet/maintenance.mdx
+++ b/examples/cosmo-cargo/pages/fleet/maintenance.mdx
@@ -1,0 +1,15 @@
+---
+sidebar_label: Maintenance
+sidebar_icon: wrench
+---
+
+# Fleet Maintenance
+
+Scheduled maintenance keeps a freighter rated for deep-space runs. Skipping a service window voids
+the hull warranty.
+
+## Service intervals
+
+- Hull integrity scan every 50 light-years.
+- Coolant flush after each warp burn.
+- Gravity plating recalibration monthly.

--- a/examples/cosmo-cargo/pages/fleet/refueling.mdx
+++ b/examples/cosmo-cargo/pages/fleet/refueling.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_label: Refueling
+sidebar_icon: fuel
+---
+
+# Refueling
+
+Plan fuel stops around known hydrogen scoops and station depots. Running a tank dry between systems
+strands the vessel until a tender arrives.
+
+## Depot network
+
+Cosmo Cargo maintains refueling depots at every major jump point. Reserve a slot through the fleet
+API before you depart.

--- a/examples/cosmo-cargo/pages/fleet/warp-drives.mdx
+++ b/examples/cosmo-cargo/pages/fleet/warp-drives.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_label: Warp Drives
+sidebar_icon: rocket
+---
+
+# Warp Drives
+
+Every Cosmo Cargo vessel ships with a calibrated warp core. This guide covers spin-up, cruise, and
+emergency shutdown of the drive during interstellar hauls.
+
+## Spin-up sequence
+
+1. Confirm the containment field is green.
+2. Charge the capacitor banks to 80%.
+3. Engage the drive once the navigation lock clears.
+
+## Cruise tuning
+
+Hold the warp factor below 7 for fragile cargo. Anything heavier than a comet fragment rides
+smoother at factor 5.

--- a/examples/cosmo-cargo/pages/support/contact.mdx
+++ b/examples/cosmo-cargo/pages/support/contact.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_label: Contact
+sidebar_icon: headset
+---
+
+# Contact Support
+
+Reach the Cosmo Cargo crew through the subspace relay at any hour. Response times scale with your
+support tier.
+
+## Channels
+
+- Subspace relay for urgent fleet issues.
+- Standard ticket queue for billing and manifests.

--- a/examples/cosmo-cargo/pages/support/escalations.mdx
+++ b/examples/cosmo-cargo/pages/support/escalations.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_label: Escalations
+sidebar_icon: siren
+---
+
+# Escalations
+
+When a shipment is at risk, escalate to the rapid response team. They coordinate recovery tenders
+and customs clearance.
+
+## When to escalate
+
+- Cargo stranded between systems.
+- A manifest flagged at customs for more than one cycle.

--- a/examples/cosmo-cargo/pages/support/faq.mdx
+++ b/examples/cosmo-cargo/pages/support/faq.mdx
@@ -1,0 +1,16 @@
+---
+sidebar_label: FAQ
+sidebar_icon: circle-help
+---
+
+# Frequently Asked Questions
+
+Answers to the questions the crew hears most often on the relay.
+
+## Can I reroute a shipment mid-warp?
+
+Yes, as long as the drive has not locked the destination. Submit a reroute through the tracking API.
+
+## What happens if a depot is offline?
+
+The fleet API redirects you to the nearest active depot automatically.

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -301,6 +301,43 @@ const config: ZudokuConfig = {
             "cargo-handbook/anomalous",
           ],
         },
+        {
+          type: "category",
+          icon: "rocket",
+          label: "Fleet Management",
+          items: [
+            "fleet/warp-drives",
+            "fleet/maintenance",
+            "fleet/crew",
+            "fleet/refueling",
+          ],
+        },
+        {
+          type: "category",
+          icon: "credit-card",
+          label: "Billing & Credits",
+          items: [
+            "billing/invoices",
+            "billing/galactic-credits",
+            "billing/refunds",
+          ],
+        },
+        {
+          type: "category",
+          icon: "shield-check",
+          label: "Compliance",
+          items: [
+            "compliance/customs",
+            "compliance/quarantine",
+            "compliance/treaties",
+          ],
+        },
+        {
+          type: "category",
+          icon: "life-buoy",
+          label: "Support",
+          items: ["support/contact", "support/faq", "support/escalations"],
+        },
         { type: "separator" },
         {
           type: "link",

--- a/packages/zudoku/src/lib/components/navigation/NavigationWrapper.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationWrapper.tsx
@@ -18,10 +18,16 @@ export const NavigationWrapper = ({
     const nav = navRef.current;
     if (!nav) return;
 
+    // Only scroll when the active item changes, so toggling a category (which
+    // mounts/unmounts content and fires the observer) doesn't re-scroll.
+    let lastActive: Element | null = null;
     const scrollActiveIntoView = () => {
       // Leaf and its category both get aria-current; the leaf is last in DOM.
       const active = nav.querySelectorAll('[aria-current="page"]');
-      scrollIntoViewIfNeeded(active.item(active.length - 1));
+      const current = active.item(active.length - 1);
+      if (current === lastActive) return;
+      lastActive = current;
+      scrollIntoViewIfNeeded(current);
     };
     scrollActiveIntoView();
 

--- a/packages/zudoku/src/lib/components/navigation/NavigationWrapper.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationWrapper.tsx
@@ -19,14 +19,18 @@ export const NavigationWrapper = ({
     if (!nav) return;
 
     // Only scroll when the active item changes, so toggling a category (which
-    // mounts/unmounts content and fires the observer) doesn't re-scroll.
-    let lastActive: Element | null = null;
+    // fires the observer by mutating the DOM) doesn't re-scroll. Track the href
+    // rather than the element: collapsing a category remounts its links, so the
+    // node identity changes even though the active page didn't.
+    let lastHref: string | null = null;
     const scrollActiveIntoView = () => {
       // Leaf and its category both get aria-current; the leaf is last in DOM.
       const active = nav.querySelectorAll('[aria-current="page"]');
       const current = active.item(active.length - 1);
-      if (current === lastActive) return;
-      lastActive = current;
+      if (!current) return;
+      const href = current.getAttribute("href");
+      if (href === lastHref) return;
+      lastHref = href;
       scrollIntoViewIfNeeded(current);
     };
     scrollActiveIntoView();


### PR DESCRIPTION
The sidebar auto-scroll from #2533 used a MutationObserver watching the nav's childList. Expanding or collapsing any category mounts/unmounts its content, which fired the observer and yanked the sidebar back to the current page. Now it only scrolls when the active item actually changes, so category toggles leave the scroll position alone.