### PR TITLE
chore: bump zudoku peer dep min to 0.82.0 in plugin-graphql

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "react": ">=19.2.0",
     "react-dom": ">=19.2.0",
-    "zudoku": ">=0.80.1"
+    "zudoku": ">=0.82.0"
   },
   "peerDependenciesMeta": {
     "zudoku": {


### PR DESCRIPTION
Bumps the `zudoku` peer dependency in `@zudoku/plugin-graphql` from `>=0.80.1` to `>=0.82.0`, the next released version.