### PR TITLE
fix(plugin-graphql): serve build-time schema for playground introspection

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zudoku/plugin-graphql",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/zuplo/zudoku",

--- a/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
@@ -50,7 +50,7 @@ export const GraphQLPlayground = ({
       // Serve build-time schema for introspection to avoid hitting live endpoint.
       if (
         graphQLParams.operationName === "IntrospectionQuery" ||
-        graphQLParams.query.includes("__schema")
+        graphQLParams.query?.includes("__schema")
       ) {
         return { data: schema };
       }

--- a/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
+++ b/packages/plugin-graphql/src/components/GraphQLPlayground.tsx
@@ -47,13 +47,15 @@ export const GraphQLPlayground = ({
 
   const fetcher = useMemo<GraphiQLFetcher>(
     () => async (graphQLParams, opts) => {
+      // Serve build-time schema for introspection to avoid hitting live endpoint.
+      if (
+        graphQLParams.operationName === "IntrospectionQuery" ||
+        graphQLParams.query.includes("__schema")
+      ) {
+        return { data: schema };
+      }
+
       if (!endpoint) {
-        if (
-          graphQLParams.operationName === "IntrospectionQuery" ||
-          graphQLParams.query.includes("__schema")
-        ) {
-          return { data: schema };
-        }
         return {
           errors: [
             {


### PR DESCRIPTION
The GraphiQL docs explorer showed "Error fetching schema" when the playground `endpoint` pointed at an auth-gated API. GraphiQL runs its introspection through the plugin's fetcher, which only served the build-time schema when no endpoint was configured. With an endpoint set, introspection hit the live endpoint and failed (401, or introspection disabled).

The fetcher now serves the build-time schema for any `IntrospectionQuery` regardless of endpoint. Real operations still go to the live endpoint with auth applied.