### PR TITLE
feat: add Microsoft Entra ID auth provider

### DIFF
--- a/docs/pages/docs/configuration/authentication-azure-ad.md
+++ b/docs/pages/docs/configuration/authentication-azure-ad.md
@@ -72,9 +72,9 @@ to integrate Azure AD with your Zudoku documentation site.
    export default {
      // ... other configuration
      authentication: {
-       type: "openid",
+       type: "entra",
        clientId: "<your-application-client-id>",
-       issuer: "https://login.microsoftonline.com/<your-tenant-id>/v2.0",
+       tenantId: "<your-tenant-id>",
        scopes: ["openid", "profile", "email"], // Optional: customize scopes
      },
      // ... other configuration
@@ -91,20 +91,21 @@ For single tenant (organization-only access):
 
 ```typescript
 authentication: {
-  type: "openid",
+  type: "entra",
   clientId: "<your-application-client-id>",
-  issuer: "https://login.microsoftonline.com/<your-tenant-id>/v2.0",
+  tenantId: "<your-tenant-id>",
   scopes: ["openid", "profile", "email"],
 }
 ```
 
-For multitenant (any Azure AD organization):
+For multitenant (any Azure AD organization), use `tenantId: "common"` or `"organizations"` — this is
+also the default if `tenantId` is omitted:
 
 ```typescript
 authentication: {
-  type: "openid",
+  type: "entra",
   clientId: "<your-application-client-id>",
-  issuer: "https://login.microsoftonline.com/common/v2.0",
+  tenantId: "common",
   scopes: ["openid", "profile", "email"],
 }
 ```
@@ -115,9 +116,9 @@ Request additional Microsoft Graph API scopes:
 
 ```typescript
 authentication: {
-  type: "openid",
+  type: "entra",
   clientId: "<your-application-client-id>",
-  issuer: "https://login.microsoftonline.com/<your-tenant-id>/v2.0",
+  tenantId: "<your-tenant-id>",
   scopes: [
     "openid",
     "profile",
@@ -136,7 +137,7 @@ Protect specific documentation routes using the `protectedRoutes` configuration:
 {
   // ... other configuration
   authentication: {
-    type: "openid",
+    type: "entra",
     // ... Azure AD config
   },
   protectedRoutes: [
@@ -217,16 +218,17 @@ Azure AD provides rich user profile data through OpenID Connect:
 2. **Redirect URI Mismatch**: The redirect URI must exactly match one configured in Azure AD,
    including protocol and path.
 
-3. **Tenant Access Issues**: For single-tenant apps, ensure users are from the correct tenant. For
-   multi-tenant, verify the issuer URL uses "common" or "organizations".
+3. **Tenant Access Issues**: For single-tenant apps, ensure users are from the correct tenant and
+   `tenantId` is set to that tenant's GUID. For multi-tenant, use `tenantId: "common"` or
+   `"organizations"`.
 
 4. **Missing User Information**: Check that required API permissions are granted and admin consent
    is provided if needed.
 
-5. **Token Validation Errors**: Ensure your issuer URL is correct and includes the `/v2.0` endpoint
-   for the Microsoft identity platform.
+5. **Token Validation Errors**: Ensure your `tenantId` is correct. If you use a CIAM tenant
+   (`*.ciamlogin.com`), set the `issuer` option to override the default issuer instead.
 
-6. **Authentication Not Working**: Verify your issuer URL and client ID are correct, and that your
+6. **Authentication Not Working**: Verify your `tenantId` and client ID are correct, and that your
    app registration is configured as a Single-page application (SPA) with the correct redirect URIs.
 
 ## Security Best Practices

--- a/docs/pages/docs/configuration/authentication.md
+++ b/docs/pages/docs/configuration/authentication.md
@@ -15,8 +15,8 @@ authentication provider you use.
 
 ## Authentication Providers
 
-Zudoku supports Clerk, Auth0, Supabase, Firebase, Azure B2C, and any OpenID Connect provider
-(including Okta, Keycloak, Authentik, and PingFederate).
+Zudoku supports Clerk, Auth0, Supabase, Firebase, Microsoft Entra ID, Azure B2C, and any OpenID
+Connect provider (including Okta, Keycloak, Authentik, and PingFederate).
 
 Not seeing your authentication provider? [Let us know](https://github.com/zuplo/zudoku/issues)
 
@@ -98,6 +98,26 @@ providing your own array of scopes.
 
 For provider-specific guides (Okta, Keycloak, etc.), see the
 [OpenID Connect setup page](./authentication-openid.md).
+
+### Microsoft Entra ID
+
+For Microsoft Entra ID (formerly Azure AD), you will need the `clientId` from your app registration
+and your `tenantId`.
+
+```typescript
+{
+  // ...
+  authentication: {
+    type: "entra",
+    clientId: "<your-application-client-id>",
+    tenantId: "<your-tenant-id>", // Or "common" for multitenant. Defaults to "common".
+  },
+  // ...
+}
+```
+
+For full setup instructions, see the
+[Azure AD / Entra ID setup guide](./authentication-azure-ad.md).
 
 ### Firebase
 

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -45,6 +45,7 @@
     "./auth/clerk": "./src/lib/authentication/providers/clerk.tsx",
     "./auth/auth0": "./src/lib/authentication/providers/auth0.tsx",
     "./auth/openid": "./src/lib/authentication/providers/openid.tsx",
+    "./auth/entra": "./src/lib/authentication/providers/entra.tsx",
     "./auth/supabase": "./src/lib/authentication/providers/supabase.tsx",
     "./auth/azureb2c": "./src/lib/authentication/providers/azureb2c.tsx",
     "./auth/firebase": "./src/lib/authentication/providers/firebase.tsx",

--- a/packages/zudoku/src/config/config.ts
+++ b/packages/zudoku/src/config/config.ts
@@ -33,3 +33,7 @@ export type AzureB2CAuthenticationConfig = Extract<
   AuthenticationConfig,
   { type: "azureb2c" }
 >;
+export type EntraAuthenticationConfig = Extract<
+  AuthenticationConfig,
+  { type: "entra" }
+>;

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -487,6 +487,25 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     forwardAuthorizationParams: z.array(z.string()).optional(),
   }),
   z.object({
+    type: z.literal("entra"),
+    basePath: z.string().optional(),
+    clientId: z.string(),
+    // Tenant id or one of Entra's multi-tenant authorities
+    // (common/organizations/consumers). Defaults to "common".
+    tenantId: z.string().optional(),
+    // Full issuer override, e.g. for CIAM tenants on *.ciamlogin.com.
+    issuer: z.string().optional(),
+    audience: z.string().optional(),
+    scopes: z.array(z.string()).optional(),
+    redirectToAfterSignUp: z.string().optional(),
+    redirectToAfterSignIn: z.string().optional(),
+    redirectToAfterSignOut: z.string().optional(),
+    signUp: SignUpOpenIdSchema.optional(),
+    disableSignUp: z.boolean().optional(),
+    authorizationParams: z.record(z.string(), z.string()).optional(),
+    forwardAuthorizationParams: z.array(z.string()).optional(),
+  }),
+  z.object({
     type: z.literal("azureb2c"),
     basePath: z.string().optional(),
     clientId: z.string(),

--- a/packages/zudoku/src/lib/auth/issuer.test.ts
+++ b/packages/zudoku/src/lib/auth/issuer.test.ts
@@ -69,6 +69,45 @@ describe("getIssuer", () => {
     expect(result).toBe("https://example.com/auth");
   });
 
+  it("should return common authority for entra authentication by default", async () => {
+    const config: ZudokuConfig = {
+      authentication: {
+        type: "entra",
+        clientId: "test-client-id",
+      },
+    };
+
+    const result = await getIssuer(config);
+    expect(result).toBe("https://login.microsoftonline.com/common/v2.0");
+  });
+
+  it("should return tenant-specific issuer for entra authentication with tenantId", async () => {
+    const config: ZudokuConfig = {
+      authentication: {
+        type: "entra",
+        clientId: "test-client-id",
+        tenantId: "tenant-123",
+      },
+    };
+
+    const result = await getIssuer(config);
+    expect(result).toBe("https://login.microsoftonline.com/tenant-123/v2.0");
+  });
+
+  it("should prefer the issuer override for entra authentication", async () => {
+    const config: ZudokuConfig = {
+      authentication: {
+        type: "entra",
+        clientId: "test-client-id",
+        tenantId: "tenant-123",
+        issuer: "https://example.ciamlogin.com/tenant-123/v2.0",
+      },
+    };
+
+    const result = await getIssuer(config);
+    expect(result).toBe("https://example.ciamlogin.com/tenant-123/v2.0");
+  });
+
   it("should return azureb2c issuer for azureb2c authentication", async () => {
     const config: ZudokuConfig = {
       authentication: {

--- a/packages/zudoku/src/lib/auth/issuer.ts
+++ b/packages/zudoku/src/lib/auth/issuer.ts
@@ -1,5 +1,8 @@
 import type { ZudokuConfig } from "../../config/validators/ZudokuConfig.js";
-import { getClerkFrontendApi } from "../authentication/providers/util.js";
+import {
+  getClerkFrontendApi,
+  getEntraIssuer,
+} from "../authentication/providers/util.js";
 
 export const getIssuer = async (config: ZudokuConfig) => {
   switch (config.authentication?.type) {
@@ -11,6 +14,9 @@ export const getIssuer = async (config: ZudokuConfig) => {
     }
     case "openid": {
       return config.authentication.issuer;
+    }
+    case "entra": {
+      return getEntraIssuer(config.authentication);
     }
     case "supabase": {
       return config.authentication.supabaseUrl;

--- a/packages/zudoku/src/lib/authentication/providers/entra.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/entra.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+import * as oauth from "oauth4webapi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useAuthState } from "../state.js";
+import entraAuth, { EntraAuthenticationProvider } from "./entra.js";
+
+vi.mock("oauth4webapi", async (importOriginal) => {
+  const actual = await importOriginal<typeof oauth>();
+  return {
+    ...actual,
+    discoveryRequest: vi.fn(),
+    processDiscoveryResponse: vi.fn(),
+    validateAuthResponse: vi.fn(),
+    authorizationCodeGrantRequest: vi.fn(),
+    processAuthorizationCodeResponse: vi.fn(),
+  };
+});
+
+const ISSUER_TEMPLATE = "https://login.microsoftonline.com/{tenantid}/v2.0";
+
+// base64url-encoded fake JWT so jose's decodeJwt can read the payload
+const fakeJwt = (payload: Record<string, unknown>) => {
+  const encode = (obj: object) =>
+    btoa(JSON.stringify(obj))
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+  return `${encode({ alg: "none" })}.${encode(payload)}.signature`;
+};
+
+const getAuthServer = (provider: EntraAuthenticationProvider) =>
+  (
+    provider as unknown as {
+      getAuthServer: () => Promise<oauth.AuthorizationServer>;
+    }
+  ).getAuthServer();
+
+describe("EntraAuthenticationProvider", () => {
+  beforeEach(() => {
+    useAuthState.getState().setLoggedOut();
+    // Replicate oauth4webapi's strict discovery issuer comparison so the
+    // tests exercise the real expected-issuer handling.
+    vi.mocked(oauth.processDiscoveryResponse).mockImplementation(
+      async (expected, response) => {
+        const json = (await response.json()) as oauth.AuthorizationServer;
+        if (new URL(json.issuer).href !== expected.href) {
+          throw new Error('"issuer" property does not match');
+        }
+        return json;
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  describe("discovery", () => {
+    test("multi-tenant authority accepts the templated issuer", async () => {
+      vi.mocked(oauth.discoveryRequest).mockResolvedValue(
+        Response.json({ issuer: ISSUER_TEMPLATE }),
+      );
+
+      const provider = entraAuth({ type: "entra", clientId: "test-client" });
+      const as = await getAuthServer(provider as EntraAuthenticationProvider);
+
+      expect(as.issuer).toBe(ISSUER_TEMPLATE);
+    });
+
+    test("concrete tenant keeps the strict issuer check", async () => {
+      const issuer = "https://login.microsoftonline.com/tenant-abc/v2.0";
+      vi.mocked(oauth.discoveryRequest).mockResolvedValue(
+        Response.json({ issuer }),
+      );
+
+      const provider = new EntraAuthenticationProvider({
+        type: "entra",
+        clientId: "test-client",
+        tenantId: "tenant-abc",
+      });
+
+      const as = await getAuthServer(provider);
+      expect(as.issuer).toBe(issuer);
+    });
+
+    test("mismatched concrete issuer still rejects", async () => {
+      vi.mocked(oauth.discoveryRequest).mockResolvedValue(
+        Response.json({
+          issuer: "https://login.microsoftonline.com/other-tenant/v2.0",
+        }),
+      );
+
+      const provider = new EntraAuthenticationProvider({
+        type: "entra",
+        clientId: "test-client",
+        tenantId: "tenant-abc",
+      });
+
+      await expect(getAuthServer(provider)).rejects.toThrow(
+        '"issuer" property does not match',
+      );
+    });
+
+    test("malformed discovery body falls through to the strict check", async () => {
+      vi.mocked(oauth.discoveryRequest).mockResolvedValue(
+        new Response("not json"),
+      );
+      vi.mocked(oauth.processDiscoveryResponse).mockImplementation(
+        async (expected) => {
+          expect(expected).toBeInstanceOf(URL);
+          expect(expected.href).toBe(
+            "https://login.microsoftonline.com/common/v2.0",
+          );
+          throw new Error("failed to parse");
+        },
+      );
+
+      const provider = new EntraAuthenticationProvider({
+        type: "entra",
+        clientId: "test-client",
+      });
+
+      await expect(getAuthServer(provider)).rejects.toThrow("failed to parse");
+    });
+  });
+
+  describe("token exchange issuer resolution", () => {
+    // Runs handleCallback up to the token exchange, capturing the
+    // authorization server it validates against, then short-circuits.
+    const captureExchangeIssuer = async (tokenResponse: object) => {
+      vi.mocked(oauth.discoveryRequest).mockResolvedValue(
+        Response.json({ issuer: ISSUER_TEMPLATE }),
+      );
+
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL(
+          "http://localhost/oauth/callback?state=test-state&code=test-code",
+        ),
+      });
+      sessionStorage.setItem("oauth-state", "test-state");
+      sessionStorage.setItem("code-verifier", "test-verifier");
+
+      vi.mocked(oauth.validateAuthResponse).mockReturnValue(
+        new URLSearchParams({ code: "test-code" }),
+      );
+      vi.mocked(oauth.authorizationCodeGrantRequest).mockResolvedValue(
+        Response.json(tokenResponse),
+      );
+
+      let issuer: string | undefined;
+      vi.mocked(oauth.processAuthorizationCodeResponse).mockImplementation(
+        async (as) => {
+          issuer = as.issuer;
+          throw new Error("stop after capture");
+        },
+      );
+
+      const provider = new EntraAuthenticationProvider({
+        type: "entra",
+        clientId: "test-client",
+      });
+      await expect(provider.handleCallback()).rejects.toThrow(
+        "stop after capture",
+      );
+
+      return issuer;
+    };
+
+    test("substitutes the ID token's tid into the templated issuer", async () => {
+      const issuer = await captureExchangeIssuer({
+        id_token: fakeJwt({ tid: "tenant-123" }),
+      });
+
+      expect(issuer).toBe("https://login.microsoftonline.com/tenant-123/v2.0");
+    });
+
+    test("keeps the template when the ID token has no tid", async () => {
+      const issuer = await captureExchangeIssuer({
+        id_token: fakeJwt({ sub: "user-1" }),
+      });
+
+      // Left as-is so oauth4webapi's iss validation fails loudly.
+      expect(issuer).toBe(ISSUER_TEMPLATE);
+    });
+
+    test("keeps the template when the response has no ID token", async () => {
+      const issuer = await captureExchangeIssuer({
+        access_token: "header.payload.signature",
+      });
+
+      expect(issuer).toBe(ISSUER_TEMPLATE);
+    });
+  });
+});

--- a/packages/zudoku/src/lib/authentication/providers/entra.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/entra.test.ts
@@ -2,6 +2,7 @@
 import * as oauth from "oauth4webapi";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { useAuthState } from "../state.js";
+import type { UserProfile } from "../state.js";
 import entraAuth, { EntraAuthenticationProvider } from "./entra.js";
 
 vi.mock("oauth4webapi", async (importOriginal) => {
@@ -189,6 +190,72 @@ describe("EntraAuthenticationProvider", () => {
       });
 
       expect(issuer).toBe(ISSUER_TEMPLATE);
+    });
+  });
+
+  describe("profile mapping", () => {
+    const buildProfile = (
+      userInfo: Record<string, unknown>,
+      claims?: Record<string, unknown>,
+    ) => {
+      const provider = new EntraAuthenticationProvider({
+        type: "entra",
+        clientId: "test-client",
+      });
+      return (
+        provider as unknown as {
+          buildUserProfile: (
+            userInfo: oauth.UserInfoResponse,
+            claims: oauth.IDToken | undefined,
+          ) => UserProfile;
+        }
+      ).buildUserProfile(
+        userInfo as oauth.UserInfoResponse,
+        claims as oauth.IDToken | undefined,
+      );
+    };
+
+    test("keeps a real email and its verified status", () => {
+      const profile = buildProfile(
+        { sub: "u1", email: "real@contoso.com" },
+        { preferred_username: "pref@contoso.com", email_verified: true },
+      );
+      expect(profile.email).toBe("real@contoso.com");
+      expect(profile.emailVerified).toBe(true);
+    });
+
+    test("falls back to preferred_username when email is absent", () => {
+      const profile = buildProfile(
+        { sub: "u1" },
+        { preferred_username: "user@external.com", tid: "tenant-x" },
+      );
+      expect(profile.email).toBe("user@external.com");
+      // A username is not a verified email.
+      expect(profile.emailVerified).toBe(false);
+    });
+
+    test("falls back to upn when email and preferred_username are absent", () => {
+      const profile = buildProfile({ sub: "u1" }, { upn: "user@external.com" });
+      expect(profile.email).toBe("user@external.com");
+    });
+
+    test("surfaces immutable oid/tid and preferred_username from claims", () => {
+      const profile = buildProfile(
+        { sub: "u1" },
+        {
+          preferred_username: "user@external.com",
+          oid: "object-123",
+          tid: "tenant-x",
+        },
+      );
+      expect(profile.preferred_username).toBe("user@external.com");
+      expect(profile.oid).toBe("object-123");
+      expect(profile.tid).toBe("tenant-x");
+    });
+
+    test("leaves email undefined when no username claim is available", () => {
+      const profile = buildProfile({ sub: "u1" }, {});
+      expect(profile.email).toBeUndefined();
     });
   });
 });

--- a/packages/zudoku/src/lib/authentication/providers/entra.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/entra.test.ts
@@ -38,8 +38,8 @@ const getAuthServer = (provider: EntraAuthenticationProvider) =>
 describe("EntraAuthenticationProvider", () => {
   beforeEach(() => {
     useAuthState.getState().setLoggedOut();
-    // Replicate oauth4webapi's strict discovery issuer comparison so the
-    // tests exercise the real expected-issuer handling.
+    // Replicates oauth4webapi's strict issuer comparison so the tests exercise
+    // the real expected-issuer handling.
     vi.mocked(oauth.processDiscoveryResponse).mockImplementation(
       async (expected, response) => {
         const json = (await response.json()) as oauth.AuthorizationServer;
@@ -126,8 +126,6 @@ describe("EntraAuthenticationProvider", () => {
   });
 
   describe("token exchange issuer resolution", () => {
-    // Runs handleCallback up to the token exchange, capturing the
-    // authorization server it validates against, then short-circuits.
     const captureExchangeIssuer = async (tokenResponse: object) => {
       vi.mocked(oauth.discoveryRequest).mockResolvedValue(
         Response.json({ issuer: ISSUER_TEMPLATE }),

--- a/packages/zudoku/src/lib/authentication/providers/entra.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/entra.tsx
@@ -7,8 +7,6 @@ import type {
 import { OpenIDAuthenticationProvider } from "./openid.js";
 import { getEntraIssuer } from "./util.js";
 
-// Entra's multi-tenant authorities (common/organizations/consumers) advertise
-// a templated issuer while each token's `iss` carries the concrete tenant id.
 const ISSUER_TENANT_PLACEHOLDER = "{tenantid}";
 
 export class EntraAuthenticationProvider
@@ -19,10 +17,11 @@ export class EntraAuthenticationProvider
     super({ ...config, type: "openid", issuer: getEntraIssuer(config) });
   }
 
-  // The templated issuer never matches the requested authority, so the strict
-  // discovery check would throw. Expect the template itself; resolveTokenIssuer
-  // resolves the concrete tenant per token. Recommended by oauth4webapi's
-  // maintainer: https://github.com/panva/oauth4webapi/issues/100
+  // Multi-tenant authorities advertise a templated issuer that never matches
+  // the requested authority, so the strict discovery check would throw. Expect
+  // the template itself; resolveTokenIssuer resolves the concrete tenant per
+  // token. Recommended by oauth4webapi's maintainer:
+  // https://github.com/panva/oauth4webapi/issues/100
   protected override async getExpectedDiscoveryIssuer(
     issuerUrl: URL,
     response: Response,
@@ -40,9 +39,8 @@ export class EntraAuthenticationProvider
     }
   }
 
-  // Substitutes the ID token's `tid` claim into the templated issuer so the
-  // strict `iss` validation compares against the token's own tenant. Without a
-  // usable ID token the template stays in place and fails validation loudly.
+  // Without a usable ID token the template stays in place and fails the strict
+  // `iss` validation loudly.
   protected override async resolveTokenIssuer(
     as: oauth.AuthorizationServer,
     response: Response,

--- a/packages/zudoku/src/lib/authentication/providers/entra.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/entra.tsx
@@ -4,6 +4,7 @@ import type {
   AuthenticationPlugin,
   AuthenticationProviderInitializer,
 } from "../authentication.js";
+import type { UserProfile } from "../state.js";
 import { OpenIDAuthenticationProvider } from "./openid.js";
 import { getEntraIssuer } from "./util.js";
 
@@ -60,6 +61,32 @@ export class EntraAuthenticationProvider
     } catch {
       return as;
     }
+  }
+
+  // Entra's `email` claim is only present when the account has a mailbox, which
+  // isn't guaranteed — often absent for users from external tenants. Its
+  // UserInfo endpoint also omits `preferred_username`, so the base profile
+  // (built from UserInfo) can lack any usable identifier. Fill `email` from the
+  // ID token's username claims, and surface the immutable `oid`/`tid` for
+  // reliable identity and tenant checks. `email`/`preferred_username` are
+  // mutable — kept unverified and unsuitable for authorization.
+  // https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+  protected override buildUserProfile(
+    userInfo: oauth.UserInfoResponse,
+    claims: oauth.IDToken | undefined,
+  ): UserProfile {
+    const profile = super.buildUserProfile(userInfo, claims);
+    const claim = (name: string) =>
+      typeof claims?.[name] === "string" ? claims[name] : undefined;
+
+    const preferredUsername = claim("preferred_username");
+    return {
+      ...profile,
+      email: profile.email ?? preferredUsername ?? claim("upn"),
+      ...(preferredUsername && { preferred_username: preferredUsername }),
+      ...(claim("oid") && { oid: claim("oid") }),
+      ...(claim("tid") && { tid: claim("tid") }),
+    };
   }
 }
 

--- a/packages/zudoku/src/lib/authentication/providers/entra.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/entra.tsx
@@ -7,10 +7,8 @@ import type {
 import { OpenIDAuthenticationProvider } from "./openid.js";
 import { getEntraIssuer } from "./util.js";
 
-// Microsoft Entra ID's multi-tenant authorities (common/organizations/
-// consumers) return a templated issuer, e.g.
-// "https://login.microsoftonline.com/{tenantid}/v2.0", while each token's
-// `iss` carries the concrete tenant id.
+// Entra's multi-tenant authorities (common/organizations/consumers) advertise
+// a templated issuer while each token's `iss` carries the concrete tenant id.
 const ISSUER_TENANT_PLACEHOLDER = "{tenantid}";
 
 export class EntraAuthenticationProvider
@@ -21,12 +19,10 @@ export class EntraAuthenticationProvider
     super({ ...config, type: "openid", issuer: getEntraIssuer(config) });
   }
 
-  // Multi-tenant authorities return a templated issuer that never matches the
-  // requested authority, so oauth4webapi's strict discovery check would throw.
-  // Expect the template itself instead; per-token `iss` validation then
-  // resolves the concrete tenant in resolveTokenIssuer. Pattern recommended by
-  // oauth4webapi's maintainer:
-  // https://github.com/panva/oauth4webapi/issues/100
+  // The templated issuer never matches the requested authority, so the strict
+  // discovery check would throw. Expect the template itself; resolveTokenIssuer
+  // resolves the concrete tenant per token. Recommended by oauth4webapi's
+  // maintainer: https://github.com/panva/oauth4webapi/issues/100
   protected override async getExpectedDiscoveryIssuer(
     issuerUrl: URL,
     response: Response,
@@ -44,11 +40,9 @@ export class EntraAuthenticationProvider
     }
   }
 
-  // Rebuilds the concrete per-tenant issuer for multi-tenant token responses:
-  // substitutes the ID token's `tid` claim into the templated issuer so
-  // oauth4webapi's strict `iss` validation compares against the right tenant.
-  // Responses without a usable ID token pass through unchanged (a leftover
-  // template then fails that validation loudly).
+  // Substitutes the ID token's `tid` claim into the templated issuer so the
+  // strict `iss` validation compares against the token's own tenant. Without a
+  // usable ID token the template stays in place and fails validation loudly.
   protected override async resolveTokenIssuer(
     as: oauth.AuthorizationServer,
     response: Response,

--- a/packages/zudoku/src/lib/authentication/providers/entra.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/entra.tsx
@@ -1,0 +1,78 @@
+import type * as oauth from "oauth4webapi";
+import type { EntraAuthenticationConfig } from "../../../config/config.js";
+import type {
+  AuthenticationPlugin,
+  AuthenticationProviderInitializer,
+} from "../authentication.js";
+import { OpenIDAuthenticationProvider } from "./openid.js";
+import { getEntraIssuer } from "./util.js";
+
+// Microsoft Entra ID's multi-tenant authorities (common/organizations/
+// consumers) return a templated issuer, e.g.
+// "https://login.microsoftonline.com/{tenantid}/v2.0", while each token's
+// `iss` carries the concrete tenant id.
+const ISSUER_TENANT_PLACEHOLDER = "{tenantid}";
+
+export class EntraAuthenticationProvider
+  extends OpenIDAuthenticationProvider
+  implements AuthenticationPlugin
+{
+  constructor(config: EntraAuthenticationConfig) {
+    super({ ...config, type: "openid", issuer: getEntraIssuer(config) });
+  }
+
+  // Multi-tenant authorities return a templated issuer that never matches the
+  // requested authority, so oauth4webapi's strict discovery check would throw.
+  // Expect the template itself instead; per-token `iss` validation then
+  // resolves the concrete tenant in resolveTokenIssuer. Pattern recommended by
+  // oauth4webapi's maintainer:
+  // https://github.com/panva/oauth4webapi/issues/100
+  protected override async getExpectedDiscoveryIssuer(
+    issuerUrl: URL,
+    response: Response,
+  ): Promise<URL> {
+    try {
+      const metadata = (await response.clone().json()) as { issuer?: unknown };
+      return typeof metadata.issuer === "string" &&
+        metadata.issuer.includes(ISSUER_TENANT_PLACEHOLDER)
+        ? new URL(metadata.issuer)
+        : issuerUrl;
+    } catch {
+      // Malformed body: keep the strict path so processDiscoveryResponse
+      // surfaces the real error.
+      return issuerUrl;
+    }
+  }
+
+  // Rebuilds the concrete per-tenant issuer for multi-tenant token responses:
+  // substitutes the ID token's `tid` claim into the templated issuer so
+  // oauth4webapi's strict `iss` validation compares against the right tenant.
+  // Responses without a usable ID token pass through unchanged (a leftover
+  // template then fails that validation loudly).
+  protected override async resolveTokenIssuer(
+    as: oauth.AuthorizationServer,
+    response: Response,
+  ): Promise<oauth.AuthorizationServer> {
+    if (!as.issuer.includes(ISSUER_TENANT_PLACEHOLDER)) return as;
+    try {
+      const body = (await response.clone().json()) as { id_token?: unknown };
+      if (typeof body.id_token !== "string") return as;
+      const { decodeJwt } = await import("jose");
+      const { tid } = decodeJwt(body.id_token);
+      return typeof tid === "string" && tid.length > 0
+        ? {
+            ...as,
+            issuer: as.issuer.replace(ISSUER_TENANT_PLACEHOLDER, () => tid),
+          }
+        : as;
+    } catch {
+      return as;
+    }
+  }
+}
+
+const entraAuth: AuthenticationProviderInitializer<
+  EntraAuthenticationConfig
+> = (options) => new EntraAuthenticationProvider(options);
+
+export default entraAuth;

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -257,12 +257,12 @@ export class OpenIDAuthenticationProvider
     });
   }
 
-  private buildUserProfile(
+  protected buildUserProfile(
     userInfo: oauth.UserInfoResponse,
-    fallbackEmailVerified: oauth.JsonValue | undefined,
+    claims: oauth.IDToken | undefined,
   ): UserProfile {
     const emailVerified =
-      userInfo.email_verified ?? fallbackEmailVerified ?? false;
+      userInfo.email_verified ?? claims?.email_verified ?? false;
     return {
       ...userInfo,
       sub: userInfo.sub,
@@ -321,12 +321,10 @@ export class OpenIDAuthenticationProvider
     const userInfo = await userInfoResponse.json();
 
     const { providerData } = useAuthState.getState();
-    const emailVerified =
-      providerData?.type === "openid"
-        ? providerData.claims?.email_verified
-        : undefined;
+    const claims =
+      providerData?.type === "openid" ? providerData.claims : undefined;
 
-    const profile = this.buildUserProfile(userInfo, emailVerified);
+    const profile = this.buildUserProfile(userInfo, claims);
 
     useAuthState.setState({
       isAuthenticated: true,
@@ -696,7 +694,7 @@ export class OpenIDAuthenticationProvider
     );
     const userInfo = await userInfoResponse.json();
 
-    const profile = this.buildUserProfile(userInfo, claims?.email_verified);
+    const profile = this.buildUserProfile(userInfo, claims);
 
     useAuthState.setState({
       isAuthenticated: true,

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -152,9 +152,9 @@ export class OpenIDAuthenticationProvider
     return this.authorizationServer;
   }
 
-  // Overridable for providers whose discovery metadata deviates from the
-  // requested issuer (see EntraAuthenticationProvider). Overrides must peek
-  // via `response.clone()`; processDiscoveryResponse still needs the body.
+  // Override points for providers whose issuers deviate from the spec (see
+  // EntraAuthenticationProvider). Overrides must peek via `response.clone()`;
+  // the body is consumed downstream.
   protected async getExpectedDiscoveryIssuer(
     issuerUrl: URL,
     _response: Response,
@@ -162,9 +162,6 @@ export class OpenIDAuthenticationProvider
     return issuerUrl;
   }
 
-  // Overridable for providers whose token `iss` differs from the discovery
-  // issuer (see EntraAuthenticationProvider). Overrides must peek via
-  // `response.clone()`; the process* call still needs the body.
   protected async resolveTokenIssuer(
     as: oauth.AuthorizationServer,
     _response: Response,

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -154,7 +154,8 @@ export class OpenIDAuthenticationProvider
 
   // Hook for providers whose discovery metadata deviates from the requested
   // issuer (see EntraAuthenticationProvider). Default: strict, expect the
-  // requested issuer.
+  // requested issuer. Overrides must not consume the response body — it is
+  // still needed by processDiscoveryResponse; peek via `response.clone()`.
   protected async getExpectedDiscoveryIssuer(
     issuerUrl: URL,
     _response: Response,
@@ -164,7 +165,8 @@ export class OpenIDAuthenticationProvider
 
   // Hook for providers whose token `iss` differs from the discovery issuer
   // (see EntraAuthenticationProvider). Runs before each token response is
-  // validated. Default: pass through.
+  // validated. Default: pass through. Overrides must not consume the response
+  // body — it is still needed by the process* call; peek via `response.clone()`.
   protected async resolveTokenIssuer(
     as: oauth.AuthorizationServer,
     _response: Response,

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -152,10 +152,9 @@ export class OpenIDAuthenticationProvider
     return this.authorizationServer;
   }
 
-  // Hook for providers whose discovery metadata deviates from the requested
-  // issuer (see EntraAuthenticationProvider). Default: strict, expect the
-  // requested issuer. Overrides must not consume the response body — it is
-  // still needed by processDiscoveryResponse; peek via `response.clone()`.
+  // Overridable for providers whose discovery metadata deviates from the
+  // requested issuer (see EntraAuthenticationProvider). Overrides must peek
+  // via `response.clone()`; processDiscoveryResponse still needs the body.
   protected async getExpectedDiscoveryIssuer(
     issuerUrl: URL,
     _response: Response,
@@ -163,10 +162,9 @@ export class OpenIDAuthenticationProvider
     return issuerUrl;
   }
 
-  // Hook for providers whose token `iss` differs from the discovery issuer
-  // (see EntraAuthenticationProvider). Runs before each token response is
-  // validated. Default: pass through. Overrides must not consume the response
-  // body — it is still needed by the process* call; peek via `response.clone()`.
+  // Overridable for providers whose token `iss` differs from the discovery
+  // issuer (see EntraAuthenticationProvider). Overrides must peek via
+  // `response.clone()`; the process* call still needs the body.
   protected async resolveTokenIssuer(
     as: oauth.AuthorizationServer,
     _response: Response,

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -143,12 +143,33 @@ export class OpenIDAuthenticationProvider
         issuerUrl,
         this.oauthOptions,
       );
+
       this.authorizationServer = await oauth.processDiscoveryResponse(
-        issuerUrl,
+        await this.getExpectedDiscoveryIssuer(issuerUrl, response),
         response,
       );
     }
     return this.authorizationServer;
+  }
+
+  // Hook for providers whose discovery metadata deviates from the requested
+  // issuer (see EntraAuthenticationProvider). Default: strict, expect the
+  // requested issuer.
+  protected async getExpectedDiscoveryIssuer(
+    issuerUrl: URL,
+    _response: Response,
+  ): Promise<URL> {
+    return issuerUrl;
+  }
+
+  // Hook for providers whose token `iss` differs from the discovery issuer
+  // (see EntraAuthenticationProvider). Runs before each token response is
+  // validated. Default: pass through.
+  protected async resolveTokenIssuer(
+    as: oauth.AuthorizationServer,
+    _response: Response,
+  ): Promise<oauth.AuthorizationServer> {
+    return as;
   }
 
   /**
@@ -496,7 +517,7 @@ export class OpenIDAuthenticationProvider
       );
 
       const result = await oauth.processRefreshTokenResponse(
-        as,
+        await this.resolveTokenIssuer(as, response),
         this.client,
         response,
       );
@@ -590,7 +611,7 @@ export class OpenIDAuthenticationProvider
           this.oauthOptions,
         );
         const result = await oauth.processRefreshTokenResponse(
-          as,
+          await this.resolveTokenIssuer(as, response),
           this.client,
           response,
         );
@@ -657,7 +678,7 @@ export class OpenIDAuthenticationProvider
     );
 
     const oauthResult = await oauth.processAuthorizationCodeResponse(
-      authServer,
+      await this.resolveTokenIssuer(authServer, response),
       this.client,
       response,
     );

--- a/packages/zudoku/src/lib/authentication/providers/util.ts
+++ b/packages/zudoku/src/lib/authentication/providers/util.ts
@@ -12,7 +12,6 @@ export const redirectToSignUpUrl = (
   }
 };
 
-// Shared between the entra provider and server-side issuer resolution.
 export const getEntraIssuer = (config: {
   issuer?: string;
   tenantId?: string;

--- a/packages/zudoku/src/lib/authentication/providers/util.ts
+++ b/packages/zudoku/src/lib/authentication/providers/util.ts
@@ -12,6 +12,14 @@ export const redirectToSignUpUrl = (
   }
 };
 
+// Shared between the entra provider and server-side issuer resolution.
+export const getEntraIssuer = (config: {
+  issuer?: string;
+  tenantId?: string;
+}) =>
+  config.issuer ??
+  `https://login.microsoftonline.com/${config.tenantId ?? "common"}/v2.0`;
+
 export const getClerkFrontendApi = (publishableKey: string) => {
   // Split by underscore and get the base64 encoded part (3rd segment)
   const parts = publishableKey.split("_");


### PR DESCRIPTION
Entra's multi-tenant authorities (`common`, `organizations`, `consumers`) return a templated discovery issuer (`https://login.microsoftonline.com/{tenantid}/v2.0`), which fails strict OIDC issuer validation. Configuring them via `type: "openid"` errors with "issuer does not match".

This adds a `type: "entra"` provider:

- `EntraAuthenticationProvider` extends `OpenIDAuthenticationProvider`. It accepts the templated issuer at discovery and validates each token's `iss` by substituting the ID token's `tid` claim into the template (the approach oauth4webapi's maintainer recommends).
- Config takes `clientId` and an optional `tenantId` (defaults to `common`). CIAM tenants can override `issuer`.
- `OpenIDAuthenticationProvider` gets two protected hooks (`getExpectedDiscoveryIssuer`, `resolveTokenIssuer`); the generic provider stays spec-strict.
- Docs updated to use the new type.