### PR TITLE
Add LandingPage and BrowserWindow components

### DIFF
--- a/docs/pages/docs/components/browser-window.mdx
+++ b/docs/pages/docs/components/browser-window.mdx
@@ -1,0 +1,92 @@
+---
+title: Browser Window
+sidebar_icon: app-window
+---
+
+import { BrowserWindow } from "zudoku/components";
+import { Button } from "zudoku/ui/Button";
+
+A mock browser window for presenting UI previews, screenshots-as-code, or full page layouts in your
+documentation. It renders its children inside a browser-style frame with a URL bar and a working
+zoom control — the current scale is displayed like in a real browser and readers can zoom in and out
+themselves.
+
+## Import
+
+```tsx
+import { BrowserWindow } from "zudoku/components";
+```
+
+## Usage
+
+<BrowserWindow>
+  <div className="flex flex-col items-center gap-3 p-10 text-center">
+    <span className="text-2xl font-bold">Hello, world!</span>
+    <p className="text-muted-foreground">Any content renders inside the browser frame.</p>
+    <Button>Get started</Button>
+  </div>
+</BrowserWindow>
+
+```tsx
+<BrowserWindow>
+  <div className="flex flex-col items-center gap-3 p-10 text-center">
+    <span className="text-2xl font-bold">Hello, world!</span>
+    <p className="text-muted-foreground">Any content renders inside the browser frame.</p>
+    <Button>Get started</Button>
+  </div>
+</BrowserWindow>
+```
+
+## Scale
+
+Use the `scale` prop to set the initial zoom of the content. This is useful for presenting
+full-width layouts, like a landing page, at a reduced size. The zoom control in the toolbar shows
+the current scale — readers can change it with the `+`/`-` buttons or click the percentage to reset
+it, just like in a real browser.
+
+<BrowserWindow scale={0.5}>
+  <div className="flex flex-col items-center gap-3 p-10 text-center">
+    <span className="text-4xl font-bold">Scaled to 50%</span>
+    <p className="text-muted-foreground">
+      The content is laid out at full width and scaled down to fit.
+    </p>
+  </div>
+</BrowserWindow>
+
+```tsx
+<BrowserWindow scale={0.5}>
+  <div className="flex flex-col items-center gap-3 p-10 text-center">
+    <span className="text-4xl font-bold">Scaled to 50%</span>
+    <p className="text-muted-foreground">
+      The content is laid out at full width and scaled down to fit.
+    </p>
+  </div>
+</BrowserWindow>
+```
+
+Scaling affects layout, not just size: at `scale={0.5}` the content is laid out at twice the
+container width and scaled down, so responsive layouts behave as if viewed on a larger screen.
+
+## URL
+
+Set the `url` prop to change the address shown in the URL bar (defaults to `localhost:3000`):
+
+<BrowserWindow url="https://developers.example.com">
+  <p className="p-10 text-center text-muted-foreground">Your developer portal</p>
+</BrowserWindow>
+
+```tsx
+<BrowserWindow url="https://developers.example.com">
+  <p className="p-10 text-center text-muted-foreground">Your developer portal</p>
+</BrowserWindow>
+```
+
+## Props
+
+| Prop               | Type        | Description                                                         |
+| ------------------ | ----------- | ------------------------------------------------------------------- |
+| `url`              | `string`    | Address displayed in the URL bar. Defaults to `localhost:3000`.     |
+| `scale`            | `number`    | Initial zoom of the content (e.g. `0.75` for 75%). Defaults to `1`. |
+| `className`        | `string`    | Additional classes for the outer frame.                             |
+| `contentClassName` | `string`    | Additional classes for the content viewport.                        |
+| `children`         | `ReactNode` | The content rendered inside the browser window.                     |

--- a/docs/pages/docs/components/landing-page.mdx
+++ b/docs/pages/docs/components/landing-page.mdx
@@ -123,7 +123,7 @@ front.
   aside={
     <div className="rounded-xl border bg-card p-4 font-mono text-sm">
       <pre>{`curl https://api.example.com/v1/shipments \\
-  -H "Authorization: Bearer sk_live_..." \\
+  -H "Authorization: Bearer $API_KEY" \\
   -d destination="alpha-centauri"`}</pre>
     </div>
   }
@@ -146,7 +146,7 @@ front.
   aside={
     <div className="rounded-xl border bg-card p-4 font-mono text-sm">
       <pre>{`curl https://api.example.com/v1/shipments \\
-  -H "Authorization: Bearer sk_live_..." \\
+  -H "Authorization: Bearer $API_KEY" \\
   -d destination="alpha-centauri"`}</pre>
     </div>
   }

--- a/docs/pages/docs/components/landing-page.mdx
+++ b/docs/pages/docs/components/landing-page.mdx
@@ -3,7 +3,7 @@ title: Landing Page
 sidebar_icon: layout-template
 ---
 
-import { LandingPage } from "zudoku/components";
+import { BrowserWindow, LandingPage } from "zudoku/components";
 import { BookOpenIcon, CodeIcon, KeyIcon, RocketIcon, WebhookIcon, ZapIcon } from "zudoku/icons";
 
 A ready-made, customizable landing page for your developer portal. It comes in three variants
