### PR TITLE
fix(markdown): pin UTC timezone for last modified date to avoid hydration mismatch

### DIFF
--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -24,6 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "zudoku/ui/Popover.js";
 import type { TocEntry } from "../../../vite/mdx/rehype-extract-toc-with-jsx.js";
 import { AiAssistantMenuItems } from "../../components/AiAssistantMenuItems.js";
 import { CategoryHeading } from "../../components/CategoryHeading.js";
+import { useIsClient } from "../../components/ClientOnly.js";
 import { useViewportAnchor } from "../../components/context/ViewportAnchorContext.js";
 import { useZudoku } from "../../components/context/ZudokuContext.js";
 import { DeveloperHint } from "../../components/DeveloperHint.js";
@@ -192,6 +193,8 @@ export const MdxPage = ({
   const lastModifiedDate = frontmatter.lastModifiedTime
     ? new Date(frontmatter.lastModifiedTime)
     : null;
+
+  const isClient = useIsClient();
 
   const editConfig =
     frontmatter.suggestEdit !== false &&
@@ -400,25 +403,26 @@ export const MdxPage = ({
               <div>
                 {showLastModified && lastModifiedDate && (
                   <div
-                    title={lastModifiedDate.toLocaleString("en-US", {
-                      dateStyle: "full",
-                      timeStyle: "medium",
-                      // Pin the locale and timezone so the prerendered (UTC,
-                      // server-default-locale) markup matches the client render
-                      // and avoids a hydration mismatch, matching the visible
-                      // date below.
-                      timeZone: "UTC",
-                    })}
+                    // Render the tooltip (full date + time in the viewer's local
+                    // timezone) only on the client. It's omitted on the server and
+                    // the first client render, so there's no hydration mismatch,
+                    // then added after mount.
+                    title={
+                      isClient
+                        ? lastModifiedDate.toLocaleString("en-US", {
+                            dateStyle: "full",
+                            timeStyle: "medium",
+                          })
+                        : undefined
+                    }
                   >
                     Last modified on{" "}
                     <time dateTime={lastModifiedDate.toISOString()}>
                       {lastModifiedDate.toLocaleDateString("en-US", {
                         dateStyle: "long",
-                        // Pin the timezone so the date formatted during prerender
-                        // (UTC) matches the client render. Without this, a doc
-                        // last modified near a UTC day boundary formats as a
-                        // different calendar day in the visitor's timezone,
-                        // causing a React hydration error (#418).
+                        // Pinned to UTC so the prerendered day matches the client
+                        // render; a local timezone would shift the day near a UTC
+                        // boundary and cause a hydration error (#418).
                         timeZone: "UTC",
                       })}
                     </time>

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -403,12 +403,21 @@ export const MdxPage = ({
                     title={lastModifiedDate.toLocaleString(undefined, {
                       dateStyle: "full",
                       timeStyle: "medium",
+                      // Pin the timezone so the prerendered (UTC) markup matches
+                      // the client render and avoids a hydration mismatch.
+                      timeZone: "UTC",
                     })}
                   >
                     Last modified on{" "}
                     <time dateTime={lastModifiedDate.toISOString()}>
                       {lastModifiedDate.toLocaleDateString("en-US", {
                         dateStyle: "long",
+                        // Pin the timezone so the date formatted during prerender
+                        // (UTC) matches the client render. Without this, a doc
+                        // last modified near a UTC day boundary formats as a
+                        // different calendar day in the visitor's timezone,
+                        // causing a React hydration error (#418).
+                        timeZone: "UTC",
                       })}
                     </time>
                   </div>

--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -400,11 +400,13 @@ export const MdxPage = ({
               <div>
                 {showLastModified && lastModifiedDate && (
                   <div
-                    title={lastModifiedDate.toLocaleString(undefined, {
+                    title={lastModifiedDate.toLocaleString("en-US", {
                       dateStyle: "full",
                       timeStyle: "medium",
-                      // Pin the timezone so the prerendered (UTC) markup matches
-                      // the client render and avoids a hydration mismatch.
+                      // Pin the locale and timezone so the prerendered (UTC,
+                      // server-default-locale) markup matches the client render
+                      // and avoids a hydration mismatch, matching the visible
+                      // date below.
                       timeZone: "UTC",
                     })}
                   >


### PR DESCRIPTION
## Problem

`zuplo.com/docs` (and any Zudoku site with `showLastModified: true`) throws a steady stream of **React hydration errors** — [minified React error #418](https://react.dev/errors/418), `args[]=text` ("text content does not match server-rendered HTML"). It fires site-wide across docs pages (`/docs`, `/docs/articles/...`, `/docs/mcp-server/introduction`, …), and was the top error in our PostHog error tracking (467 occurrences / 348 users / 30 days, across all browsers and OSes).

## Root cause

In `MdxPage.tsx`, the "Last modified on {date}" footer formats the date with `toLocaleDateString`/`toLocaleString` **without a `timeZone` option**, so it uses the *runtime's* timezone:

- The prerender/SSR runs in **UTC**
- The browser runs in the **visitor's timezone**

The `lastModifiedTime` value is baked into frontmatter at build time (from the git commit date), so the timestamp itself is identical on server and client — only the *formatting* differs. For a document last modified near a UTC day boundary (e.g. `…T02:00Z`), the server renders e.g. "June 19, 2026" while a US-Pacific visitor renders "June 18, 2026". That text-node mismatch triggers #418 and React discards the hydrated subtree.

A previous fix (#1439) pinned the **locale** to `en-US` for the visible text but left the **timezone** unpinned, which is why the mismatch became intermittent (timezone-boundary-dependent) rather than constant.

## Fix

Pin `timeZone: "UTC"` on both the visible `<time>` text and the `title` tooltip so server and client format the date deterministically. Minimal, presentational-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)