### PR TITLE
fix(plugin-graphql): use `deploymentUrl` for playground endpoint

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zudoku/plugin-graphql",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/zuplo/zudoku",

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "react": ">=19.2.0",
     "react-dom": ">=19.2.0",
-    "zudoku": ">=0.82.0"
+    "zudoku": ">=0.82.2"
   },
   "peerDependenciesMeta": {
     "zudoku": {

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "react": ">=19.2.0",
     "react-dom": ">=19.2.0",
-    "zudoku": ">=0.82.2"
+    "zudoku": ">=0.82.0"
   },
   "peerDependenciesMeta": {
     "zudoku": {

--- a/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
@@ -245,7 +245,7 @@ const GraphQLWorkbenchDrawer = ({
 }) => {
   const { options, schema, endpoint: configuredEndpoint } = useGraphQLSchema();
   const { env } = useZudoku();
-  const gatewayUrl = env.ZUPLO_GATEWAY_SERVICE_URL;
+  const gatewayUrl = env.ZUPLO_PUBLIC_DEPLOYMENT_URL;
   const endpoint =
     resolveEndpointUrl(configuredEndpoint, gatewayUrl) ??
     (gatewayUrl ? joinUrl(gatewayUrl, "graphql") : undefined);

--- a/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLWorkbench.tsx
@@ -245,7 +245,7 @@ const GraphQLWorkbenchDrawer = ({
 }) => {
   const { options, schema, endpoint: configuredEndpoint } = useGraphQLSchema();
   const { env } = useZudoku();
-  const gatewayUrl = env.ZUPLO_PUBLIC_DEPLOYMENT_URL;
+  const gatewayUrl = env.ZUPLO_SERVER_URL;
   const endpoint =
     resolveEndpointUrl(configuredEndpoint, gatewayUrl) ??
     (gatewayUrl ? joinUrl(gatewayUrl, "graphql") : undefined);

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -101,6 +101,8 @@ export async function getViteConfig(
     getZuploSystemConfigurations(process.env.ZUPLO_SYSTEM_CONFIGURATIONS)
       ?.__ZUPLO_DEPLOYMENT_NAME;
 
+  const deploymentUrl = ZuploEnv.buildConfig?.deploymentUrl;
+
   const viteConfig: InlineConfig = {
     root: dir,
     base,
@@ -129,6 +131,8 @@ export async function getViteConfig(
       "import.meta.env.ZUDOKU_HAS_SERVER": JSON.stringify(options.ssr === true),
       "import.meta.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME":
         JSON.stringify(deploymentName),
+      "import.meta.env.ZUPLO_PUBLIC_DEPLOYMENT_URL":
+        JSON.stringify(deploymentUrl),
       ...defineEnvVars([
         "SENTRY_DSN",
         "ZUPLO_BUILD_ID",

--- a/packages/zudoku/src/vite/config.ts
+++ b/packages/zudoku/src/vite/config.ts
@@ -101,8 +101,6 @@ export async function getViteConfig(
     getZuploSystemConfigurations(process.env.ZUPLO_SYSTEM_CONFIGURATIONS)
       ?.__ZUPLO_DEPLOYMENT_NAME;
 
-  const deploymentUrl = ZuploEnv.buildConfig?.deploymentUrl;
-
   const viteConfig: InlineConfig = {
     root: dir,
     base,
@@ -131,8 +129,6 @@ export async function getViteConfig(
       "import.meta.env.ZUDOKU_HAS_SERVER": JSON.stringify(options.ssr === true),
       "import.meta.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME":
         JSON.stringify(deploymentName),
-      "import.meta.env.ZUPLO_PUBLIC_DEPLOYMENT_URL":
-        JSON.stringify(deploymentUrl),
       ...defineEnvVars([
         "SENTRY_DSN",
         "ZUPLO_BUILD_ID",


### PR DESCRIPTION
The GraphQL playground resolved relative endpoints against `ZUPLO_GATEWAY_SERVICE_URL`, an internal service URL. It now uses `ZUPLO_SERVER_URL`