### PR TITLE
Migrate gsutil to gcloud storage in cdn-metadata script

### DIFF
--- a/packages/zudoku/scripts/cdn-metadata.sh
+++ b/packages/zudoku/scripts/cdn-metadata.sh
@@ -11,6 +11,6 @@ CACHE_CONTROL="public, max-age=31536000"
 echo "Updating Cache-Control for all objects with prefix '${PREFIX}' in bucket '${BUCKET_NAME}'..."
 
 # List all objects with the prefix and apply the new Cache-Control header
-gsutil -m setmeta -h "Cache-Control:${CACHE_CONTROL}" "gs://${BUCKET_NAME}/${PREFIX}**"
+gcloud storage objects update "gs://${BUCKET_NAME}/${PREFIX}**" --cache-control="${CACHE_CONTROL}"
 
 echo "Cache-Control update complete."


### PR DESCRIPTION
## Why

Google Cloud is dropping `gsutil` from the default Cloud CLI bundle in **March 2027**. `gsutil` stays available as a separate PyPI install, but `gcloud storage` is the supported path going forward. This script is the only remaining `gsutil` caller in the repo.

## What

`packages/zudoku/scripts/cdn-metadata.sh`:

```
gsutil -m setmeta -h "Cache-Control:${CACHE_CONTROL}" "gs://${BUCKET_NAME}/${PREFIX}**"
```
→
```
gcloud storage objects update "gs://${BUCKET_NAME}/${PREFIX}**" --cache-control="${CACHE_CONTROL}"
```

- `setmeta -h "Cache-Control:…"` → `objects update --cache-control=…`
- `gcloud storage` expands `**` natively and parallelizes by default, so the `-m` flag is dropped.

No behavior change — same objects, same Cache-Control value.

## Verify after merge

Run the script against `cdn.zudoku.dev` and confirm objects under `geist/` report `Cache-Control: public, max-age=31536000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)