### PR TITLE
fix: resolve markdown links to custom-path and index routes

### DIFF
--- a/packages/zudoku/src/vite/mdx/remark-link-rewrite.test.ts
+++ b/packages/zudoku/src/vite/mdx/remark-link-rewrite.test.ts
@@ -1,0 +1,135 @@
+import type { Link, Root } from "mdast";
+import { VFile } from "vfile";
+import { describe, expect, it } from "vitest";
+import { remarkLinkRewrite } from "./remark-link-rewrite.js";
+
+const linkTree = (url: string): Root => ({
+  type: "root",
+  children: [
+    {
+      type: "paragraph",
+      children: [{ type: "link", url, children: [] }],
+    },
+  ],
+});
+
+const rewrite = (
+  url: string,
+  {
+    basePath = "",
+    routesByFile = new Map<string, string>(),
+    file = "/root/docs/articles/source.mdx",
+  }: {
+    basePath?: string;
+    routesByFile?: Map<string, string>;
+    file?: string;
+  } = {},
+) => {
+  const tree = linkTree(url);
+  remarkLinkRewrite(basePath, routesByFile)(tree, new VFile({ path: file }));
+  return ((tree.children[0] as { children: Link[] }).children[0] as Link).url;
+};
+
+describe("remarkLinkRewrite", () => {
+  const routes = new Map([
+    ["/root/docs/articles/monetization/index", "/articles/monetization"],
+    ["/root/docs/articles/monetization/plans", "/articles/monetization/plans"],
+    ["/root/docs/articles/intro", "/articles/intro"],
+    // An index file with no custom path keeps its `/index` route.
+    ["/root/docs/articles/guides/index", "/articles/guides/index"],
+  ]);
+
+  it("collapses an index.mdx link to its custom route", () => {
+    expect(rewrite("./monetization/index.mdx", { routesByFile: routes })).toBe(
+      "/articles/monetization",
+    );
+  });
+
+  it("resolves a sibling .mdx link to the real route", () => {
+    expect(rewrite("./monetization/plans.mdx", { routesByFile: routes })).toBe(
+      "/articles/monetization/plans",
+    );
+  });
+
+  it("does not collapse an index link without a custom path", () => {
+    expect(rewrite("./guides/index.mdx", { routesByFile: routes })).toBe(
+      "/articles/guides/index",
+    );
+  });
+
+  it("resolves a link that traverses up directories", () => {
+    expect(
+      rewrite("../intro.mdx", {
+        routesByFile: routes,
+        file: "/root/docs/articles/monetization/index.mdx",
+      }),
+    ).toBe("/articles/intro");
+  });
+
+  it("preserves a hash on a resolved markdown link", () => {
+    expect(
+      rewrite("./monetization/index.mdx#pricing", { routesByFile: routes }),
+    ).toBe("/articles/monetization#pricing");
+  });
+
+  it("preserves a query string on a resolved markdown link", () => {
+    expect(
+      rewrite("./monetization/index.mdx?tab=plans", { routesByFile: routes }),
+    ).toBe("/articles/monetization?tab=plans");
+  });
+
+  it("emits a basePath-free route (the router applies basename)", () => {
+    expect(
+      rewrite("./monetization/index.mdx", {
+        basePath: "/docs",
+        routesByFile: routes,
+      }),
+    ).toBe("/articles/monetization");
+  });
+
+  it("resolves a .md link to a route mapped from an .mdx file", () => {
+    expect(rewrite("./monetization/plans.md", { routesByFile: routes })).toBe(
+      "/articles/monetization/plans",
+    );
+  });
+
+  it("resolves a relative link without a leading ./", () => {
+    expect(rewrite("intro.mdx", { routesByFile: routes })).toBe(
+      "/articles/intro",
+    );
+  });
+
+  it("normalizes backslash paths before resolving", () => {
+    expect(
+      rewrite(".\\monetization\\index.mdx", { routesByFile: routes }),
+    ).toBe("/articles/monetization");
+  });
+
+  it("does not resolve absolute .mdx links, only strips the extension", () => {
+    expect(rewrite("/articles/intro.mdx", { routesByFile: routes })).toBe(
+      "/articles/intro",
+    );
+  });
+
+  it("falls back to extension stripping when the file is not in the route map", () => {
+    expect(rewrite("./unknown.mdx", { routesByFile: routes })).toBe(
+      "../unknown",
+    );
+  });
+
+  it("strips the basePath on a fallback (unmapped) link", () => {
+    expect(
+      rewrite("/docs/other.mdx", { basePath: "/docs", routesByFile: routes }),
+    ).toBe("/other");
+  });
+
+  it("leaves external links untouched", () => {
+    expect(
+      rewrite("https://example.com/page.mdx", { routesByFile: routes }),
+    ).toBe("https://example.com/page.mdx");
+  });
+
+  it("leaves bare anchor links untouched", () => {
+    expect(rewrite("#section", { routesByFile: routes })).toBe("#section");
+  });
+});

