### PR TITLE
chore: add build tooling to publish the GraphQL plugin

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "react": ">=19.2.0",
     "react-dom": ">=19.2.0",
-    "zudoku": ">=0.80.0"
+    "zudoku": ">=0.80.1"
   },
   "peerDependenciesMeta": {
     "zudoku": {

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -1,18 +1,42 @@
 {
   "name": "@zudoku/plugin-graphql",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zuplo/zudoku",
+    "directory": "packages/plugin-graphql"
+  },
   "type": "module",
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "exports": {
-    ".": "./src/index.tsx"
+    ".": "./src/index.tsx",
+    "./vite-plugin": "./vite-plugin.ts"
   },
   "files": [
-    "src",
-    "vite.config.ts",
-    "vite-plugin.ts"
+    "dist",
+    "vite.config.ts"
   ],
-  "scripts": {},
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "prepublishOnly": "pnpm typecheck && pnpm build",
+    "typecheck": "tsc --project tsconfig.json"
+  },
+  "publishConfig": {
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs"
+      },
+      "./vite-plugin": {
+        "types": "./dist/vite-plugin.d.mts",
+        "import": "./dist/vite-plugin.mjs"
+      }
+    }
+  },
   "dependencies": {
     "graphql": "catalog:",
     "zod": "catalog:"
@@ -23,6 +47,7 @@
     "@types/react-dom": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "tsdown": "catalog:",
     "typescript": "catalog:",
     "zudoku": "workspace:*"
   },
@@ -30,5 +55,10 @@
     "react": ">=19.2.0",
     "react-dom": ">=19.2.0",
     "zudoku": "*"
+  },
+  "peerDependenciesMeta": {
+    "zudoku": {
+      "optional": true
+    }
   }
 }

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "react": ">=19.2.0",
     "react-dom": ">=19.2.0",
