### PR TITLE
fix(plugin-graphql): render markdown in schema list and search descriptions

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zudoku/plugin-graphql",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/zuplo/zudoku",

--- a/packages/plugin-graphql/src/components/LinkSafeMarkdown.tsx
+++ b/packages/plugin-graphql/src/components/LinkSafeMarkdown.tsx
@@ -1,0 +1,23 @@
+import { Markdown } from "zudoku/components";
+
+/**
+ * Markdown for descriptions rendered inside a `<Link>`/`<a>` (cards, search
+ * rows). Paragraphs render inline and links become spans, so we never nest
+ * anchors or put a `<p>` inside an `<a>`, both of which break hydration.
+ */
+export const LinkSafeMarkdown = ({
+  content,
+  className,
+}: {
+  content: string;
+  className?: string;
+}) => (
+  <Markdown
+    content={content}
+    className={className}
+    components={{
+      p: ({ children }) => children,
+      a: ({ node, href, target, rel, ...props }) => <span {...props} />,
+    }}
+  />
+);

--- a/packages/plugin-graphql/src/components/SchemaSearch.tsx
+++ b/packages/plugin-graphql/src/components/SchemaSearch.tsx
@@ -8,6 +8,7 @@ import { Input } from "zudoku/ui/Input.js";
 import { useGraphQLSchema } from "../context.js";
 import type { SchemaIndex } from "../util/schemaIndex.js";
 import { kindToRootType, ROOT_TYPES, typeMetadata } from "../util/types.js";
+import { LinkSafeMarkdown } from "./LinkSafeMarkdown.js";
 
 type SearchItem = {
   id: string;
@@ -69,9 +70,10 @@ export const SchemaSearch = () => {
                 </Badge>
               </div>
               {item.detail && (
-                <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
-                  {item.detail}
-                </p>
+                <LinkSafeMarkdown
+                  content={item.detail}
+                  className="prose-sm mt-1 line-clamp-1 text-xs text-muted-foreground"
+                />
               )}
             </Link>
           ))}

--- a/packages/plugin-graphql/src/pages/TypeListPage.tsx
+++ b/packages/plugin-graphql/src/pages/TypeListPage.tsx
@@ -7,6 +7,7 @@ import {
   ItemDescription,
   ItemTitle,
 } from "zudoku/ui/Item.js";
+import { LinkSafeMarkdown } from "../components/LinkSafeMarkdown.js";
 import { useGraphQLSchema } from "../context.js";
 import type { SchemaIndex } from "../util/schemaIndex.js";
 import { ROOT_TYPES, type RootType, typeMetadata } from "../util/types.js";
@@ -99,8 +100,11 @@ export const TypeListPage = ({ kind }: TypeListPageProps) => {
                       </code>
                     </ItemTitle>
                     {item.description && (
-                      <ItemDescription className="line-clamp-2">
-                        {item.description}
+                      <ItemDescription asChild>
+                        <LinkSafeMarkdown
+                          content={item.description}
+                          className="prose-sm text-pretty"
+                        />
                       </ItemDescription>
                     )}
                   </ItemContent>


### PR DESCRIPTION
Operation and type descriptions in the GraphQL schema docs rendered as raw text, so authored markdown (bold, code, links) and inline MDX like `<Badge>` showed literally in the list cards and search results.

`TypeListPage` cards and `SchemaSearch` rows now render descriptions through `<Markdown>`, matching the detail pages and the OpenAPI tag-list pattern. Added a small `LinkSafeMarkdown` wrapper that renders paragraphs inline and turns links into spans, since these descriptions sit inside a `<Link>` where a nested anchor or `<p>` would break hydration.