--- a/packages/zudoku/src/vite/mdx/remark-link-rewrite.ts
+++ b/packages/zudoku/src/vite/mdx/remark-link-rewrite.ts
@@ -1,15 +1,52 @@
 import path from "node:path";
 import type { Root } from "mdast";
 import { visit } from "unist-util-visit";
+import type { VFile } from "vfile";
+
+const markdownExtension = /\.mdx?$/;
+
+// Resolve a relative markdown link (e.g. `./foo/index.mdx`) to the route its
+// target file is served at, honoring custom navigation paths. This keeps links
+// pointing at the built page when a custom path collapses a route (e.g.
+// `articles/monetization/index` served at `/articles/monetization`). Returns a
+// basePath-free route; the router applies `basename` at render time.
+const resolveToRoute = (
+  url: string,
+  filePath: string,
+  routesByFile: Map<string, string>,
+): string | undefined => {
+  const [, pathname = "", suffix = ""] = url.match(/^([^#?]*)(.*)$/) ?? [];
+
+  // Only relative file links are resolved against the route map; bare links and
+  // absolute paths fall through to the default rewrite below.
+  if (!markdownExtension.test(pathname) || pathname.startsWith("/")) {
+    return undefined;
+  }
+
+  const targetFile = path
+    .resolve(path.dirname(filePath), pathname)
+    .replace(markdownExtension, "");
+
+  const route = routesByFile.get(targetFile);
+  if (route === undefined) return undefined;
+
+  return `${route}${suffix}`;
+};
 
 export const remarkLinkRewrite =
-  (basePath = "") =>
-  (tree: Root) => {
+  (basePath = "", routesByFile: Map<string, string> = new Map()) =>
+  (tree: Root, vfile: VFile) => {
     visit(tree, "link", (node) => {
       if (!node.url) return;
       if (node.url.startsWith("http") || node.url.startsWith("mailto:")) return;
 
       node.url = node.url.replace(/\\/g, "/");
+
+      const resolved = resolveToRoute(node.url, vfile.path, routesByFile);
+      if (resolved !== undefined) {
+        node.url = resolved;
+        return;
+      }
 
       const base = path.posix.join(basePath);
       if (basePath && node.url.startsWith(base)) {

--- a/packages/zudoku/src/vite/plugin-mdx.ts
+++ b/packages/zudoku/src/vite/plugin-mdx.ts
@@ -28,6 +28,10 @@ import { remarkLinkRewrite } from "./mdx/remark-link-rewrite.js";
 import { remarkNormalizeImageUrl } from "./mdx/remark-normalize-image-url.js";
 import { remarkStaticGeneration } from "./mdx/remark-static-generation.js";
 import { exportMdxjsConst } from "./mdx/utils.js";
+import {
+  globMarkdownFiles,
+  resolveCustomNavigationPaths,
+} from "./plugin-docs.js";
 
 // Convert mdxJsxFlowElement img elements to regular element nodes
 // so rehype-mdx-import-media can pick them up
@@ -86,6 +90,19 @@ const viteMdxPlugin = async (): Promise<Plugin> => {
   const buildConfig = await getBuildConfig();
   const highlighter = await highlighterPromise;
 
+  // Map each markdown file (absolute path, no extension) to its route so link
+  // rewriting can resolve `./foo/index.mdx` links to the real page route.
+  // Computed once at plugin init. In dev this is a snapshot; editing a custom
+  // path needs a server restart to re-sync link rewriting.
+  const routesByFile = new Map<string, string>();
+  const fileMapping = await resolveCustomNavigationPaths(
+    config,
+    await globMarkdownFiles(config, { absolute: true }),
+  );
+  for (const [route, filePath] of Object.entries(fileMapping)) {
+    routesByFile.set(filePath.replace(/\.mdx?$/, ""), route);
+  }
+
   const defaultRemarkPlugins = [
     remarkStaticGeneration,
     [remarkInjectFilepath, config.__meta.rootDir],
@@ -100,7 +117,7 @@ const viteMdxPlugin = async (): Promise<Plugin> => {
     remarkDirective,
     remarkDirectiveRehype,
     remarkCodeTabs,
-    [remarkLinkRewrite, config.basePath],
+    [remarkLinkRewrite, config.basePath, routesByFile],
     [remarkNormalizeImageUrl, config.basePath],
     ...(config.build?.remarkPlugins ?? []),
   ] satisfies PluggableList;


### PR DESCRIPTION
Fixes #2572.

A doc page given a custom navigation path (for example file `articles/monetization/index` served at `/articles/monetization`) builds at the clean route, but Markdown links written as file paths (`./monetization/index.mdx`) were rewritten to `/articles/monetization/index`, a route that does not exist. The link rewriter only stripped the extension and never knew the page had a custom path.

The rewriter now gets the file-to-route mapping and resolves each Markdown link to the route its target file is served at, so links match the built page. This also fixes sibling links from a collapsed page (`./plans.mdx` was landing in the wrong folder). Index files without a custom path keep their `/index` route, so default behavior is unchanged.