### PR TITLE
Support custom MCP server names and versions in Zuplo handler options

### DIFF
--- a/docs/pages/docs/guides/mcp-servers.md
+++ b/docs/pages/docs/guides/mcp-servers.md
@@ -187,3 +187,29 @@ since they use a different interaction model.
 If you are using [Zuplo](https://zuplo.com) to host your API, the `x-mcp-server` extension is
 automatically added to POST operations that use the `mcpServerHandler`. No manual schema changes are
 needed. See the [Zuplo MCP documentation](https://zuplo.com/docs/handlers/mcp-server) for details.
+
+The server name shown in the install snippets (for example `claude mcp add … 'MCP Server' …`) is
+taken from the handler's `name` option — the same name your MCP server advertises to clients. Set it
+to override the default `"MCP Server"` title:
+
+```json title="config/routes.oas.json (paths section)"
+{
+  "/mcp": {
+    "post": {
+      "operationId": "mcpServerHandler",
+      "x-zuplo-route": {
+        "handler": {
+          "export": "mcpServerHandler",
+          "module": "$import(@zuplo/runtime)",
+          "options": {
+            "name": "Acme API",
+            "operations": [{ "file": "./config/routes.oas.json", "id": "get-users" }]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+With this configuration the snippets read `claude mcp add --transport http 'Acme API' …`.

--- a/examples/cosmo-cargo/schema/ai-cargo.json
+++ b/examples/cosmo-cargo/schema/ai-cargo.json
@@ -403,6 +403,118 @@
         }
       }
     },
+    "/mcp/navigator": {
+      "post": {
+        "tags": ["Quantum Transport"],
+        "summary": "Quantum Navigator MCP endpoint",
+        "description": "A dedicated Model Context Protocol (MCP) server for interstellar route planning. Lets AI tools plot quantum tunneling lanes, check lane stability, and estimate warp energy budgets before committing a shipment to the void.\n\nThis is a distinct MCP server from the universal endpoint — it sets its own title via `x-mcp-server.name`, so the generated install snippets read `claude mcp add … 'Quantum Navigator' …` rather than a generic default.",
+        "operationId": "mcpNavigator",
+        "x-mcp-server": {
+          "name": "Quantum Navigator",
+          "version": "2.4.0",
+          "tools": [
+            {
+              "name": "plot_quantum_route",
+              "description": "Plot an optimal quantum tunneling route between two star systems"
+            },
+            {
+              "name": "check_lane_stability",
+              "description": "Report the current stability of a quantum tunneling lane"
+            },
+            {
+              "name": "estimate_warp_energy",
+              "description": "Estimate the warp energy budget for a payload over a given distance"
+            }
+          ],
+          "security": [
+            {
+              "ApiKeyAuth": []
+            }
+          ],
+          "securitySchemes": {
+            "ApiKeyAuth": {
+              "type": "apiKey",
+              "in": "header",
+              "name": "X-API-Key"
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["action", "parameters"],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "plot_quantum_route",
+                      "check_lane_stability",
+                      "estimate_warp_energy"
+                    ],
+                    "description": "The navigation action to perform"
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Action-specific parameters"
+                  }
+                }
+              },
+              "example": {
+                "action": "plot_quantum_route",
+                "parameters": {
+                  "origin": "Earth Station Alpha",
+                  "destination": "Proxima Cargo Depot",
+                  "maxLaneInstability": 0.15
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "MCP request processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MCPResponse"
+                },
+                "example": {
+                  "success": true,
+                  "message": "Quantum route plotted successfully",
+                  "data": {
+                    "routeId": "q-7f3a-warp-88",
+                    "entryPoint": "Sol Gateway",
+                    "exitPoint": "Proxima Lane 4",
+                    "distance": 4.24,
+                    "quantumStability": 0.92,
+                    "energyRequired": 1840
+                  },
+                  "mcpMetadata": {
+                    "processingTime": 128.7,
+                    "aiModel": "QuantumNavigator-v2.4",
+                    "confidence": 0.97
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid MCP request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/optimize": {
       "post": {
         "tags": ["AI Operations"],

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
@@ -7,13 +7,16 @@ import { removeExtensions } from "../lib/plugins/openapi/processors/removeExtens
 import { removePaths } from "../lib/plugins/openapi/processors/removePaths.js";
 import { enrichWithZuploMcpServerData } from "./enrich-with-zuplo-mcp.js";
 
-const mcpRouteHandler = (operations: Array<{ file: string; id: string }>) => ({
+const mcpRouteHandler = (
+  operations: Array<{ file: string; id: string }>,
+  options: Record<string, unknown> = {},
+) => ({
   "x-zuplo-route": {
     corsPolicy: "none",
     handler: {
       export: "mcpServerHandler",
       module: "$import(@zuplo/runtime)",
-      options: { operations },
+      options: { operations, ...options },
     },
     policies: { inbound: [] },
   },
@@ -87,6 +90,91 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(op["x-mcp-server"].name).toBe("MCP Server");
     expect(op["x-mcp-server"].tools).toHaveLength(1);
     expect(op["x-mcp-server"].tools[0].name).toBe("get-users");
+  });
+
+  it("should use the configured handler name and version for x-mcp-server", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            ...mcpRouteHandler(
+              [{ file: "./config/routes.oas.json", id: "get-users" }],
+              { name: "Cosmo Cargo MCP", version: "2.1.0" },
+            ),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].name).toBe("Cosmo Cargo MCP");
+    expect(op["x-mcp-server"].version).toBe("2.1.0");
+  });
+
+  it("should fall back to the default name when the handler name is blank", async () => {
+    await writeApiFile("config/routes.oas.json", {
+      openapi: "3.1.0",
+      info: { title: "Routes API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            operationId: "get-users",
+            summary: "Get all users",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    });
+
+    const schema = {
+      openapi: "3.1.0",
+      info: { title: "Test MCP API", version: "1.0.0" },
+      paths: {
+        "/mcp": {
+          post: {
+            summary: "MCP Server",
+            operationId: "mcp-endpoint",
+            ...mcpRouteHandler(
+              [{ file: "./config/routes.oas.json", id: "get-users" }],
+              { name: "   " },
+            ),
+            responses: { "200": { description: "MCP response" } },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].name).toBe("MCP Server");
   });
 
   it("should group operations from the same file", async () => {

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -18,6 +18,12 @@ const MCP_TAG_NAME = "MCP";
 const MCP_TAG_DESCRIPTION =
   "Model Context Protocol (MCP) server endpoints for AI tool integration";
 
+// Reads a non-empty string from an untyped handler option, returning undefined
+// for missing, blank, or non-string values so callers can fall back to a
+// default.
+const readStringOption = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() !== "" ? value : undefined;
+
 // extracts x-mcp-server metadata from the operation using x-zuplo-mcp-tool
 // as a first class citizen.
 const extractOperationSchema = (
@@ -222,9 +228,15 @@ export const enrichWithZuploMcpServerData = ({
           allOperationIds,
         );
 
+      // Mirror the runtime's server identity (ZuploMcpServer resolves these
+      // from `opts.name` / `opts.version`) so the documented server name shown
+      // in the install snippets matches what MCP clients actually connect to.
+      // Falls back to the shared defaults when the handler leaves them unset.
       const mcpExtension: ExtensionMcpServer = {
-        name: DEFAULT_MCP_SERVER_NAME,
-        version: DEFAULT_MCP_SERVER_VERSION,
+        name: readStringOption(handler.options.name) ?? DEFAULT_MCP_SERVER_NAME,
+        version:
+          readStringOption(handler.options.version) ??
+          DEFAULT_MCP_SERVER_VERSION,
       };
 
       if (allTools.length > 0) {


### PR DESCRIPTION
## Summary

Adds support for configuring custom MCP server names and versions via the Zuplo `mcpServerHandler` options, allowing the documented server identity in OpenAPI schemas to match what MCP clients actually connect to.

## Changes

- **Schema enrichment**: Modified `enrichWithZuploMcpServerData` to read `name` and `version` from handler options and populate `x-mcp-server` metadata accordingly, falling back to defaults when unset or blank
- **Helper utility**: Added `readStringOption()` to safely extract non-empty string values from untyped handler options
- **Test coverage**: Added two new test cases:
  - Verifies custom handler name and version are correctly reflected in `x-mcp-server`
  - Verifies fallback to default name when handler name is blank/whitespace
- **Test infrastructure**: Updated `mcpRouteHandler` test helper to accept optional handler options
- **Documentation**: Added guide section explaining how to configure custom server names via handler options with a concrete JSON example
- **Example schema**: Added `/mcp/navigator` endpoint to the Cosmo Cargo example demonstrating a custom-named MCP server ("Quantum Navigator" v2.4.0)

## Implementation Details

The `readStringOption()` utility validates that values are non-empty strings, returning `undefined` for missing, blank, or non-string values. This allows callers to safely fall back to defaults. The enrichment logic now mirrors the runtime's server identity resolution so install snippets (e.g., `claude mcp add … 'Quantum Navigator' …`) match the actual MCP server name advertised to clients.

https://claude.ai/code/session_01JBqjAJgSycNgHz4YhGJWY2