@@ -47,34 +47,37 @@ import { LandingPage } from "zudoku/components";
 ### Hero (default)
 
 A centered hero with call-to-action buttons and an optional feature grid below. The classic landing
-page for product-focused portals.
+page for product-focused portals. The previews on this page are presented in a
+[Browser Window](./browser-window) component.
 
-<LandingPage
-  eyebrow="Developer Platform"
-  title="Build with our API"
-  description="Everything you need to integrate payments, webhooks, and more — in minutes, not days."
-  actions={[
-    { label: "Get started", href: "/docs/getting-started" },
-    { label: "API Reference", href: "/docs", variant: "outline" },
-  ]}
-  features={[
-    {
-      icon: <ZapIcon />,
-      title: "Fast integration",
-      description: "Go from zero to your first API call in under five minutes.",
-    },
-    {
-      icon: <KeyIcon />,
-      title: "API keys built in",
-      description: "Issue, rotate, and revoke keys right from the portal.",
-    },
-    {
-      icon: <WebhookIcon />,
-      title: "Webhooks",
-      description: "Subscribe to events and react to changes in real time.",
-    },
-  ]}
-/>
+<BrowserWindow url="https://developers.example.com" scale={0.75} contentClassName="px-8">
+  <LandingPage
+    eyebrow="Developer Platform"
+    title="Build with our API"
+    description="Everything you need to integrate payments, webhooks, and more — in minutes, not days."
+    actions={[
+      { label: "Get started", href: "/docs/getting-started" },
+      { label: "API Reference", href: "/docs", variant: "outline" },
+    ]}
+    features={[
+      {
+        icon: <ZapIcon />,
+        title: "Fast integration",
+        description: "Go from zero to your first API call in under five minutes.",
+      },
+      {
+        icon: <KeyIcon />,
+        title: "API keys built in",
+        description: "Issue, rotate, and revoke keys right from the portal.",
+      },
+      {
+        icon: <WebhookIcon />,
+        title: "Webhooks",
+        description: "Subscribe to events and react to changes in real time.",
+      },
+    ]}
+  />
+</BrowserWindow>
 
 ```tsx
 <LandingPage
@@ -111,23 +114,25 @@ A two-column hero with your own content on the side — an illustration, screens
 passed via the `aside` prop. A great fit for developer-oriented portals that want to show code up
 front.
 
-<LandingPage
-  variant="split"
-  eyebrow="Shipping API"
-  title="Ship anywhere in the whole universe"
-  description="Create and manage shipments, track packages in real-time, and integrate with multiple carriers through a single interface."
-  actions={[
-    { label: "Get started", href: "/docs/getting-started" },
-    { label: "View on GitHub", href: "https://github.com/zuplo/zudoku", variant: "outline" },
-  ]}
-  aside={
-    <div className="rounded-xl border bg-card p-4 font-mono text-sm">
-      <pre>{`curl https://api.example.com/v1/shipments \\
+<BrowserWindow url="https://shipping.example.com" scale={0.75} contentClassName="px-8">
+  <LandingPage
+    variant="split"
+    eyebrow="Shipping API"
+    title="Ship anywhere in the whole universe"
+    description="Create and manage shipments, track packages in real-time, and integrate with multiple carriers through a single interface."
+    actions={[
+      { label: "Get started", href: "/docs/getting-started" },
+      { label: "View on GitHub", href: "https://github.com/zuplo/zudoku", variant: "outline" },
+    ]}
+    aside={
+      <div className="rounded-xl border bg-card p-4 font-mono text-sm">
+        <pre>{`curl https://api.example.com/v1/shipments \\
   -H "Authorization: Bearer $API_KEY" \\
   -d destination="alpha-centauri"`}</pre>
-    </div>
-  }
-/>
+      </div>
+    }
+  />
+</BrowserWindow>
 
 ```tsx
 <LandingPage
@@ -168,37 +173,39 @@ The `aside` accepts any React node — use an `<img />` for an illustration inst
 A compact header followed by prominent, clickable feature cards. Ideal as a documentation hub that
 routes visitors to the right section quickly.
 
-<LandingPage
-  variant="grid"
-  title="Documentation"
-  description="Explore guides, API references, and examples to get the most out of the platform."
-  features={[
-    {
-      icon: <RocketIcon />,
-      title: "Getting Started",
-      description: "Set up your account and make your first request.",
-      href: "/docs/getting-started",
-    },
-    {
-      icon: <BookOpenIcon />,
-      title: "Guides",
-      description: "Step-by-step tutorials for common use cases.",
-      href: "/docs",
-    },
-    {
-      icon: <CodeIcon />,
-      title: "API Reference",
-      description: "Complete reference for every endpoint and type.",
-      href: "/docs",
-    },
-    {
-      icon: <WebhookIcon />,
-      title: "Webhooks",
-      description: "Listen to events and build real-time integrations.",
-      href: "/docs",
-    },
-  ]}
-/>
+<BrowserWindow url="https://developers.example.com/docs" scale={0.75} contentClassName="px-8">
+  <LandingPage
+    variant="grid"
+    title="Documentation"
+    description="Explore guides, API references, and examples to get the most out of the platform."
+    features={[
+      {
+        icon: <RocketIcon />,
+        title: "Getting Started",
+        description: "Set up your account and make your first request.",
+        href: "/docs/getting-started",
+      },
+      {
+        icon: <BookOpenIcon />,
+        title: "Guides",
+        description: "Step-by-step tutorials for common use cases.",
+        href: "/docs",
+      },
+      {
+        icon: <CodeIcon />,
+        title: "API Reference",
+        description: "Complete reference for every endpoint and type.",
+        href: "/docs",
+      },
+      {
+        icon: <WebhookIcon />,
+        title: "Webhooks",
+        description: "Listen to events and build real-time integrations.",
+        href: "/docs",
+      },
+    ]}
+  />
+</BrowserWindow>
 
 ```tsx
 <LandingPage

