### PR TITLE
fix(plugin-ai): read dev portal URL from ZUPLO_BUILD_CONFIG.urls.devPortal

### DIFF
--- a/packages/plugin-ai/src/index.test.tsx
+++ b/packages/plugin-ai/src/index.test.tsx
@@ -103,11 +103,26 @@ describe("getZuploDeploymentUrl", () => {
     expect(getZuploDeploymentUrl()).toBeUndefined();
   });
 
-  it("reads the deployment URL from ZUPLO_BUILD_CONFIG", () => {
+  it("reads the dev portal URL from ZUPLO_BUILD_CONFIG urls.devPortal", () => {
+    // Core sends a DeploymentUrlConfig ({ api, devPortal }); the dev portal URL
+    // is the deployed Zudoku site, while `api` is the gateway URL.
+    vi.stubEnv(
+      "ZUPLO_BUILD_CONFIG",
+      JSON.stringify({
+        urls: {
+          api: { defaultUrl: "https://gateway.zuplo.dev", urls: [] },
+          devPortal: { defaultUrl: "https://portal.zuplo.dev", urls: [] },
+        },
+      }),
+    );
+    expect(getZuploDeploymentUrl()).toBe("https://portal.zuplo.dev");
+  });
+
+  it("ignores a top-level deploymentUrl that core never sends", () => {
     vi.stubEnv(
       "ZUPLO_BUILD_CONFIG",
       JSON.stringify({ deploymentUrl: "https://portal.zuplo.dev" }),
     );
-    expect(getZuploDeploymentUrl()).toBe("https://portal.zuplo.dev");
+    expect(getZuploDeploymentUrl()).toBeUndefined();
   });
 });

--- a/packages/plugin-ai/src/site.ts
+++ b/packages/plugin-ai/src/site.ts
@@ -18,15 +18,21 @@ export const isLocalhostHostname = (hostname: string): boolean =>
  *
  * The reference must be the exact `import.meta.env.ZUPLO_BUILD_CONFIG` form so
  * the consuming Zudoku/Vite build replaces it (see `defineEnvVars` in core).
+ *
+ * The deployed dev portal URL lives at `urls.devPortal.defaultUrl` — core sends
+ * a `DeploymentUrlConfig` (`{ api, devPortal }`), not a top-level
+ * `deploymentUrl`. `urls.api.defaultUrl` is the gateway URL (a.k.a.
+ * `ZUPLO_SERVER_URL`), so it must NOT be used here.
  */
 export const getZuploDeploymentUrl = (): string | undefined => {
   const raw = import.meta.env.ZUPLO_BUILD_CONFIG;
   if (typeof raw !== "string") return undefined;
   try {
-    const config = JSON.parse(raw) as { deploymentUrl?: unknown };
-    return typeof config.deploymentUrl === "string" && config.deploymentUrl
-      ? config.deploymentUrl
-      : undefined;
+    const config = JSON.parse(raw) as {
+      urls?: { devPortal?: { defaultUrl?: unknown } };
+    };
+    const url = config.urls?.devPortal?.defaultUrl;
+    return typeof url === "string" && url ? url : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

Stacked on top of `claude/intelligent-hawking-drec6n` (the "use the Zuplo dev portal deployment URL for `docs`" branch).

That branch's `getZuploDeploymentUrl()` reads a top-level `ZUPLO_BUILD_CONFIG.deploymentUrl`, but **core never sends that key**. The Zudoku dev-portal build in `zuplo/core` (`packages/deploy/src/dev-portal/zudoku/build.ts`) serializes a `RemoteBuildConfigEnvVar`, whose URL data lives under:

```ts
urls: DeploymentUrlConfig // { api: UrlConfig; devPortal: UrlConfig }
// UrlConfig = { defaultUrl: string; urls: string[] }
```

There is no top-level `deploymentUrl`. As a result, on a real Zuplo build `getZuploDeploymentUrl()` always returned `undefined`, so the deployment-URL path never engaged — Zuplo projects silently fell back to `origin + basePath` and showed the "unavailable on localhost" notice, exactly the case the parent branch was trying to fix.

## What changed

- `packages/plugin-ai/src/site.ts`: read the deployed Zudoku site URL from `urls.devPortal.defaultUrl`. `urls.api.defaultUrl` is the gateway URL (a.k.a. `ZUPLO_SERVER_URL`) and is intentionally **not** used. Added a doc comment explaining the payload shape.
- `packages/plugin-ai/src/index.test.tsx`: updated the unit test to the real `ZUPLO_BUILD_CONFIG` payload (`{ urls: { api, devPortal } }`), and added a regression test asserting a top-level `deploymentUrl` is ignored.

## Why the bug slipped through

The original test stubbed `ZUPLO_BUILD_CONFIG` with a hand-written `{ deploymentUrl: ... }` shape that core does not produce, so the test passed while the real path was dead.

## Verification

- `pnpm vitest run packages/plugin-ai/src/index.test.tsx` → 11 passed
- `pnpm -F @zudoku/plugin-ai typecheck` → clean
- `pnpm biome ci` + `oxfmt` (via pre-commit) → clean

## Note (out of scope)

`packages/zudoku/src/app/ZuploBuildConfig.ts` still declares a dead `deploymentUrl: z.optional(z.string())` and lacks a `urls` field. It's unrelated to the chat plugin (which parses the raw env itself), but it's the same trap; worth cleaning up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CARAhak2bTT6hWNNXDsEGU)_