### PR TITLE
feat(plugin-graphql): default playground endpoint to gateway URL

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zudoku/plugin-graphql",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/zuplo/zudoku",

--- a/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
@@ -57,7 +57,8 @@ export const GraphQLPlayground = ({
         return {
           errors: [
             {
-              message: "Configure options.endpoint to run GraphQL operations.",
+              message:
+                "Configure the plugin's endpoint to run GraphQL operations.",
             },
           ],
         };

--- a/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
@@ -57,8 +57,7 @@ export const GraphQLPlayground = ({
         return {
           errors: [
             {
-              message:
-                "Configure options.playground.endpoint to run GraphQL operations.",
+              message: "Configure options.endpoint to run GraphQL operations.",
             },
           ],
         };

--- a/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
@@ -9,8 +9,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { cn } from "zudoku";
+import { cn, joinUrl } from "zudoku";
 import { ApiIdentityPicker } from "zudoku/components";
+import { useZudoku } from "zudoku/hooks";
 import {
   ChevronsDownIcon,
   ChevronsUpIcon,
@@ -20,6 +21,7 @@ import {
 } from "zudoku/icons";
 import { Button } from "zudoku/ui/Button.js";
 import { useGraphQLSchema } from "../context.js";
+import { resolveEndpointUrl } from "../interfaces.js";
 import {
   GraphQLPlayground,
   type GraphQLPlaygroundOperation,
@@ -242,6 +244,11 @@ const GraphQLWorkbenchDrawer = ({
   updateWorkbenchOperation: GraphQLWorkbenchContextValue["updateWorkbenchOperation"];
 }) => {
   const { options, schema } = useGraphQLSchema();
+  const { env } = useZudoku();
+  const gatewayUrl = env.ZUPLO_GATEWAY_SERVICE_URL;
+  const endpoint =
+    resolveEndpointUrl(options.endpoint, gatewayUrl) ??
+    (gatewayUrl ? joinUrl(gatewayUrl, "graphql") : undefined);
   const drawerRef = useRef<HTMLDivElement>(null);
   const hasOpened = useRef(false);
   if (state !== "collapsed") hasOpened.current = true;
@@ -367,7 +374,7 @@ const GraphQLWorkbenchDrawer = ({
         </div>
         {hasOpened.current && (
           <GraphQLPlayground
-            endpoint={options.playground?.endpoint}
+            endpoint={endpoint}
             headers={options.playground?.headers}
             schema={{ __schema: schema }}
             operation={operation}

--- a/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
@@ -243,11 +243,11 @@ const GraphQLWorkbenchDrawer = ({
   onStateChange: (state: WorkbenchState) => void;
   updateWorkbenchOperation: GraphQLWorkbenchContextValue["updateWorkbenchOperation"];
 }) => {
-  const { options, schema } = useGraphQLSchema();
+  const { options, schema, endpoint: configuredEndpoint } = useGraphQLSchema();
   const { env } = useZudoku();
   const gatewayUrl = env.ZUPLO_GATEWAY_SERVICE_URL;
   const endpoint =
-    resolveEndpointUrl(options.endpoint, gatewayUrl) ??
+    resolveEndpointUrl(configuredEndpoint, gatewayUrl) ??
     (gatewayUrl ? joinUrl(gatewayUrl, "graphql") : undefined);
   const drawerRef = useRef<HTMLDivElement>(null);
   const hasOpened = useRef(false);

--- a/packages/plugin-graphql/src/context.tsx
+++ b/packages/plugin-graphql/src/context.tsx
@@ -7,6 +7,7 @@ type GraphQLContextValue = {
   schema: GraphQLSchema;
   index: SchemaIndex;
   basePath: string;
+  endpoint: string | undefined;
   options: GraphQLPluginOptions;
 };
 

--- a/packages/plugin-graphql/src/index.tsx
+++ b/packages/plugin-graphql/src/index.tsx
@@ -14,26 +14,26 @@ import { ROOT_TYPES, type RootType, typeMetadata } from "./util/types.js";
 
 const resolveOptions = (
   config: GraphQLConfig,
-): { basePath: string; options: GraphQLPluginOptions } => {
+): {
+  basePath: string;
+  endpoint: string | undefined;
+  options: GraphQLPluginOptions;
+} => {
   const endpoint =
-    config.options?.endpoint ??
-    (isSchemaUrl(config.schema) ? config.schema : undefined);
-
-  const options: GraphQLPluginOptions = {
-    ...config.options,
-    endpoint,
-  };
+    config.endpoint ??
+    (config.schema && isSchemaUrl(config.schema) ? config.schema : undefined);
 
   return {
     basePath: joinUrl(config.path),
-    options,
+    endpoint,
+    options: config.options ?? {},
   };
 };
 
 export const graphqlPlugin = createPlugin(
   GRAPHQL_PLUGIN_NAME,
   (config: GraphQLConfig): ZudokuPlugin => {
-    const { basePath, options } = resolveOptions(config);
+    const { basePath, endpoint, options } = resolveOptions(config);
 
     return {
       getRoutes: () => {
@@ -43,6 +43,7 @@ export const graphqlPlugin = createPlugin(
         return getRoutes({
           basePath,
           manifest,
+          endpoint,
           options,
           loadSchema: () => loadSchema().then((module) => module.default),
         });

--- a/packages/plugin-graphql/src/index.tsx
+++ b/packages/plugin-graphql/src/index.tsx
@@ -15,16 +15,13 @@ import { ROOT_TYPES, type RootType, typeMetadata } from "./util/types.js";
 const resolveOptions = (
   config: GraphQLConfig,
 ): { basePath: string; options: GraphQLPluginOptions } => {
-  const playgroundEndpoint =
-    config.options?.playground?.endpoint ??
+  const endpoint =
+    config.options?.endpoint ??
     (isSchemaUrl(config.schema) ? config.schema : undefined);
 
   const options: GraphQLPluginOptions = {
     ...config.options,
-    playground: {
-      ...config.options?.playground,
-      endpoint: playgroundEndpoint,
-    },
+    endpoint,
   };
 
   return {

--- a/packages/plugin-graphql/src/interfaces.test.ts
+++ b/packages/plugin-graphql/src/interfaces.test.ts
@@ -93,7 +93,7 @@ describe("playground endpoint default", () => {
     resolveEndpointUrl(endpoint, gatewayUrl) ??
     (gatewayUrl ? joinUrl(gatewayUrl, "graphql") : undefined);
 
-  it("defaults to ${gateway}/graphql when nothing is configured", () => {
+  it("defaults to the gateway URL with a /graphql suffix when unconfigured", () => {
     expect(resolve(undefined, GATEWAY)).toBe(`${GATEWAY}/graphql`);
   });
 

--- a/packages/plugin-graphql/src/interfaces.test.ts
+++ b/packages/plugin-graphql/src/interfaces.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { joinUrl } from "zudoku";
+import {
+  isSchemaUrl,
+  resolveEndpointUrl,
+  resolveSchemaSource,
+} from "./interfaces.js";
+
+const GATEWAY = "https://gw.example.com";
+
+describe("isSchemaUrl", () => {
+  it("treats http(s) values as URLs", () => {
+    expect(isSchemaUrl("https://api.example.com/graphql")).toBe(true);
+    expect(isSchemaUrl("http://api.example.com/graphql")).toBe(true);
+  });
+
+  it("treats file paths as non-URLs", () => {
+    expect(isSchemaUrl("./schema.graphql")).toBe(false);
+    expect(isSchemaUrl("graphql")).toBe(false);
+    expect(isSchemaUrl("/v1/graphql")).toBe(false);
+  });
+});
+
+describe("resolveEndpointUrl", () => {
+  it("returns undefined when no endpoint is configured", () => {
+    expect(resolveEndpointUrl(undefined, GATEWAY)).toBeUndefined();
+    expect(resolveEndpointUrl(undefined, undefined)).toBeUndefined();
+  });
+
+  it("keeps an absolute URL as-is, ignoring the base", () => {
+    const url = "https://api.example.com/graphql";
+    expect(resolveEndpointUrl(url, GATEWAY)).toBe(url);
+    expect(resolveEndpointUrl(url, undefined)).toBe(url);
+  });
+
+  it("prepends the base URL to a relative path", () => {
+    expect(resolveEndpointUrl("my-api", GATEWAY)).toBe(`${GATEWAY}/my-api`);
+    expect(resolveEndpointUrl("/my-api", GATEWAY)).toBe(`${GATEWAY}/my-api`);
+    expect(resolveEndpointUrl("my-api/graphql", GATEWAY)).toBe(
+      `${GATEWAY}/my-api/graphql`,
+    );
+  });
+
+  it("leaves a relative path untouched when no base URL is defined", () => {
+    expect(resolveEndpointUrl("/my-api", undefined)).toBe("/my-api");
+  });
+});
+
+describe("resolveSchemaSource", () => {
+  it("uses the configured schema (file path or URL)", () => {
+    expect(resolveSchemaSource({ path: "g", schema: "./schema.graphql" })).toBe(
+      "./schema.graphql",
+    );
+    expect(
+      resolveSchemaSource({ path: "g", schema: "https://api.example.com/gql" }),
+    ).toBe("https://api.example.com/gql");
+  });
+
+  it("falls back to the endpoint when it's a URL", () => {
+    expect(
+      resolveSchemaSource({
+        path: "g",
+        endpoint: "https://api.example.com/gql",
+      }),
+    ).toBe("https://api.example.com/gql");
+  });
+
+  it("prefers the schema over the endpoint", () => {
+    expect(
+      resolveSchemaSource({
+        path: "g",
+        schema: "./schema.graphql",
+        endpoint: "https://api.example.com/gql",
+      }),
+    ).toBe("./schema.graphql");
+  });
+
+  it("returns undefined when nothing resolves to a schema source", () => {
+    expect(resolveSchemaSource({ path: "g" })).toBeUndefined();
+    expect(
+      resolveSchemaSource({ path: "g", endpoint: "/relative" }),
+    ).toBeUndefined();
+  });
+});
+
+// Mirrors the workbench: a relative/absolute endpoint resolves first, then an
+// unset endpoint defaults to `${gatewayUrl}/graphql` for Zuplo projects.
+describe("playground endpoint default", () => {
+  const resolve = (
+    endpoint: string | undefined,
+    gatewayUrl: string | undefined,
+  ) =>
+    resolveEndpointUrl(endpoint, gatewayUrl) ??
+    (gatewayUrl ? joinUrl(gatewayUrl, "graphql") : undefined);
+
+  it("defaults to ${gateway}/graphql when nothing is configured", () => {
+    expect(resolve(undefined, GATEWAY)).toBe(`${GATEWAY}/graphql`);
+  });
+
+  it("is undefined without a gateway URL or endpoint", () => {
+    expect(resolve(undefined, undefined)).toBeUndefined();
+  });
+
+  it("does not append /graphql to a configured endpoint", () => {
+    expect(resolve("https://api.example.com/v2", GATEWAY)).toBe(
+      "https://api.example.com/v2",
+    );
+    expect(resolve("custom", GATEWAY)).toBe(`${GATEWAY}/custom`);
+  });
+});

--- a/packages/plugin-graphql/src/interfaces.ts
+++ b/packages/plugin-graphql/src/interfaces.ts
@@ -48,5 +48,5 @@ export const resolveEndpointUrl = (
   if (!endpoint) return undefined;
   if (isSchemaUrl(endpoint)) return endpoint;
 
-  return baseUrl ? joinUrl(baseUrl, endpoint) : endpoint;
+  return baseUrl ? joinUrl(baseUrl, endpoint) : joinUrl(endpoint);
 };

--- a/packages/plugin-graphql/src/interfaces.ts
+++ b/packages/plugin-graphql/src/interfaces.ts
@@ -1,10 +1,12 @@
+import { joinUrl } from "zudoku";
+
 export type GraphQLPluginOptions = {
   title?: string;
   description?: string;
   showDeprecated?: boolean;
+  endpoint?: string;
   playground?: {
     enabled?: boolean;
-    endpoint?: string;
     headers?: Record<string, string>;
   };
 };
@@ -21,3 +23,13 @@ export const GRAPHQL_PLUGIN_NAME = "graphql";
 /** Treat the schema as a remote endpoint when it's an http(s) URL. */
 export const isSchemaUrl = (schema: string): boolean =>
   /^https?:\/\//i.test(schema);
+
+export const resolveEndpointUrl = (
+  endpoint: string | undefined,
+  baseUrl: string | undefined,
+): string | undefined => {
+  if (!endpoint) return undefined;
+  if (isSchemaUrl(endpoint)) return endpoint;
+
+  return baseUrl ? joinUrl(baseUrl, endpoint) : endpoint;
+};

--- a/packages/plugin-graphql/src/interfaces.ts
+++ b/packages/plugin-graphql/src/interfaces.ts
@@ -4,7 +4,6 @@ export type GraphQLPluginOptions = {
   title?: string;
   description?: string;
   showDeprecated?: boolean;
-  endpoint?: string;
   playground?: {
     enabled?: boolean;
     headers?: Record<string, string>;
@@ -13,8 +12,14 @@ export type GraphQLPluginOptions = {
 
 export type GraphQLConfig = {
   /** A URL to a GraphQL endpoint or a path to a GraphQL SDL file. */
-  schema: string;
+  schema?: string;
   path: string;
+  /**
+   * GraphQL endpoint the playground sends operations to. An absolute URL is
+   * used as-is; a relative path is resolved against the Zuplo gateway URL when
+   * available. Defaults to `${gatewayUrl}/graphql` for Zuplo projects.
+   */
+  endpoint?: string;
   options?: GraphQLPluginOptions;
 };
 
@@ -23,6 +28,18 @@ export const GRAPHQL_PLUGIN_NAME = "graphql";
 /** Treat the schema as a remote endpoint when it's an http(s) URL. */
 export const isSchemaUrl = (schema: string): boolean =>
   /^https?:\/\//i.test(schema);
+
+/**
+ * Resolve where to load the schema from: the configured `schema`, falling back
+ * to the `endpoint` when it's a URL we can introspect.
+ */
+export const resolveSchemaSource = (
+  config: GraphQLConfig,
+): string | undefined =>
+  config.schema ??
+  (config.endpoint && isSchemaUrl(config.endpoint)
+    ? config.endpoint
+    : undefined);
 
 export const resolveEndpointUrl = (
   endpoint: string | undefined,

--- a/packages/plugin-graphql/src/routes/getRoutes.tsx
+++ b/packages/plugin-graphql/src/routes/getRoutes.tsx
@@ -9,6 +9,7 @@ import { ROOT_TYPES, type RootType } from "../util/types.js";
 type RouteConfig = {
   basePath: string;
   manifest: GraphQLManifest;
+  endpoint: string | undefined;
   options: GraphQLPluginOptions;
   loadSchema: () => Promise<IntrospectionQuery>;
 };
@@ -31,6 +32,7 @@ const createGraphQLProvider = (
             schema,
             index: buildSchemaIndex(schema),
             basePath: config.basePath,
+            endpoint: config.endpoint,
             options: config.options,
           }}
         >

--- a/packages/plugin-graphql/vite-plugin.ts
+++ b/packages/plugin-graphql/vite-plugin.ts
@@ -18,6 +18,7 @@ import {
   type GraphQLConfig,
   GRAPHQL_PLUGIN_NAME,
   isSchemaUrl,
+  resolveSchemaSource,
 } from "./src/interfaces.js";
 import { buildManifest } from "./src/util/manifest.js";
 
@@ -152,8 +153,19 @@ const loadInstanceSchema = (
 const getInstances = (): Instance[] => {
   const rootDir = getZudokuConfig().__meta.rootDir;
   return getPluginConfigs<GraphQLConfig>(GRAPHQL_PLUGIN_NAME).map((config) => {
+    const schema = resolveSchemaSource(config);
+    if (!schema) {
+      throw new Error(
+        `GraphQL plugin for path "${config.path}" has no schema to load. Set "schema" to a file path or URL, or set "endpoint" to a GraphQL URL to introspect.`,
+      );
+    }
     const basePath = joinUrl(config.path);
-    return { config, basePath, slug: slugify(basePath), rootDir };
+    return {
+      config: { ...config, schema },
+      basePath,
+      slug: slugify(basePath),
+      rootDir,
+    };
   });
 };
 


### PR DESCRIPTION
Adds a top-level `endpoint` field to the GraphQL plugin config and makes both `schema` and `endpoint` optional.

The playground endpoint now defaults to `${ZUPLO_GATEWAY_SERVICE_URL}/graphql` for Zuplo projects, so it works without configuration. A configured `endpoint` overrides this. Absolute URLs are used as-is, relative paths are resolved against the gateway URL when defined.

Schema resolution is symmetric: the build loads the schema from `schema`, or falls back to introspecting `endpoint` when it's a URL. The build fails if a config resolves to neither.

The resolution logic lives in two helpers, `resolveEndpointUrl(endpoint, baseUrl)` and `resolveSchemaSource(config)`, shared between the runtime and the Vite plugin.