### PR TITLE
fix(plugin-graphql): stop importing bare zudoku in build-path code

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zudoku/plugin-graphql",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/zuplo/zudoku",

--- a/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
@@ -21,7 +21,7 @@ import {
 } from "zudoku/icons";
 import { Button } from "zudoku/ui/Button.js";
 import { useGraphQLSchema } from "../context.js";
-import { resolveEndpointUrl } from "../interfaces.js";
+import { resolveEndpointUrl } from "../resolveEndpointUrl.js";
 import {
   GraphQLPlayground,
   type GraphQLPlaygroundOperation,

--- a/packages/plugin-graphql/src/interfaces.test.ts
+++ b/packages/plugin-graphql/src/interfaces.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { joinUrl } from "zudoku";
-import {
-  isSchemaUrl,
-  resolveEndpointUrl,
-  resolveSchemaSource,
-} from "./interfaces.js";
+import { isSchemaUrl, resolveSchemaSource } from "./interfaces.js";
+import { resolveEndpointUrl } from "./resolveEndpointUrl.js";
 
 const GATEWAY = "https://gw.example.com";
 

--- a/packages/plugin-graphql/src/interfaces.ts
+++ b/packages/plugin-graphql/src/interfaces.ts
@@ -1,5 +1,3 @@
-import { joinUrl } from "zudoku";
-
 export type GraphQLPluginOptions = {
   title?: string;
   description?: string;
@@ -40,13 +38,3 @@ export const resolveSchemaSource = (
   (config.endpoint && isSchemaUrl(config.endpoint)
     ? config.endpoint
     : undefined);
-
-export const resolveEndpointUrl = (
-  endpoint: string | undefined,
-  baseUrl: string | undefined,
-): string | undefined => {
-  if (!endpoint) return undefined;
-  if (isSchemaUrl(endpoint)) return endpoint;
-
-  return baseUrl ? joinUrl(baseUrl, endpoint) : joinUrl(endpoint);
-};

--- a/packages/plugin-graphql/src/resolveEndpointUrl.ts
+++ b/packages/plugin-graphql/src/resolveEndpointUrl.ts
@@ -1,0 +1,12 @@
+import { joinUrl } from "zudoku";
+import { isSchemaUrl } from "./interfaces.js";
+
+export const resolveEndpointUrl = (
+  endpoint: string | undefined,
+  baseUrl: string | undefined,
+): string | undefined => {
+  if (!endpoint) return undefined;
+  if (isSchemaUrl(endpoint)) return endpoint;
+
+  return baseUrl ? joinUrl(baseUrl, endpoint) : joinUrl(endpoint);
+};


### PR DESCRIPTION
`@zudoku/plugin-graphql` v0.0.6 failed to build in consumer projects. `src/interfaces.ts` imported `joinUrl` from bare `zudoku`, which the package publishes as TypeScript source. That module is reachable from the plugin's `vite.config.ts`, which the consumer's zudoku loads through Node, and Node refuses to strip types from files under `node_modules`.

Moved `resolveEndpointUrl` (the only `joinUrl` user, and client-only) into its own module so `interfaces.ts` no longer imports `zudoku` at all.