### PR TITLE
fix(monetization): pricing page crash after logout

### DIFF
--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.test.tsx
@@ -1,6 +1,8 @@
 import { act, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ZudokuContext } from "zudoku";
 import { StaticZudoku } from "zudoku/testing";
+import { pricingPageQuery } from "./queries.js";
 import type { Plan } from "./types/PlanType.js";
 import { zuploMonetizationPlugin } from "./ZuploMonetizationPlugin";
 import { queryClient } from "./ZuploMonetizationWrapper";
@@ -64,5 +66,85 @@ describe("PricingPage", () => {
     expect(screen.getByTestId("subtitle")).toHaveTextContent(
       "See our pricing options and choose the one that best suits your needs.",
     );
+  });
+});
+
+describe("pricing query signing after logout", () => {
+  // Simulates the OpenID end_session logout race: the pricing prefetch is
+  // built while localStorage still says authenticated, but by the time the
+  // request fires the logout callback has cleared auth state.
+  const createFakeContext = (authState: { isAuthenticated: boolean }) => {
+    const signRequest = vi.fn(async (_request: Request): Promise<Request> => {
+      throw new Error("Invalid or incompatible provider data");
+    });
+    const context = {
+      env: { ZUPLO_PUBLIC_DEPLOYMENT_NAME: "test" },
+      getAuthState: () => authState,
+      signRequest,
+    } as unknown as ZudokuContext;
+    return { context, signRequest };
+  };
+
+  beforeEach(() => {
+    queryClient.clear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ items: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches unsigned when logged out after the query was built", async () => {
+    const authState = { isAuthenticated: true };
+    const { context, signRequest } = createFakeContext(authState);
+
+    const opts = pricingPageQuery(context);
+    authState.isAuthenticated = false;
+
+    await queryClient.prefetchQuery(opts);
+
+    expect(signRequest).not.toHaveBeenCalled();
+    expect(queryClient.getQueryState(opts.queryKey)?.status).toBe("success");
+  });
+
+  it("renders /pricing after a logout-poisoned prefetch", async () => {
+    const authState = { isAuthenticated: true };
+    const { context } = createFakeContext(authState);
+
+    const opts = pricingPageQuery(context);
+    authState.isAuthenticated = false;
+    await queryClient.prefetchQuery(opts);
+
+    await act(async () => {
+      render(
+        <StaticZudoku
+          env={{ ZUPLO_PUBLIC_DEPLOYMENT_NAME: "test" }}
+          plugins={[zuploMonetizationPlugin({ pricing: { title: "Pricing" } })]}
+          path="/pricing"
+        />,
+      );
+    });
+
+    expect(screen.getByTestId("title")).toHaveTextContent("Pricing");
+  });
+
+  it("signs the request when authenticated at fetch time", async () => {
+    const authState = { isAuthenticated: true };
+    const { context, signRequest } = createFakeContext(authState);
+    signRequest.mockImplementation(async (request: Request) => request);
+
+    await queryClient.prefetchQuery(pricingPageQuery(context));
+
+    expect(signRequest).toHaveBeenCalledOnce();
   });
 });

--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.tsx
@@ -36,6 +36,17 @@ export const zuploMonetizationPlugin = createPlugin(
       }
     },
 
+    events: {
+      auth: ({ prev, next }) => {
+        // Drop cached user-scoped data (and any entry poisoned by a signed
+        // request that raced the logout) so nothing survives into the
+        // anonymous session.
+        if (prev.isAuthenticated && !next.isAuthenticated) {
+          queryClient.removeQueries();
+        }
+      },
+    },
+
     getIdentities: async (context) => {
       // Subscriptions require auth; unexpected failures are handled by
       // `getApiIdentities`, which settles plugins individually.

--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationWrapper.tsx
@@ -59,8 +59,14 @@ export const queryClient = new QueryClient({
           },
         });
 
+        // Sign based on live auth state, not the state when the query was
+        // built: a query created while authenticated must not sign (and fail)
+        // after logout, e.g. the prefetch racing the logout callback.
+        const queryContext = q.meta?.context;
         const response = await fetch(
-          q.meta?.context ? await q.meta.context.signRequest(request) : request,
+          queryContext?.getAuthState().isAuthenticated
+            ? await queryContext.signRequest(request)
+            : request,
         );
 
         await throwIfProblemJson(response);
@@ -122,8 +128,11 @@ export const queryClient = new QueryClient({
           },
         });
 
+        const mutationContext = m.meta?.context;
         const response = await fetch(
-          m.meta?.context ? await m.meta.context.signRequest(request) : request,
+          mutationContext?.getAuthState().isAuthenticated
+            ? await mutationContext.signRequest(request)
+            : request,
         );
 
         await throwIfProblemJson(response);

--- a/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.tsx
@@ -63,7 +63,7 @@ const CheckoutPage = () => {
   const planId = searchParams.get("planId");
 
   if (!planId) {
-    return <Navigate to="/pricing" />;
+    return <Navigate to="/pricing" replace />;
   }
 
   return <CheckoutRedirect planId={planId} />;

--- a/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.tsx
@@ -1,24 +1,18 @@
 import { useAuth, useZudoku } from "zudoku/hooks";
 import { ShieldIcon } from "zudoku/icons";
 import { useQuery } from "zudoku/react-query";
-import { Link, useSearchParams } from "zudoku/router";
+import { Link, Navigate, useSearchParams } from "zudoku/router";
 import { Alert, AlertAction, AlertDescription } from "zudoku/ui/Alert";
 import { Button } from "zudoku/ui/Button";
 import { RedirectPage } from "../components/RedirectPage.js";
 import { useDeploymentName } from "../hooks/useDeploymentName";
 import { useUrlUtils } from "../hooks/useUrlUtils";
 
-const CheckoutPage = () => {
-  const [searchParams] = useSearchParams();
-  const planId = searchParams.get("planId");
+const CheckoutRedirect = ({ planId }: { planId: string }) => {
   const zudoku = useZudoku();
   const auth = useAuth();
   const { generateUrl } = useUrlUtils();
   const deploymentName = useDeploymentName();
-
-  if (!planId) {
-    throw new Error(`missing planId in URL`);
-  }
 
   const checkoutLink = useQuery<{ url: string }>({
     queryKey: [
@@ -62,6 +56,17 @@ const CheckoutPage = () => {
       )}
     </RedirectPage>
   );
+};
+
+const CheckoutPage = () => {
+  const [searchParams] = useSearchParams();
+  const planId = searchParams.get("planId");
+
+  if (!planId) {
+    return <Navigate to="/pricing" />;
+  }
+
+  return <CheckoutRedirect planId={planId} />;
 };
 
 export default CheckoutPage;


### PR DESCRIPTION
After logging out through an IdP with an `end_session_endpoint`, SPA-navigating to /pricing crashed with `AuthorizationError: Invalid or incompatible provider data`.

The decision to sign monetization requests was snapshotted into query `meta` when the query was built. On the logout callback page, the pricing prefetch starts while local auth state still says authenticated, then the callback clears it mid-flight. The signed request fails, `prefetchQuery` swallows the error, and the pricing query gets cached in an error state in the module singleton `queryClient`. The next navigation to /pricing reads that poisoned entry and throws into the route error boundary.

Now `queryFn`/`mutationFn` check `getAuthState().isAuthenticated` at fetch time instead of using the snapshot, and the plugin drops its cached queries when auth transitions to logged out. `CheckoutPage` also redirects to /pricing instead of throwing when `planId` is missing.