### PR TITLE
fix(config): apply schema defaults and transforms to the loaded config

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -48,6 +48,22 @@
 - Use UI components from the `zudoku/ui` module. (based on shadcn/ui)
 - Use icons from the `zudoku/icons` module (based on Lucide icons)
 
+## Config Schema (Zod)
+
+- The loader parses the user config via `validateConfig()`, so schema `.default()`/`.transform()`
+  values apply to everything downstream. Don't re-parse config sections in consumers.
+- Order is always transform-then-parse: plugin `transformConfig` hooks run on the RAW authored
+  config (same shape they see in the client bundle), then the result is schema-parsed. Hook
+  additions must conform to the schema; unknown keys are stripped on the server side.
+- Zod only applies nested `.default()`s when the parent object is present in the input. A parent
+  that is `.optional()` short-circuits to `undefined` and inner defaults never run. Sub-schemas
+  whose defaults should apply when omitted must use `.prefault({})` on the schema itself (see
+  `DocsConfigSchema`). `.default({})` does NOT work for this: it returns the literal `{}` without
+  running the inner schema.
+- Exceptions that read the raw (unparsed) config: the client bundle via `virtual:zudoku-config`, and
+  `buildManifest` when called from the SSR entry. The prerender worker parses the built bundle's
+  config itself via `validateConfig()`.
+
 ## OpenAPI Schema Processing Pipeline
 
 There are two distinct pipelines depending on how schemas are loaded:

--- a/packages/zudoku/src/config/loader.test.ts
+++ b/packages/zudoku/src/config/loader.test.ts
@@ -126,3 +126,31 @@ describe("loadZudokuConfig", () => {
     );
   });
 });
+
+describe("loadZudokuConfig parsed result", () => {
+  it("applies schema defaults and transforms to the loaded config", async () => {
+    const plugin = { getRoutes: () => [] };
+    vi.mocked(fileExists).mockResolvedValue(true);
+    vi.mocked(runnerImport).mockResolvedValue({
+      module: {
+        default: {
+          docs: { files: "/custom/**/*.md" },
+          cdnUrl: "https://cdn.example.com",
+          plugins: [plugin],
+        },
+      },
+      dependencies: [],
+    } as never);
+
+    const { config } = await loadZudokuConfig(configEnv, "/defaults-project");
+
+    expect(config.docs.publishMarkdown).toBe(true);
+    expect(config.docs.files).toEqual(["/custom/**/*.md"]);
+    expect(config.cdnUrl).toEqual({
+      base: "https://cdn.example.com",
+      media: "https://cdn.example.com",
+    });
+    expect(config.plugins?.[0]).toBe(plugin);
+    expect(config.__meta.rootDir).toBe("/defaults-project");
+  });
+});

--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -12,10 +12,13 @@ import { getZudokuRootDir } from "../cli/common/package-json.js";
 import { runPluginTransformConfig } from "../lib/core/transform-config.js";
 import invariant from "../lib/util/invariant.js";
 import { fileExists } from "./file-exists.js";
-import type { ZudokuConfig } from "./validators/ZudokuConfig.js";
+import type {
+  ResolvedZudokuConfig,
+  ZudokuConfig,
+} from "./validators/ZudokuConfig.js";
 import { validateConfig } from "./validators/ZudokuConfig.js";
 
