### PR TITLE
feat: toggle sidebar categories by clicking the whole row

### DIFF
--- a/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
@@ -106,8 +106,9 @@ const NavigationCategoryInner = ({
       onOpenChange={(value) => {
         // Categories with a link navigate on row click, so they only open here
         // (closing is done via the chevron). Without a link the row toggles.
-        setOpen(category.link ? true : value);
-        setHasInteracted(true);
+        const nextOpen = category.link ? true : value;
+        if (nextOpen !== open) setHasInteracted(true);
+        setOpen(nextOpen);
       }}
     >
       <Collapsible.Trigger className="group" asChild disabled={!isCollapsible}>

--- a/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
@@ -103,7 +103,12 @@ const NavigationCategoryInner = ({
       className="flex flex-col"
       defaultOpen={isDefaultOpen}
       open={open}
-      onOpenChange={() => setOpen(true)}
+      onOpenChange={(value) => {
+        // Categories with a link navigate on row click, so they only open here
+        // (closing is done via the chevron). Without a link the row toggles.
+        setOpen(category.link ? true : value);
+        setHasInteracted(true);
+      }}
     >
       <Collapsible.Trigger className="group" asChild disabled={!isCollapsible}>
         {category.link ? (


### PR DESCRIPTION
## Summary

Clicking anywhere on a sidebar category row now toggles it open/closed — previously the row could only *open* a category and collapsing required clicking the chevron.

- **Categories without a link** (the common case): the whole row toggles open ↔ closed.
- **Categories with a link**: unchanged — clicking the row navigates and opens; collapsing stays on the chevron, since a row click can't both navigate and close.
- Row clicks now also trigger the expand/collapse animation (previously only the chevron did).

## Implementation

The row was already the `Collapsible.Trigger`, but `onOpenChange` ignored the toggle value and forced `setOpen(true)`. It now respects the toggle when the category has no link, and sets `hasInteracted` so the animation plays.

## Testing

Verified in the browser against the cosmo-cargo example:
- No-link category: row click expands, second click collapses; chevron still toggles independently.
- Link category: row click navigates + opens, stays open on repeat clicks; chevron collapses without navigating.
- `pnpm -F zudoku typecheck` and `pnpm biome ci` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)