### PR TITLE
Upgrade Node.js to 22.22.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 22.22.0
+nodejs 22.22.2
 pnpm 11.0.0


### PR DESCRIPTION
## Summary
Updates the Node.js version specified in `.tool-versions` from 22.22.0 to 22.22.2, a patch release that includes bug fixes and security improvements.

## Changes
- Bumped Node.js version from 22.22.0 to 22.22.2 in `.tool-versions`

## Notes
This is a patch version update within the same minor release line (22.22.x), ensuring compatibility with existing tooling and dependencies while incorporating the latest stability improvements.

https://claude.ai/code/session_01SHzxSvVjdbWfaLoe4ejYQY