### PR TITLE
fix(search): index protected routes in SSG Pagefind build

### DIFF
--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -26,7 +26,7 @@ import type { Adapter } from "./adapter.js";
 import { getRoutesByConfig } from "./main.js";
 import { protectChunks as rawProtectChunks } from "./protectChunks.js";
 import { getSsrCacheControl } from "./ssrCacheControl.js";
-import { wrapProtectedRoutes } from "./wrapProtectedRoutes.js";
+import { wrapProtectedRoutesForRender } from "./wrapProtectedRoutes.js";
 
 export { getRoutesByConfig };
 export type { Adapter, AdapterContext } from "./adapter.js";
@@ -104,12 +104,16 @@ export const handleRequest = async ({
   const ssrAuth = await resolveSsrAuth(request);
 
   // No-op lazy() on protected subtrees for unauthed requests so loaders
-  // don't run for a 401 render.
-  const effectiveRoutes = wrapProtectedRoutes(
+  // don't run for a 401 render. A bypass render (search-index pass) keeps the
+  // real content so Pagefind can index protected routes.
+  const effectiveRoutes = wrapProtectedRoutesForRender(
     routes,
     config.protectedRoutes,
-    !!ssrAuth?.profile,
-    basePath,
+    {
+      isAuthenticated: !!ssrAuth?.profile,
+      bypassProtection,
+      basePath,
+    },
   );
 
   const { query, dataRoutes } = createStaticHandler(effectiveRoutes, {

--- a/packages/zudoku/src/app/wrapProtectedRoutes.test.ts
+++ b/packages/zudoku/src/app/wrapProtectedRoutes.test.ts
@@ -1,0 +1,121 @@
+import type { RouteObject } from "react-router";
+import { describe, expect, it } from "vitest";
+import {
+  wrapProtectedRoutes,
+  wrapProtectedRoutesForRender,
+} from "./wrapProtectedRoutes.js";
+
+// Distinct lazy() references so we can assert by identity whether a route's
+// chunk was preserved or replaced with the no-op stub.
+const protectedLazy: RouteObject["lazy"] = async () => ({
+  Component: () => null,
+});
+const publicLazy: RouteObject["lazy"] = async () => ({
+  Component: () => null,
+});
+
+const makeRoutes = (): RouteObject[] => [
+  { path: "introduction", lazy: protectedLazy },
+  { path: "public", lazy: publicLazy },
+];
+
+describe("wrapProtectedRoutes", () => {
+  it("stubs protected lazy routes when unauthenticated", () => {
+    const wrapped = wrapProtectedRoutes(
+      makeRoutes(),
+      ["/introduction/*"],
+      false,
+    );
+    expect(wrapped[0]?.lazy).not.toBe(protectedLazy);
+    expect(wrapped[1]?.lazy).toBe(publicLazy);
+  });
+
+  it("preserves all routes when authenticated", () => {
+    const wrapped = wrapProtectedRoutes(
+      makeRoutes(),
+      ["/introduction/*"],
+      true,
+    );
+    expect(wrapped[0]?.lazy).toBe(protectedLazy);
+    expect(wrapped[1]?.lazy).toBe(publicLazy);
+  });
+
+  it("returns routes unchanged when there are no protected patterns", () => {
+    const routes = makeRoutes();
+    expect(wrapProtectedRoutes(routes, undefined, false)).toBe(routes);
+  });
+
+  it("stub renders nothing so the gated chunk never loads", async () => {
+    const wrapped = wrapProtectedRoutes(
+      makeRoutes(),
+      ["/introduction/*"],
+      false,
+    );
+    const stubbed = wrapped[0];
+    if (typeof stubbed?.lazy !== "function") {
+      throw new Error("expected the protected route to keep a lazy()");
+    }
+    await expect(stubbed.lazy()).resolves.toEqual({ element: null });
+  });
+});
+
+describe("wrapProtectedRoutesForRender", () => {
+  // Regression for #2672: the search-index bypass pass must render the real
+  // protected content (so Pagefind indexes it), so it keeps the lazy chunk
+  // even when the request is unauthenticated.
+  it("keeps protected content during a bypass render", () => {
+    const wrapped = wrapProtectedRoutesForRender(
+      makeRoutes(),
+      ["/introduction/*"],
+      { isAuthenticated: false, bypassProtection: true },
+    );
+    expect(wrapped[0]?.lazy).toBe(protectedLazy);
+  });
+
+  it("stubs protected content for an unauthenticated non-bypass render", () => {
+    const wrapped = wrapProtectedRoutesForRender(
+      makeRoutes(),
+      ["/introduction/*"],
+      { isAuthenticated: false, bypassProtection: false },
+    );
+    expect(wrapped[0]?.lazy).not.toBe(protectedLazy);
+  });
+
+  it("keeps protected content when authenticated", () => {
+    const wrapped = wrapProtectedRoutesForRender(
+      makeRoutes(),
+      ["/introduction/*"],
+      { isAuthenticated: true },
+    );
+    expect(wrapped[0]?.lazy).toBe(protectedLazy);
+  });
+
+  // SSR safety: a live SSR request never passes `bypassProtection`, so an
+  // unauthenticated request must still be gated exactly as before — only the
+  // internal search-index pass ever sets the flag. If this regressed,
+  // protected content would leak to logged-out users during SSR.
+  it("gates protected routes for an unauthenticated SSR request (flag omitted)", () => {
+    const wrapped = wrapProtectedRoutesForRender(
+      makeRoutes(),
+      ["/introduction/*"],
+      { isAuthenticated: false },
+    );
+    expect(wrapped[0]?.lazy).not.toBe(protectedLazy);
+  });
+
+  // A non-bypass render must behave identically to the original wrapper, so
+  // the SSR request path is unchanged by this fix.
+  it.each([false, true])(
+    "matches wrapProtectedRoutes for a non-bypass render (authenticated=%s)",
+    (isAuthenticated) => {
+      const routes = makeRoutes();
+      expect(
+        wrapProtectedRoutesForRender(routes, ["/introduction/*"], {
+          isAuthenticated,
+        }),
+      ).toEqual(
+        wrapProtectedRoutes(routes, ["/introduction/*"], isAuthenticated),
+      );
+    },
+  );
+});

--- a/packages/zudoku/src/app/wrapProtectedRoutes.ts
+++ b/packages/zudoku/src/app/wrapProtectedRoutes.ts
@@ -47,6 +47,31 @@ export const wrapProtectedRoutes = (
   });
 };
 
+// Route-wrapping decision for an SSR/SSG render. The prerender does a second
+// "bypass" pass over protected routes to build the search index; that pass must
+// render the real (unstubbed) protected content, so it is treated as
+// authenticated here. Without this, the bypass pass renders an empty shell and
+// the Pagefind index for protected routes ends up empty (issue #2672).
+export const wrapProtectedRoutesForRender = (
+  routes: RouteObject[],
+  protectedRoutes: ProtectedRoutesInput,
+  {
+    isAuthenticated,
+    bypassProtection,
+    basePath,
+  }: {
+    isAuthenticated: boolean;
+    bypassProtection?: boolean;
+    basePath?: string;
+  },
+): RouteObject[] =>
+  wrapProtectedRoutes(
+    routes,
+    protectedRoutes,
+    isAuthenticated || bypassProtection === true,
+    basePath,
+  );
+
 // Inline elements can't be chunk-isolated; RouteGuard still blocks render,
 // but the JS ships in the main bundle. Only meaningful in dev.
 export const warnInlineProtectedRoutes = (

--- a/packages/zudoku/src/vite/prerender/prerender.ts
+++ b/packages/zudoku/src/vite/prerender/prerender.ts
@@ -183,7 +183,24 @@ export const prerender = async ({
   }
 
   if (pagefindIndex) {
-    const pagesToIndex = selectPagesToIndex(workerResults, paths);
+    const { include: pagesToIndex, exclude } = selectPagesToIndex(
+      workerResults,
+      paths,
+    );
+
+    // Surface anything dropped from the index (e.g. a protected route whose
+    // bypass render returned >= 400). A page silently missing from the index
+    // is the exact symptom of #2672, so make it visible rather than quiet.
+    if (exclude.length > 0) {
+      const details = exclude
+        .map(({ url, status }) => `${url} (${status})`)
+        .join(", ");
+      logger.warn(
+        colors.yellow(
+          `⚠ ${exclude.length} route(s) excluded from the search index (render status >= 400): ${details}`,
+        ),
+      );
+    }
     // Batch size caps concurrent IPC writes to the pagefind child process;
     // higher values can overflow its pipe buffer and trigger ENOBUFS.
     const BATCH_SIZE = 40;

--- a/packages/zudoku/src/vite/prerender/prerender.ts
+++ b/packages/zudoku/src/vite/prerender/prerender.ts
@@ -20,7 +20,11 @@ import {
 } from "../plugin-markdown-export.js";
 import { isTTY, throttle, writeLine } from "../reporter.js";
 import { generateSitemap } from "../sitemap.js";
-import { routesToPaths, routesToRewrites } from "./utils.js";
+import {
+  routesToPaths,
+  routesToRewrites,
+  selectPagesToIndex,
+} from "./utils.js";
 import type { StaticWorkerData, WorkerData } from "./worker.js";
 
 const Piscina = PiscinaImport as unknown as typeof PiscinaImport.default;
@@ -28,7 +32,13 @@ const Piscina = PiscinaImport as unknown as typeof PiscinaImport.default;
 export type WorkerResult = {
   outputPath: string;
   html: string;
+  // Status of the page as served statically (the file written to disk). For a
+  // protected route during SSG this is 401 (the sign-in page).
   statusCode: number;
+  // Status of the render whose HTML is fed to the search index. Equals
+  // `statusCode` for normal routes; for protected routes it's the bypass
+  // render (200) so the full content gets indexed (issue #2672).
+  indexStatusCode: number;
   redirect?: { from: string; to: string };
 };
 
@@ -173,9 +183,7 @@ export const prerender = async ({
   }
 
   if (pagefindIndex) {
-    const pagesToIndex = workerResults.flatMap(({ statusCode, html }, i) =>
-      statusCode < 400 ? { url: paths[i], html } : [],
-    );
+    const pagesToIndex = selectPagesToIndex(workerResults, paths);
     // Batch size caps concurrent IPC writes to the pagefind child process;
     // higher values can overflow its pipe buffer and trigger ENOBUFS.
     const BATCH_SIZE = 40;

--- a/packages/zudoku/src/vite/prerender/utils.test.ts
+++ b/packages/zudoku/src/vite/prerender/utils.test.ts
@@ -1,6 +1,10 @@
 import type { RouteObject } from "react-router";
 import { describe, expect, it } from "vitest";
-import { routesToPaths, routesToRewrites } from "./utils.js";
+import {
+  routesToPaths,
+  routesToRewrites,
+  selectPagesToIndex,
+} from "./utils.js";
 
 describe("routesToPaths", () => {
   it("returns paths for simple routes", () => {
@@ -118,5 +122,50 @@ describe("routesToRewrites", () => {
 
   it("returns empty for empty input", () => {
     expect(routesToRewrites([])).toEqual([]);
+  });
+});
+
+describe("selectPagesToIndex", () => {
+  it("indexes successful pages", () => {
+    const pages = [
+      { indexStatusCode: 200, html: "<p>home</p>" },
+      { indexStatusCode: 200, html: "<p>about</p>" },
+    ];
+    expect(selectPagesToIndex(pages, ["/", "/about"])).toEqual([
+      { url: "/", html: "<p>home</p>" },
+      { url: "/about", html: "<p>about</p>" },
+    ]);
+  });
+
+  // Regression for #2672: a protected route's static file is the 401 sign-in
+  // page, but its indexed HTML comes from the 200 bypass render. It must be
+  // indexed, keyed on `indexStatusCode` (200), not the page status (401).
+  it("indexes protected routes via their bypass-render status", () => {
+    const pages = [
+      { indexStatusCode: 200, html: "<p>public</p>" },
+      { indexStatusCode: 200, html: "<p>protected content</p>" },
+    ];
+    expect(
+      selectPagesToIndex(pages, ["/public", "/introduction/secret"]),
+    ).toEqual([
+      { url: "/public", html: "<p>public</p>" },
+      { url: "/introduction/secret", html: "<p>protected content</p>" },
+    ]);
+  });
+
+  it("excludes pages whose indexed render failed (4xx/5xx)", () => {
+    const pages = [
+      { indexStatusCode: 200, html: "<p>ok</p>" },
+      { indexStatusCode: 404, html: "<p>not found</p>" },
+      { indexStatusCode: 500, html: "<p>error</p>" },
+    ];
+    expect(selectPagesToIndex(pages, ["/ok", "/missing", "/boom"])).toEqual([
+      { url: "/ok", html: "<p>ok</p>" },
+    ]);
+  });
+
+  it("skips entries without a matching path", () => {
+    const pages = [{ indexStatusCode: 200, html: "<p>orphan</p>" }];
+    expect(selectPagesToIndex(pages, [])).toEqual([]);
   });
 });

--- a/packages/zudoku/src/vite/prerender/utils.test.ts
+++ b/packages/zudoku/src/vite/prerender/utils.test.ts
@@ -131,10 +131,12 @@ describe("selectPagesToIndex", () => {
       { indexStatusCode: 200, html: "<p>home</p>" },
       { indexStatusCode: 200, html: "<p>about</p>" },
     ];
-    expect(selectPagesToIndex(pages, ["/", "/about"])).toEqual([
+    const { include, exclude } = selectPagesToIndex(pages, ["/", "/about"]);
+    expect(include).toEqual([
       { url: "/", html: "<p>home</p>" },
       { url: "/about", html: "<p>about</p>" },
     ]);
+    expect(exclude).toEqual([]);
   });
 
   // Regression for #2672: a protected route's static file is the 401 sign-in
@@ -145,27 +147,39 @@ describe("selectPagesToIndex", () => {
       { indexStatusCode: 200, html: "<p>public</p>" },
       { indexStatusCode: 200, html: "<p>protected content</p>" },
     ];
-    expect(
-      selectPagesToIndex(pages, ["/public", "/introduction/secret"]),
-    ).toEqual([
+    const { include } = selectPagesToIndex(pages, [
+      "/public",
+      "/introduction/secret",
+    ]);
+    expect(include).toEqual([
       { url: "/public", html: "<p>public</p>" },
       { url: "/introduction/secret", html: "<p>protected content</p>" },
     ]);
   });
 
-  it("excludes pages whose indexed render failed (4xx/5xx)", () => {
+  // A protected route whose bypass render failed (e.g. a check returning
+  // FORBIDDEN) must not vanish from the index silently — it's reported so the
+  // build can warn about it, which is the whole point of #2672.
+  it("excludes pages whose indexed render failed (4xx/5xx) and reports them", () => {
     const pages = [
       { indexStatusCode: 200, html: "<p>ok</p>" },
       { indexStatusCode: 404, html: "<p>not found</p>" },
       { indexStatusCode: 500, html: "<p>error</p>" },
     ];
-    expect(selectPagesToIndex(pages, ["/ok", "/missing", "/boom"])).toEqual([
-      { url: "/ok", html: "<p>ok</p>" },
+    const { include, exclude } = selectPagesToIndex(pages, [
+      "/ok",
+      "/missing",
+      "/boom",
+    ]);
+    expect(include).toEqual([{ url: "/ok", html: "<p>ok</p>" }]);
+    expect(exclude).toEqual([
+      { url: "/missing", status: 404 },
+      { url: "/boom", status: 500 },
     ]);
   });
 
   it("skips entries without a matching path", () => {
     const pages = [{ indexStatusCode: 200, html: "<p>orphan</p>" }];
-    expect(selectPagesToIndex(pages, [])).toEqual([]);
+    expect(selectPagesToIndex(pages, [])).toEqual({ include: [], exclude: [] });
   });
 });

--- a/packages/zudoku/src/vite/prerender/utils.ts
+++ b/packages/zudoku/src/vite/prerender/utils.ts
@@ -74,3 +74,19 @@ export const routesToPaths = (routes: RouteObject[]): string[] =>
 
 export const routesToRewrites = (routes: RouteObject[]): RouteRewrite[] =>
   collectRewrites(resolveRoutes(routes));
+
+type IndexablePage = { indexStatusCode: number; html: string };
+
+// Selects which prerendered pages get added to the search index, keyed by their
+// path. `indexStatusCode` is the status of the render whose HTML is indexed —
+// for protected routes that's the bypass render (200), not the gated main
+// render (401), so protected pages aren't silently dropped (issue #2672).
+export const selectPagesToIndex = (
+  pages: IndexablePage[],
+  paths: string[],
+): { url: string; html: string }[] =>
+  pages.flatMap(({ indexStatusCode, html }, i) => {
+    const url = paths[i];
+    if (url === undefined || indexStatusCode >= 400) return [];
+    return [{ url, html }];
+  });

--- a/packages/zudoku/src/vite/prerender/utils.ts
+++ b/packages/zudoku/src/vite/prerender/utils.ts
@@ -77,16 +77,33 @@ export const routesToRewrites = (routes: RouteObject[]): RouteRewrite[] =>
 
 type IndexablePage = { indexStatusCode: number; html: string };
 
-// Selects which prerendered pages get added to the search index, keyed by their
-// path. `indexStatusCode` is the status of the render whose HTML is indexed —
-// for protected routes that's the bypass render (200), not the gated main
-// render (401), so protected pages aren't silently dropped (issue #2672).
+type IndexSelection = {
+  include: { url: string; html: string }[];
+  exclude: { url: string; status: number }[];
+};
+
+// Splits prerendered pages into those added to the search index and those
+// skipped because their indexed render failed. `indexStatusCode` is the status
+// of the render whose HTML is indexed: for protected routes that's the bypass
+// render (200), not the gated main render (401), so protected pages aren't
+// silently dropped (issue #2672). Excluded pages are returned rather than
+// dropped in silence so the caller can warn about them, since a protected page
+// missing from the index is exactly the symptom this fix targets.
 export const selectPagesToIndex = (
   pages: IndexablePage[],
   paths: string[],
-): { url: string; html: string }[] =>
-  pages.flatMap(({ indexStatusCode, html }, i) => {
+): IndexSelection => {
+  const withUrl = pages.flatMap(({ indexStatusCode, html }, i) => {
     const url = paths[i];
-    if (url === undefined || indexStatusCode >= 400) return [];
-    return [{ url, html }];
+    return url === undefined ? [] : [{ url, html, indexStatusCode }];
   });
+
+  return {
+    include: withUrl
+      .filter((p) => p.indexStatusCode < 400)
+      .map(({ url, html }) => ({ url, html })),
+    exclude: withUrl
+      .filter((p) => p.indexStatusCode >= 400)
+      .map(({ url, indexStatusCode }) => ({ url, status: indexStatusCode })),
+  };
+};

--- a/packages/zudoku/src/vite/prerender/worker.ts
+++ b/packages/zudoku/src/vite/prerender/worker.ts
@@ -64,6 +64,7 @@ const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
       outputPath,
       redirect: { from: pathname, to: redirectTo },
       statusCode: response.status,
+      indexStatusCode: response.status,
       html: "",
     };
   }
@@ -77,8 +78,12 @@ const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
   // Get HTML content for file write
   const fileContent = response.body ? await response.text() : "";
 
-  // For protected routes, do a second render with protection bypassed for search index
+  // For protected routes, do a second render with protection bypassed so the
+  // search index gets the full content instead of the gated sign-in page. The
+  // file on disk stays the gated (401) render; only `html`/`indexStatusCode`
+  // reflect the bypass render.
   let html = fileContent;
+  let indexStatusCode = response.status;
   if (isProtectedRoute) {
     const bypassRequest = new Request(url);
     const bypassResponse = await server.handleRequest({
@@ -96,6 +101,7 @@ const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
     }
 
     html = bypassResponse.body ? await bypassResponse.text() : "";
+    indexStatusCode = bypassResponse.status;
   }
 
   // Write the file
@@ -105,6 +111,7 @@ const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
   return {
     outputPath,
     statusCode: response.status,
+    indexStatusCode,
     redirect: undefined,
     html,
   };

--- a/packages/zudoku/src/vite/sitemap.test.ts
+++ b/packages/zudoku/src/vite/sitemap.test.ts
@@ -57,18 +57,21 @@ it("getRedirectUrls strips basePath and normalizes trailing slash", () => {
       outputPath: "/index.html",
       html: "",
       statusCode: 301,
+      indexStatusCode: 301,
       redirect: { from: "/docs/", to: "/docs/intro" },
     },
     {
       outputPath: "/index.html",
       html: "",
       statusCode: 301,
+      indexStatusCode: 301,
       redirect: { from: "/docs", to: "/docs/intro" },
     },
     {
       outputPath: "/intro.html",
       html: "",
       statusCode: 200,
+      indexStatusCode: 200,
     },
   ];
 
@@ -82,6 +85,7 @@ it("getRedirectUrls works without basePath", () => {
       outputPath: "/index.html",
       html: "",
       statusCode: 301,
+      indexStatusCode: 301,
       redirect: { from: "/old", to: "/new" },
     },
   ];


### PR DESCRIPTION
`protectedRoutes` pages are left out of the Pagefind index in a production `zudoku build`, so Cmd+K finds nothing for them even after signing in. Fixes #2672.

PR #864's approach (render protected pages a second time with protection bypassed, index that copy, tag it `section:protected`) was broken by two later regressions:

1. `handleRequest` stubs a protected route's `lazy()` chunk to a no-op for unauthenticated requests, but ignored the `bypassProtection` flag, so the index pass rendered an empty shell.
2. The index filter only keeps pages with status under 400, but a protected route's main render is the 401 sign-in page, so all of them were dropped.

Fix:

- `wrapProtectedRoutesForRender` treats a bypass render as authenticated so the real content renders.
- The worker reports `indexStatusCode` (the 200 bypass render, not the 401 file on disk), and the filter uses that.
- Index selection moved into `selectPagesToIndex` for testing.

The static file stays the 401 sign-in page; only the copy sent to Pagefind has full content, still tagged so logged-out search hides it.

SSR is unaffected: only the build and dev index passes set `bypassProtection`, so live requests hit the same path as before. Tests cover the SSR equivalence, the index selection, and the bypass wrapping. Full suite green.

<!-- Session: https://claude.ai/code/session_01PwHMvQM1VMy3SnqNQk8rCf -->