-    "zudoku": "*"
+    "zudoku": ">=0.80.0"
   },
   "peerDependenciesMeta": {
     "zudoku": {

--- a/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
@@ -89,7 +89,6 @@ export const GraphQLPlayground = ({
       shouldPersistHeaders
       hideToolbarButtons
       resetKey={operation?.id ?? "empty"}
-      logo={<span className="text-sm font-semibold">GraphQL Playground</span>}
       className={cn(
         "h-full border rounded-lg overflow-hidden bg-background font-sans text-foreground",
         className,

--- a/packages/plugin-graphql/src/env.d.ts
+++ b/packages/plugin-graphql/src/env.d.ts
@@ -1,0 +1,7 @@
+// biome-ignore-all lint: ambient type shim for zudoku source Vite globals
+interface ImportMeta {
+  env: any;
+  hot?: any;
+}
+
+declare module "*.css" {}

--- a/packages/plugin-graphql/tsconfig.json
+++ b/packages/plugin-graphql/tsconfig.json
@@ -11,8 +11,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "useUnknownInCatchVariables": false,
-    "jsx": "react-jsx",
-    "types": ["node"]
+    "noEmit": true,
+    "jsx": "react-jsx"
   },
   "include": ["src", "vite.config.ts", "vite-plugin.ts"]
 }

--- a/packages/plugin-graphql/tsdown.config.ts
+++ b/packages/plugin-graphql/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "./src/index.tsx",
+    "vite-plugin": "./vite-plugin.ts",
+  },
+  dts: true,
+  format: ["esm"],
+  external: [/^virtual:/],
+});

--- a/packages/plugin-graphql/vite-plugin.ts
+++ b/packages/plugin-graphql/vite-plugin.ts
@@ -8,8 +8,12 @@ import {
   type IntrospectionQuery,
 } from "graphql";
 import { z } from "zod/mini";
-import { joinUrl } from "zudoku";
-import { getPluginConfigs, getZudokuConfig, type Plugin } from "zudoku/vite";
+import {
+  getPluginConfigs,
+  getZudokuConfig,
+  joinUrl,
+  type Plugin,
+} from "zudoku/vite";
 import { type GraphQLConfig, GRAPHQL_PLUGIN_NAME } from "./src/interfaces.js";
 import { buildManifest } from "./src/util/manifest.js";
 

--- a/packages/plugin-graphql/vite.config.ts
+++ b/packages/plugin-graphql/vite.config.ts
@@ -1,4 +1,4 @@
+import { graphqlSchemaPlugin } from "@zudoku/plugin-graphql/vite-plugin";
 import type { UserConfig } from "zudoku/vite";
-import { graphqlSchemaPlugin } from "./vite-plugin.js";
 
 export default { plugins: [graphqlSchemaPlugin()] } satisfies UserConfig;

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -72,7 +72,7 @@
     "./testing": "./src/lib/testing/index.tsx"
   },
   "scripts": {
-    "build": "esbuild src/cli/cli.ts src/vite/prerender/worker.ts --outdir=dist/cli --entry-names=[name] --bundle --format=esm --packages=external --target=node20 --platform=node --log-level=error",
+    "build": "tsx scripts/build.ts",
     "postbuild": "tsx scripts/check-external-deps.ts",
     "typecheck": "tsc --project tsconfig.app.json --noEmit",
     "generate:types": "tsx scripts/generate-types.js && tsx scripts/generate-flat-config.js",

--- a/packages/zudoku/project.json
+++ b/packages/zudoku/project.json
@@ -24,7 +24,7 @@
     },
     "build": {
       "dependsOn": ["^build", "generate:types"],
-      "outputs": ["{projectRoot}/dist/cli"],
+      "outputs": ["{projectRoot}/dist/cli", "{projectRoot}/dist/vite"],
       "inputs": [
         "{projectRoot}/src/**/*.ts",
         "{projectRoot}/src/**/*.tsx",

--- a/packages/zudoku/scripts/build.ts
+++ b/packages/zudoku/scripts/build.ts
@@ -1,0 +1,25 @@
+import { build, type BuildOptions } from "esbuild";
+
+const shared: BuildOptions = {
+  bundle: true,
+  format: "esm",
+  packages: "external",
+  target: "node20",
+  platform: "node",
+  logLevel: "error",
+};
+
+await Promise.all([
+  build({
+    ...shared,
+    entryPoints: ["src/cli/cli.ts", "src/vite/prerender/worker.ts"],
+    outdir: "dist/cli",
+    entryNames: "[name]",
+  }),
+  // Build-time API for external plugins: must be JS (imported from Node), not raw .ts.
+  build({
+    ...shared,
+    entryPoints: ["src/vite/index.ts"],
+    outfile: "dist/vite/index.js",
+  }),
+]);

--- a/packages/zudoku/scripts/generate-publish-exports.ts
+++ b/packages/zudoku/scripts/generate-publish-exports.ts
@@ -108,6 +108,12 @@ const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
 // Exports that don't point to source files
 const IGNORED_EXPORTS = new Set(["./package.json", "./main.css", "./client"]);
 
+// Entries that ship as bundled JS, not raw source: external plugins import
+// these from Node at build time (e.g. a vite.config), where .ts can't load.
+const BUILT_ENTRIES: Record<string, string> = {
+  "./vite": "./dist/vite/index.js",
+};
+
 const isSource = (p: string) =>
   p.startsWith("./src/") && (/\.tsx?$/.test(p) || p.endsWith("*"));
 
@@ -164,10 +170,18 @@ const addTypes = (value: unknown): unknown => {
     : { ...(value as Record<string, unknown>), types };
 };
 
+const toBuiltEntry = (value: unknown, built: string): unknown => {
+  const src = getSourcePath(value);
+  return { types: src ? toDts(src) : undefined, import: built, default: built };
+};
+
 pkg.publishConfig = {
   ...pkg.publishConfig,
   exports: Object.fromEntries(
-    Object.entries(pkg.exports).map(([k, v]) => [k, addTypes(v)]),
+    Object.entries(pkg.exports).map(([k, v]) => [
+      k,
+      BUILT_ENTRIES[k] ? toBuiltEntry(v, BUILT_ENTRIES[k]) : addTypes(v),
+    ]),
   ),
 };
 

--- a/packages/zudoku/src/vite/index.ts
+++ b/packages/zudoku/src/vite/index.ts
@@ -3,6 +3,7 @@ import { selectPluginConfigs } from "../lib/core/plugin-config.js";
 
 export type { ConfigEnv, Plugin, PluginOption, UserConfig } from "vite";
 export { defineConfig, mergeConfig } from "vite";
+export { joinUrl } from "../lib/util/joinUrl.js";
 export { getCurrentConfig as getZudokuConfig };
 
 // Read configs of all plugins registered with `createPlugin(name, ...)`. Used by

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(publint@0.3.21)(tsx@4.22.4)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
Gives the GraphQL plugin the same build and publish tooling the monetization plugin has, so we can publish it to npm. Publishing is manual for now since there's no release workflow yet. It builds with tsdown to dist and exposes a self-contained vite-plugin entry, so consumers get the schema plugin without us shipping source.

Testing the published package against a local registry turned up a deeper problem: zudoku's build-time API (zudoku/vite) shipped as raw TypeScript, which an external plugin can't load from Node when the production CLI evaluates its vite config. zudoku now ships zudoku/vite as bundled JS through a small build.ts script, and the plugin pulls its build-time helpers (joinUrl, getPluginConfigs) from there.