--- a/docs/pages/docs/components/landing-page.mdx
+++ b/docs/pages/docs/components/landing-page.mdx
@@ -1,0 +1,276 @@
+---
+title: Landing Page
+sidebar_icon: layout-template
+---
+
+import { LandingPage } from "zudoku/components";
+import { BookOpenIcon, CodeIcon, KeyIcon, RocketIcon, WebhookIcon, ZapIcon } from "zudoku/icons";
+
+A ready-made, customizable landing page for your developer portal. It comes in three variants
+covering the most common layouts: a centered hero, a two-column split hero, and a compact
+documentation hub.
+
+Use it as the `element` of a [custom page](/docs/custom-pages) — typically your home page:
+
+```tsx title=zudoku.config.tsx
+import { LandingPage } from "zudoku/components";
+
+const config = {
+  navigation: [
+    {
+      type: "custom-page",
+      path: "/",
+      element: (
+        <LandingPage
+          title="Build with our API"
+          description="Everything you need to integrate in minutes."
+          actions={[
+            { label: "Get started", href: "/getting-started" },
+            { label: "API Reference", href: "/api" },
+          ]}
+        />
+      ),
+    },
+    // ...
+  ],
+};
+```
+
+## Import
+
+```tsx
+import { LandingPage } from "zudoku/components";
+```
+
+## Variants
+
+### Hero (default)
+
+A centered hero with call-to-action buttons and an optional feature grid below. The classic landing
+page for product-focused portals.
+
+<LandingPage
+  eyebrow="Developer Platform"
+  title="Build with our API"
+  description="Everything you need to integrate payments, webhooks, and more — in minutes, not days."
+  actions={[
+    { label: "Get started", href: "/docs/getting-started" },
+    { label: "API Reference", href: "/docs", variant: "outline" },
+  ]}
+  features={[
+    {
+      icon: <ZapIcon />,
+      title: "Fast integration",
+      description: "Go from zero to your first API call in under five minutes.",
+    },
+    {
+      icon: <KeyIcon />,
+      title: "API keys built in",
+      description: "Issue, rotate, and revoke keys right from the portal.",
+    },
+    {
+      icon: <WebhookIcon />,
+      title: "Webhooks",
+      description: "Subscribe to events and react to changes in real time.",
+    },
+  ]}
+/>
+
+```tsx
+<LandingPage
+  eyebrow="Developer Platform"
+  title="Build with our API"
+  description="Everything you need to integrate payments, webhooks, and more — in minutes, not days."
+  actions={[
+    { label: "Get started", href: "/getting-started" },
+    { label: "API Reference", href: "/api", variant: "outline" },
+  ]}
+  features={[
+    {
+      icon: <ZapIcon />,
+      title: "Fast integration",
+      description: "Go from zero to your first API call in under five minutes.",
+    },
+    {
+      icon: <KeyIcon />,
+      title: "API keys built in",
+      description: "Issue, rotate, and revoke keys right from the portal.",
+    },
+    {
+      icon: <WebhookIcon />,
+      title: "Webhooks",
+      description: "Subscribe to events and react to changes in real time.",
+    },
+  ]}
+/>
+```
+
+### Split
+
+A two-column hero with your own content on the side — an illustration, screenshot, or code sample
+passed via the `aside` prop. A great fit for developer-oriented portals that want to show code up
+front.
+
+<LandingPage
+  variant="split"
+  eyebrow="Shipping API"
+  title="Ship anywhere in the whole universe"
+  description="Create and manage shipments, track packages in real-time, and integrate with multiple carriers through a single interface."
+  actions={[
+    { label: "Get started", href: "/docs/getting-started" },
+    { label: "View on GitHub", href: "https://github.com/zuplo/zudoku", variant: "outline" },
+  ]}
+  aside={
+    <div className="rounded-xl border bg-card p-4 font-mono text-sm">
+      <pre>{`curl https://api.example.com/v1/shipments \\
+  -H "Authorization: Bearer sk_live_..." \\
+  -d destination="alpha-centauri"`}</pre>
+    </div>
+  }
+/>
+
+```tsx
+<LandingPage
+  variant="split"
+  eyebrow="Shipping API"
+  title="Ship anywhere in the whole universe"
+  description="Create and manage shipments, track packages in real-time, and integrate with multiple carriers through a single interface."
+  actions={[
+    { label: "Get started", href: "/getting-started" },
+    {
+      label: "View on GitHub",
+      href: "https://github.com/zuplo/zudoku",
+      variant: "outline",
+    },
+  ]}
+  aside={
+    <div className="rounded-xl border bg-card p-4 font-mono text-sm">
+      <pre>{`curl https://api.example.com/v1/shipments \\
+  -H "Authorization: Bearer sk_live_..." \\
+  -d destination="alpha-centauri"`}</pre>
+    </div>
+  }
+/>
+```
+
+The `aside` accepts any React node — use an `<img />` for an illustration instead of code:
+
+```tsx
+<LandingPage
+  variant="split"
+  title="Ship anywhere"
+  aside={<img src="/hero.webp" alt="Hero" className="rounded-3xl" />}
+/>
+```
+
+### Grid
+
+A compact header followed by prominent, clickable feature cards. Ideal as a documentation hub that
+routes visitors to the right section quickly.
+
+<LandingPage
+  variant="grid"
+  title="Documentation"
+  description="Explore guides, API references, and examples to get the most out of the platform."
+  features={[
+    {
+      icon: <RocketIcon />,
+      title: "Getting Started",
+      description: "Set up your account and make your first request.",
+      href: "/docs/getting-started",
+    },
+    {
+      icon: <BookOpenIcon />,
+      title: "Guides",
+      description: "Step-by-step tutorials for common use cases.",
+      href: "/docs",
+    },
+    {
+      icon: <CodeIcon />,
+      title: "API Reference",
+      description: "Complete reference for every endpoint and type.",
+      href: "/docs",
+    },
+    {
+      icon: <WebhookIcon />,
+      title: "Webhooks",
+      description: "Listen to events and build real-time integrations.",
+      href: "/docs",
+    },
+  ]}
+/>
+
+```tsx
+<LandingPage
+  variant="grid"
+  title="Documentation"
+  description="Explore guides, API references, and examples to get the most out of the platform."
+  features={[
+    {
+      icon: <RocketIcon />,
+      title: "Getting Started",
+      description: "Set up your account and make your first request.",
+      href: "/getting-started",
+    },
+    {
+      icon: <BookOpenIcon />,
+      title: "Guides",
+      description: "Step-by-step tutorials for common use cases.",
+      href: "/guides",
+    },
+    {
+      icon: <CodeIcon />,
+      title: "API Reference",
+      description: "Complete reference for every endpoint and type.",
+      href: "/api",
+    },
+    {
+      icon: <WebhookIcon />,
+      title: "Webhooks",
+      description: "Listen to events and build real-time integrations.",
+      href: "/webhooks",
+    },
+  ]}
+/>
+```
+
+## Props
+
+| Prop          | Type                          | Description                                                                                      |
+| ------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ |
+| `variant`     | `"hero" \| "split" \| "grid"` | Layout variant. Defaults to `"hero"`.                                                            |
+| `title`       | `ReactNode`                   | Main headline. Required.                                                                         |
+| `eyebrow`     | `ReactNode`                   | Short label displayed above the title.                                                           |
+| `description` | `ReactNode`                   | Supporting text below the title.                                                                 |
+| `actions`     | `LandingPageAction[]`         | Call-to-action buttons. Each action has `label`, `href`, and an optional Button `variant`.       |
+| `features`    | `LandingPageFeature[]`        | Feature cards with optional `icon`, `title`, `description`, and `href` (making the card a link). |
+| `aside`       | `ReactNode`                   | Side content for the `split` variant (image, code sample, …).                                    |
+| `children`    | `ReactNode`                   | Additional content rendered below the built-in sections.                                         |
+| `className`   | `string`                      | Additional classes for the outer `<section>`.                                                    |
+
+### Links
+
+`href` values in `actions` and `features` are rendered as client-side router links for internal
+paths (e.g. `/getting-started`) and as regular links opening in a new tab for external URLs (e.g.
+`https://github.com/...`).
+
+## Customization
+
+- **Buttons**: The first action defaults to the primary button style, all following actions to
+  `outline`. Override per action with `variant` (any [Button](/docs/components/button) variant).
+- **Rich titles**: `title`, `description`, and `eyebrow` accept any React node, so you can use
+  custom markup like highlighted words:
+  `title={<>Ship <span className="text-primary">faster</span></>}`.
+- **Extra sections**: Pass `children` to append your own sections (testimonials, pricing, …) below
+  the built-in layout.
+- **Page metadata**: Combine with the [Head](/docs/components/head) component to set the page title:
+
+```tsx
+import { Head, LandingPage } from "zudoku/components";
+
+<LandingPage title="Build with our API">
+  <Head>
+    <title>Home</title>
+  </Head>
+</LandingPage>;
+```

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -163,6 +163,7 @@ export const components: Navigation = [
       "docs/components/alert",
       "docs/components/callout",
       "docs/components/badge",
+      "docs/components/browser-window",
       "docs/components/card",
       "docs/components/icons",
       "docs/components/landing-page",

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -165,6 +165,7 @@ export const components: Navigation = [
       "docs/components/badge",
       "docs/components/card",
       "docs/components/icons",
+      "docs/components/landing-page",
       "docs/components/markdown",
       "docs/components/typography",
     ],

--- a/packages/zudoku/src/lib/components/BrowserWindow.test.tsx
+++ b/packages/zudoku/src/lib/components/BrowserWindow.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BrowserWindow } from "./BrowserWindow.js";
+
+describe("BrowserWindow", () => {
+  it("renders children and the default url", () => {
+    render(
+      <BrowserWindow>
+        <div>Page content</div>
+      </BrowserWindow>,
+    );
+
+    expect(screen.getByText("Page content")).toBeDefined();
+    expect(screen.getByText("localhost:3000")).toBeDefined();
+  });
+
+  it("renders a custom url", () => {
+    render(
+      <BrowserWindow url="https://api.example.com">
+        <div>Content</div>
+      </BrowserWindow>,
+    );
+
+    expect(screen.getByText("https://api.example.com")).toBeDefined();
+  });
+
+  it("shows the current scale as a percentage", () => {
+    render(
+      <BrowserWindow scale={0.75}>
+        <div>Content</div>
+      </BrowserWindow>,
+    );
+
+    expect(screen.getByText("75%")).toBeDefined();
+  });
+
+  it("steps through zoom levels with the zoom buttons", () => {
+    render(
+      <BrowserWindow>
+        <div>Content</div>
+      </BrowserWindow>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    expect(screen.getByText("110%")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+    fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+    expect(screen.getByText("90%")).toBeDefined();
+  });
+
+  it("resets to the initial scale when clicking the percentage", () => {
+    render(
+      <BrowserWindow scale={0.75}>
+        <div>Content</div>
+      </BrowserWindow>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    expect(screen.getByText("80%")).toBeDefined();
+
+    fireEvent.click(screen.getByTitle("Reset zoom"));
+    expect(screen.getByText("75%")).toBeDefined();
+  });
+
+  it("disables the zoom buttons at the zoom limits", () => {
+    render(
+      <BrowserWindow scale={0.25}>
+        <div>Content</div>
+      </BrowserWindow>,
+    );
+
+    const zoomOut = screen.getByRole("button", { name: "Zoom out" });
+    expect(zoomOut.hasAttribute("disabled")).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Zoom in" }).hasAttribute("disabled"),
+    ).toBe(false);
+  });
+});

--- a/packages/zudoku/src/lib/components/BrowserWindow.tsx
+++ b/packages/zudoku/src/lib/components/BrowserWindow.tsx
@@ -1,0 +1,124 @@
+import { MinusIcon, PlusIcon } from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Button } from "../ui/Button.js";
+import { cn } from "../util/cn.js";
+
+// Zoom steps as found in real browsers
+const ZOOM_LEVELS = [
+  0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2,
+];
+const MIN_ZOOM = Math.min(...ZOOM_LEVELS);
+const MAX_ZOOM = Math.max(...ZOOM_LEVELS);
+
+export type BrowserWindowProps = {
+  /** Address displayed in the URL bar */
+  url?: string;
+  /** Initial zoom applied to the content (e.g. `0.75` for 75%) */
+  scale?: number;
+  className?: string;
+  /** Additional classes for the content viewport */
+  contentClassName?: string;
+  children: ReactNode;
+};
+
+export const BrowserWindow = ({
+  url = "localhost:3000",
+  scale: initialScale = 1,
+  className,
+  contentClassName,
+  children,
+}: BrowserWindowProps) => {
+  const [scale, setScale] = useState(initialScale);
+  const [contentHeight, setContentHeight] = useState<number>();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() =>
+      setContentHeight(content.offsetHeight),
+    );
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
+
+  const zoomIn = () =>
+    setScale((current) => ZOOM_LEVELS.find((l) => l > current) ?? current);
+  const zoomOut = () =>
+    setScale(
+      (current) => ZOOM_LEVELS.filter((l) => l < current).at(-1) ?? current,
+    );
+
+  return (
+    <div
+      className={cn(
+        "not-prose overflow-hidden rounded-xl border bg-background shadow-sm",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3 border-b bg-muted/50 px-4 py-2.5">
+        <div className="flex gap-1.5">
+          <span className="size-3 rounded-full bg-red-400" />
+          <span className="size-3 rounded-full bg-yellow-400" />
+          <span className="size-3 rounded-full bg-green-400" />
+        </div>
+        <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border bg-background px-3 text-xs text-muted-foreground">
+          <span className="truncate">{url}</span>
+        </div>
+        <div className="flex items-center">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={zoomOut}
+            disabled={scale <= MIN_ZOOM}
+            aria-label="Zoom out"
+          >
+            <MinusIcon />
+          </Button>
+          <button
+            type="button"
+            onClick={() => setScale(initialScale)}
+            title="Reset zoom"
+            className="w-11 text-center text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {Math.round(scale * 100)}%
+          </button>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={zoomIn}
+            disabled={scale >= MAX_ZOOM}
+            aria-label="Zoom in"
+          >
+            <PlusIcon />
+          </Button>
+        </div>
+      </div>
+      <div
+        className="overflow-hidden"
+        style={
+          scale !== 1 && contentHeight != null
+            ? { height: contentHeight * scale }
+            : undefined
+        }
+      >
+        <div
+          ref={contentRef}
+          className={contentClassName}
+          style={
+            scale !== 1
+              ? {
+                  width: `${100 / scale}%`,
+                  transform: `scale(${scale})`,
+                  transformOrigin: "top left",
+                }
+              : undefined
+          }
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/zudoku/src/lib/components/LandingPage.test.tsx
+++ b/packages/zudoku/src/lib/components/LandingPage.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+import { LandingPage, type LandingPageProps } from "./LandingPage.js";
+
+const renderLandingPage = (props: LandingPageProps) => {
+  const router = createMemoryRouter(
+    [{ path: "/", element: <LandingPage {...props} /> }],
+    { initialEntries: ["/"] },
+  );
+  return render(<RouterProvider router={router} />);
+};
+
+describe("LandingPage", () => {
+  it("renders title, eyebrow, description, and features in the hero variant", () => {
+    renderLandingPage({
+      eyebrow: "Developer Platform",
+      title: "Build with our API",
+      description: "Everything you need",
+      features: [{ title: "Fast integration", description: "Quick start" }],
+    });
+
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+      "Build with our API",
+    );
+    expect(screen.getByText("Developer Platform")).toBeDefined();
+    expect(screen.getByText("Everything you need")).toBeDefined();
+    expect(screen.getByText("Fast integration")).toBeDefined();
+    expect(screen.getByText("Quick start")).toBeDefined();
+  });
+
+  it("renders internal actions as router links and external actions in a new tab", () => {
+    renderLandingPage({
+      title: "Title",
+      actions: [
+        { label: "Get started", href: "/getting-started" },
+        { label: "GitHub", href: "https://github.com/zuplo/zudoku" },
+      ],
+    });
+
+    const internal = screen.getByRole("link", { name: "Get started" });
+    expect(internal.getAttribute("href")).toBe("/getting-started");
+    expect(internal.getAttribute("target")).toBeNull();
+
+    const external = screen.getByRole("link", { name: "GitHub" });
+    expect(external.getAttribute("href")).toBe(
+      "https://github.com/zuplo/zudoku",
+    );
+    expect(external.getAttribute("target")).toBe("_blank");
+    expect(external.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("renders non-http schemes as plain links without opening a new tab", () => {
+    renderLandingPage({
+      title: "Title",
+      actions: [{ label: "Email us", href: "mailto:support@example.com" }],
+    });
+
+    const link = screen.getByRole("link", { name: "Email us" });
+    expect(link.getAttribute("href")).toBe("mailto:support@example.com");
+    expect(link.getAttribute("target")).toBeNull();
+    expect(link.getAttribute("rel")).toBeNull();
+  });
+
+  it("renders aside content in the split variant", () => {
+    renderLandingPage({
+      variant: "split",
+      title: "Title",
+      aside: <div>Code sample</div>,
+    });
+
+    expect(screen.getByText("Code sample")).toBeDefined();
+  });
+
+  it("renders features as clickable cards in the grid variant", () => {
+    renderLandingPage({
+      variant: "grid",
+      title: "Docs",
+      features: [
+        { title: "Getting Started", href: "/getting-started" },
+        { title: "Plain card" },
+      ],
+    });
+
+    const card = screen.getByRole("link", { name: /Getting Started/ });
+    expect(card.getAttribute("href")).toBe("/getting-started");
+    expect(screen.getByText("Plain card")).toBeDefined();
+    expect(screen.queryByRole("link", { name: /Plain card/ })).toBeNull();
+  });
+
+  it("renders children below the built-in sections", () => {
+    renderLandingPage({
+      title: "Title",
+      children: <div>Custom section</div>,
+    });
+
+    expect(screen.getByText("Custom section")).toBeDefined();
+  });
+});

--- a/packages/zudoku/src/lib/components/LandingPage.tsx
+++ b/packages/zudoku/src/lib/components/LandingPage.tsx
@@ -39,7 +39,8 @@ export type LandingPageProps = {
   className?: string;
 };
 
-const isExternal = (href: string) => /^(https?:)?\/\//.test(href);
+// Anything with a scheme (https:, mailto:, tel:, …) or protocol-relative is not an internal route
+const isExternal = (href: string) => /^([a-z][a-z0-9+.-]*:|\/\/)/i.test(href);
 
 const SmartLink = ({
   href,
@@ -49,21 +50,27 @@ const SmartLink = ({
   href: string;
   className?: string;
   children: ReactNode;
-}) =>
-  isExternal(href) ? (
+}) => {
+  if (!isExternal(href)) {
+    return (
+      <Link to={href} className={className}>
+        {children}
+      </Link>
+    );
+  }
+
+  const opensNewTab = /^(https?:)?\/\//.test(href);
+  return (
     <a
       href={href}
-      target="_blank"
-      rel="noopener noreferrer"
+      target={opensNewTab ? "_blank" : undefined}
+      rel={opensNewTab ? "noopener noreferrer" : undefined}
       className={className}
     >
       {children}
     </a>
-  ) : (
-    <Link to={href} className={className}>
-      {children}
-    </Link>
   );
+};
 
 const Actions = ({
   actions,

--- a/packages/zudoku/src/lib/components/LandingPage.tsx
+++ b/packages/zudoku/src/lib/components/LandingPage.tsx
@@ -1,0 +1,240 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { Button, type ButtonProps } from "../ui/Button.js";
+import { cn } from "../util/cn.js";
+
+export type LandingPageAction = {
+  label: ReactNode;
+  /** Internal path (rendered as client-side link) or external URL (opens in a new tab) */
+  href: string;
+  variant?: ButtonProps["variant"];
+};
+
+export type LandingPageFeature = {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  /** Renders the feature as a clickable card linking to this path or URL */
+  href?: string;
+};
+
+export type LandingPageProps = {
+  /**
+   * - `hero`: centered hero with actions and a feature grid below (default)
+   * - `split`: two-column hero with custom content (image, code sample, …) on the side
+   * - `grid`: compact header with prominent feature cards, ideal as a documentation hub
+   */
+  variant?: "hero" | "split" | "grid";
+  /** Short label displayed above the title */
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  /** Call-to-action buttons. The first action uses the primary button style by default. */
+  actions?: LandingPageAction[];
+  features?: LandingPageFeature[];
+  /** Content displayed next to the text in the `split` variant */
+  aside?: ReactNode;
+  /** Additional content rendered below the page sections */
+  children?: ReactNode;
+  className?: string;
+};
+
+const isExternal = (href: string) => /^(https?:)?\/\//.test(href);
+
+const SmartLink = ({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className?: string;
+  children: ReactNode;
+}) =>
+  isExternal(href) ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
+      {children}
+    </a>
+  ) : (
+    <Link to={href} className={className}>
+      {children}
+    </Link>
+  );
+
+const Actions = ({
+  actions,
+  size = "xl",
+  className,
+}: {
+  actions?: LandingPageAction[];
+  size?: ButtonProps["size"];
+  className?: string;
+}) => {
+  if (!actions?.length) return null;
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-4", className)}>
+      {actions.map((action, index) => (
+        <Button
+          key={action.href}
+          size={size}
+          variant={action.variant ?? (index === 0 ? "default" : "outline")}
+          asChild
+        >
+          <SmartLink href={action.href}>{action.label}</SmartLink>
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+const FeatureGrid = ({
+  features,
+  prominent,
+}: {
+  features?: LandingPageFeature[];
+  prominent?: boolean;
+}) => {
+  if (!features?.length) return null;
+
+  return (
+    <div
+      className={cn(
+        "grid gap-4 sm:grid-cols-2",
+        prominent ? "lg:gap-5" : "lg:grid-cols-3",
+      )}
+    >
+      {features.map((feature, index) => {
+        const content = (
+          <>
+            {feature.icon && (
+              <div className="mb-3 flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary [&_svg]:size-5">
+                {feature.icon}
+              </div>
+            )}
+            <div className="font-semibold">{feature.title}</div>
+            {feature.description && (
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                {feature.description}
+              </p>
+            )}
+          </>
+        );
+        const classes = cn(
+          "rounded-xl border bg-card p-5 text-card-foreground",
+          prominent && "p-6",
+          feature.href &&
+            "transition-colors hover:border-primary/50 hover:bg-muted/50",
+        );
+
+        return feature.href ? (
+          <SmartLink key={feature.href} href={feature.href} className={classes}>
+            {content}
+          </SmartLink>
+        ) : (
+          // biome-ignore lint/suspicious/noArrayIndexKey: Stable because it's statically defined in the config
+          <div key={index} className={classes}>
+            {content}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const Eyebrow = ({ children }: { children: ReactNode }) =>
+  children ? (
+    <span className="text-sm font-semibold uppercase tracking-wider text-primary">
+      {children}
+    </span>
+  ) : null;
+
+export const LandingPage = ({
+  variant = "hero",
+  eyebrow,
+  title,
+  description,
+  actions,
+  features,
+  aside,
+  children,
+  className,
+}: LandingPageProps) => {
+  if (variant === "split") {
+    return (
+      <section
+        className={cn(
+          "not-prose flex flex-col gap-12 py-10 lg:py-16",
+          className,
+        )}
+      >
+        <div className="grid items-center gap-10 lg:grid-cols-2 lg:gap-16">
+          <div className="flex flex-col items-start gap-6">
+            <Eyebrow>{eyebrow}</Eyebrow>
+            <h1 className="text-4xl font-extrabold tracking-tight text-balance md:text-5xl">
+              {title}
+            </h1>
+            {description && (
+              <p className="text-lg text-muted-foreground">{description}</p>
+            )}
+            <Actions actions={actions} />
+          </div>
+          {aside && <div className="w-full">{aside}</div>}
+        </div>
+        <FeatureGrid features={features} />
+        {children}
+      </section>
+    );
+  }
+
+  if (variant === "grid") {
+    return (
+      <section
+        className={cn(
+          "not-prose flex flex-col gap-10 py-8 lg:py-12",
+          className,
+        )}
+      >
+        <div className="flex flex-col items-start gap-4">
+          <Eyebrow>{eyebrow}</Eyebrow>
+          <h1 className="text-3xl font-bold tracking-tight text-balance md:text-4xl">
+            {title}
+          </h1>
+          {description && (
+            <p className="max-w-2xl text-lg text-muted-foreground">
+              {description}
+            </p>
+          )}
+          <Actions actions={actions} size="default" className="gap-2" />
+        </div>
+        <FeatureGrid features={features} prominent />
+        {children}
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className={cn("not-prose flex flex-col gap-16 py-12 lg:py-20", className)}
+    >
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
+        <Eyebrow>{eyebrow}</Eyebrow>
+        <h1 className="text-4xl font-extrabold tracking-tight text-balance md:text-5xl xl:text-6xl">
+          {title}
+        </h1>
+        {description && (
+          <p className="text-lg text-muted-foreground md:text-xl">
+            {description}
+          </p>
+        )}
+        <Actions actions={actions} className="justify-center" />
+      </div>
+      <FeatureGrid features={features} />
+      {children}
+    </section>
+  );
+};

--- a/packages/zudoku/src/lib/components/index.ts
+++ b/packages/zudoku/src/lib/components/index.ts
@@ -7,6 +7,12 @@ export { ZudokuError } from "../util/invariant.js";
 export { CategoryHeading } from "./CategoryHeading.js";
 export { ClientOnly } from "./ClientOnly.js";
 export { Heading } from "./Heading.js";
+export {
+  LandingPage,
+  type LandingPageAction,
+  type LandingPageFeature,
+  type LandingPageProps,
+} from "./LandingPage.js";
 export { Markdown } from "./Markdown.js";
 export { Search } from "./Search.js";
 export { type CustomSlotNames, Slot } from "./Slot.js";

--- a/packages/zudoku/src/lib/components/index.ts
+++ b/packages/zudoku/src/lib/components/index.ts
@@ -1,6 +1,7 @@
 export { Head } from "@unhead/react";
 export { Link } from "react-router";
 export { Anchor } from "./Anchor.js";
+export { BrowserWindow, type BrowserWindowProps } from "./BrowserWindow.js";
 export { Button } from "../ui/Button.js";
 export { Callout } from "../ui/Callout.js";
 export { ZudokuError } from "../util/invariant.js";


### PR DESCRIPTION
## Summary

Adds two reusable, documented components to `zudoku/components`:

### `LandingPage`

A customizable landing page for building developer portal home pages, with three layout variants covering the most common landing page patterns:

- **`hero`** (default): centered headline with eyebrow, description, CTA buttons, and a 3-column feature grid below
- **`split`**: two-column hero with custom content (code sample, screenshot, illustration) passed via the `aside` prop
- **`grid`**: compact header with prominent, clickable feature cards — ideal as a documentation hub

Everything is driven by structured props (`title`, `eyebrow`, `description`, `actions`, `features`, `aside`, `children`, `className`), so users can build a landing page from `zudoku.config.tsx` without writing layout code:

```tsx
{
  type: "custom-page",
  path: "/",
  element: (
    <LandingPage
      title="Build with our API"
      description="Everything you need to integrate in minutes."
      actions={[
        { label: "Get started", href: "/getting-started" },
        { label: "API Reference", href: "/api" },
      ]}
    />
  ),
}
```

Details:

- `href`s in actions and feature cards render as client-side router links for internal paths and as plain links for any URL with a scheme (`https:`, `mailto:`, `tel:`, …); http(s) links open in a new tab
- First action defaults to the primary button style, subsequent ones to `outline`; overridable per action with any `Button` variant
- `title`/`description`/`eyebrow` accept any `ReactNode`; `children` appends custom sections below

### `BrowserWindow`

A mock browser window for presenting UI previews in documentation. It frames its children in browser-style chrome (traffic lights + URL bar) with a working zoom control:

- `scale` prop sets the initial zoom (e.g. `0.75`)
- The current scale is displayed like in a real browser; readers can change it via `+`/`-` buttons (stepping through real browser zoom levels, 25%–200%) or click the percentage to reset
- Content is laid out at compensated width (`100/scale%`) and scaled down, so responsive layouts behave as if viewed on a larger screen; the viewport height tracks the scaled content via `ResizeObserver`

## Documentation

- `docs/pages/docs/components/landing-page.mdx` — live previews of all three variants (presented inside `BrowserWindow` frames at 75%), props table, customization guide
- `docs/pages/docs/components/browser-window.mdx` — usage, scale, and URL examples with live previews
- Both registered in the "General" category of the components sidebar

## Testing

- Unit tests for both components (`LandingPage.test.tsx`, `BrowserWindow.test.tsx`) covering variants, link handling, zoom stepping/reset/limits — `LandingPage.tsx` at 100% line coverage
- `pnpm -F zudoku typecheck`, biome, and oxfmt pass
- Full docs site builds and prerenders successfully; zoom interactivity verified in the built site via headless browser

https://claude.ai/code/session_0158XwVMbie39KUJKyKXWDMX