### PR TITLE
feat(plugin-graphql): replace type/input with single schema field

### DIFF
--- a/examples/graphql/zudoku.config.ts
+++ b/examples/graphql/zudoku.config.ts
@@ -109,8 +109,7 @@ const config: ZudokuConfig = {
   plugins: [
     demoApiIdentityPlugin,
     graphqlPlugin({
-      type: "file",
-      input: "./schema.graphql",
+      schema: "./schema.graphql",
       path: "graphql/default",
       options: {
         title: "E-Commerce GraphQL API",
@@ -119,8 +118,7 @@ const config: ZudokuConfig = {
       },
     }),
     graphqlPlugin({
-      type: "file",
-      input: "./schema.graphql",
+      schema: "./schema.graphql",
       path: "graphql/dev",
       options: {
         title: "Developer GraphQL API",
@@ -129,8 +127,7 @@ const config: ZudokuConfig = {
       },
     }),
     graphqlPlugin({
-      type: "file",
-      input: "./schema.graphql",
+      schema: "./schema.graphql",
       path: "graphql/analytics",
       options: {
         title: "Analytics GraphQL API",

--- a/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
+++ b/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
@@ -103,8 +103,7 @@ const config: ZudokuConfig = {
   // another plugin, place both inside a single `plugins: [...]` array.
   // plugins: [
   //   graphqlPlugin({
-  //     type: "url",
-  //     input: "https://api.example.com/graphql",
+  //     schema: "https://api.example.com/graphql",
   //     path: "graphql",
   //     options: {
   //       title: "My GraphQL API",

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zudoku/plugin-graphql",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/zuplo/zudoku",

--- a/packages/plugin-graphql/src/index.tsx
+++ b/packages/plugin-graphql/src/index.tsx
@@ -6,6 +6,7 @@ import {
   type GraphQLConfig,
   GRAPHQL_PLUGIN_NAME,
   type GraphQLPluginOptions,
+  isSchemaUrl,
 } from "./interfaces.js";
 import { getRoutes } from "./routes/getRoutes.js";
 import type { GraphQLManifest } from "./util/manifest.js";
@@ -16,9 +17,7 @@ const resolveOptions = (
 ): { basePath: string; options: GraphQLPluginOptions } => {
   const playgroundEndpoint =
     config.options?.playground?.endpoint ??
-    (config.type === "url" && typeof config.input === "string"
-      ? config.input
-      : undefined);
+    (isSchemaUrl(config.schema) ? config.schema : undefined);
 
   const options: GraphQLPluginOptions = {
     ...config.options,

--- a/packages/plugin-graphql/src/interfaces.ts
+++ b/packages/plugin-graphql/src/interfaces.ts
@@ -9,20 +9,15 @@ export type GraphQLPluginOptions = {
   };
 };
 
-type GraphQLUrlConfig = {
-  type: "url";
-  input: string;
+export type GraphQLConfig = {
+  /** A URL to a GraphQL endpoint or a path to a GraphQL SDL file. */
+  schema: string;
   path: string;
   options?: GraphQLPluginOptions;
 };
-
-type GraphQLFileConfig = {
-  type: "file";
-  input: string;
-  path: string;
-  options?: GraphQLPluginOptions;
-};
-
-export type GraphQLConfig = GraphQLUrlConfig | GraphQLFileConfig;
 
 export const GRAPHQL_PLUGIN_NAME = "graphql";
+
+/** Treat the schema as a remote endpoint when it's an http(s) URL. */
+export const isSchemaUrl = (schema: string): boolean =>
+  /^https?:\/\//i.test(schema);

--- a/packages/plugin-graphql/vite-plugin.ts
+++ b/packages/plugin-graphql/vite-plugin.ts
@@ -14,29 +14,33 @@ import {
   joinUrl,
   type Plugin,
 } from "zudoku/vite";
-import { type GraphQLConfig, GRAPHQL_PLUGIN_NAME } from "./src/interfaces.js";
+import {
+  type GraphQLConfig,
+  GRAPHQL_PLUGIN_NAME,
+  isSchemaUrl,
+} from "./src/interfaces.js";
 import { buildManifest } from "./src/util/manifest.js";
 
 const MANIFEST_ID = "virtual:@zudoku/plugin-graphql/schema";
 const SCHEMA_PREFIX = `${MANIFEST_ID}/`;
 
-// Versioned inputs (input as array) are not supported yet, so only single-input
-// instances get a schema baked.
-const hasStringInput = (
+// Runtime guard: config arrives untyped from getPluginConfigs, so skip any
+// instance whose schema isn't a string before baking it.
+const hasStringSchema = (
   config: GraphQLConfig,
-): config is GraphQLConfig & { input: string } =>
-  typeof config.input === "string";
+): config is GraphQLConfig & { schema: string } =>
+  typeof config.schema === "string";
 
 const slugify = (value: string) =>
   value.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "schema";
 
-const resolveInputPath = (
-  config: GraphQLConfig & { input: string },
+const resolveSchemaPath = (
+  config: GraphQLConfig & { schema: string },
   rootDir: string,
 ) =>
-  path.isAbsolute(config.input)
-    ? config.input
-    : path.join(rootDir, config.input);
+  path.isAbsolute(config.schema)
+    ? config.schema
+    : path.join(rootDir, config.schema);
 
 const sharedIntrospectionOptions = {
   inputValueDeprecation: true,
@@ -95,26 +99,29 @@ const fetchIntrospection = async (
 };
 
 const loadSchema = async (
-  config: GraphQLConfig & { input: string },
+  config: GraphQLConfig & { schema: string },
   rootDir: string,
 ): Promise<IntrospectionQuery> => {
-  if (config.type === "url") {
+  if (isSchemaUrl(config.schema)) {
     try {
-      return await fetchIntrospection(config.input, sharedIntrospectionOptions);
+      return await fetchIntrospection(
+        config.schema,
+        sharedIntrospectionOptions,
+      );
     } catch {
       // Older servers reject the modern introspection fields
       // (specifiedByURL, schema description, input value deprecation);
       // retry with the plain query.
-      return fetchIntrospection(config.input);
+      return fetchIntrospection(config.schema);
     }
   }
 
-  const sdl = await fs.readFile(resolveInputPath(config, rootDir), "utf-8");
+  const sdl = await fs.readFile(resolveSchemaPath(config, rootDir), "utf-8");
   return introspectionFromSchema(buildSchema(sdl), sharedIntrospectionOptions);
 };
 
 type Instance = {
-  config: GraphQLConfig & { input: string };
+  config: GraphQLConfig & { schema: string };
   basePath: string;
   slug: string;
   rootDir: string;
@@ -138,7 +145,7 @@ const loadInstanceSchema = (
 const getInstances = (): Instance[] => {
   const rootDir = getZudokuConfig().__meta.rootDir;
   return getPluginConfigs<GraphQLConfig>(GRAPHQL_PLUGIN_NAME)
-    .filter(hasStringInput)
+    .filter(hasStringSchema)
     .map((config) => {
       const basePath = joinUrl(config.path);
       return { config, basePath, slug: slugify(basePath), rootDir };
@@ -163,8 +170,8 @@ export const graphqlSchemaPlugin = (): Plugin => {
       // load re-reads it.
       for (const instance of getInstances()) {
         if (
-          instance.config.type === "file" &&
-          resolveInputPath(instance.config, instance.rootDir) === id
+          !isSchemaUrl(instance.config.schema) &&
+          resolveSchemaPath(instance.config, instance.rootDir) === id
         ) {
           schemaCache.delete(instance.slug);
         }
@@ -184,9 +191,9 @@ export const graphqlSchemaPlugin = (): Plugin => {
         for (const instance of instances) {
           // Vite reloads both the client and the SSR module runner when a
           // watched file changes; a manual watcher would only reach the client.
-          if (instance.config.type === "file") {
+          if (!isSchemaUrl(instance.config.schema)) {
             this.addWatchFile(
-              resolveInputPath(instance.config, instance.rootDir),
+              resolveSchemaPath(instance.config, instance.rootDir),
             );
           }
           manifests[instance.basePath] = buildManifest(
@@ -216,9 +223,9 @@ export const graphqlSchemaPlugin = (): Plugin => {
         const instance = getInstances().find((i) => i.slug === slug);
         if (!instance) return;
 
-        if (instance.config.type === "file") {
+        if (!isSchemaUrl(instance.config.schema)) {
           this.addWatchFile(
-            resolveInputPath(instance.config, instance.rootDir),
+            resolveSchemaPath(instance.config, instance.rootDir),
           );
         }
         const introspection = await loadInstanceSchema(instance);


### PR DESCRIPTION
The GraphQL plugin took a `type: "url" | "file"` discriminator alongside an `input` field. Replaced both with a single `schema` field that accepts either a URL or a relative path, detecting URLs by their `http(s)` scheme. Bumps `@zudoku/plugin-graphql` to 0.0.4.