### PR TITLE
ci: revert Node to 22.22.0 (22.22.2 ships a broken npm)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 22.22.2
+nodejs 22.22.0
 pnpm 11.0.0


### PR DESCRIPTION
## Summary

Fixes the `promise-retry` `MODULE_NOT_FOUND` crash in the Release workflow's `npm install -g` step.

The Actions toolcache build of **Node 22.22.2 bundles a broken npm (10.9.7)** — its `@npmcli/arborist` cannot resolve `promise-retry`, so *any* `npm install -g` aborts immediately with `MODULE_NOT_FOUND`, regardless of the target version. This is a known upstream regression specific to 22.22.2:
- https://github.com/nodejs/node/issues/62425
- https://github.com/actions/runner-images/issues/13883
- https://github.com/npm/cli/issues/9151

The earlier Node bump to 22.22.2 (#2695) is what introduced this. Reverting to **22.22.0**, whose bundled npm (10.9.4) works, resolves it.

## Changes

- `.tool-versions`: `nodejs 22.22.2` → `22.22.0`

## Why this is correct

- Node 22.22.0's toolcache npm is not broken (the original failing run reached the engine check without a `promise-retry` crash).
- The `npm@11` pin from #2696 stays. `npm install -g npm@11` resolves to **11.18.0**, whose engine is `^20.17.0 || >=22.9.0` — satisfied by Node 22.22.0, so no `EBADENGINE`.
- npm 11.18.0 still provides the OIDC trusted-publishing support the release steps were upgraded for (added in 11.5.1).

Verified locally: `npm install -g npm@11` → 11.18.0, engine `>=22.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHzxSvVjdbWfaLoe4ejYQY)_