### PR TITLE
Log plugin versions during config load

### DIFF
--- a/packages/zudoku/src/config/loader.ts
+++ b/packages/zudoku/src/config/loader.ts
@@ -12,6 +12,7 @@ import { getZudokuRootDir } from "../cli/common/package-json.js";
 import { runPluginTransformConfig } from "../lib/core/transform-config.js";
 import invariant from "../lib/util/invariant.js";
 import { fileExists } from "./file-exists.js";
+import { getPluginVersions } from "./plugin-versions.js";
 import type {
   ResolvedZudokuConfig,
   ZudokuConfig,
@@ -239,6 +240,20 @@ export async function loadZudokuConfig(
       colors.cyan(`loaded config file `) + colors.dim(config.__meta.configPath),
       { timestamp: true },
     );
+
+    // Surface which versions of external plugins (created via `createPlugin`)
+    // the build is running, so build logs can pin down e.g. the monetization
+    // plugin version without each plugin having to log it itself.
+    const pluginVersions = await getPluginVersions(config.__pluginDirs ?? []);
+    if (pluginVersions.length > 0) {
+      logger.info(
+        colors.cyan(`loaded plugins `) +
+          colors.dim(
+            pluginVersions.map((p) => `${p.name}@${p.version}`).join(", "),
+          ),
+        { timestamp: true },
+      );
+    }
 
     return { config, envPrefix, publicEnv };
   } catch (error) {

--- a/packages/zudoku/src/config/plugin-versions.test.ts
+++ b/packages/zudoku/src/config/plugin-versions.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock("../vite/package-root.js", () => ({
+  findPackageRoot: vi.fn(),
+}));
+
+import { readFile } from "node:fs/promises";
+import { findPackageRoot } from "../vite/package-root.js";
+import { getPluginVersions } from "./plugin-versions.js";
+
+const pkg = (name: string, version: string) =>
+  JSON.stringify({ name, version });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getPluginVersions", () => {
+  it("returns an empty array when there are no plugin dirs", async () => {
+    expect(await getPluginVersions([])).toEqual([]);
+    expect(findPackageRoot).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("resolves name and version from each plugin's package.json", async () => {
+    vi.mocked(findPackageRoot).mockImplementation(async (dir) =>
+      dir === "/a/src" ? "/a" : "/b",
+    );
+    vi.mocked(readFile).mockImplementation(async (file) =>
+      String(file).startsWith("/a")
+        ? pkg("@zuplo/zudoku-plugin-monetization", "0.0.45")
+        : pkg("@zudoku/plugin-graphql", "0.0.12"),
+    );
+
+    expect(await getPluginVersions(["/a/src", "/b/src"])).toEqual([
+      { name: "@zuplo/zudoku-plugin-monetization", version: "0.0.45" },
+      { name: "@zudoku/plugin-graphql", version: "0.0.12" },
+    ]);
+  });
+
+  it("dedupes plugins that record their directory more than once", async () => {
+    vi.mocked(findPackageRoot).mockResolvedValue("/a");
+    vi.mocked(readFile).mockResolvedValue(
+      pkg("@zudoku/plugin-graphql", "1.0.0"),
+    );
+
+    expect(await getPluginVersions(["/a/x", "/a/y"])).toEqual([
+      { name: "@zudoku/plugin-graphql", version: "1.0.0" },
+    ]);
+  });
+
+  it("skips dirs without a resolvable package root", async () => {
+    vi.mocked(findPackageRoot).mockResolvedValue(undefined);
+
+    expect(await getPluginVersions(["/nowhere"])).toEqual([]);
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("skips packages with an unreadable or nameless package.json", async () => {
+    vi.mocked(findPackageRoot).mockImplementation(async (dir) => dir);
+    vi.mocked(readFile).mockImplementation(async (file) => {
+      if (String(file).startsWith("/broken")) throw new Error("ENOENT");
+      return JSON.stringify({ version: "1.0.0" }); // no name
+    });
+
+    expect(await getPluginVersions(["/broken", "/nameless"])).toEqual([]);
+  });
+
+  it("falls back to 'unknown' when a version is missing", async () => {
+    vi.mocked(findPackageRoot).mockResolvedValue("/a");
+    vi.mocked(readFile).mockResolvedValue(
+      JSON.stringify({ name: "@zudoku/plugin-graphql" }),
+    );
+
+    expect(await getPluginVersions(["/a"])).toEqual([
+      { name: "@zudoku/plugin-graphql", version: "unknown" },
+    ]);
+  });
+});

--- a/packages/zudoku/src/config/plugin-versions.ts
+++ b/packages/zudoku/src/config/plugin-versions.ts
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { findPackageRoot } from "../vite/package-root.js";
+
+export type PluginVersion = { name: string; version: string };
+
+// Resolves the npm package `name`@`version` for each plugin directory recorded
+// by `createPlugin` in `config.__pluginDirs`. This lets core surface which
+// plugin versions a build is running (e.g. in the build logs) without every
+// plugin having to log its own version. Reads each plugin's nearest
+// package.json and dedupes by package name (a plugin used multiple times
+// records its directory more than once).
+export const getPluginVersions = async (
+  pluginDirs: readonly string[],
+): Promise<PluginVersion[]> => {
+  const roots = await Promise.all(
+    [...new Set(pluginDirs)].map(findPackageRoot),
+  );
+
+  const resolved = await Promise.all(
+    roots.map(async (root): Promise<PluginVersion | undefined> => {
+      if (!root) return undefined;
+      try {
+        const pkg = JSON.parse(
+          await readFile(path.join(root, "package.json"), "utf-8"),
+        ) as { name?: string; version?: string };
+        if (!pkg.name) return undefined;
+        return { name: pkg.name, version: pkg.version ?? "unknown" };
+      } catch {
+        // A plugin without a readable package.json simply isn't reported.
+        return undefined;
+      }
+    }),
+  );
+
+  const byName = new Map<string, PluginVersion>();
+  for (const version of resolved) {
+    if (version && !byName.has(version.name)) byName.set(version.name, version);
+  }
+
+  return [...byName.values()];
+};

--- a/packages/zudoku/src/config/plugin-versions.ts
+++ b/packages/zudoku/src/config/plugin-versions.ts
@@ -4,12 +4,8 @@ import { findPackageRoot } from "../vite/package-root.js";
 
 export type PluginVersion = { name: string; version: string };
 
-// Resolves the npm package `name`@`version` for each plugin directory recorded
-// by `createPlugin` in `config.__pluginDirs`. This lets core surface which
-// plugin versions a build is running (e.g. in the build logs) without every
-// plugin having to log its own version. Reads each plugin's nearest
-// package.json and dedupes by package name (a plugin used multiple times
-// records its directory more than once).
+// Reads the `name`@`version` from each plugin dir's nearest package.json,
+// deduped by package name.
 export const getPluginVersions = async (
   pluginDirs: readonly string[],
 ): Promise<PluginVersion[]> => {


### PR DESCRIPTION
Surfaces external plugin versions in build/dev logs so you can tell which plugin version a portal is running (e.g. the monetization plugin) — done in core, not per-plugin. Resolves ZUP-6098.

Core already records each `createPlugin` plugin's directory in `config.__pluginDirs`. A new `getPluginVersions()` helper reads `name`@`version` from each, and `loadZudokuConfig` logs them after the existing `loaded config file` line:

```
zudoku  loaded plugins  @zuplo/zudoku-plugin-monetization@0.0.45
```
