### PR TITLE
Detect and error on conflicting routes between plugins

### DIFF
--- a/packages/zudoku/src/app/detectRouteConflicts.test.ts
+++ b/packages/zudoku/src/app/detectRouteConflicts.test.ts
@@ -1,0 +1,71 @@
+import type { RouteObject } from "react-router";
+import { describe, expect, it } from "vitest";
+import { detectRouteConflicts } from "./detectRouteConflicts.js";
+
+describe("detectRouteConflicts", () => {
+  it("returns no conflicts for disjoint plugin routes", () => {
+    const a: RouteObject[] = [{ path: "/docs" }];
+    const b: RouteObject[] = [{ path: "/api" }];
+
+    expect(detectRouteConflicts([a, b])).toEqual([]);
+  });
+
+  it("detects the same path registered by two plugins", () => {
+    const a: RouteObject[] = [{ path: "/docs", element: null }];
+    const b: RouteObject[] = [{ path: "/docs", element: null }];
+
+    expect(detectRouteConflicts([a, b])).toEqual(["/docs"]);
+  });
+
+  it("normalizes trailing slashes before comparing", () => {
+    const a: RouteObject[] = [{ path: "/docs/" }];
+    const b: RouteObject[] = [{ path: "/docs" }];
+
+    expect(detectRouteConflicts([a, b])).toEqual(["/docs"]);
+  });
+
+  it("does not flag a path repeated within a single plugin", () => {
+    // A plugin legitimately repeats a path across a parent and its children.
+    const plugin: RouteObject[] = [
+      {
+        path: "/api",
+        children: [{ index: true, path: "/api" }, { path: "/api/tags" }],
+      },
+    ];
+
+    expect(detectRouteConflicts([plugin])).toEqual([]);
+  });
+
+  it("joins relative child paths with their parent", () => {
+    const a: RouteObject[] = [
+      { path: "/section", children: [{ path: "page" }] },
+    ];
+    const b: RouteObject[] = [{ path: "/section/page" }];
+
+    expect(detectRouteConflicts([a, b])).toEqual(["/section/page"]);
+  });
+
+  it("keeps absolute child paths absolute", () => {
+    // Mirrors the OpenAPI plugin, whose children repeat the full parent path.
+    const a: RouteObject[] = [
+      { path: "/api", children: [{ path: "/api/tags" }] },
+    ];
+    const b: RouteObject[] = [{ path: "/api/tags" }];
+
+    expect(detectRouteConflicts([a, b])).toEqual(["/api/tags"]);
+  });
+
+  it("reports every conflicting path sorted", () => {
+    const a: RouteObject[] = [{ path: "/b" }, { path: "/a" }];
+    const b: RouteObject[] = [{ path: "/a" }, { path: "/b" }];
+
+    expect(detectRouteConflicts([a, b])).toEqual(["/a", "/b"]);
+  });
+
+  it("ignores pathless layout routes", () => {
+    const a: RouteObject[] = [{ children: [{ path: "/docs" }] }];
+    const b: RouteObject[] = [{ children: [{ path: "/api" }] }];
+
+    expect(detectRouteConflicts([a, b])).toEqual([]);
+  });
+});

--- a/packages/zudoku/src/app/detectRouteConflicts.test.ts
+++ b/packages/zudoku/src/app/detectRouteConflicts.test.ts
@@ -68,4 +68,22 @@ describe("detectRouteConflicts", () => {
 
     expect(detectRouteConflicts([a, b])).toEqual([]);
   });
+
+  it("detects a top-level index route conflicting with an explicit root path", () => {
+    // An index route with no path matches the root "/".
+    const a: RouteObject[] = [{ index: true, element: null }];
+    const b: RouteObject[] = [{ path: "/", element: null }];
+
+    expect(detectRouteConflicts([a, b])).toEqual(["/"]);
+  });
+
+  it("detects a nested index route conflicting with its parent path", () => {
+    // Mirrors the OpenAPI plugin's `{ index: true }` redirect under a version.
+    const a: RouteObject[] = [
+      { path: "/api", children: [{ index: true, element: null }] },
+    ];
+    const b: RouteObject[] = [{ path: "/api", element: null }];
+
+    expect(detectRouteConflicts([a, b])).toEqual(["/api"]);
+  });
 });

--- a/packages/zudoku/src/app/detectRouteConflicts.ts
+++ b/packages/zudoku/src/app/detectRouteConflicts.ts
@@ -1,9 +1,11 @@
 import type { RouteObject } from "react-router";
 import { joinUrl } from "../lib/util/joinUrl.js";
 
-// Collect the absolute path of every route that declares one. Child paths in
+// Collect the absolute path of every route that resolves to one. Child paths in
 // zudoku plugins are authored as absolute (already basePath-joined), so only
