### PR TITLE
Fix documentation link path in landing page component

### DIFF
--- a/docs/pages/docs/components/landing-page.mdx
+++ b/docs/pages/docs/components/landing-page.mdx
@@ -10,7 +10,7 @@ A ready-made, customizable landing page for your developer portal. It comes in t
 covering the most common layouts: a centered hero, a two-column split hero, and a compact
 documentation hub.
 
-Use it as the `element` of a [custom page](/docs/custom-pages) — typically your home page:
+Use it as the `element` of a [custom page](/docs/guides/custom-pages) — typically your home page:
 
 ```tsx title=zudoku.config.tsx
 import { LandingPage } from "zudoku/components";


### PR DESCRIPTION
## Summary
Updated an incorrect documentation link in the landing page component documentation to point to the correct path structure.

## Changes
- Fixed the link path from `/docs/custom-pages` to `/docs/guides/custom-pages` in the landing page documentation example