### PR TITLE
fix(auth): restore session tokens after full navigation in SSR mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,25 @@ responses/request bodies is passed as `JSONSchemaScalar`, which serializes the r
 through `handleCircularRefs()`. Media-type level `example`/`examples` are resolved into
 `ExampleItem` arrays by the GraphQL resolvers before reaching the client.
 
+## SSR and Module-Level State
+
+Most of `src/lib` and `src/app` is evaluated in BOTH the client bundle and the SSR bundle. On the
+server, module-level mutable state (`let`, singletons, the zustand stores) is shared across ALL
+requests and users for the lifetime of the process — never store per-request or per-user data there.
+Rules:
+
+- Per-request server state (auth, profile, tokens) must flow through request-scoped channels:
+  `resolveSsrAuth()` → `SSRAuthState` → `RenderContext` (see `entry.server.tsx`). The `authState`
+  zustand store is NOT trusted on the server; `hook.ts` reads from `RenderContext` instead.
+- Client-only side effects (writing auth state, fetch to same-origin endpoints, storage access) must
+  sit behind a `typeof window === "undefined"` guard, like `setupCookieSync` and the
+  `hydrateFromServerSession` call in `getAccessToken`. Module-level `let`s written only behind such
+  guards are fine: on the client they are per-tab state; on the server they stay at their initial
+  value.
+- The same applies to react-query: a module-level `QueryClient` rendered during SSR leaks one user's
+  cached data into another user's HTML. Create per-request clients on the server (`entry.server.tsx`
+  does) and dehydrate/hydrate instead.
+
 ## Polyfills
 
 `polyfills.ts` is a side-effect module imported in `main.tsx` and listed in `package.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENT.md
+AGENTS.md

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -9,13 +9,14 @@ import {
 import "vite/modulepreload-polyfill";
 import config from "virtual:zudoku-config";
 import { setupCookieSync } from "../lib/authentication/cookie-sync.js";
+import { SESSION_ENDPOINT_PATH } from "../lib/authentication/cookies.js";
 import { authState } from "../lib/authentication/state.js";
 import { BootstrapClient } from "../lib/components/Bootstrap.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { getRoutesByConfig, shikiReady } from "./main.js";
 
 if (import.meta.env.ZUDOKU_HAS_SERVER) {
-  setupCookieSync(authState, joinUrl(config.basePath, "/__z/auth/session"));
+  setupCookieSync(authState, joinUrl(config.basePath, SESSION_ENDPOINT_PATH));
 }
 
 const routes = getRoutesByConfig(config);

--- a/packages/zudoku/src/lib/authentication/cookie-sync.test.ts
+++ b/packages/zudoku/src/lib/authentication/cookie-sync.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { createStore } from "zustand";
-import { setupCookieSync, waitForSessionSync } from "./cookie-sync.js";
+import {
+  fetchServerSession,
+  setupCookieSync,
+  waitForSessionSync,
+} from "./cookie-sync.js";
 import type { UserProfile } from "./state.js";
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -307,5 +311,73 @@ describe("setupCookieSync", () => {
     resolveFetch(new Response(null, { status: 200 }));
     await wait;
     expect(settled).toBe(true);
+  });
+});
+
+describe("fetchServerSession", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns the session on 200", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ accessToken: "tok", expiresAt: 123 }),
+    );
+    await expect(fetchServerSession(ENDPOINT)).resolves.toEqual({
+      accessToken: "tok",
+      expiresAt: 123,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(ENDPOINT);
+  });
+
+  test("handles absent expiresAt", async () => {
+    fetchMock.mockResolvedValueOnce(Response.json({ accessToken: "tok" }));
+    await expect(fetchServerSession(ENDPOINT)).resolves.toEqual({
+      accessToken: "tok",
+    });
+  });
+
+  test("returns undefined on 401 (no session)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    await expect(fetchServerSession(ENDPOINT)).resolves.toBeUndefined();
+  });
+
+  test("returns undefined on 501 (provider opted out)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 501 }));
+    await expect(fetchServerSession(ENDPOINT)).resolves.toBeUndefined();
+  });
+
+  test("throws on malformed 200 so it isn't treated as logout", async () => {
+    fetchMock.mockResolvedValueOnce(Response.json({ unexpected: true }));
+    await expect(fetchServerSession(ENDPOINT)).rejects.toThrow("malformed");
+  });
+
+  test("does not POST a token that was just restored from the server", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ accessToken: "restored-token" }),
+    );
+    await fetchServerSession(ENDPOINT);
+
+    const store = createSlice({ isAuthenticated: true, profile: PROFILE });
+    setup(store);
+    store.setState({ providerData: { accessToken: "restored-token" } });
+    await flush();
+
+    // Only the session GET above; no cookie-sync POST for the same token.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws on transient failures so they aren't treated as logout", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 502 }));
+    await expect(fetchServerSession(ENDPOINT)).rejects.toThrow("502");
+
+    fetchMock.mockRejectedValueOnce(new TypeError("network down"));
+    await expect(fetchServerSession(ENDPOINT)).rejects.toThrow("network down");
   });
 });

--- a/packages/zudoku/src/lib/authentication/cookie-sync.ts
+++ b/packages/zudoku/src/lib/authentication/cookie-sync.ts
@@ -1,7 +1,16 @@
+import { z } from "zod/mini";
 import type { StoreApi } from "zustand";
 import type { AuthState } from "./state.js";
 
-type TokenBearer = { accessToken?: string; refreshToken?: string };
+const TokenBearerSchema = z.object({
+  accessToken: z.optional(z.string()),
+  refreshToken: z.optional(z.string()),
+});
+
+const ServerSessionSchema = z.object({
+  accessToken: z.string(),
+  expiresAt: z.optional(z.number()),
+});
 
 // Latest in-flight cookie sync, so a post-login redirect can await the cookie
 // write before navigating. Resolved by default. See redirectAfterAuth.
@@ -20,16 +29,32 @@ export const waitForSessionSync = async (): Promise<void> => {
   } while (awaited !== pendingSessionSync);
 };
 
-const readTokens = (providerData: unknown): TokenBearer => {
-  if (!providerData || typeof providerData !== "object") return {};
-  const data = providerData as Record<string, unknown>;
-  return {
-    accessToken:
-      typeof data.accessToken === "string" ? data.accessToken : undefined,
-    refreshToken:
-      typeof data.refreshToken === "string" ? data.refreshToken : undefined,
-  };
+// Access token the server itself just handed out via fetchServerSession.
+// POSTing it back would only re-set the cookie it came from, so the cookie
+// sync below skips it.
+let serverProvidedAccessToken: string | undefined;
+
+// Fetch the access token from the SSR session cookie. Returns undefined if no
+// valid session exists (401/501). Transient failures throw.
+export const fetchServerSession = async (sessionEndpoint: string) => {
+  const response = await fetch(sessionEndpoint);
+  if (response.status === 401 || response.status === 501) return;
+
+  if (!response.ok) {
+    throw new Error(`Session request failed with status ${response.status}`);
+  }
+
+  const parsed = ServerSessionSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error("Session response is malformed");
+  }
+
+  serverProvidedAccessToken = parsed.data.accessToken;
+  return parsed.data;
 };
+
+const readTokens = (providerData: unknown) =>
+  TokenBearerSchema.safeParse(providerData).data ?? {};
 
 // Mirror client auth state to SSR cookies so the next HTML render is authed
 // on first paint. Reads tokens off providerData. No-op on the server.
@@ -41,12 +66,10 @@ export const setupCookieSync = (
 ) => {
   if (typeof window === "undefined") return;
 
-  // In-flight controller so a later auth event can abort an earlier request.
-  // Without this, a logout can race a slow login and the late POST would
-  // re-establish the session after the user explicitly signed out.
+  // Abort earlier requests to prevent logout racing with slow login.
   let inflight: AbortController | undefined;
 
-  const send = (init: RequestInit) => {
+  const send = async (init: RequestInit) => {
     inflight?.abort();
     const controller = new AbortController();
     inflight = controller;
@@ -54,26 +77,31 @@ export const setupCookieSync = (
       () => controller.abort(),
       SESSION_SYNC_TIMEOUT_MS,
     );
-    return fetch(sessionEndpoint, {
-      ...init,
-      signal: controller.signal,
-    }).finally(() => clearTimeout(timeout));
+
+    try {
+      return await fetch(sessionEndpoint, {
+        ...init,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
   };
 
   const postSession = async (providerData: unknown) => {
     const { accessToken, refreshToken } = readTokens(providerData);
-    if (!accessToken) return;
+    if (!accessToken || accessToken === serverProvidedAccessToken) return;
 
     try {
-      const r = await send({
+      const response = await send({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ accessToken, refreshToken }),
       });
       // 501 = provider opted out of SSR auth; any other failure is surfaced.
-      if (!r.ok && r.status !== 501) {
+      if (!response.ok && response.status !== 501) {
         // biome-ignore lint/suspicious/noConsole: Surface SSR auth failures
-        console.error("SSR auth cookie sync failed:", r.status);
+        console.error("SSR auth cookie sync failed:", response.status);
       }
     } catch (e) {
       if ((e as Error)?.name === "AbortError") return;

--- a/packages/zudoku/src/lib/authentication/cookies.ts
+++ b/packages/zudoku/src/lib/authentication/cookies.ts
@@ -2,8 +2,9 @@ import type { UserProfile } from "./state.js";
 
 export const SESSION_ENDPOINT_PATH = "/__z/auth/session";
 
-// 1 hour fallback when the verifier omits expiresAt. Shared by the session
-// cookie max-age (server) and the restored token's expiry (client).
+// Session lifetime (seconds) when the verifier omits expiresAt, and the upper
+// bound for the session cookie max-age even when expiresAt is longer. Shared
+// by the session cookie (server) and the restored token's expiry (client).
 export const DEFAULT_SESSION_MAX_AGE = 60 * 60;
 export const ACCESS_TOKEN_COOKIE = "zudoku-access-token";
 export const REFRESH_TOKEN_COOKIE = "zudoku-refresh-token";

--- a/packages/zudoku/src/lib/authentication/cookies.ts
+++ b/packages/zudoku/src/lib/authentication/cookies.ts
@@ -1,5 +1,10 @@
 import type { UserProfile } from "./state.js";
 
+export const SESSION_ENDPOINT_PATH = "/__z/auth/session";
+
+// 1 hour fallback when the verifier omits expiresAt. Shared by the session
+// cookie max-age (server) and the restored token's expiry (client).
+export const DEFAULT_SESSION_MAX_AGE = 60 * 60;
 export const ACCESS_TOKEN_COOKIE = "zudoku-access-token";
 export const REFRESH_TOKEN_COOKIE = "zudoku-refresh-token";
 export const AUTH_PROFILE_COOKIE = "zudoku-auth-profile";

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -15,6 +15,8 @@ import { CoreAuthenticationPlugin } from "../AuthenticationPlugin.js";
 import { CallbackHandler } from "../components/CallbackHandler.js";
 import { LogoutCallbackHandler } from "../components/LogoutCallbackHandler.js";
 import { OAuthErrorPage } from "../components/OAuthErrorPage.js";
+import { fetchServerSession } from "../cookie-sync.js";
+import { DEFAULT_SESSION_MAX_AGE, SESSION_ENDPOINT_PATH } from "../cookies.js";
 import { AuthorizationError, OAuthAuthorizationError } from "../errors.js";
 import { type UserProfile, useAuthState } from "../state.js";
 import { redirectToSignUpUrl } from "./util.js";
@@ -83,6 +85,8 @@ export class OpenIDAuthenticationProvider
     "acr_values",
   ];
   private readonly allowInsecureRequests: boolean;
+  private readonly sessionEndpoint: string;
+  private serverSessionHydration?: Promise<OpenIdProviderData | undefined>;
 
   constructor({
     issuer,
@@ -108,6 +112,7 @@ export class OpenIDAuthenticationProvider
     this.issuer = issuer;
     // This is the callback URL for the OAuth provider. So it needs the base path.
     this.callbackUrlPath = joinUrl(basePath, OPENID_CALLBACK_PATH);
+    this.sessionEndpoint = joinUrl(basePath, SESSION_ENDPOINT_PATH);
     this.scopes = scopes ?? ["openid", "profile", "email"];
     this.allowInsecureRequests = allowInsecureRequests ?? false;
 
@@ -414,19 +419,72 @@ export class OpenIDAuthenticationProvider
     }
   }
 
+  // In SSR mode tokens live in httpOnly cookies and don't survive a full
+  // navigation. Restore the access token from the session endpoint and cache
+  // it as providerData so subsequent calls take the regular path.
+  private async restoreServerSession(): Promise<
+    OpenIdProviderData | undefined
+  > {
+    const session = await fetchServerSession(this.sessionEndpoint);
+    if (!session) return;
+
+    const expiresAt =
+      session.expiresAt ?? (await decodeJwtExp(session.accessToken));
+
+    const providerData: OpenIdProviderData = {
+      type: "openid",
+      accessToken: session.accessToken,
+      expiresOn: expiresAt
+        ? new Date(expiresAt * 1000)
+        : new Date(Date.now() + DEFAULT_SESSION_MAX_AGE * 1000),
+      tokenType: "Bearer",
+      claims: undefined,
+    };
+
+    useAuthState.setState({ providerData });
+
+    return providerData;
+  }
+
+  // Dedupe concurrent restores. Only a restored session stays cached: "no
+  // session" and failures clear the cache so a later call can pick up a
+  // session created in the meantime (e.g. login in another tab) or retry.
+  private hydrateFromServerSession() {
+    this.serverSessionHydration ??= this.restoreServerSession()
+      .then((providerData) => {
+        if (!providerData) this.serverSessionHydration = undefined;
+        return providerData;
+      })
+      .catch((e) => {
+        this.serverSessionHydration = undefined;
+        throw e;
+      });
+    return this.serverSessionHydration;
+  }
+
   async getAccessToken(): Promise<string> {
     const as = await this.getAuthServer();
     const { providerData, setLoggedOut } = useAuthState.getState();
 
+    let tokenState =
+      providerData &&
+      (providerData.type === "openid" || providerData.type === undefined)
+        ? providerData
+        : undefined;
+
     if (
-      !providerData ||
-      (providerData?.type !== "openid" && providerData?.type !== undefined)
+      !tokenState &&
+      import.meta.env.ZUDOKU_HAS_SERVER &&
+      typeof window !== "undefined"
     ) {
-      useAuthState.getState().setLoggedOut();
-      throw new AuthorizationError("Invalid or incompatible provider data");
+      tokenState = await this.hydrateFromServerSession();
     }
 
-    const tokenState = providerData;
+    // A missing session is a confirmed logout; transient failures threw above.
+    if (!tokenState) {
+      setLoggedOut();
+      throw new AuthorizationError("Invalid or incompatible provider data");
+    }
 
     if (new Date(tokenState.expiresOn) < new Date()) {
       if (!tokenState.refreshToken) {

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -446,19 +446,14 @@ export class OpenIDAuthenticationProvider
     return providerData;
   }
 
-  // Dedupe concurrent restores. Only a restored session stays cached: "no
-  // session" and failures clear the cache so a later call can pick up a
-  // session created in the meantime (e.g. login in another tab) or retry.
+  // Dedupes concurrent restores only: the cache is dropped once settled. A
+  // successful restore lives on in providerData, and anything else (no
+  // session, failure, a later logout clearing providerData) must re-check the
+  // cookie-backed session instead of reusing a stale result.
   private hydrateFromServerSession() {
-    this.serverSessionHydration ??= this.restoreServerSession()
-      .then((providerData) => {
-        if (!providerData) this.serverSessionHydration = undefined;
-        return providerData;
-      })
-      .catch((e) => {
-        this.serverSessionHydration = undefined;
-        throw e;
-      });
+    this.serverSessionHydration ??= this.restoreServerSession().finally(() => {
+      this.serverSessionHydration = undefined;
+    });
     return this.serverSessionHydration;
   }
 

--- a/packages/zudoku/src/lib/authentication/session-handler.test.ts
+++ b/packages/zudoku/src/lib/authentication/session-handler.test.ts
@@ -233,6 +233,77 @@ describe("sessionHandler POST", () => {
   });
 });
 
+describe("sessionHandler GET", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const get = (extraHeaders: Record<string, string> = {}) =>
+    new Request("http://localhost/", {
+      method: "GET",
+      headers: { "Sec-Fetch-Site": "same-origin", ...extraHeaders },
+    });
+
+  test("rejects cross-site GET", async () => {
+    const res = await handler.fetch(get({ "Sec-Fetch-Site": "cross-site" }));
+    expect(res.status).toBe(403);
+  });
+
+  test("returns 501 when provider has no verifier", async () => {
+    const res = await noProviderHandler.fetch(get());
+    expect(res.status).toBe(501);
+  });
+
+  test("returns 401 without a session cookie", async () => {
+    const res = await handler.fetch(get());
+    expect(res.status).toBe(401);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  test("returns the access token and expiry from the cookie", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    verifyAccessToken.mockResolvedValueOnce(verifierResult(nowSec + 120));
+    const res = await handler.fetch(
+      get({ cookie: "zudoku-access-token=tok123" }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.json()).toEqual({
+      accessToken: "tok123",
+      expiresAt: nowSec + 120,
+    });
+  });
+
+  test("never returns the refresh token", async () => {
+    verifyAccessToken.mockResolvedValueOnce(verifierResult());
+    const res = await handler.fetch(
+      get({ cookie: "zudoku-access-token=tok123; zudoku-refresh-token=rt" }),
+    );
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(await res.json())).not.toContain("rt");
+  });
+
+  test("clears cookies and returns 401 when the token no longer verifies", async () => {
+    verifyAccessToken.mockResolvedValueOnce(null);
+    const res = await handler.fetch(
+      get({ cookie: "zudoku-access-token=stale" }),
+    );
+    expect(res.status).toBe(401);
+    const cookies = res.headers.getSetCookie().join(";");
+    expect(cookies).toContain("zudoku-access-token=;");
+    expect(cookies).toContain("zudoku-refresh-token=;");
+    expect(cookies).toContain("zudoku-auth-profile=;");
+  });
+
+  test("returns 502 when verifier throws", async () => {
+    verifyAccessToken.mockRejectedValueOnce(new Error("jwks fetch failed"));
+    const res = await handler.fetch(
+      get({ cookie: "zudoku-access-token=tok123" }),
+    );
+    expect(res.status).toBe(502);
+  });
+});
+
 describe("sessionHandler DELETE", () => {
   test("clears all auth cookies when same-origin", async () => {
     const res = await handler.fetch(

--- a/packages/zudoku/src/lib/authentication/session-handler.ts
+++ b/packages/zudoku/src/lib/authentication/session-handler.ts
@@ -1,10 +1,11 @@
-import { Hono } from "hono";
-import { deleteCookie, setCookie } from "hono/cookie";
+import { type Context, Hono } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import type { CookieOptions } from "hono/utils/cookie";
 import type { VerifyAccessTokenResult } from "./authentication.js";
 import {
   ACCESS_TOKEN_COOKIE,
   AUTH_PROFILE_COOKIE,
+  DEFAULT_SESSION_MAX_AGE,
   REFRESH_TOKEN_COOKIE,
 } from "./cookies.js";
 
@@ -20,7 +21,6 @@ const baseCookieOptions: Omit<CookieOptions, "maxAge"> = {
 };
 
 const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
-const DEFAULT_SESSION_MAX_AGE = 60 * 60; // 1 hour fallback when verifier omits expiresAt
 
 const cookieMaxAge = (
   expiresAt: number | undefined,
@@ -33,6 +33,12 @@ const cookieMaxAge = (
 
 const MAX_COOKIE_SIZE = 3900; // Leave margin under 4096 browser limit
 const MAX_BODY_SIZE = 64 * 1024;
+
+const clearAuthCookies = (c: Context) => {
+  deleteCookie(c, ACCESS_TOKEN_COOKIE, baseCookieOptions);
+  deleteCookie(c, REFRESH_TOKEN_COOKIE, baseCookieOptions);
+  deleteCookie(c, AUTH_PROFILE_COOKIE, baseCookieOptions);
+};
 
 const sameOriginCheck = (c: {
   req: { header: (name: string) => string | undefined };
@@ -67,6 +73,44 @@ const sameOriginCheck = (c: {
  */
 export const createSessionHandler = (verify: VerifyAccessToken | undefined) =>
   new Hono()
+    // Returns the access token to same-origin JS. In SSR mode tokens live
+    // only in httpOnly cookies, so after a full navigation this is the only
+    // way for the client to sign API requests again. The refresh token is
+    // never returned.
+    .get("/", async (c) => {
+      if (!sameOriginCheck(c)) {
+        return c.json({ error: "CSRF check failed" }, 403);
+      }
+
+      if (!verify) {
+        return c.json(
+          { error: "SSR authentication is not supported for this provider" },
+          501,
+        );
+      }
+
+      c.header("Cache-Control", "no-store");
+
+      const accessToken = getCookie(c, ACCESS_TOKEN_COOKIE);
+      if (!accessToken) {
+        return c.json({ error: "No session" }, 401);
+      }
+
+      let verified: VerifyAccessTokenResult;
+      try {
+        verified = await verify(accessToken);
+      } catch (e) {
+        // biome-ignore lint/suspicious/noConsole: Surface verifier failures
+        console.error("SSR auth verifier error:", e);
+        return c.json({ error: "Verifier error" }, 502);
+      }
+      if (!verified) {
+        clearAuthCookies(c);
+        return c.json({ error: "Invalid access token" }, 401);
+      }
+
+      return c.json({ accessToken, expiresAt: verified.expiresAt });
+    })
     .post("/", async (c) => {
       if (!sameOriginCheck(c)) {
         return c.json({ error: "CSRF check failed" }, 403);
@@ -156,9 +200,7 @@ export const createSessionHandler = (verify: VerifyAccessToken | undefined) =>
         return c.json({ error: "CSRF check failed" }, 403);
       }
 
-      deleteCookie(c, ACCESS_TOKEN_COOKIE, baseCookieOptions);
-      deleteCookie(c, REFRESH_TOKEN_COOKIE, baseCookieOptions);
-      deleteCookie(c, AUTH_PROFILE_COOKIE, baseCookieOptions);
+      clearAuthCookies(c);
 
       return c.json({ ok: true });
     });

--- a/packages/zudoku/src/lib/manifest.ts
+++ b/packages/zudoku/src/lib/manifest.ts
@@ -3,6 +3,7 @@ import {
   ACCESS_TOKEN_COOKIE,
   AUTH_PROFILE_COOKIE,
   REFRESH_TOKEN_COOKIE,
+  SESSION_ENDPOINT_PATH,
 } from "./authentication/cookies.js";
 import { normalizeProtectedRoutes } from "./core/ZudokuContext.js";
 import { joinUrl } from "./util/joinUrl.js";
@@ -53,7 +54,7 @@ export const buildManifest = (
       routePatterns,
     },
     auth: {
-      sessionEndpoint: joinUrl(config.basePath, "/__z/auth/session"),
+      sessionEndpoint: joinUrl(config.basePath, SESSION_ENDPOINT_PATH),
       cookies: {
         access: ACCESS_TOKEN_COOKIE,
         refresh: REFRESH_TOKEN_COOKIE,

--- a/packages/zudoku/src/vite/dev-server.ts
+++ b/packages/zudoku/src/vite/dev-server.ts
@@ -16,6 +16,7 @@ import { printDiagnosticsToConsole } from "../cli/common/output.js";
 import { findAvailablePort } from "../cli/common/utils/ports.js";
 import type { LoadedConfig } from "../config/config.js";
 import { loadZudokuConfig } from "../config/loader.js";
+import { SESSION_ENDPOINT_PATH } from "../lib/authentication/cookies.js";
 import { createGraphQLServer } from "../lib/oas/graphql/index.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import {
@@ -136,10 +137,14 @@ export class DevServer {
     vite.middlewares.use(graphql.graphqlEndpoint, graphql);
 
     // Auth session endpoint for cookie sync
-    const sessionEndpoint = joinUrl(config.basePath, "/__z/auth/session");
+    const sessionEndpoint = joinUrl(config.basePath, SESSION_ENDPOINT_PATH);
     vite.middlewares.use(sessionEndpoint, async (req, res) => {
-      if (req.method !== "POST" && req.method !== "DELETE") {
-        res.writeHead(405, { Allow: "POST, DELETE" });
+      if (
+        req.method !== "GET" &&
+        req.method !== "POST" &&
+        req.method !== "DELETE"
+      ) {
+        res.writeHead(405, { Allow: "GET, POST, DELETE" });
         res.end();
         return;
       }
@@ -182,8 +187,7 @@ export class DevServer {
         res.appendHeader("Set-Cookie", cookie);
       }
       res.writeHead(response.status);
-      const text = await response.text();
-      res.end(text);
+      res.end(Buffer.from(await response.arrayBuffer()));
     });
 
     // Pagefind reindex endpoint (SSE)


### PR DESCRIPTION
After #2538 enabled SSR auth in dev, logging in on a site that signs API requests (api-keys, monetization plugin) logged you straight back out. In SSR mode tokens live only in httpOnly cookies, so after the post-login navigation `getAccessToken()` found no client tokens, called `setLoggedOut()`, and the cookie sync then deleted the server session cookies too.

The fix:
- Adds a same-origin GET to the session endpoint that returns the access token from the cookie (`Cache-Control: no-store`). The refresh token is never returned to JS.
- The OpenID provider (and Auth0) restores providerData from that endpoint on demand. Only a confirmed 401 logs out; transient failures throw without clearing state.
- The dev server middleware copied compressed session responses as text, corrupting them (`ERR_CONTENT_DECODING_FAILED`). It now copies raw bytes.

Clerk, Supabase, and Azure B2C are unaffected since their SDKs persist tokens themselves.

Also renames AGENT.md to AGENTS.md and adds SSR module-state guidance.