### PR TITLE
Add GraphQL plugin documentation to Zuplo template

### DIFF
--- a/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
+++ b/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
@@ -103,31 +103,12 @@ const config: ZudokuConfig = {
   // another plugin, place both inside a single `plugins: [...]` array.
   // plugins: [
   //   graphqlPlugin({
-  //     // How the schema is loaded: "file" reads a local SDL file at build
-  //     // time, "url" fetches it from a live endpoint (which also powers the
-  //     // playground).
-  //     type: "file",
-  //     // Path to the schema file (for type: "file") or the GraphQL endpoint
-  //     // URL (for type: "url").
-  //     input: "./schema.graphql",
-  //     // The route the GraphQL docs are served under, e.g. /graphql.
+  //     type: "url",
+  //     input: "https://api.example.com/graphql",
   //     path: "graphql",
   //     options: {
   //       title: "My GraphQL API",
   //       description: "Explore the schema and try queries in the playground.",
-  //       // Include fields/types marked with @deprecated in the reference docs.
-  //       showDeprecated: false,
-  //       playground: {
-  //         // Enable the interactive query playground.
-  //         enabled: true,
-  //         // Endpoint the playground sends operations to. Defaults to `input`
-  //         // when type is "url".
-  //         endpoint: "https://api.example.com/graphql",
-  //         // Default headers sent with every playground request.
-  //         headers: {
-  //           Authorization: "Bearer <token>",
-  //         },
-  //       },
   //     },
   //   }),
   // ],

--- a/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
+++ b/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
@@ -1,6 +1,9 @@
 // Uncomment the import below to enable Zuplo monetization (pricing, checkout,
 // subscriptions). See: https://zuplo.com/docs/articles/monetization
 // import { zuploMonetizationPlugin } from "@zuplo/zudoku-plugin-monetization";
+// Uncomment the import below to document a GraphQL API (schema reference docs
+// and an interactive playground).
+// import { graphqlPlugin } from "@zudoku/plugin-graphql";
 import type { ZudokuConfig } from "zudoku";
 
 /**
@@ -94,6 +97,40 @@ const config: ZudokuConfig = {
   // Uncomment to enable monetization. Don't forget to also uncomment the
   // `zuploMonetizationPlugin` import at the top of this file.
   // plugins: [zuploMonetizationPlugin()],
+  //
+  // Uncomment to document a GraphQL API. Don't forget to also uncomment the
+  // `graphqlPlugin` import at the top of this file. To enable this alongside
+  // another plugin, place both inside a single `plugins: [...]` array.
+  // plugins: [
+  //   graphqlPlugin({
+  //     // How the schema is loaded: "file" reads a local SDL file at build
+  //     // time, "url" fetches it from a live endpoint (which also powers the
+  //     // playground).
+  //     type: "file",
+  //     // Path to the schema file (for type: "file") or the GraphQL endpoint
+  //     // URL (for type: "url").
+  //     input: "./schema.graphql",
+  //     // The route the GraphQL docs are served under, e.g. /graphql.
+  //     path: "graphql",
+  //     options: {
+  //       title: "My GraphQL API",
+  //       description: "Explore the schema and try queries in the playground.",
+  //       // Include fields/types marked with @deprecated in the reference docs.
+  //       showDeprecated: false,
+  //       playground: {
+  //         // Enable the interactive query playground.
+  //         enabled: true,
+  //         // Endpoint the playground sends operations to. Defaults to `input`
+  //         // when type is "url".
+  //         endpoint: "https://api.example.com/graphql",
+  //         // Default headers sent with every playground request.
+  //         headers: {
+  //           Authorization: "Bearer <token>",
+  //         },
+  //       },
+  //     },
+  //   }),
+  // ],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
Added commented-out documentation and example configuration for the GraphQL plugin to the Zuplo template's `zudoku.config.tsx` file. This helps users understand how to enable and configure GraphQL API documentation alongside other features.

## Changes
- Added import comment for `graphqlPlugin` from `@zudoku/plugin-graphql`
- Added comprehensive commented example showing how to enable the GraphQL plugin with:
  - Schema loading options (file vs. URL)
  - Configuration for schema path and documentation route
  - Interactive playground setup with endpoint and headers
  - Deprecation display options
- Included inline comments explaining each configuration option
- Noted that the plugin can be combined with other plugins in a single `plugins` array

## Implementation Details
The example configuration demonstrates both common use cases:
- Loading schema from a local SDL file at build time
- Serving GraphQL docs under a `/graphql` route
- Configuring an interactive playground with custom endpoint and authorization headers

This follows the existing pattern in the template for documenting optional plugin features (similar to the Zuplo monetization plugin example).

https://claude.ai/code/session_01EmcjG735MKpvBWjnCRDpak