### PR TITLE
fix: render raw HTML in markdown files

### DIFF
--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -94,6 +94,7 @@
     "@graphql-typed-document-node/core": "3.2.0",
     "@hono/node-server": "2.0.3",
     "@lekoarts/rehype-meta-as-attributes": "3.0.3",
+    "@mdx-js/mdx": "3.1.0",
     "@mdx-js/react": "3.1.1",
     "@mdx-js/rollup": "3.1.1",
     "@pothos/core": "4.12.0",

--- a/packages/zudoku/src/vite/plugin-mdx.test.ts
+++ b/packages/zudoku/src/vite/plugin-mdx.test.ts
@@ -1,0 +1,37 @@
+import { compile, nodeTypes } from "@mdx-js/mdx";
+import rehypeRaw from "rehype-raw";
+import { describe, expect, it } from "vitest";
+
+// Mirrors how plugin-mdx wires rehype-raw so raw HTML in `.md` files survives.
+const rehypePlugins = [[rehypeRaw, { passThrough: nodeTypes }]] as const;
+
+describe("raw HTML handling in the mdx pipeline", () => {
+  it("preserves a raw HTML anchor in a markdown (.md) file", async () => {
+    const md = `Download the spec:
+
+<a href="/documents/api-spec.pdf" download="/documents/api-spec.pdf">Download</a>
+`;
+    const out = String(await compile(md, { format: "md", rehypePlugins }));
+
+    expect(out).toContain('href: "/documents/api-spec.pdf"');
+    expect(out).toContain('download: "/documents/api-spec.pdf"');
+    expect(out).toContain("_components.a");
+  });
+
+  it("keeps MDX imports, components and expressions intact (.mdx)", async () => {
+    const mdx = `import { Foo } from "./foo.js";
+
+<Foo bar="baz" />
+
+{1 + 2}
+
+<a href="/x.pdf">Download</a>
+`;
+    const out = String(await compile(mdx, { format: "mdx", rehypePlugins }));
+
+    expect(out).toMatch(/import\s*\{\s*Foo\s*\}/);
+    expect(out).toMatch(/_jsx\(Foo/);
+    expect(out).toContain("1 + 2");
+    expect(out).toContain('href: "/x.pdf"');
+  });
+});

--- a/packages/zudoku/src/vite/plugin-mdx.test.ts
+++ b/packages/zudoku/src/vite/plugin-mdx.test.ts
@@ -1,9 +1,10 @@
 import { compile, nodeTypes } from "@mdx-js/mdx";
 import rehypeRaw from "rehype-raw";
+import type { PluggableList } from "unified";
 import { describe, expect, it } from "vitest";
 
 // Mirrors how plugin-mdx wires rehype-raw so raw HTML in `.md` files survives.
-const rehypePlugins = [[rehypeRaw, { passThrough: nodeTypes }]] as const;
+const rehypePlugins: PluggableList = [[rehypeRaw, { passThrough: nodeTypes }]];
 
 describe("raw HTML handling in the mdx pipeline", () => {
   it("preserves a raw HTML anchor in a markdown (.md) file", async () => {

--- a/packages/zudoku/src/vite/plugin-mdx.ts
+++ b/packages/zudoku/src/vite/plugin-mdx.ts
@@ -1,8 +1,10 @@
 import rehypeMetaAsAttributes from "@lekoarts/rehype-meta-as-attributes";
+import { nodeTypes } from "@mdx-js/mdx";
 import mdx from "@mdx-js/rollup";
 import type { Root as HastRoot } from "hast";
 import { toString as hastToString } from "hast-util-to-string";
 import rehypeMdxImportMedia from "rehype-mdx-import-media";
+import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import remarkComment from "remark-comment";
 import remarkDirective from "remark-directive";
@@ -128,6 +130,7 @@ const viteMdxPlugin = async (): Promise<Plugin> => {
       : [...defaultRemarkPlugins, ...(buildConfig?.remarkPlugins ?? [])];
 
   const defaultRehypePlugins = [
+    [rehypeRaw, { passThrough: nodeTypes }],
     rehypeSlug,
     rehypeExtractTocWithJsx,
     rehypeExtractTocWithJsxExport,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,12 +650,15 @@ importers:
       '@lekoarts/rehype-meta-as-attributes':
         specifier: 3.0.3
         version: 3.0.3
+      '@mdx-js/mdx':
+        specifier: 3.1.0
+        version: 3.1.0(acorn@8.17.0)
       '@mdx-js/react':
         specifier: 3.1.1
         version: 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@mdx-js/rollup':
         specifier: 3.1.1
-        version: 3.1.1(acorn@8.16.0)(rollup@4.59.0)
+        version: 3.1.1(acorn@8.17.0)(rollup@4.59.0)
       '@pothos/core':
         specifier: 4.12.0
         version: 4.12.0(graphql@16.14.0)
@@ -12135,7 +12138,7 @@ snapshots:
     dependencies:
       unist-util-visit: 5.1.0
 
-  '@mdx-js/mdx@3.1.0(acorn@8.16.0)':
+  '@mdx-js/mdx@3.1.0(acorn@8.17.0)':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -12149,7 +12152,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.0(acorn@8.16.0)
+      recma-jsx: 1.0.0(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.0.1
@@ -12171,9 +12174,9 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
-  '@mdx-js/rollup@3.1.1(acorn@8.16.0)(rollup@4.59.0)':
+  '@mdx-js/rollup@3.1.1(acorn@8.17.0)(rollup@4.59.0)':
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
+      '@mdx-js/mdx': 3.1.0(acorn@8.17.0)
       '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
       rollup: 4.59.0
       source-map: 0.7.6
@@ -14737,10 +14740,13 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn@8.16.0: {}
 
-  acorn@8.17.0:
-    optional: true
+  acorn@8.17.0: {}
 
   address@2.0.3: {}
 
@@ -15565,7 +15571,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.16.0
+      acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
 
@@ -17897,9 +17903,9 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.0(acorn@8.16.0):
+  recma-jsx@1.0.0(acorn@8.17.0):
     dependencies:
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0


### PR DESCRIPTION
Raw HTML in `.md` files, like the `<a download>` link the Static Files docs recommend for downloads, was silently stripped to plain text during build, so no link appeared in the output. The build-time MDX pipeline was missing `rehype-raw`, which the runtime `Markdown` component already uses.

This adds `rehype-raw` with `passThrough: nodeTypes` so raw HTML in `.md` files renders correctly while `.mdx` JSX, imports and expressions stay intact. `.mdx` output is unchanged; only `.md` files that contain raw HTML are affected, and that content was already broken.