### PR TITLE
fix(navigation): consistent sidebar row heights

### DIFF
--- a/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
@@ -67,7 +67,8 @@ const NavigationCategoryInner = ({
       size="icon"
       aria-label={open ? "Collapse section" : "Expand section"}
       aria-expanded={open}
-      className="size-6 hover:bg-[hsl(from_var(--accent)_h_s_calc(l+6*var(--dark)))]"
+      // -my-0.5 keeps the chevron from making folder rows taller than plain ones
+      className="size-6 -my-0.5 rounded-full hover:bg-[hsl(from_var(--accent)_h_s_calc(l+6*var(--dark)))]"
     >
       <ChevronRightIcon
         size={16}

--- a/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
+++ b/packages/zudoku/src/lib/components/navigation/NavigationCategory.tsx
@@ -63,12 +63,12 @@ const NavigationCategoryInner = ({
         setOpen((prev) => !prev);
         setHasInteracted(true);
       }}
-      variant="ghost"
+      variant="none"
       size="icon"
       aria-label={open ? "Collapse section" : "Expand section"}
       aria-expanded={open}
       // -my-0.5 keeps the chevron from making folder rows taller than plain ones
-      className="size-6 -my-0.5 rounded-full hover:bg-[hsl(from_var(--accent)_h_s_calc(l+6*var(--dark)))]"
+      className="size-6 -my-0.5"
     >
       <ChevronRightIcon
         size={16}

--- a/packages/zudoku/src/lib/components/navigation/StackRows.tsx
+++ b/packages/zudoku/src/lib/components/navigation/StackRows.tsx
@@ -24,7 +24,7 @@ export const StackDrillRow = ({
     className={cn(navigationListItem(), "group justify-between", className)}
   >
     <span className="flex items-center gap-2 truncate">{children}</span>
-    <span className="grid size-6 shrink-0 place-items-center">
+    <span className="grid size-6 -my-0.5 shrink-0 place-items-center">
       <ChevronRightIcon size={16} />
     </span>
   </Link>


### PR DESCRIPTION
Folder rows in the docs sidebar (categories with a chevron) were 4px taller than plain link rows because the chevron sits in a `size-6` (24px) control while the row text is only 20px tall. This equalizes them so every sidebar row is the same height, and drops the background from the collapse chevron so it reads as a plain arrow.

Applies to collapsible categories, drill (`stack`) categories, and plain items alike.