### PR TITLE
Support full Inkeep settings in search config

### DIFF
--- a/docs/pages/docs/configuration/search.md
+++ b/docs/pages/docs/configuration/search.md
@@ -168,3 +168,38 @@ your [Zudoku Configuration](./overview.md):
   // ...
 }
 ```
+
+### Customizing Inkeep
+
+Any other [base settings](https://docs.inkeep.com/cloud/ui-components/common-settings/base) can be
+set alongside the required fields, for example `filters` to scope results or `transformSource` to
+customize how sources are displayed.
+
+You can also pass
+[`searchSettings`](https://docs.inkeep.com/cloud/ui-components/common-settings/search),
+[`aiChatSettings`](https://docs.inkeep.com/cloud/ui-components/common-settings/ai-chat), and
+`modalSettings` to customize the respective parts of the search experience. They are merged with
+Zudoku's defaults.
+
+For example, to categorize results into tabs based on their URL:
+
+```typescript
+{
+  // ...
+  search: {
+    type: "inkeep",
+    // ...required fields from above
+    transformSource: (source) => {
+      if (!source.url.includes("/blog/")) return source;
+      return { ...source, tabs: [...(source.tabs ?? []), "Blog"] };
+    },
+    searchSettings: {
+      tabs: [["All", { isAlwaysVisible: true }], "Blog"],
+    },
+    aiChatSettings: {
+      aiAssistantName: "My Assistant",
+    },
+  }
+  // ...
+}
+```

--- a/docs/pages/docs/configuration/search.md
+++ b/docs/pages/docs/configuration/search.md
@@ -199,7 +199,7 @@ For example, to categorize results into tabs based on their URL:
     aiChatSettings: {
       aiAssistantName: "My Assistant",
     },
-  }
+  },
   // ...
 }
 ```

