### PR TITLE
Only show BrowserWindow zoom control when a scale is passed

### DIFF
--- a/docs/pages/docs/components/browser-window.mdx
+++ b/docs/pages/docs/components/browser-window.mdx
@@ -7,7 +7,7 @@ import { BrowserWindow } from "zudoku/components";
 import { Button } from "zudoku/ui/Button";
 
 A mock browser window for presenting UI previews, screenshots-as-code, or full page layouts in your
-documentation. It renders its children inside a browser-style frame with a URL bar and a working
+documentation. It renders its children inside a browser-style frame with a URL bar and an optional
 zoom control — the current scale is displayed like in a real browser and readers can zoom in and out
 themselves.
 
@@ -40,9 +40,11 @@ import { BrowserWindow } from "zudoku/components";
 ## Scale
 
 Use the `scale` prop to set the initial zoom of the content. This is useful for presenting
-full-width layouts, like a landing page, at a reduced size. The zoom control in the toolbar shows
-the current scale — readers can change it with the `+`/`-` buttons or click the percentage to reset
-it, just like in a real browser.
+full-width layouts, like a landing page, at a reduced size. Passing a `scale` enables the zoom
+control in the toolbar showing the current scale — readers can change it with the `+`/`-` buttons or
+click the percentage to reset it, just like in a real browser. Without a `scale`, the zoom control
+is hidden and the content renders at full size (pass `scale={1}` to start at 100% with the control
+enabled).
 
 <BrowserWindow scale={0.5}>
   <div className="flex flex-col items-center gap-3 p-10 text-center">
@@ -83,10 +85,10 @@ Set the `url` prop to change the address shown in the URL bar (defaults to `loca
 
 ## Props
 
-| Prop               | Type        | Description                                                         |
-| ------------------ | ----------- | ------------------------------------------------------------------- |
-| `url`              | `string`    | Address displayed in the URL bar. Defaults to `localhost:3000`.     |
-| `scale`            | `number`    | Initial zoom of the content (e.g. `0.75` for 75%). Defaults to `1`. |
-| `className`        | `string`    | Additional classes for the outer frame.                             |
-| `contentClassName` | `string`    | Additional classes for the content viewport.                        |
-| `children`         | `ReactNode` | The content rendered inside the browser window.                     |
+| Prop               | Type        | Description                                                                                                                                      |
+| ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `url`              | `string`    | Address displayed in the URL bar. Defaults to `localhost:3000`.                                                                                  |
+| `scale`            | `number`    | Initial zoom of the content (e.g. `0.75` for 75%). Enables the zoom control; if omitted, the control is hidden and content renders at full size. |
+| `className`        | `string`    | Additional classes for the outer frame.                                                                                                          |
+| `contentClassName` | `string`    | Additional classes for the content viewport.                                                                                                     |
+| `children`         | `ReactNode` | The content rendered inside the browser window.                                                                                                  |

--- a/packages/zudoku/src/lib/components/BrowserWindow.test.tsx
+++ b/packages/zudoku/src/lib/components/BrowserWindow.test.tsx
@@ -38,9 +38,21 @@ describe("BrowserWindow", () => {
     expect(screen.getByText("75%")).toBeDefined();
   });
 
-  it("steps through zoom levels with the zoom buttons", () => {
+  it("hides the zoom control when no scale is passed", () => {
     render(
       <BrowserWindow>
+        <div>Content</div>
+      </BrowserWindow>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Zoom in" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Zoom out" })).toBeNull();
+    expect(screen.queryByTitle("Reset zoom")).toBeNull();
+  });
+
+  it("steps through zoom levels with the zoom buttons", () => {
+    render(
+      <BrowserWindow scale={1}>
         <div>Content</div>
       </BrowserWindow>,
     );

--- a/packages/zudoku/src/lib/components/BrowserWindow.tsx
+++ b/packages/zudoku/src/lib/components/BrowserWindow.tsx
@@ -13,7 +13,10 @@ const MAX_ZOOM = Math.max(...ZOOM_LEVELS);
 export type BrowserWindowProps = {
   /** Address displayed in the URL bar */
   url?: string;
-  /** Initial zoom applied to the content (e.g. `0.75` for 75%) */
+  /**
+   * Initial zoom applied to the content (e.g. `0.75` for 75%).
+   * The zoom control is only shown when a value is passed.
+   */
   scale?: number;
   className?: string;
   /** Additional classes for the content viewport */
@@ -23,12 +26,12 @@ export type BrowserWindowProps = {
 
 export const BrowserWindow = ({
   url = "localhost:3000",
-  scale: initialScale = 1,
+  scale: initialScale,
   className,
   contentClassName,
   children,
 }: BrowserWindowProps) => {
-  const [scale, setScale] = useState(initialScale);
+  const [scale, setScale] = useState(initialScale ?? 1);
   const [contentHeight, setContentHeight] = useState<number>();
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -66,34 +69,36 @@ export const BrowserWindow = ({
         <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border bg-background px-3 text-xs text-muted-foreground">
           <span className="truncate">{url}</span>
         </div>
-        <div className="flex items-center">
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            onClick={zoomOut}
-            disabled={scale <= MIN_ZOOM}
-            aria-label="Zoom out"
-          >
-            <MinusIcon />
-          </Button>
-          <button
-            type="button"
-            onClick={() => setScale(initialScale)}
-            title="Reset zoom"
-            className="w-11 text-center text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {Math.round(scale * 100)}%
-          </button>
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            onClick={zoomIn}
-            disabled={scale >= MAX_ZOOM}
-            aria-label="Zoom in"
-          >
-            <PlusIcon />
-          </Button>
-        </div>
+        {initialScale != null && (
+          <div className="flex items-center">
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={zoomOut}
+              disabled={scale <= MIN_ZOOM}
+              aria-label="Zoom out"
+            >
+              <MinusIcon />
+            </Button>
+            <button
+              type="button"
+              onClick={() => setScale(initialScale)}
+              title="Reset zoom"
+              className="w-11 text-center text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {Math.round(scale * 100)}%
+            </button>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={zoomIn}
+              disabled={scale >= MAX_ZOOM}
+              aria-label="Zoom in"
+            >
+              <PlusIcon />
+            </Button>
+          </div>
+        )}
       </div>
       <div
         className="overflow-hidden"


### PR DESCRIPTION
## Summary

Follow-up to #2592: the `BrowserWindow` zoom control is now opt-in. It only renders when a `scale` value is explicitly passed — without one, the toolbar shows just the traffic lights and URL bar, and the content renders at full size.

- `scale` no longer defaults to `1`; the prop now both sets the initial zoom and enables the zoom control
- Passing `scale={1}` starts at 100% with the control enabled
- Docs updated to describe the new behavior (intro, Scale section, props table)

## Testing

- New test asserting the zoom control (buttons + percentage) is hidden when no `scale` is passed; existing zoom tests updated to pass an explicit `scale` — all 7 `BrowserWindow` tests pass
- `pnpm -F zudoku typecheck`, biome, and oxfmt pass

https://claude.ai/code/session_0158XwVMbie39KUJKyKXWDMX

---
_Generated by [Claude Code](https://claude.ai/code/session_0158XwVMbie39KUJKyKXWDMX)_