-// join with the parent when the child path is relative.
+// join with the parent when the child path is relative. Index routes
+// (`{ index: true }`) carry no `path` but match their parent path (or `/` at the
+// top level), so they're recorded against that path too.
 const collectPaths = (
   routes: RouteObject[],
   parent = "",
@@ -18,6 +20,7 @@ const collectPaths = (
         : parent;
 
     if (route.path != null) acc.add(fullPath);
+    else if (route.index) acc.add(joinUrl(parent));
     if (route.children) collectPaths(route.children, fullPath, acc);
   }
 

--- a/packages/zudoku/src/app/detectRouteConflicts.ts
+++ b/packages/zudoku/src/app/detectRouteConflicts.ts
@@ -1,0 +1,49 @@
+import type { RouteObject } from "react-router";
+import { joinUrl } from "../lib/util/joinUrl.js";
+
+// Collect the absolute path of every route that declares one. Child paths in
+// zudoku plugins are authored as absolute (already basePath-joined), so only
+// join with the parent when the child path is relative.
+const collectPaths = (
+  routes: RouteObject[],
+  parent = "",
+  acc = new Set<string>(),
+): Set<string> => {
+  for (const route of routes) {
+    const fullPath =
+      route.path != null
+        ? route.path.startsWith("/")
+          ? joinUrl(route.path)
+          : joinUrl(parent, route.path)
+        : parent;
+
+    if (route.path != null) acc.add(fullPath);
+    if (route.children) collectPaths(route.children, fullPath, acc);
+  }
+
+  return acc;
+};
+
+/**
+ * Detect routes registered by more than one plugin. Each entry in
+ * `pluginRoutes` is the route tree returned by a single plugin's `getRoutes()`.
+ * Paths are deduplicated within a plugin (a plugin legitimately repeats a path
+ * across a parent and its index child), so only paths owned by multiple plugins
+ * are reported. Returns the conflicting paths sorted alphabetically.
+ */
+export const detectRouteConflicts = (
+  pluginRoutes: RouteObject[][],
+): string[] => {
+  const counts = new Map<string, number>();
+
+  for (const routes of pluginRoutes) {
+    for (const path of collectPaths(routes)) {
+      counts.set(path, (counts.get(path) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([path]) => path)
+    .sort();
+};

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -105,7 +105,9 @@ export const getRoutesByOptions = (
     isNavigationPlugin(plugin) ? plugin.getRoutes() : [],
   );
 
-  const conflicts = detectRouteConflicts(pluginRoutes);
+  const conflicts = import.meta.env.DEV
+    ? detectRouteConflicts(pluginRoutes)
+    : [];
   if (conflicts.length > 0) {
     throw new ZudokuError(
       `Multiple plugins registered the same route${

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -28,6 +28,8 @@ import { isNavigationPlugin } from "../lib/core/plugins.js";
 import { RouteGuard } from "../lib/core/RouteGuard.js";
 import type { ZudokuContextOptions } from "../lib/core/ZudokuContext.js";
 import { RouterError } from "../lib/errors/RouterError.js";
+import { ZudokuError } from "../lib/util/invariant.js";
+import { detectRouteConflicts } from "./detectRouteConflicts.js";
 import { ZuploEnv } from "./env.js";
 import { processRoutes } from "./processRoutes.js";
 import { createRedirectRoutes } from "./utils/createRedirectRoutes.js";
@@ -99,8 +101,26 @@ export const getRoutesByOptions = (
     ...(options.authentication ? [options.authentication] : []),
   ];
 
-  const routes = allPlugins
-    .flatMap((plugin) => (isNavigationPlugin(plugin) ? plugin.getRoutes() : []))
+  const pluginRoutes = allPlugins.map((plugin) =>
+    isNavigationPlugin(plugin) ? plugin.getRoutes() : [],
+  );
+
+  const conflicts = detectRouteConflicts(pluginRoutes);
+  if (conflicts.length > 0) {
+    throw new ZudokuError(
+      `Multiple plugins registered the same route${
+        conflicts.length > 1 ? "s" : ""
+      }: ${conflicts.map((path) => `"${path}"`).join(", ")}.`,
+      {
+        title: "Conflicting routes",
+        developerHint:
+          "Two or more plugins resolve to the same path, so one silently shadows the others. Check your OpenAPI/markdown/custom-page plugins for overlapping `path`s or `basePath`s and give each a unique route.",
+      },
+    );
+  }
+
+  const routes = pluginRoutes
+    .flat()
     .concat(
       enableStatusPages
         ? [400, 404, 500].map((statusCode) => ({
@@ -114,8 +134,6 @@ export const getRoutesByOptions = (
       ...route,
       errorElement: <RouterError className="w-full m-0" />,
     }));
-
-  // @TODO Detect conflicts in routes and log warning
 
   return routes;
 };


### PR DESCRIPTION
## Summary

Add route conflict detection to prevent multiple plugins from silently shadowing each other when they register the same path. In development mode, the app now throws a `ZudokuError` if conflicts are detected, with a helpful error message and developer hint.

## Changes

- **New module `detectRouteConflicts.ts`**: Implements conflict detection by collecting all absolute paths from plugin route trees, accounting for:
  - Relative vs. absolute child paths (relative paths are joined with parent, absolute paths are kept as-is)
  - Trailing slash normalization via `joinUrl()`
  - Deduplication within a single plugin (legitimate parent/child path repetition)
  - Pathless layout routes (ignored)

- **New test suite `detectRouteConflicts.test.ts`**: Comprehensive test coverage for all edge cases including disjoint routes, duplicate paths, path normalization, nested routes, and sorting

- **Updated `main.tsx`**: 
  - Refactored route collection to preserve per-plugin route arrays for conflict checking
  - Added dev-mode conflict detection that throws a `ZudokuError` with actionable guidance
  - Removed TODO comment about route conflict detection

## Implementation Details

The conflict detection runs only in development mode (`import.meta.env.DEV`) to avoid runtime overhead in production. When conflicts are found, the error includes:
- A clear message listing all conflicting paths
- A developer hint suggesting to check for overlapping `path`s or `basePath`s in plugins
- Proper pluralization of "route" vs "routes"

The `collectPaths()` function recursively traverses route trees and handles the nuance that zudoku plugins author child paths as absolute (already basePath-joined), so only relative child paths are joined with their parent.

https://claude.ai/code/session_01RGUndHnRZeugHft6LLJjvS