### PR TITLE
chore: fix security reports

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
@@ -40,7 +40,7 @@ jobs:
 
       - run: pnpm install nx --global
 
-      - uses: nrwl/nx-set-shas@v5
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5
 
       - name: Detect monetization plugin changes
         if: github.event_name == 'pull_request'
@@ -90,14 +90,14 @@ jobs:
 
       - name: Coverage report comment (with comparison)
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.base-coverage.outputs.cache-matched-key != ''
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2
         with:
           json-summary-path: coverage/coverage-summary.json
           json-summary-compare-path: coverage-base/coverage-summary.json
 
       - name: Coverage report comment
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.base-coverage.outputs.cache-matched-key == ''
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2
         with:
           json-summary-path: coverage/coverage-summary.json
 
@@ -148,10 +148,12 @@ jobs:
   check-links:
     name: Check Links
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
@@ -178,7 +180,7 @@ jobs:
           restore-keys: cache-lychee-v4-
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >-
             --config ./docs/lychee.toml

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
@@ -70,7 +70,7 @@ jobs:
 
       - run: pnpm install nx --global
 
-      - uses: nrwl/nx-set-shas@v5
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5
 
       # This must be a real github account otherwise vercel thows ugly errors
       - run: git config --global user.email "integrations@zuplo.com"
@@ -137,7 +137,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: github.ref == 'refs/heads/main'
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           token_format: access_token
           workload_identity_provider: ${{ vars.GCP_ACTIONS_IDENTITY_PROVIDER }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload CSS
         if: github.ref == 'refs/heads/main'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload Javascript
         if: github.ref == 'refs/heads/main'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload HTML (Latest)
         if: env.IS_RELEASE == 'true'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone/index.html
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload CSS (Latest)
         if: env.IS_RELEASE == 'true'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone
@@ -194,7 +194,7 @@ jobs:
 
       - name: Upload Javascript (Latest)
         if: env.IS_RELEASE == 'true'
-        uses: google-github-actions/upload-cloud-storage@v3
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         with:
           process_gcloudignore: false
           path: packages/zudoku/standalone

--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 

--- a/packages/create-zudoku/helpers/examples.ts
+++ b/packages/create-zudoku/helpers/examples.ts
@@ -53,8 +53,12 @@ export async function getRepoInfo(
   }
 
   // If examplePath is available, the branch name takes the entire path
+  const escapedFilePath = filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const branch = examplePath
-    ? `${_branch}/${file.join("/")}`.replace(new RegExp(`/${filePath}|/$`), "")
+    ? `${_branch}/${file.join("/")}`.replace(
+        new RegExp(`/${escapedFilePath}|/$`),
+        "",
+      )
     : _branch;
 
   if (username && name && branch && t === "tree") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ overrides:
   lodash-es: '>=4.18.0 <5'
   defu: '>=6.1.5 <7'
   picomatch: '>=4.0.4 <5'
+  shell-quote: '>=1.8.4'
 
 patchedDependencies:
   decode-named-character-reference@1.2.0:
@@ -8758,8 +8759,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@4.2.0:
@@ -11298,7 +11299,7 @@ snapshots:
       listr2: 10.2.1
       log-symbols: 7.0.1
       micromatch: 4.0.8
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string-env-interpolation: 1.0.1
       ts-log: 3.0.2
       tslib: 2.8.1
@@ -18072,7 +18073,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@4.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ packages:
   - examples/**
   - website
   - docs
+  # Exclude build output; SSR examples emit a dist/package.json that pnpm would
+  # otherwise register as a workspace package and write into the lockfile.
+  - "!**/dist/**"
+  - "!**/dist"
 
 catalog:
   "@testing-library/dom": 10.4.1
@@ -45,6 +49,7 @@ overrides:
   lodash-es: ">=4.18.0 <5"
   defu: ">=6.1.5 <7"
   picomatch: ">=4.0.4 <5"
+  shell-quote: ">=1.8.4"
 
 patchedDependencies:
   decode-named-character-reference@1.2.0: patches/decode-named-character-reference@1.2.0.patch


### PR DESCRIPTION
Resolves the open GitHub code-scanning alerts and the critical pnpm audit finding, and fixes a recurring lockfile annoyance.

Third-party GitHub Actions are now pinned to commit SHAs instead of mutable tags, so a compromised or retagged action can't run with our release credentials. Added a least-privilege permissions block to the check-links job, and escaped a user-supplied path before it goes into a RegExp in create-zudoku.

Bumped shell-quote to 1.8.4 via a pnpm override to clear the one critical audit vulnerability.

Also excluded dist from the workspace globs. The SSR examples emit a dist/package.json, which pnpm was treating as a workspace package and writing into the lockfile, so it kept getting re-added on every branch.