### PR TITLE
fix: copy page button bottom half not clickable

### DIFF
--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -273,7 +273,7 @@ export const MdxPage = ({
           centered && "xl:mx-auto",
         )}
       >
-        <header className="flow-root">
+        <header className="flow-root isolate">
           {showTocSidebar && (
             <>
               <Slot.Source name="top-navigation-side" type="append">
@@ -289,7 +289,7 @@ export const MdxPage = ({
           )}
           {(copyMarkdownConfig || showTocPopover) && (
             <div
-              className="float-end ms-4 mt-1 flex items-center gap-2"
+              className="relative z-10 float-end ms-4 mt-1 flex items-center gap-2"
               role="group"
               aria-label="Page actions"
             >


### PR DESCRIPTION
The h1 rendered by `Heading` has `relative` baked in, so its transparent full-width box painted above the floated page actions and swallowed clicks on the bottom half of the Copy page button. The button container now gets `relative z-10`, with `isolate` on the page `<header>` so the z-index can't escape and compete with the sticky site header.