### PR TITLE
fix: prevent LazyMotion renderer crash from undefined motion features

### DIFF
--- a/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
@@ -9,7 +9,7 @@ import type { NavigationFrame } from "./useNavigationFrame.js";
 import { navigationItemKey, navigationListItem } from "./utils.js";
 
 const loadFeatures = () =>
-  import("./motionFeatures.js").then((mod) => mod.default ?? {});
+  import("./motionFeatures.js").then((mod) => mod.default);
 
 const variants = {
   enter: (direction: number) => ({

--- a/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationFrames.tsx
@@ -9,7 +9,7 @@ import type { NavigationFrame } from "./useNavigationFrame.js";
 import { navigationItemKey, navigationListItem } from "./utils.js";
 
 const loadFeatures = () =>
-  import("./motionFeatures.js").then((mod) => mod.default);
+  import("./motionFeatures.js").then((mod) => mod.default ?? {});
 
 const variants = {
   enter: (direction: number) => ({

--- a/packages/zudoku/src/lib/components/navigation/motionFeatures.ts
+++ b/packages/zudoku/src/lib/components/navigation/motionFeatures.ts
@@ -1,2 +1,5 @@
-// Lazy-loaded animation features for LazyMotion (keeps the main bundle small).
-export { domAnimation as default } from "motion/react";
+// Lazy load motion features
+// See: https://motion.dev/docs/react-lazy-motion
+import { domAnimation } from "motion/react";
+
+export default domAnimation;


### PR DESCRIPTION
Fixes a crash some users hit on the stacked sub-navigation: `Cannot destructure property 'renderer' of undefined` thrown inside `LazyMotion`.

The lazily imported `motionFeatures` module re-exported `domAnimation` as `export { domAnimation as default } from "motion/react"`. That pure re-export keeps the chunk's default as a transitive live binding, which can resolve to `undefined` under circular chunk init order, so `LazyMotion` destructured `{ renderer }` off an undefined value. Switched to the `import` plus `export default` form the Motion docs recommend, so the chunk holds a concrete value.