### PR TITLE
chore(create-zudoku): refresh plugin comments in zuplo template

### DIFF
--- a/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
+++ b/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
@@ -91,13 +91,12 @@ const config: ZudokuConfig = {
     enabled: true,
   },
   plugins: [
-    // Uncomment to document a GraphQL API.
+    // Uncomment to document a GraphQL API:
     // graphqlPlugin({
-    //   schema: "schema.graphql",
+    //   schema: "./schema.graphql",
     //   endpoint: "/mygraph", // (optional, default: "/graphql")
     // }),
-    // Uncomment to enable monetization. Don't forget to also uncomment the
-    // `zuploMonetizationPlugin` import at the top of this file.
+    // Uncomment to enable monetization:
     // zuploMonetizationPlugin(),
   ],
 };

--- a/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
+++ b/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
@@ -1,8 +1,4 @@
-// Uncomment the import below to enable Zuplo monetization (pricing, checkout,
-// subscriptions). See: https://zuplo.com/docs/articles/monetization
 // import { zuploMonetizationPlugin } from "@zuplo/zudoku-plugin-monetization";
-// Uncomment the import below to document a GraphQL API (schema reference docs
-// and an interactive playground).
 // import { graphqlPlugin } from "@zudoku/plugin-graphql";
 import type { ZudokuConfig } from "zudoku";
 
@@ -94,23 +90,16 @@ const config: ZudokuConfig = {
   apiKeys: {
     enabled: true,
   },
-  // Uncomment to enable monetization. Don't forget to also uncomment the
-  // `zuploMonetizationPlugin` import at the top of this file.
-  // plugins: [zuploMonetizationPlugin()],
-  //
-  // Uncomment to document a GraphQL API. Don't forget to also uncomment the
-  // `graphqlPlugin` import at the top of this file. To enable this alongside
-  // another plugin, place both inside a single `plugins: [...]` array.
-  // plugins: [
-  //   graphqlPlugin({
-  //     schema: "https://api.example.com/graphql",
-  //     path: "graphql",
-  //     options: {
-  //       title: "My GraphQL API",
-  //       description: "Explore the schema and try queries in the playground.",
-  //     },
-  //   }),
-  // ],
+  plugins: [
+    // Uncomment to document a GraphQL API.
+    // graphqlPlugin({
+    //   schema: "schema.graphql",
+    //   endpoint: "/mygraph", // (optional, default: "/graphql")
+    // }),
+    // Uncomment to enable monetization. Don't forget to also uncomment the
+    // `zuploMonetizationPlugin` import at the top of this file.
+    // zuploMonetizationPlugin(),
+  ],
 };
 
 export default config;

--- a/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
+++ b/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
@@ -93,6 +93,7 @@ const config: ZudokuConfig = {
   plugins: [
     // Uncomment to document a GraphQL API:
     // graphqlPlugin({
+    //   path: "/graphql",
     //   schema: "./schema.graphql",
     //   endpoint: "/graphql", // (optional, default: "/graphql")
     // }),

--- a/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
+++ b/packages/create-zudoku/templates/zuplo/zudoku.config.tsx
@@ -94,7 +94,7 @@ const config: ZudokuConfig = {
     // Uncomment to document a GraphQL API:
     // graphqlPlugin({
     //   schema: "./schema.graphql",
-    //   endpoint: "/mygraph", // (optional, default: "/graphql")
+    //   endpoint: "/graphql", // (optional, default: "/graphql")
     // }),
     // Uncomment to enable monetization:
     // zuploMonetizationPlugin(),


### PR DESCRIPTION
Restructure the GraphQL and monetization plugin guidance into a single plugins array with updated graphqlPlugin example (schema + endpoint).