### PR TITLE
fix: generate `.md` files when `publishMarkdown` default applies

### DIFF
--- a/packages/zudoku/src/lib/plugins/openapi/SchemaInfo.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/SchemaInfo.tsx
@@ -274,6 +274,7 @@ export const SchemaInfo = ({
     data: { schema },
   } = useSuspenseQuery(query);
   const { title, description } = schema;
+  const sidebarCollapsed = useSidebar((s) => s.isCollapsed);
 
   useWarmupSchema();
 
@@ -302,7 +303,6 @@ export const SchemaInfo = ({
   const tags = schema.tags.flatMap(({ name, description, extensions }) =>
     name ? { name, description, extensions } : [],
   );
-  const sidebarCollapsed = useSidebar((s) => s.isCollapsed);
 
   return (
     <div

--- a/packages/zudoku/src/vite/plugin-markdown-export.ts
+++ b/packages/zudoku/src/vite/plugin-markdown-export.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { Plugin } from "vite";
 import { getCurrentConfig } from "../config/loader.js";
 import { ProtectedRoutesSchema } from "../config/validators/ProtectedRoutesSchema.js";
+import { DocsConfigSchema } from "../config/validators/ZudokuConfig.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { readFrontmatter } from "../lib/util/readFrontmatter.js";
 import { matchesAnyProtectedPattern } from "../lib/util/url.js";
@@ -85,12 +86,15 @@ const viteMarkdownExportPlugin = (): Plugin => {
     },
     async buildStart() {
       const config = getCurrentConfig();
-      const llmsConfig = config.docs?.llms;
+      // Parse so schema defaults (e.g. publishMarkdown) apply; the loaded
+      // config isn't run through the schema.
+      const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
+      const llmsConfig = docsConfig.llms ?? {};
 
       const needsMdFiles =
-        config.docs?.publishMarkdown ||
-        llmsConfig?.llmsTxt ||
-        llmsConfig?.llmsTxtFull;
+        docsConfig.publishMarkdown ||
+        llmsConfig.llmsTxt ||
+        llmsConfig.llmsTxtFull;
 
       if (config.__meta.mode === "standalone" || !needsMdFiles) {
         return;
@@ -118,13 +122,13 @@ const viteMarkdownExportPlugin = (): Plugin => {
     },
     async configureServer(server) {
       const config = getCurrentConfig();
-      const llmsConfig = config.docs?.llms;
+      const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
+      const llmsConfig = docsConfig.llms ?? {};
 
-      // Serve .md files if markdown export is needed
       const needsMdFiles =
-        config.docs?.publishMarkdown ||
-        llmsConfig?.llmsTxt ||
-        llmsConfig?.llmsTxtFull;
+        docsConfig.publishMarkdown ||
+        llmsConfig.llmsTxt ||
+        llmsConfig.llmsTxtFull;
 
       if (!needsMdFiles) return;
 
@@ -157,12 +161,13 @@ const viteMarkdownExportPlugin = (): Plugin => {
     },
     async closeBundle() {
       const config = getCurrentConfig();
-      const llmsConfig = config.docs?.llms;
+      const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
+      const llmsConfig = docsConfig.llms ?? {};
 
       const needsMdFiles =
-        config.docs?.publishMarkdown ||
-        llmsConfig?.llmsTxt ||
-        llmsConfig?.llmsTxtFull;
+        docsConfig.publishMarkdown ||
+        llmsConfig.llmsTxt ||
+        llmsConfig.llmsTxtFull;
 
       if (
         process.env.NODE_ENV !== "production" ||
@@ -208,7 +213,7 @@ const viteMarkdownExportPlugin = (): Plugin => {
         }
       }
 
-      if (config.docs?.llms?.llmsTxt || config.docs?.llms?.llmsTxtFull) {
+      if (llmsConfig.llmsTxt || llmsConfig.llmsTxtFull) {
         const markdownInfoPath = path.join(
           config.__meta.rootDir,
           "node_modules/.zudoku/markdown-info.json",


### PR DESCRIPTION
The `.md` copy-page routes 404 unless a config explicitly sets `docs.publishMarkdown`, even though it defaults to true. Schema defaults never reach the loaded config (`validateConfig` safeParses but discards the result), so the markdown-export plugin read a raw `undefined` and skipped writing the files, while the client still rendered the Copy page button.

This parses the docs block the same way `plugin-docs` and `prerender` already do, so the default applies and `.md` files generate even when `docs` is omitted. The broader issue of defaults not propagating is tracked separately.