### PR TITLE
refactor: simplify navigation schema recursion with zod 4 getters

### DIFF
--- a/packages/zudoku/src/config/validators/InputNavigationSchema.test.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  InputNavigationSchema,
+  NavigationRulesSchema,
+} from "./InputNavigationSchema.js";
+
+describe("InputNavigationSchema", () => {
+  it("parses all item types", () => {
+    const input = [
+      "docs/getting-started",
+      { type: "doc", file: "docs/intro", label: "Intro", path: "/intro" },
+      { type: "link", to: "https://example.com", label: "External" },
+      { type: "custom-page", path: "/custom", element: null },
+      { type: "separator" },
+      { type: "section", label: "Section" },
+      { type: "filter", placeholder: "Search..." },
+    ];
+
+    expect(InputNavigationSchema.parse(input)).toEqual(input);
+  });
+
+  it("parses recursively nested categories", () => {
+    const input = [
+      {
+        type: "category",
+        label: "Level 1",
+        link: "docs/overview",
+        items: [
+          "docs/shorthand",
+          {
+            type: "category",
+            label: "Level 2",
+            link: { type: "doc", file: "docs/nested" },
+            items: [
+              {
+                type: "category",
+                label: "Level 3",
+                items: [{ type: "link", to: "/deep", label: "Deep" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(InputNavigationSchema.parse(input)).toEqual(input);
+  });
+
+  it("strips unknown keys from items", () => {
+    const result = InputNavigationSchema.parse([
+      { type: "doc", file: "docs/intro", unknown: true },
+    ]);
+
+    expect(result).toEqual([{ type: "doc", file: "docs/intro" }]);
+  });
+
+  it("accepts a display function", () => {
+    const display = () => true;
+    const result = InputNavigationSchema.parse([
+      { type: "separator", display },
+    ]);
+
+    expect(result).toEqual([{ type: "separator", display }]);
+  });
+
+  it("rejects items with an invalid type", () => {
+    const result = InputNavigationSchema.safeParse([{ type: "lnk", to: "/" }]);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects nested items missing required fields", () => {
+    const result = InputNavigationSchema.safeParse([
+      { type: "category", label: "Cat", items: [{ type: "doc" }] },
+    ]);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("NavigationRulesSchema", () => {
+  it("parses insert rules with nested navigation items", () => {
+    const input = [
+      {
+        type: "insert",
+        match: "docs/intro",
+        position: "after",
+        items: [
+          "docs/shorthand",
+          { type: "category", label: "Cat", items: ["docs/nested"] },
+        ],
+      },
+      { type: "remove", match: "docs/old" },
+      { type: "move", match: "docs/a", to: "docs/b", position: "before" },
+      { type: "modify", match: "docs/c", set: { label: "New", stack: true } },
+    ];
+
+    expect(NavigationRulesSchema.parse(input)).toEqual(input);
+  });
+
+  it("accepts a sort rule comparator function", () => {
+    const by = () => 0;
+    const result = NavigationRulesSchema.parse([
+      { type: "sort", match: "docs", by },
+    ]);
+
+    expect(result).toEqual([{ type: "sort", match: "docs", by }]);
+  });
+});

--- a/packages/zudoku/src/config/validators/InputNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.ts
@@ -183,7 +183,6 @@ export type NavigationRemoveRule = z.infer<typeof NavigationRemoveRuleSchema>;
 export type NavigationSortRule = z.infer<typeof NavigationSortRuleSchema>;
 export type NavigationMoveRule = z.infer<typeof NavigationMoveRuleSchema>;
 
-
 export type InputNavigationDoc =
   | string
   | z.infer<typeof InputNavigationDocObjectSchema>;

--- a/packages/zudoku/src/config/validators/InputNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.ts
@@ -38,6 +38,91 @@ export const DisplaySchema = z
   ])
   .optional();
 
+const CommonItemFields = {
+  icon: IconSchema.optional(),
+  badge: BadgeSchema.optional(),
+  display: DisplaySchema,
+};
+
+const InputNavigationDocObjectSchema = z.object({
+  type: z.literal("doc"),
+  file: z.string(),
+  // Custom URL path for this document (overrides file-based path)
+  path: z.string().optional(),
+  label: z.string().optional(),
+  ...CommonItemFields,
+});
+
+const InputNavigationLinkSchema = z.object({
+  type: z.literal("link"),
+  to: z.string(),
+  label: z.string(),
+  target: z.enum(["_self", "_blank"]).optional(),
+  stack: z.boolean().optional(),
+  ...CommonItemFields,
+});
+
+const InputNavigationCustomPageSchema = z.object({
+  type: z.literal("custom-page"),
+  path: z.string(),
+  label: z.string().optional(),
+  element: z.any(),
+  layout: z.enum(["default", "none"]).optional(),
+  ...CommonItemFields,
+});
+
+const InputNavigationSeparatorSchema = z.object({
+  type: z.literal("separator"),
+  display: DisplaySchema,
+});
+
+const InputNavigationSectionSchema = z.object({
+  type: z.literal("section"),
+  label: z.string(),
+  display: DisplaySchema,
+});
+
+const InputNavigationFilterSchema = z.object({
+  type: z.literal("filter"),
+  placeholder: z.string().optional(),
+  display: DisplaySchema,
+});
+
+// Category fields without `items`, needed to define `InputNavigationCategory`
+// without a circular type reference
+const BaseInputNavigationCategorySchema = z.object({
+  type: z.literal("category"),
+  icon: IconSchema.optional(),
+  label: z.string(),
+  collapsible: z.boolean().optional(),
+  collapsed: z.boolean().optional(),
+  link: InputNavigationCategoryLinkDocSchema.optional(),
+  display: DisplaySchema,
+  stack: z.boolean().optional(),
+});
+
+const InputNavigationCategorySchema = z.object({
+  ...BaseInputNavigationCategorySchema.shape,
+  get items(): z.ZodType<InputNavigationItem[]> {
+    return InputNavigationItemSchema.array();
+  },
+});
+
+const InputNavigationItemSchema = z.union([
+  z.string(),
+  z.discriminatedUnion("type", [
+    InputNavigationDocObjectSchema,
+    InputNavigationLinkSchema,
+    InputNavigationCustomPageSchema,
+    InputNavigationSeparatorSchema,
+    InputNavigationSectionSchema,
+    InputNavigationFilterSchema,
+    InputNavigationCategorySchema,
+  ]),
+]);
+
+export const InputNavigationSchema = InputNavigationItemSchema.array();
+
 const NavigationModifyRuleSchema = z.object({
   type: z.literal("modify"),
   match: z.string(),
@@ -58,7 +143,7 @@ const NavigationInsertRuleSchema = z.object({
   type: z.literal("insert"),
   match: z.string(),
   position: z.enum(["before", "after"]),
-  items: z.lazy(() => InputNavigationItemSchema.array()),
+  items: InputNavigationItemSchema.array(),
 });
 
 const NavigationRemoveRuleSchema = z.object({
@@ -98,103 +183,11 @@ export type NavigationRemoveRule = z.infer<typeof NavigationRemoveRuleSchema>;
 export type NavigationSortRule = z.infer<typeof NavigationSortRuleSchema>;
 export type NavigationMoveRule = z.infer<typeof NavigationMoveRuleSchema>;
 
-const InputNavigationDocSchema = z.union([
-  z.string(),
-  z.object({
-    type: z.literal("doc"),
-    file: z.string(),
-    // Custom URL path for this document (overrides file-based path)
-    path: z.string().optional(),
-    icon: IconSchema.optional(),
-    label: z.string().optional(),
-    badge: BadgeSchema.optional(),
-    display: DisplaySchema,
-  }),
-]);
+type _InputNavigationItem = z.infer<typeof InputNavigationItemSchema>;
 
-const InputNavigationLinkSchema = z.object({
-  type: z.literal("link"),
-  to: z.string(),
-  label: z.string(),
-  target: z.enum(["_self", "_blank"]).optional(),
-  icon: IconSchema.optional(),
-  badge: BadgeSchema.optional(),
-  display: DisplaySchema,
-  stack: z.boolean().optional(),
-});
-
-const InputNavigationCustomPageSchema = z.object({
-  type: z.literal("custom-page"),
-  path: z.string(),
-  label: z.string().optional(),
-  element: z.any(),
-  icon: IconSchema.optional(),
-  badge: BadgeSchema.optional(),
-  display: DisplaySchema,
-  layout: z.enum(["default", "none"]).optional(),
-});
-
-const InputNavigationSeparatorSchema = z.object({
-  type: z.literal("separator"),
-  display: DisplaySchema,
-});
-
-const InputNavigationSectionSchema = z.object({
-  type: z.literal("section"),
-  label: z.string(),
-  display: DisplaySchema,
-});
-
-const InputNavigationFilterSchema = z.object({
-  type: z.literal("filter"),
-  placeholder: z.string().optional(),
-  display: DisplaySchema,
-});
-
-// Base category schema without items
-const BaseInputNavigationCategorySchema = z.object({
-  type: z.literal("category"),
-  icon: IconSchema.optional(),
-  label: z.string(),
-  collapsible: z.boolean().optional(),
-  collapsed: z.boolean().optional(),
-  link: InputNavigationCategoryLinkDocSchema.optional(),
-  display: DisplaySchema,
-  stack: z.boolean().optional(),
-});
-
-export type InputNavigationItem =
-  | z.infer<typeof InputNavigationDocSchema>
-  | z.infer<typeof InputNavigationLinkSchema>
-  | z.infer<typeof InputNavigationCustomPageSchema>
-  | z.infer<typeof InputNavigationSeparatorSchema>
-  | z.infer<typeof InputNavigationSectionSchema>
-  | z.infer<typeof InputNavigationFilterSchema>
-  | (z.infer<typeof BaseInputNavigationCategorySchema> & {
-      items: InputNavigationItem[];
-    });
-
-const InputNavigationCategorySchema: z.ZodType<
-  z.infer<typeof BaseInputNavigationCategorySchema> & {
-    items: InputNavigationItem[];
-  }
-> = BaseInputNavigationCategorySchema.extend({
-  items: z.lazy(() => InputNavigationItemSchema.array()),
-});
-
-const InputNavigationItemSchema: z.ZodType<InputNavigationItem> = z.union([
-  InputNavigationDocSchema,
-  InputNavigationLinkSchema,
-  InputNavigationCustomPageSchema,
-  InputNavigationSeparatorSchema,
-  InputNavigationSectionSchema,
-  InputNavigationFilterSchema,
-  InputNavigationCategorySchema,
-]);
-
-export const InputNavigationSchema = InputNavigationItemSchema.array();
-
-export type InputNavigationDoc = z.infer<typeof InputNavigationDocSchema>;
+export type InputNavigationDoc =
+  | string
+  | z.infer<typeof InputNavigationDocObjectSchema>;
 export type InputNavigationLink = z.infer<typeof InputNavigationLinkSchema>;
 export type InputNavigationCustomPage = z.infer<
   typeof InputNavigationCustomPageSchema
@@ -213,4 +206,13 @@ export type InputNavigationCategoryLinkDoc = z.infer<
   typeof InputNavigationCategoryLinkDocSchema
 >;
 
-export type InputNavigation = z.infer<typeof InputNavigationSchema>;
+export type InputNavigationItem =
+  | InputNavigationDoc
+  | InputNavigationLink
+  | InputNavigationCustomPage
+  | InputNavigationSeparator
+  | InputNavigationSection
+  | InputNavigationFilter
+  | InputNavigationCategory;
+
+export type InputNavigation = InputNavigationItem[];

--- a/packages/zudoku/src/config/validators/InputNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/InputNavigationSchema.ts
@@ -183,7 +183,6 @@ export type NavigationRemoveRule = z.infer<typeof NavigationRemoveRuleSchema>;
 export type NavigationSortRule = z.infer<typeof NavigationSortRuleSchema>;
 export type NavigationMoveRule = z.infer<typeof NavigationMoveRuleSchema>;
 
-type _InputNavigationItem = z.infer<typeof InputNavigationItemSchema>;
 
 export type InputNavigationDoc =
   | string

--- a/packages/zudoku/src/config/validators/NavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/NavigationSchema.ts
@@ -335,7 +335,7 @@ export class NavigationResolver {
 
         const items = (
           await Promise.all(
-            (categoryItem.items as InputNavigationItem[]).map((subItem) =>
+            categoryItem.items.map((subItem) =>
               this.resolveItem(subItem, categoryItem.label),
             ),
           )


### PR DESCRIPTION
The navigation schema used zod 3 era workarounds for recursion: `z.lazy`, two whole-schema `ZodType` annotations, and a base/`.extend()` split. Zod 4 getters replace these with a single annotated getter. Items now parse through a discriminated union, so a typo in `type` reports an invalid discriminator instead of errors from all seven union branches.

The `InputNavigationItem` type union stays hand-written since TypeScript can't infer recursion cycles that pass through unions. Adds unit tests for the recursive parsing.