-export type ConfigWithMeta = ZudokuConfig & {
+export type ConfigWithMeta = ResolvedZudokuConfig & {
   __meta: {
     rootDir: string;
     moduleDir: string;
@@ -69,9 +72,11 @@ const virtualModuleStubPlugin: VitePlugin = {
   },
 };
 
+type RawConfigWithMeta = ZudokuConfig & { __meta: ConfigWithMeta["__meta"] };
+
 async function loadZudokuConfigWithMeta(
   rootDir: string,
-): Promise<ConfigWithMeta> {
+): Promise<RawConfigWithMeta> {
   const configPath = await getConfigFilePath(rootDir);
 
   let module: { default: ZudokuConfig };
@@ -119,12 +124,8 @@ async function loadZudokuConfigWithMeta(
     );
   }
 
-  const config = module.default;
-
-  validateConfig(config, configPath);
-
-  const configWithMetadata: ConfigWithMeta = {
-    ...config,
+  return {
+    ...module.default,
     __meta: {
       rootDir,
       moduleDir: getZudokuRootDir(),
@@ -133,8 +134,6 @@ async function loadZudokuConfigWithMeta(
       configPath,
     },
   };
-
-  return configWithMetadata;
 }
 
 function loadEnv(configEnv: ConfigEnv, rootDir: string) {
@@ -227,7 +226,13 @@ export async function loadZudokuConfig(
 
   try {
     const loadedConfig = await loadZudokuConfigWithMeta(rootDir);
-    const config = await runPluginTransformConfig(loadedConfig);
+    // Transform first (plugin hooks see the same raw shape as in the client
+    // bundle), then parse so schema defaults and transforms apply.
+    const transformed = await runPluginTransformConfig(loadedConfig);
+    const config: ConfigWithMeta = {
+      ...validateConfig(transformed, transformed.__meta.configPath),
+      __meta: transformed.__meta,
+    };
     setConfig(config);
 
     logger.info(
@@ -264,6 +269,7 @@ export async function loadZudokuConfig(
 
 export const setStandaloneConfig = (rootDir: string) => {
   setConfig({
+    ...validateConfig({}),
     __meta: {
       rootDir,
       moduleDir: getZudokuRootDir(),

--- a/packages/zudoku/src/config/validators/NavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/NavigationSchema.ts
@@ -27,7 +27,6 @@ import type {
   NavigationRule,
   NavigationSortRule,
 } from "./InputNavigationSchema.js";
-import { DocsConfigSchema } from "./ZudokuConfig.js";
 
 type ReplaceFields<Base, Overrides> = Omit<Base, keyof Overrides> & Overrides;
 // string icons will be transformed to `LucideIcon` in `vite/plugin-navigation.ts`
@@ -176,7 +175,7 @@ export class NavigationResolver {
 
   constructor(config: ConfigWithMeta) {
     this.rootDir = config.__meta.rootDir;
-    this.globPatterns = DocsConfigSchema.parse(config.docs ?? {}).files;
+    this.globPatterns = config.docs.files;
     this.items = config.navigation ?? [];
   }
 

--- a/packages/zudoku/src/config/validators/ProtectedRoutesSchema.ts
+++ b/packages/zudoku/src/config/validators/ProtectedRoutesSchema.ts
@@ -19,7 +19,7 @@ type ProtectedRouteCallback = (c: CallbackContext) => ProtectedRouteResult;
 export type ProtectedRoutesInput = z.input<typeof ProtectedRoutesInputSchema>;
 export type ProtectedRoutes = z.output<typeof ProtectedRoutesInputSchema>;
 
-export const ProtectedRoutesInputSchema = z.optional(
+const ProtectedRoutesInputSchema = z.optional(
   z.union([
     z.array(z.string()),
     z.record(

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -528,4 +528,24 @@ describe("validateConfig parsed result", () => {
     expect(result.docs.publishMarkdown).toBe(true);
     spy.mockRestore();
   });
+
+  it("keeps nested defaults when an invalid section is merged back in dev", () => {
+    process.env.NODE_ENV = "development";
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = validateConfig({
+      docs: { publishMarkdown: "no" },
+    });
+
+    // Raw invalid value survives, but sibling defaults stay resolved so
+    // consumers like `config.docs.llms.llmsTxt` don't crash.
+    expect(result.docs.publishMarkdown).toBe("no");
+    expect(result.docs.files).toEqual(["/pages/**/*.{md,mdx}"]);
+    expect(result.docs.llms).toEqual({
+      llmsTxt: false,
+      llmsTxtFull: false,
+      includeProtected: false,
+    });
+    spy.mockRestore();
+  });
 });

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -451,3 +451,81 @@ describe("validateConfig", () => {
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 });
+
+describe("validateConfig parsed result", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("applies docs defaults when docs is omitted", () => {
+    const result = validateConfig({});
+
+    expect(result.docs.publishMarkdown).toBe(true);
+    expect(result.docs.files).toEqual(["/pages/**/*.{md,mdx}"]);
+    expect(result.docs.llms).toEqual({
+      llmsTxt: false,
+      llmsTxtFull: false,
+      includeProtected: false,
+    });
+  });
+
+  it("transforms docs.files string into an array", () => {
+    const result = validateConfig({ docs: { files: "/docs/**/*.md" } });
+
+    expect(result.docs.files).toEqual(["/docs/**/*.md"]);
+    expect(result.docs.publishMarkdown).toBe(true);
+  });
+
+  it("transforms cdnUrl string into a base/media object", () => {
+    const result = validateConfig({ cdnUrl: "https://cdn.example.com" });
+
+    expect(result.cdnUrl).toEqual({
+      base: "https://cdn.example.com",
+      media: "https://cdn.example.com",
+    });
+  });
+
+  it("normalizes protectedRoutes array into a record of callbacks", () => {
+    const result = validateConfig({ protectedRoutes: ["/private/*"] });
+
+    expect(Object.keys(result.protectedRoutes ?? {})).toEqual(["/private/*"]);
+    expect(typeof result.protectedRoutes?.["/private/*"]).toBe("function");
+  });
+
+  it("leaves clerk jwtTemplateName absent when omitted", () => {
+    const result = validateConfig({
+      authentication: { type: "clerk", clerkPubKey: "pk_test_abc" },
+    });
+
+    expect(result.authentication).not.toHaveProperty("jwtTemplateName");
+  });
+
+  it("preserves plugin instances by reference", () => {
+    const plugin = { getRoutes: () => [] };
+    const result = validateConfig({ plugins: [plugin] });
+
+    expect(result.plugins?.[0]).toBe(plugin);
+  });
+
+  it("keeps raw values for invalid sections and resolves the remainder in dev", () => {
+    process.env.NODE_ENV = "development";
+    // The file-level spy is restored by the first describe's afterAll.
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = validateConfig({
+      authentication: { type: "auth0", clientId: "x", domain: "invalid" },
+      basePath: "/docs",
+    });
+
+    expect(spy).toHaveBeenCalled();
+    expect(result.authentication).toMatchObject({
+      type: "auth0",
+      domain: "invalid",
+    });
+    expect(result.basePath).toBe("/docs");
+    expect(result.docs.publishMarkdown).toBe(true);
+    spy.mockRestore();
+  });
+});

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -182,11 +182,7 @@ const ApiKeysSchema = z.object({
     .optional(),
   createKey: z
     .custom<
-      ({
-        apiKey,
-        context,
-        auth,
-      }: {
+      (args: {
         apiKey: { description: string; expiresOn?: string };
         context: ZudokuContext;
         auth: UseAuthReturn;
@@ -222,7 +218,7 @@ export const FooterSocialIcons = [
   "telegram",
 ] as const;
 
-export const FooterSocialSchema = z.object({
+const FooterSocialSchema = z.object({
   label: z.string().optional(),
   href: z.string(),
   icon: z
@@ -319,38 +315,43 @@ const LlmsConfigSchema = z
         "When enabled, includes content from protected routes in the generated .md files and llms.txt files. By default, protected routes are excluded.",
       ),
   })
-  .partial();
+  .partial()
+  // `prefault` so parsing an absent value still yields the inner defaults
+  .prefault({});
 
-export const DocsConfigSchema = z.object({
-  files: z
-    .union([z.string(), z.array(z.string())])
-    .transform((val) => (typeof val === "string" ? [val] : val))
-    .default([DEFAULT_DOCS_FILES]),
-  publishMarkdown: z
-    .boolean()
-    .default(true)
-    .describe(
-      "When enabled, generates .md files for each document during build. Access documents at their URL path with .md extension (e.g., /foo/hello.md). Markdown files are generated without frontmatter.",
-    ),
-  defaultOptions: z
-    .object({
-      toc: z.boolean(),
-      copyPage: z.boolean().optional(),
-      disablePager: z.boolean(),
-      showLastModified: z.boolean(),
-      fullWidth: z.boolean().optional(),
-      centered: z.boolean().optional(),
-      suggestEdit: z
-        .object({
-          url: z.string(),
-          text: z.string().optional(),
-        })
-        .optional(),
-    })
-    .partial()
-    .optional(),
-  llms: LlmsConfigSchema.optional(),
-});
+const DocsConfigSchema = z
+  .object({
+    files: z
+      .union([z.string(), z.array(z.string())])
+      .transform((val) => (typeof val === "string" ? [val] : val))
+      .default([DEFAULT_DOCS_FILES]),
+    publishMarkdown: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When enabled, generates .md files for each document during build. Access documents at their URL path with .md extension (e.g., /foo/hello.md). Markdown files are generated without frontmatter.",
+      ),
+    defaultOptions: z
+      .object({
+        toc: z.boolean(),
+        copyPage: z.boolean().optional(),
+        disablePager: z.boolean(),
+        showLastModified: z.boolean(),
+        fullWidth: z.boolean().optional(),
+        centered: z.boolean().optional(),
+        suggestEdit: z
+          .object({
+            url: z.string(),
+            text: z.string().optional(),
+          })
+          .optional(),
+      })
+      .partial()
+      .optional(),
+    llms: LlmsConfigSchema,
+  })
+  // `prefault` so parsing an absent value still yields the inner defaults
+  .prefault({});
 
 const Redirect = z.object({
   from: z.string(),
@@ -419,7 +420,9 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
       .refine((val) => /^pk_(test|live)_\w+$/.test(val), {
         message: "Clerk public key invalid, must start with pk_test or pk_live",
       }),
-    jwtTemplateName: z.string().optional().default("dev-portal"),
+    // No default: an absent template must stay absent so Clerk issues its
+    // standard session token instead of requesting a non-existent template.
+    jwtTemplateName: z.string().optional(),
     redirectToAfterSignUp: z.string().optional(),
     redirectToAfterSignIn: z.string().optional(),
     redirectToAfterSignOut: z.string().optional(),
@@ -589,7 +592,7 @@ const CssObject = z.record(
 );
 
 const ThemeConfigSchema = z.object({
-  registryUrl: z.string().url().optional(),
+  registryUrl: z.url().optional(),
   /**
    * @deprecated Import a `.css` file from your `zudoku.config.ts` instead.
    * Inline CSS via this option still works but requires a dev server restart
@@ -661,7 +664,7 @@ const ApiCatalogSchema = z.object({
     .optional(),
 });
 
-export const CdnUrlSchema = z
+const CdnUrlSchema = z
   .union([
     z.string(),
     z.object({
@@ -674,8 +677,7 @@ export const CdnUrlSchema = z
       return { base: val, media: val };
     }
     return { base: val.base, media: val.media };
-  })
-  .optional();
+  });
 
 const BaseConfigSchema = z.object({
   slots: z.record(z.string(), z.custom<SlotType>()),
@@ -731,7 +733,6 @@ const BaseConfigSchema = z.object({
   metadata: MetadataSchema,
   authentication: AuthenticationSchema,
   search: SearchSchema,
-  docs: DocsConfigSchema.optional(),
   apis: z.union([ApiSchema, z.array(ApiSchema)]),
   catalogs: z.union([ApiCatalogSchema, z.array(ApiCatalogSchema)]),
   apiKeys: ApiKeysSchema,
@@ -750,60 +751,77 @@ const BaseConfigSchema = z.object({
   __pluginDirs: z.array(z.string()),
 });
 
-export const ZudokuConfig = BaseConfigSchema.partial();
+// `docs` is added after `.partial()` because partial's ZodOptional wrapper
+// would widen its output type to `| undefined`, even though the prefault
+// keeps it present at runtime.
+export const ZudokuConfig = BaseConfigSchema.partial().extend({
+  docs: DocsConfigSchema,
+});
 
-export type ZudokuApiConfig = z.infer<typeof ApiSchema>;
 export type VersionConfig = z.infer<typeof VersionConfigSchema>;
 export type ZudokuSiteMapConfig = z.infer<typeof SiteMapSchema>;
 export type ZudokuDocsConfig = z.infer<typeof DocsConfigSchema>;
-export type ZudokuLlmsConfig = z.infer<typeof LlmsConfigSchema>;
 export type ZudokuRedirect = z.infer<typeof Redirect>;
 export type AuthenticationConfig = z.infer<typeof AuthenticationSchema>;
 
-// Use `z.input` type for flexibility with transforms,
-// but override navigation with `z.infer` for strict validation
-type BaseZudokuConfig = z.input<typeof ZudokuConfig>;
-export type ZudokuConfig = Omit<
-  BaseZudokuConfig,
-  "header" | "navigation" | "navigationRules"
-> & {
-  header?: {
-    navigation?: z.infer<typeof HeaderNavigationSchema>;
-    themeSwitcher?: {
-      enabled?: boolean;
-    };
-    placements?: {
-      navigation?: "start" | "center" | "end";
-      search?: "start" | "center" | "end";
-      auth?: "start" | "center" | "end" | "navigation";
-    };
-  };
+// Pin navigation types to their strict inferred form (z.input widens them due to z.lazy recursion).
+type InputOverrides = {
   navigation?: z.infer<typeof InputNavigationSchema>;
   navigationRules?: z.infer<typeof NavigationRulesSchema>;
 };
 
-export function validateConfig(config: unknown, configPath?: string) {
+type BaseZudokuConfig = z.input<typeof ZudokuConfig>;
+export type ZudokuConfig = Omit<BaseZudokuConfig, keyof InputOverrides> &
+  InputOverrides;
+
+export type ResolvedZudokuConfig = z.output<typeof ZudokuConfig>;
+
+export function validateConfig(
+  config: unknown,
+  configPath?: string,
+): ResolvedZudokuConfig {
   warnUnsafeConfigKeys(config);
 
   const validationResult = ZudokuConfig.safeParse(config);
 
-  if (!validationResult.success) {
-    const prettyErrors = z.prettifyError(validationResult.error);
-    const location = configPath ? ` at ${configPath}` : "";
-
-    // In production (build mode), throw an error to fail the build
-    if (process.env.NODE_ENV === "production") {
-      throw new Error(
-        `Invalid Zudoku configuration${location}:\n${prettyErrors}`,
-      );
-    }
-
-    // In development mode, log warnings but don't fail
-    // biome-ignore lint/suspicious/noConsole: Logging allowed here
-    console.log(colors.yellow(`Invalid Zudoku configuration${location}:`));
-    // biome-ignore lint/suspicious/noConsole: Logging allowed here
-    console.log(colors.yellow(prettyErrors));
+  if (validationResult.success) {
+    return validationResult.data;
   }
+
+  const prettyErrors = z.prettifyError(validationResult.error);
+  const location = configPath ? ` at ${configPath}` : "";
+
+  // In production (build mode), throw an error to fail the build
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      `Invalid Zudoku configuration${location}:\n${prettyErrors}`,
+    );
+  }
+
+  // In development mode, log warnings but don't fail
+  // biome-ignore lint/suspicious/noConsole: Logging allowed here
+  console.log(colors.yellow(`Invalid Zudoku configuration${location}:`));
+  // biome-ignore lint/suspicious/noConsole: Logging allowed here
+  console.log(colors.yellow(prettyErrors));
+
+  // Keep the dev server running: parse the valid sections, keep the user's
+  // raw values for the invalid ones (more useful in dev than dropping them).
+  const invalidKeys = new Set(
+    validationResult.error.issues.map((issue) => issue.path[0]),
+  );
+  const rawEntries =
+    typeof config === "object" && config !== null ? Object.entries(config) : [];
+  const sanitized = Object.fromEntries(
+    rawEntries.filter(([key]) => !invalidKeys.has(key)),
+  );
+
+  const fallback = ZudokuConfig.safeParse(sanitized);
+  const resolved = fallback.success ? fallback.data : ZudokuConfig.parse({});
+  const rawInvalidSections = Object.fromEntries(
+    rawEntries.filter(([key]) => invalidKeys.has(key)),
+  );
+
+  return { ...resolved, ...rawInvalidSections } as ResolvedZudokuConfig;
 }
 
 // `UNSAFE_` prefixed config options that are deprecated and will be removed soon.

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -8,6 +8,7 @@ import type { UseAuthReturn } from "../../lib/authentication/hook.js";
 import type { AuthState } from "../../lib/authentication/state.js";
 import type { SlotType } from "../../lib/components/context/SlotProvider.js";
 import type { ZudokuPlugin } from "../../lib/core/plugins.js";
+import { mergeConfig } from "../../lib/core/transform-config.js";
 import type { ZudokuContext } from "../../lib/core/ZudokuContext.js";
 import type { FilterCatalogItemsFn } from "../../lib/plugins/api-catalog/index.js";
 import type { ApiConsumer } from "../../lib/plugins/api-keys/index.js";
@@ -821,7 +822,7 @@ export function validateConfig(
     rawEntries.filter(([key]) => invalidKeys.has(key)),
   );
 
-  return { ...resolved, ...rawInvalidSections } as ResolvedZudokuConfig;
+  return mergeConfig(resolved, rawInvalidSections) as ResolvedZudokuConfig;
 }
 
 // `UNSAFE_` prefixed config options that are deprecated and will be removed soon.

--- a/packages/zudoku/src/lib/core/plugins.ts
+++ b/packages/zudoku/src/lib/core/plugins.ts
@@ -71,6 +71,12 @@ export interface ConfigHookContext {
 }
 
 export interface TransformConfigContext {
+  /**
+   * The raw authored config; schema defaults and transforms are not applied
+   * yet. On the server/build side the transformed result is schema-parsed
+   * afterwards, so additions must conform to the schema (unknown keys are
+   * stripped there).
+   */
   config: ZudokuConfig;
   merge: <T extends Partial<ZudokuConfig>>(partial: T) => ZudokuConfig & T;
 }

--- a/packages/zudoku/src/lib/manifest.ts
+++ b/packages/zudoku/src/lib/manifest.ts
@@ -1,10 +1,10 @@
 import type { ZudokuConfig } from "../config/config.js";
-import { ProtectedRoutesSchema } from "../config/validators/ProtectedRoutesSchema.js";
 import {
   ACCESS_TOKEN_COOKIE,
   AUTH_PROFILE_COOKIE,
   REFRESH_TOKEN_COOKIE,
 } from "./authentication/cookies.js";
+import { normalizeProtectedRoutes } from "./core/ZudokuContext.js";
 import { joinUrl } from "./util/joinUrl.js";
 
 export const PROTECTED_CHUNK_DIR = "_protected";
@@ -37,7 +37,9 @@ export type ZudokuManifest = {
 export const buildManifest = (
   config: Pick<ZudokuConfig, "basePath" | "protectedRoutes">,
 ): ZudokuManifest => {
-  const protectedRoutes = ProtectedRoutesSchema.parse(config.protectedRoutes);
+  // Called with the raw config from the SSR entry (`virtual:zudoku-config`),
+  // so normalization must happen here. Idempotent for parsed configs.
+  const protectedRoutes = normalizeProtectedRoutes(config.protectedRoutes);
   const routePatterns = protectedRoutes ? Object.keys(protectedRoutes) : [];
   return {
     version: MANIFEST_VERSION,

--- a/packages/zudoku/src/lib/plugins/markdown/index.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/index.tsx
@@ -4,7 +4,10 @@ import type { ZudokuDocsConfig } from "../../../config/validators/ZudokuConfig.j
 import type { Toc } from "../../../vite/mdx/rehype-extract-toc-with-jsx.js";
 import type { ZudokuPlugin } from "../../core/plugins.js";
 
-export interface MarkdownPluginOptions extends ZudokuDocsConfig {
+export interface MarkdownPluginOptions extends Pick<
+  ZudokuDocsConfig,
+  "defaultOptions" | "publishMarkdown"
+> {
   basePath: string;
   fileImports: Record<string, () => Promise<MDXImport>>;
 }

--- a/packages/zudoku/src/vite/api/SchemaManager.test.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.test.ts
@@ -5,6 +5,7 @@ import type { OpenAPIV3_1 } from "openapi-types";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ConfigWithMeta } from "../../config/loader.js";
 import type { Processor } from "../../config/validators/BuildSchema.js";
+import { validateConfig } from "../../config/validators/ZudokuConfig.js";
 import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
 import { flattenAllOfProcessor } from "../../lib/util/flattenAllOfProcessor.js";
 import invariant from "../../lib/util/invariant.js";
@@ -22,17 +23,20 @@ const mockSchema = {
 describe("SchemaManager", () => {
   let tempDir: string;
   let storeDir: string;
-  let __meta: ConfigWithMeta["__meta"];
+  let baseConfig: ConfigWithMeta;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "zudoku-test-"));
     storeDir = path.join(tempDir, "store");
-    __meta = {
-      rootDir: tempDir,
-      moduleDir: path.join(tempDir, "node_modules"),
-      mode: "module",
-      dependencies: [],
-      configPath: path.join(tempDir, "zudoku.config.ts"),
+    baseConfig = {
+      ...validateConfig({}),
+      __meta: {
+        rootDir: tempDir,
+        moduleDir: path.join(tempDir, "node_modules"),
+        mode: "module",
+        dependencies: [],
+        configPath: path.join(tempDir, "zudoku.config.ts"),
+      },
     };
     await fs.mkdir(storeDir);
   });
@@ -46,7 +50,7 @@ describe("SchemaManager", () => {
     await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [{ type: "file", path: "test-api", input: schemaPath }],
     };
 
@@ -73,7 +77,7 @@ describe("SchemaManager", () => {
     );
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [
         {
           type: "file",
@@ -107,7 +111,7 @@ describe("SchemaManager", () => {
     );
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [
         {
           type: "file",
@@ -142,7 +146,7 @@ describe("SchemaManager", () => {
     await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [
         {
           type: "file",
@@ -171,7 +175,7 @@ describe("SchemaManager", () => {
     await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [{ type: "file", path: "test-api", input: schemaPath }],
     };
 
@@ -227,7 +231,7 @@ describe("SchemaManager", () => {
     await fs.writeFile(schemaPath, JSON.stringify(schemaWithRefs));
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [{ type: "file", path: "test-api", input: schemaPath }],
     };
 
@@ -283,7 +287,7 @@ describe("SchemaManager", () => {
     const manager = new SchemaManager({
       storeDir,
       config: {
-        __meta,
+        ...baseConfig,
         apis: [{ type: "file", path: "test-api", input: schemaPath }],
       },
       processors: [flattenAllOfProcessor],
@@ -328,7 +332,7 @@ describe("SchemaManager", () => {
     };
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [
         {
           type: "file",
@@ -391,7 +395,7 @@ describe("SchemaManager", () => {
     await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
 
     const config: ConfigWithMeta = {
-      __meta,
+      ...baseConfig,
       apis: [
         {
           type: "file",

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -16,7 +16,6 @@ import {
   getZudokuRootDir,
 } from "../cli/common/package-json.js";
 import { loadZudokuConfig } from "../config/loader.js";
-import { CdnUrlSchema } from "../config/validators/ZudokuConfig.js";
 import { PROTECTED_CHUNK_DIR } from "../lib/manifest.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import type { SSRAdapter } from "./build.js";
@@ -69,7 +68,7 @@ export async function getViteConfig(
     chunk.moduleIds.some(isProtectedSource);
 
   const isWorker = options.adapter === "cloudflare";
-  const cdnUrl = CdnUrlSchema.parse(config.cdnUrl);
+  const cdnUrl = config.cdnUrl;
 
   const base = cdnUrl?.base
     ? joinUrl(cdnUrl.base, config.basePath)

--- a/packages/zudoku/src/vite/plugin-docs.test.ts
+++ b/packages/zudoku/src/vite/plugin-docs.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ConfigWithMeta } from "../config/loader.js";
+import { validateConfig } from "../config/validators/ZudokuConfig.js";
 import { isNavigationPlugin } from "../lib/core/plugins.js";
 import {
   type MarkdownPluginOptions,
@@ -49,8 +50,8 @@ describe("resolveCustomNavigationPaths", () => {
 
   const resolve = async (navigation: ConfigWithMeta["navigation"]) => {
     const config: ConfigWithMeta = {
+      ...validateConfig({ docs: { files: "pages/**/*.{md,mdx}" } }),
       __meta,
-      docs: { files: "pages/**/*.{md,mdx}" },
       navigation,
     };
     return resolveCustomNavigationPaths(
@@ -123,7 +124,6 @@ describe("resolveCustomNavigationPaths", () => {
     const plugin = markdownPlugin({
       basePath: "",
       fileImports,
-      files: ["pages/**/*.{md,mdx}"],
       publishMarkdown: false,
     });
     const routes = isNavigationPlugin(plugin) ? plugin.getRoutes() : [];

--- a/packages/zudoku/src/vite/plugin-docs.ts
+++ b/packages/zudoku/src/vite/plugin-docs.ts
@@ -7,7 +7,6 @@ import {
   type NavigationItem,
   NavigationResolver,
 } from "../config/validators/NavigationSchema.js";
-import { DocsConfigSchema } from "../config/validators/ZudokuConfig.js";
 import { traverseNavigation } from "../lib/components/navigation/utils.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { readFrontmatter } from "../lib/util/readFrontmatter.js";
@@ -20,10 +19,9 @@ export const globMarkdownFiles = async (
   config: ConfigWithMeta,
   options: { absolute: boolean } = { absolute: false },
 ): Promise<Record<string, string>> => {
-  const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
   const fileMapping: Record<string, string> = {};
 
-  for (const globPattern of docsConfig.files) {
+  for (const globPattern of config.docs.files) {
     const globbedFiles = await glob(globPattern, {
       root: config.__meta.rootDir,
       ignore: ["**/node_modules/**", "**/dist/**", "**/.git/**"],
@@ -146,8 +144,6 @@ const viteDocsPlugin = (): Plugin => {
         'import { markdownPlugin } from "zudoku/plugins/markdown";',
       ];
 
-      const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
-
       // Glob markdown files and resolve custom navigation paths
       const fileMapping = await resolveCustomNavigationPaths(
         config,
@@ -171,8 +167,8 @@ const viteDocsPlugin = (): Plugin => {
         `export const configuredDocsPlugin = markdownPlugin({`,
         `  basePath: "${config.basePath ?? ""}",`,
         `  fileImports,`,
-        `  defaultOptions: ${JSON.stringify(docsConfig.defaultOptions)},`,
-        `  publishMarkdown: ${JSON.stringify(docsConfig.publishMarkdown)},`,
+        `  defaultOptions: ${JSON.stringify(config.docs.defaultOptions)},`,
+        `  publishMarkdown: ${JSON.stringify(config.docs.publishMarkdown)},`,
         `});`,
       );
 

--- a/packages/zudoku/src/vite/plugin-markdown-export.ts
+++ b/packages/zudoku/src/vite/plugin-markdown-export.ts
@@ -1,9 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Plugin } from "vite";
-import { getCurrentConfig } from "../config/loader.js";
-import { ProtectedRoutesSchema } from "../config/validators/ProtectedRoutesSchema.js";
-import { DocsConfigSchema } from "../config/validators/ZudokuConfig.js";
+import { type ConfigWithMeta, getCurrentConfig } from "../config/loader.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { readFrontmatter } from "../lib/util/readFrontmatter.js";
 import { matchesAnyProtectedPattern } from "../lib/util/url.js";
@@ -75,6 +73,11 @@ export const resolveMarkdownRoutePath = (
   return routePath;
 };
 
+const needsMdFiles = (config: ConfigWithMeta) =>
+  config.docs.publishMarkdown ||
+  config.docs.llms.llmsTxt ||
+  config.docs.llms.llmsTxtFull;
+
 const viteMarkdownExportPlugin = (): Plugin => {
   let markdownFiles: Record<string, string> = {};
   let markdownFileInfos: MarkdownFileInfo[] = [];
@@ -86,17 +89,8 @@ const viteMarkdownExportPlugin = (): Plugin => {
     },
     async buildStart() {
       const config = getCurrentConfig();
-      // Parse so schema defaults (e.g. publishMarkdown) apply; the loaded
-      // config isn't run through the schema.
-      const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
-      const llmsConfig = docsConfig.llms ?? {};
 
-      const needsMdFiles =
-        docsConfig.publishMarkdown ||
-        llmsConfig.llmsTxt ||
-        llmsConfig.llmsTxtFull;
-
-      if (config.__meta.mode === "standalone" || !needsMdFiles) {
+      if (config.__meta.mode === "standalone" || !needsMdFiles(config)) {
         return;
       }
 
@@ -106,10 +100,8 @@ const viteMarkdownExportPlugin = (): Plugin => {
       );
 
       // Filter out protected routes unless `includeProtected` is true
-      if (!llmsConfig?.includeProtected) {
-        const protectedRoutes = ProtectedRoutesSchema.parse(
-          config.protectedRoutes,
-        );
+      if (!config.docs.llms.includeProtected) {
+        const protectedRoutes = config.protectedRoutes;
         if (protectedRoutes) {
           const patterns = Object.keys(protectedRoutes);
           for (const routePath of Object.keys(markdownFiles)) {
@@ -122,15 +114,9 @@ const viteMarkdownExportPlugin = (): Plugin => {
     },
     async configureServer(server) {
       const config = getCurrentConfig();
-      const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
-      const llmsConfig = docsConfig.llms ?? {};
 
-      const needsMdFiles =
-        docsConfig.publishMarkdown ||
-        llmsConfig.llmsTxt ||
-        llmsConfig.llmsTxtFull;
-
-      if (!needsMdFiles) return;
+      // Serve .md files if markdown export is needed
+      if (!needsMdFiles(config)) return;
 
       markdownFiles = await resolveCustomNavigationPaths(
         config,
@@ -161,18 +147,11 @@ const viteMarkdownExportPlugin = (): Plugin => {
     },
     async closeBundle() {
       const config = getCurrentConfig();
-      const docsConfig = DocsConfigSchema.parse(config.docs ?? {});
-      const llmsConfig = docsConfig.llms ?? {};
-
-      const needsMdFiles =
-        docsConfig.publishMarkdown ||
-        llmsConfig.llmsTxt ||
-        llmsConfig.llmsTxtFull;
 
       if (
         process.env.NODE_ENV !== "production" ||
         Object.keys(markdownFiles).length === 0 ||
-        !needsMdFiles
+        !needsMdFiles(config)
       ) {
         return;
       }
@@ -213,7 +192,7 @@ const viteMarkdownExportPlugin = (): Plugin => {
         }
       }
 
-      if (llmsConfig.llmsTxt || llmsConfig.llmsTxtFull) {
+      if (config.docs.llms.llmsTxt || config.docs.llms.llmsTxtFull) {
         const markdownInfoPath = path.join(
           config.__meta.rootDir,
           "node_modules/.zudoku/markdown-info.json",

--- a/packages/zudoku/src/vite/prerender/prerender.ts
+++ b/packages/zudoku/src/vite/prerender/prerender.ts
@@ -10,7 +10,7 @@ import type { getRoutesByConfig } from "../../app/main.js";
 import { logger } from "../../cli/common/logger.js";
 import { fileExists } from "../../config/file-exists.js";
 import { getBuildConfig } from "../../config/validators/BuildSchema.js";
-import type { ZudokuConfig } from "../../config/validators/ZudokuConfig.js";
+import { validateConfig } from "../../config/validators/ZudokuConfig.js";
 import { runPluginTransformConfig } from "../../lib/core/transform-config.js";
 import invariant from "../../lib/util/invariant.js";
 import { joinUrl } from "../../lib/util/joinUrl.js";
@@ -69,10 +69,9 @@ export const prerender = async ({
     path.join(distDir, "server/entry.server.js"),
   ).href;
 
-  const rawConfig: ZudokuConfig = await import(serverConfigPath).then(
-    (m) => m.default,
-  );
-  const config = await runPluginTransformConfig(rawConfig);
+  // Same order as the loader: transform the raw bundle config, then parse.
+  const rawConfig = await import(serverConfigPath).then((m) => m.default);
+  const config = validateConfig(await runPluginTransformConfig(rawConfig));
 
   const buildConfig = await getBuildConfig();
   const module = await import(entryServerPath);
@@ -224,49 +223,43 @@ export const prerender = async ({
   });
 
   // Generate llms.txt files if markdown export is enabled
-  if (config.docs) {
-    const { DocsConfigSchema } =
-      await import("../../config/validators/ZudokuConfig.js");
+  const llmsConfig = config.docs.llms;
+
+  const markdownInfoPath = path.join(
+    dir,
+    "node_modules/.zudoku/markdown-info.json",
+  );
+  let markdownFileInfos: MarkdownFileInfo[] = [];
+
+  if (await fileExists(markdownInfoPath)) {
+    const markdownInfoContent = await readFile(markdownInfoPath, "utf-8");
+    markdownFileInfos = JSON.parse(markdownInfoContent);
+  }
+
+  if (llmsConfig.llmsTxt || llmsConfig.llmsTxtFull) {
     const { generateLlmsTxtFiles } = await import("../llms.js");
+    await generateLlmsTxtFiles({
+      markdownFileInfos,
+      basePath: config.basePath,
+      outputUrls: paths,
+      baseOutputDir: distDir,
+      siteName: config.site?.title,
+      llmsTxt: llmsConfig.llmsTxt,
+      llmsTxtFull: llmsConfig.llmsTxtFull,
+      redirectUrls,
+    });
+  }
 
-    const docsConfig = DocsConfigSchema.parse(config.docs);
-    const llmsConfig = docsConfig.llms ?? {};
-
-    const markdownInfoPath = path.join(
-      dir,
-      "node_modules/.zudoku/markdown-info.json",
+  if (!config.docs.publishMarkdown) {
+    await Promise.all(
+      markdownFileInfos.map((info) => {
+        const outputPath = getMarkdownOutputPath(distDir, info.routePath);
+        if (!path.resolve(outputPath).startsWith(path.resolve(distDir))) {
+          return;
+        }
+        return rm(outputPath).catch(() => {});
+      }),
     );
-    let markdownFileInfos: MarkdownFileInfo[] = [];
-
-    if (await fileExists(markdownInfoPath)) {
-      const markdownInfoContent = await readFile(markdownInfoPath, "utf-8");
-      markdownFileInfos = JSON.parse(markdownInfoContent);
-    }
-
-    if (llmsConfig.llmsTxt || llmsConfig.llmsTxtFull) {
-      await generateLlmsTxtFiles({
-        markdownFileInfos,
-        basePath: config.basePath,
-        outputUrls: paths,
-        baseOutputDir: distDir,
-        siteName: config.site?.title,
-        llmsTxt: llmsConfig.llmsTxt,
-        llmsTxtFull: llmsConfig.llmsTxtFull,
-        redirectUrls,
-      });
-    }
-
-    if (!docsConfig.publishMarkdown) {
-      await Promise.all(
-        markdownFileInfos.map((info) => {
-          const outputPath = getMarkdownOutputPath(distDir, info.routePath);
-          if (!path.resolve(outputPath).startsWith(path.resolve(distDir))) {
-            return;
-          }
-          return rm(outputPath).catch(() => {});
-        }),
-      );
-    }
   }
 
   return { workerResults, rewrites };

--- a/packages/zudoku/src/vite/prerender/worker.ts
+++ b/packages/zudoku/src/vite/prerender/worker.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import Piscina from "piscina";
-import { ProtectedRoutesSchema } from "../../config/validators/ProtectedRoutesSchema.js";
-import type { ZudokuConfig } from "../../config/validators/ZudokuConfig.js";
+import { validateConfig } from "../../config/validators/ZudokuConfig.js";
 import { runPluginTransformConfig } from "../../lib/core/transform-config.js";
 import { joinUrl } from "../../lib/util/joinUrl.js";
 import { matchesAnyProtectedPattern } from "../../lib/util/url.js";
@@ -24,10 +23,9 @@ const { template, distDir, serverConfigPath, entryServerPath, writeRedirects } =
   Piscina.workerData as StaticWorkerData;
 
 const server: EntryServer = await import(entryServerPath);
-const rawConfig: ZudokuConfig = await import(serverConfigPath).then(
-  (m) => m.default,
-);
-const config = await runPluginTransformConfig(rawConfig);
+// Same order as the loader: transform the raw bundle config, then parse.
+const rawConfig = await import(serverConfigPath).then((m) => m.default);
+const config = validateConfig(await runPluginTransformConfig(rawConfig));
 
 const routes = server.getRoutesByConfig(config);
 const { basePath } = config;
@@ -40,9 +38,8 @@ const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
 
   const request = new Request(url);
 
-  const protectedRoutes = ProtectedRoutesSchema.parse(config.protectedRoutes);
-  const isProtectedRoute = protectedRoutes
-    ? matchesAnyProtectedPattern(Object.keys(protectedRoutes), urlPath)
+  const isProtectedRoute = config.protectedRoutes
+    ? matchesAnyProtectedPattern(Object.keys(config.protectedRoutes), urlPath)
     : false;
 
   // Get the main response

--- a/packages/zudoku/src/vite/protected/build.test.ts
+++ b/packages/zudoku/src/vite/protected/build.test.ts
@@ -158,7 +158,10 @@ describe("assertProtectedPatternsCovered", () => {
 
   const configWith = (patterns: string[]) =>
     ({
-      protectedRoutes: patterns,
+      // Normalized record shape, as produced by the parsed loader config
+      protectedRoutes: Object.fromEntries(
+        patterns.map((pattern) => [pattern, () => true]),
+      ),
       __meta: { rootDir: "/tmp" },
     }) as never;
 
@@ -207,7 +210,10 @@ describe("assertCloudflareWranglerGatesProtected", () => {
 
   const configWith = (patterns: string[]) =>
     ({
-      protectedRoutes: patterns,
+      // Normalized record shape, as produced by the parsed loader config
+      protectedRoutes: Object.fromEntries(
+        patterns.map((pattern) => [pattern, () => true]),
+      ),
       __meta: { rootDir: "/tmp" },
     }) as never;
 

--- a/packages/zudoku/src/vite/protected/registry.test.ts
+++ b/packages/zudoku/src/vite/protected/registry.test.ts
@@ -84,7 +84,10 @@ describe("getProtectedSourceMatcher", () => {
 
   const configWith = (patterns: string[] | undefined) =>
     ({
-      protectedRoutes: patterns,
+      // Normalized record shape, as produced by the parsed loader config
+      protectedRoutes: patterns
+        ? Object.fromEntries(patterns.map((pattern) => [pattern, () => true]))
+        : undefined,
       __meta: { rootDir: "/tmp" },
     }) as never;
 

--- a/packages/zudoku/src/vite/protected/registry.ts
+++ b/packages/zudoku/src/vite/protected/registry.ts
@@ -1,6 +1,5 @@
 import { matchPath } from "react-router";
 import type { ConfigWithMeta } from "../../config/loader.js";
-import { ProtectedRoutesSchema } from "../../config/validators/ProtectedRoutesSchema.js";
 import { joinUrl } from "../../lib/util/joinUrl.js";
 import { matchesProtectedPattern } from "../../lib/util/url.js";
 
@@ -53,11 +52,11 @@ export const scopeMatchesPattern = (
 export const getProtectedSourceMatcher = (
   config: ConfigWithMeta,
 ): { match: ProtectedSourceMatcher; enabled: boolean; patterns: string[] } => {
-  const protectedRoutes = ProtectedRoutesSchema.parse(config.protectedRoutes);
-  const patterns = protectedRoutes ? Object.keys(protectedRoutes) : [];
+  const patterns = Object.keys(config.protectedRoutes ?? {});
   if (patterns.length === 0) {
     return { match: () => false, enabled: false, patterns };
   }
+
   return {
     enabled: true,
     patterns,


### PR DESCRIPTION
Zod defaults and transforms declared in the config schema (like `docs.publishMarkdown` or the `cdnUrl` transform) never reached runtime because `validateConfig` discarded the parse result. Consumers papered over this with local re-parses, which drifted apart (see #2574: copy page button visible but the .md files missing).

The loader, prerender, and worker now use the parsed config. Plugin `transformConfig` hooks run on the raw authored config first (the same shape they see in the client bundle), then the result is schema-parsed once. The scattered `DocsConfigSchema.parse` / `ProtectedRoutesSchema.parse` / `CdnUrlSchema.parse` call sites are gone. On invalid config in dev, valid sections still resolve to their defaults and invalid sections keep their raw values.

Notes:
- `jwtTemplateName`'s never-applied `dev-portal` default is removed so Clerk setups without that template keep working.
- `MarkdownPluginOptions` now only declares the options the plugin actually reads (`defaultOptions`, `publishMarkdown`).