### PR TITLE
fix: respect collapsible property on nav category row click

### DIFF
--- a/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
@@ -104,6 +104,7 @@ const NavigationCategoryInner = ({
       defaultOpen={isDefaultOpen}
       open={open}
       onOpenChange={(value) => {
+        if (!isCollapsible) return;
         // Categories with a link navigate on row click, so they only open here
         // (closing is done via the chevron). Without a link the row toggles.
         const nextOpen = category.link ? true : value;


### PR DESCRIPTION
Non-collapsible nav categories could still be collapsed by clicking the row, because the disabled `Collapsible.Trigger` doesn't block clicks on the non-button element rendered via `asChild`. Guard `onOpenChange` to never toggle when the category is not collapsible.

Fixes #2623