--- a/docs/pages/docs/configuration/search.md
+++ b/docs/pages/docs/configuration/search.md
@@ -179,7 +179,8 @@ You can also pass
 [`searchSettings`](https://docs.inkeep.com/cloud/ui-components/common-settings/search),
 [`aiChatSettings`](https://docs.inkeep.com/cloud/ui-components/common-settings/ai-chat), and
 `modalSettings` to customize the respective parts of the search experience. They are merged with
-Zudoku's defaults.
+Zudoku's defaults and passed through to Inkeep as-is, so any option Inkeep supports can be used —
+including ones added after this Zudoku version was released.
 
 For example, to categorize results into tabs based on their URL:
 

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -450,4 +450,31 @@ describe("validateConfig", () => {
 
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
+
+  it("should accept inkeep search with nested settings", () => {
+    const config = {
+      search: {
+        type: "inkeep" as const,
+        apiKey: "key",
+        integrationId: "integration",
+        organizationId: "org",
+        primaryBrandColor: "#26D6FF",
+        organizationDisplayName: "Example",
+        transformSource: (source: unknown) => source,
+        searchSettings: {
+          tabs: ["Docs", ["All", { isAlwaysVisible: true }]],
+        },
+        aiChatSettings: {
+          aiAssistantName: "Example Assistant",
+        },
+        modalSettings: {
+          shortcutKey: "k",
+        },
+      },
+    };
+
+    validateConfig(config);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
 });

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -461,8 +461,10 @@ describe("validateConfig", () => {
         primaryBrandColor: "#26D6FF",
         organizationDisplayName: "Example",
         transformSource: (source: unknown) => source,
+        someFutureBaseSetting: true,
         searchSettings: {
           tabs: ["Docs", ["All", { isAlwaysVisible: true }]],
+          someFutureSearchSetting: true,
         },
         aiChatSettings: {
           aiAssistantName: "Example Assistant",

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -1,8 +1,3 @@
-import type {
-  InkeepAIChatSettings,
-  InkeepModalSettings,
-  InkeepSearchSettings,
-} from "@inkeep/cxkit-types";
 import type { Options } from "@mdx-js/rollup";
 import colors from "picocolors";
 import type { ComponentType, ReactNode } from "react";
@@ -20,6 +15,7 @@ import type {
   GenerateCodeSnippetFn,
   TransformExamplesFn,
 } from "../../lib/plugins/openapi/interfaces.js";
+import type { InkeepSearchPluginOptions } from "../../lib/plugins/search-inkeep/index.js";
 import type { PagefindSearchFragment } from "../../lib/plugins/search-pagefind/types.js";
 import type { MdxComponentsType } from "../../lib/util/MdxComponents.js";
 import type { ExposedComponentProps } from "../../lib/util/useExposedProps.js";
@@ -373,9 +369,15 @@ const SearchSchema = z
       organizationId: z.string(),
       primaryBrandColor: z.string(),
       organizationDisplayName: z.string(),
-      searchSettings: z.custom<InkeepSearchSettings>().optional(),
-      aiChatSettings: z.custom<InkeepAIChatSettings>().optional(),
-      modalSettings: z.custom<InkeepModalSettings>().optional(),
+      searchSettings: z
+        .custom<NonNullable<InkeepSearchPluginOptions["searchSettings"]>>()
+        .optional(),
+      aiChatSettings: z
+        .custom<NonNullable<InkeepSearchPluginOptions["aiChatSettings"]>>()
+        .optional(),
+      modalSettings: z
+        .custom<NonNullable<InkeepSearchPluginOptions["modalSettings"]>>()
+        .optional(),
     }),
     z.object({
       type: z.literal("pagefind"),

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -1,3 +1,8 @@
+import type {
+  InkeepAIChatSettings,
+  InkeepModalSettings,
+  InkeepSearchSettings,
+} from "@inkeep/cxkit-types";
 import type { Options } from "@mdx-js/rollup";
 import colors from "picocolors";
 import type { ComponentType, ReactNode } from "react";
@@ -368,6 +373,9 @@ const SearchSchema = z
       organizationId: z.string(),
       primaryBrandColor: z.string(),
       organizationDisplayName: z.string(),
+      searchSettings: z.custom<InkeepSearchSettings>().optional(),
+      aiChatSettings: z.custom<InkeepAIChatSettings>().optional(),
+      modalSettings: z.custom<InkeepModalSettings>().optional(),
     }),
     z.object({
       type: z.literal("pagefind"),

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
@@ -1,17 +1,20 @@
 import type {
+  InkeepAIChatSettings,
   InkeepBaseSettings,
   InkeepComponentInstance,
   InkeepJS,
+  InkeepModalSettings,
+  InkeepSearchSettings,
   InkeepSettings,
 } from "@inkeep/cxkit-types";
 import { useEffect, useMemo, useState } from "react";
 import { ClientOnly } from "../../components/ClientOnly.js";
 import type { ZudokuPlugin } from "../../core/plugins.js";
 import {
-  aiChatSettings,
-  baseSettings,
-  modalSettings,
-  searchSettings,
+  aiChatSettings as defaultAiChatSettings,
+  baseSettings as defaultBaseSettings,
+  modalSettings as defaultModalSettings,
+  searchSettings as defaultSearchSettings,
 } from "./inkeep.js";
 
 declare global {
@@ -20,6 +23,12 @@ declare global {
   }
 }
 
+export type InkeepSearchPluginOptions = InkeepBaseSettings & {
+  searchSettings?: InkeepSearchSettings;
+  aiChatSettings?: InkeepAIChatSettings;
+  modalSettings?: InkeepModalSettings;
+};
+
 const InkeepSearch = ({
   isOpen,
   onClose,
@@ -27,32 +36,43 @@ const InkeepSearch = ({
 }: {
   isOpen: boolean;
   onClose: () => void;
-  settings: InkeepBaseSettings;
+  settings: InkeepSearchPluginOptions;
 }) => {
-  const config = useMemo<InkeepSettings>(
-    () => ({
+  const config = useMemo<InkeepSettings>(() => {
+    const { searchSettings, aiChatSettings, modalSettings, ...baseSettings } =
+      settings;
+
+    return {
       baseSettings: {
+        ...defaultBaseSettings,
         ...baseSettings,
-        ...settings,
         colorMode: {
           sync: {
             target: "html",
             attributes: ["class"],
             isDarkMode: (attrs) => attrs.class?.includes("dark") ?? false,
           },
+          ...baseSettings.colorMode,
         },
       },
       modalSettings: {
+        ...defaultModalSettings,
         ...modalSettings,
         onOpenChange: (newOpen: boolean) => {
+          modalSettings?.onOpenChange?.(newOpen);
           if (!newOpen) onClose();
         },
       },
-      searchSettings,
-      aiChatSettings,
-    }),
-    [onClose, settings],
-  );
+      searchSettings: {
+        ...defaultSearchSettings,
+        ...searchSettings,
+      },
+      aiChatSettings: {
+        ...defaultAiChatSettings,
+        ...aiChatSettings,
+      },
+    };
+  }, [onClose, settings]);
   const [searchInstance, setSearchInstance] = useState<
     InkeepComponentInstance | undefined
   >(
@@ -85,7 +105,7 @@ const InkeepSearch = ({
 };
 
 export const inkeepSearchPlugin = (
-  settings: InkeepBaseSettings,
+  settings: InkeepSearchPluginOptions,
 ): ZudokuPlugin => {
   return {
     getHead: () => {

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
@@ -24,6 +24,8 @@ declare global {
 }
 
 export type InkeepSearchPluginOptions = InkeepBaseSettings & {
+  // Discriminator from the Zudoku `search` config; not passed to Inkeep
+  type?: "inkeep";
   searchSettings?: InkeepSearchSettings;
   aiChatSettings?: InkeepAIChatSettings;
   modalSettings?: InkeepModalSettings;
@@ -39,8 +41,13 @@ const InkeepSearch = ({
   settings: InkeepSearchPluginOptions;
 }) => {
   const config = useMemo<InkeepSettings>(() => {
-    const { searchSettings, aiChatSettings, modalSettings, ...baseSettings } =
-      settings;
+    const {
+      type: _type,
+      searchSettings,
+      aiChatSettings,
+      modalSettings,
+      ...baseSettings
+    } = settings;
 
     return {
       baseSettings: {

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
@@ -23,13 +23,17 @@ declare global {
   }
 }
 
-export type InkeepSearchPluginOptions = InkeepBaseSettings & {
-  // Discriminator from the Zudoku `search` config; not passed to Inkeep
-  type?: "inkeep";
-  searchSettings?: InkeepSearchSettings;
-  aiChatSettings?: InkeepAIChatSettings;
-  modalSettings?: InkeepModalSettings;
-};
+// All settings are intersected with Record<string, unknown> and passed through
+// as-is, so settings added in newer Inkeep versions can be used before they
+// appear in the type definitions.
+export type InkeepSearchPluginOptions = InkeepBaseSettings &
+  Record<string, unknown> & {
+    // Discriminator from the Zudoku `search` config; not passed to Inkeep
+    type?: "inkeep";
+    searchSettings?: InkeepSearchSettings & Record<string, unknown>;
+    aiChatSettings?: InkeepAIChatSettings & Record<string, unknown>;
+    modalSettings?: InkeepModalSettings & Record<string, unknown>;
+  };
 
 const InkeepSearch = ({
   isOpen,


### PR DESCRIPTION
## Summary

The Inkeep search plugin spread the entire `search` config into Inkeep's `baseSettings` and hardcoded `searchSettings`, `aiChatSettings`, and `modalSettings`. That made it impossible to configure features that live in those sections — e.g. [search result tabs](https://docs.inkeep.com/cloud/ui-components/customization-guides/source-transformation), the search placeholder, or the AI assistant name — without replacing the whole plugin.

- Accept optional `searchSettings`, `aiChatSettings`, and `modalSettings` in the `search: { type: "inkeep" }` config and merge each with Zudoku's defaults; everything else continues to flow into `baseSettings` as before.
- A user-supplied `modalSettings.onOpenChange` is composed with the internal close handling rather than overwritten.
- User `colorMode` settings now merge with the built-in dark-mode sync instead of being silently discarded.
- Typed the new fields in the config schema (`z.custom` against `@inkeep/cxkit-types`) so config authors get IntelliSense.
- Documented the customization options on the search configuration page.

Motivating use case: on zuplo.com/docs we want search results categorized into Docs / Reference / Blog tabs via `transformSource` + `searchSettings.tabs`, which previously required bypassing the built-in plugin entirely.

## Testing

- Added a config validator test covering the nested settings.
- `pnpm -F zudoku typecheck`, `pnpm check`, `pnpm -F zudoku build`, and the config test suites pass.
- Verified the equivalent settings object end-to-end against the real Inkeep widget (tabs render and categorize correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)