### PR TITLE
fix(plugin-zuplo-monetization): use configured gateway URL for anonymous pricing page requests

### DIFF
--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
@@ -32,6 +32,16 @@ const getBaseUrl = (context?: ZudokuContext) => {
   return context.env.ZUPLO_GATEWAY_SERVICE_URL || DEFAULT_GATEWAY_URL;
 };
 
+// Sign only when authenticated: signRequest throws for anonymous users,
+// but the context is still needed to resolve the gateway URL on endpoints
+// that support anonymous access (e.g. pricing page). The zustand auth state
+// is not request-scoped on the server, so SSR checks per-request ssrAuth
+// (same signal signRequest uses).
+const shouldSignRequest = (context: ZudokuContext) =>
+  typeof window === "undefined"
+    ? !!context.ssrAuth?.accessToken
+    : context.getAuthState().isAuthenticated;
+
 const hasVariables = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value != null;
 
@@ -60,11 +70,8 @@ export const queryClient = new QueryClient({
           },
         });
 
-        // Sign only when authenticated: signRequest throws for anonymous
-        // users, but the context is still needed to resolve the gateway URL
-        // on endpoints that support anonymous access (e.g. pricing page).
         const response = await fetch(
-          context?.getAuthState().isAuthenticated
+          context && shouldSignRequest(context)
             ? await context.signRequest(request)
             : request,
         );

--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
@@ -51,7 +51,8 @@ export const queryClient = new QueryClient({
           throw new Error("URL is required");
         }
 
-        const request = new Request(joinUrl(getBaseUrl(q.meta?.context), url), {
+        const context = q.meta?.context;
+        const request = new Request(joinUrl(getBaseUrl(context), url), {
           ...q.meta?.request,
           headers: {
             "Content-Type": "application/json",
@@ -59,8 +60,13 @@ export const queryClient = new QueryClient({
           },
         });
 
+        // Sign only when authenticated: signRequest throws for anonymous
+        // users, but the context is still needed to resolve the gateway URL
+        // on endpoints that support anonymous access (e.g. pricing page).
         const response = await fetch(
-          q.meta?.context ? await q.meta.context.signRequest(request) : request,
+          context?.getAuthState().isAuthenticated
+            ? await context.signRequest(request)
+            : request,
         );
 
         await throwIfProblemJson(response);

--- a/packages/plugin-zuplo-monetization/src/queries.ts
+++ b/packages/plugin-zuplo-monetization/src/queries.ts
@@ -16,9 +16,7 @@ export const pricingPageQuery = (context: ZudokuContext) =>
     queryKey: [
       `/v3/zudoku-metering/${getDeploymentName(context)}/pricing-page`,
     ],
-    meta: {
-      context: context.getAuthState().isAuthenticated ? context : undefined,
-    },
+    meta: { context },
   });
 
 export const subscriptionsQuery = (context: ZudokuContext) =>


### PR DESCRIPTION
## Problem

The pricing page supports anonymous access, so `pricingPageQuery` omitted the Zudoku context from the query meta for unauthenticated users to avoid `signRequest` throwing when nobody is logged in.

However, the context is also how the query client resolves the gateway base URL (`ZUPLO_GATEWAY_SERVICE_URL`). Without it, anonymous pricing page requests silently fell back to `DEFAULT_GATEWAY_URL`, so in any environment where the configured gateway URL differs from the default, logged-out visitors got a 401 on the pricing page while logged-in users were fine.

## Fix

Separate "which gateway to call" from "whether to sign the request":

- `pricingPageQuery` now always passes the context in meta, so the configured gateway URL is used regardless of auth state.
- The default `queryFn` now checks auth state at fetch time and only calls `signRequest` when the user is authenticated. Authenticated pricing page requests remain signed (the endpoint returns additional user-specific results with a valid token).

## Testing

- `pnpm -F @zuplo/zudoku-plugin-monetization typecheck`
- `pnpm vitest run packages/plugin-zuplo-monetization` (407 tests pass)
- `biome` and `oxfmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wz82sixq1NqFiLXMvw5sw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz82sixq1NqFiLXMvw5sw6)_