### PR TITLE
ci: pin npm to v11 instead of latest

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -47,7 +47,7 @@ jobs:
           cache: "pnpm"
 
       - name: Update npm for OIDC trusted publishing support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Follow-up to #2695. After bumping Node to 22.22.2, `npm install -g npm@latest` still failed in CI because `npm@latest` now resolves to **npm@12.0.0** — a broken release that crashes on startup with `MODULE_NOT_FOUND` for its bundled `promise-retry` dependency ([failing run](https://github.com/zuplo/zudoku/actions/runs/28999983790/job/86058041487)).

## Changes

- `.github/workflows/main.yaml`: `npm install -g npm@latest` → `npm@11`
- `.github/workflows/release-monetization.yaml`: same change

## Notes

npm 11.x is stable and still provides the OIDC trusted-publishing support these steps were added for. Pinning to a major line (rather than `latest`) also prevents a future broken `latest` release from breaking CI again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHzxSvVjdbWfaLoe4ejYQY)_