### PR TITLE
Extract deployment name resolution into reusable utility

### DIFF
--- a/packages/plugin-zuplo-monetization/src/deploymentName.test.ts
+++ b/packages/plugin-zuplo-monetization/src/deploymentName.test.ts
@@ -22,4 +22,12 @@ describe("resolveDeploymentName", () => {
   it("throws when the deployment name is an empty string", () => {
     expect(() => resolveDeploymentName("")).toThrow(ZudokuError);
   });
+
+  it("throws when the deployment name is only whitespace", () => {
+    expect(() => resolveDeploymentName("   ")).toThrow(ZudokuError);
+  });
+
+  it("trims surrounding whitespace from the deployment name", () => {
+    expect(resolveDeploymentName("  my-deployment  ")).toBe("my-deployment");
+  });
 });

--- a/packages/plugin-zuplo-monetization/src/deploymentName.test.ts
+++ b/packages/plugin-zuplo-monetization/src/deploymentName.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { ZudokuError } from "zudoku/components";
+import { resolveDeploymentName } from "./deploymentName.js";
+
+describe("resolveDeploymentName", () => {
+  it("returns the deployment name when set", () => {
+    expect(resolveDeploymentName("my-deployment")).toBe("my-deployment");
+  });
+
+  it("throws a ZudokuError guiding the user to run `zuplo link`", () => {
+    try {
+      resolveDeploymentName(undefined);
+      expect.unreachable("expected resolveDeploymentName to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ZudokuError);
+      const zudokuError = error as ZudokuError;
+      expect(zudokuError.title).toBe("Not linked to a Zuplo deployment");
+      expect(zudokuError.developerHint).toContain("zuplo link");
+    }
+  });
+
+  it("throws when the deployment name is an empty string", () => {
+    expect(() => resolveDeploymentName("")).toThrow(ZudokuError);
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/deploymentName.ts
+++ b/packages/plugin-zuplo-monetization/src/deploymentName.ts
@@ -1,0 +1,24 @@
+import { ZudokuError } from "zudoku/components";
+
+/**
+ * Resolves the Zuplo deployment name from the environment.
+ *
+ * `ZUPLO_PUBLIC_DEPLOYMENT_NAME` is populated by `zuplo link`, so a missing
+ * value almost always means the project hasn't been linked yet (the common
+ * case when running the docs locally). Throw a `ZudokuError` with actionable
+ * guidance rather than a bare "not set" so the UI can surface the fix.
+ */
+export const resolveDeploymentName = (deploymentName?: string): string => {
+  if (!deploymentName) {
+    throw new ZudokuError(
+      "This project is not linked to a Zuplo deployment, so the monetization plugin can't load pricing or subscriptions.",
+      {
+        title: "Not linked to a Zuplo deployment",
+        developerHint:
+          "Run `zuplo link` to connect this project to your Zuplo deployment. This sets the `ZUPLO_PUBLIC_DEPLOYMENT_NAME` environment variable that the monetization plugin needs.",
+      },
+    );
+  }
+
+  return deploymentName;
+};

--- a/packages/plugin-zuplo-monetization/src/deploymentName.ts
+++ b/packages/plugin-zuplo-monetization/src/deploymentName.ts
@@ -9,7 +9,11 @@ import { ZudokuError } from "zudoku/components";
  * guidance rather than a bare "not set" so the UI can surface the fix.
  */
 export const resolveDeploymentName = (deploymentName?: string): string => {
-  if (!deploymentName) {
+  // Trim so a whitespace-only env value doesn't slip into request URLs
+  // (e.g. `/v3/zudoku-metering/   /...`); treat blank as unset.
+  const trimmed = deploymentName?.trim();
+
+  if (!trimmed) {
     throw new ZudokuError(
       "This project is not linked to a Zuplo deployment, so the monetization plugin can't load pricing or subscriptions.",
       {
@@ -20,5 +24,5 @@ export const resolveDeploymentName = (deploymentName?: string): string => {
     );
   }
 
-  return deploymentName;
+  return trimmed;
 };

--- a/packages/plugin-zuplo-monetization/src/hooks/useDeploymentName.ts
+++ b/packages/plugin-zuplo-monetization/src/hooks/useDeploymentName.ts
@@ -1,12 +1,8 @@
 import { useZudoku } from "zudoku/hooks";
+import { resolveDeploymentName } from "../deploymentName.js";
 
 export const useDeploymentName = () => {
   const zudoku = useZudoku();
-  const deploymentName = zudoku.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME;
 
-  if (!deploymentName) {
-    throw new Error("ZUPLO_PUBLIC_DEPLOYMENT_NAME is not set");
-  }
-
-  return deploymentName;
+  return resolveDeploymentName(zudoku.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME);
 };

--- a/packages/plugin-zuplo-monetization/src/queries.ts
+++ b/packages/plugin-zuplo-monetization/src/queries.ts
@@ -1,15 +1,11 @@
 import type { ZudokuContext } from "zudoku";
 import { queryOptions } from "zudoku/react-query";
+import { resolveDeploymentName } from "./deploymentName.js";
 import type { SubscriptionsResponse } from "./hooks/useSubscriptions.js";
 import type { Plan } from "./types/PlanType.js";
 
-const getDeploymentName = (context: ZudokuContext) => {
-  const deploymentName = context.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME;
-  if (!deploymentName) {
-    throw new Error("ZUPLO_PUBLIC_DEPLOYMENT_NAME is not set");
-  }
-  return deploymentName;
-};
+const getDeploymentName = (context: ZudokuContext) =>
+  resolveDeploymentName(context.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME);
 
 export const pricingPageQuery = (context: ZudokuContext) =>
   queryOptions<{ items: Plan[] }>({


### PR DESCRIPTION
## Summary

Refactored deployment name resolution logic into a dedicated utility function to improve error handling and reduce code duplication across the monetization plugin.

## Key Changes

- **New module**: `deploymentName.ts` exports `resolveDeploymentName()` utility that validates the `ZUPLO_PUBLIC_DEPLOYMENT_NAME` environment variable
- **Better error handling**: Replaced generic `Error` with `ZudokuError` to provide actionable guidance when the deployment name is missing, directing users to run `zuplo link`
- **Reduced duplication**: Consolidated validation logic previously duplicated in `queries.ts` and `useDeploymentName.ts` hook
- **Comprehensive tests**: Added `deploymentName.test.ts` with test coverage for success case, missing deployment name, and empty string scenarios

## Implementation Details

The `resolveDeploymentName()` function throws a `ZudokuError` with:
- Clear title: "Not linked to a Zuplo deployment"
- Developer hint explaining the `zuplo link` command and its purpose in setting the required environment variable

This allows the UI to surface the error appropriately while providing users with the exact steps needed to resolve the issue.

https://claude.ai/code/session_01D4F7VMkbn1yznscCuEdRnk