### PR TITLE
Support volume pricing mode in tiered price formatting

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
@@ -943,7 +943,7 @@ describe("SwitchPlanModal", () => {
     // The transition line still names the pricing model…
     expect(within(card).getByText("Tiered pricing")).toBeInTheDocument();
     // …but the decision-relevant schedule is shown beneath it.
-    expect(within(card).getByText("Up to 1,000: Included")).toBeInTheDocument();
+    expect(within(card).getByText("First 1,000: Included")).toBeInTheDocument();
     expect(
       within(card).getByText("Over 1,000: $0.01/unit"),
     ).toBeInTheDocument();

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/deriveUsageView.ts
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/deriveUsageView.ts
@@ -1,4 +1,5 @@
 import type { Item } from "../../types/SubscriptionType.js";
+import { pluralizeUnit } from "../../utils/pluralizeUnit.js";
 import { priceIncludedUnits } from "../../utils/priceIncludedUnits.js";
 
 /** The metered access values the usage endpoint reports for one feature. */
@@ -54,12 +55,6 @@ const formatAmount = (amount: string | undefined): string | undefined => {
   const value = parseFloat(amount ?? "");
   return Number.isFinite(value) ? `$${value.toFixed(2)}` : undefined;
 };
-
-// The unit name comes from the pricing config (`pricing.units` keyed by rate
-// card or feature key); "unit" is the configured fallback everywhere else in
-// the plugin (see categorizeRateCards), so it is here too.
-const pluralizeUnit = (unitName: string) =>
-  unitName.endsWith("s") ? unitName : `${unitName}s`;
 
 /** The label for what additional usage costs, when the shape has one number. */
 const rateLabelFor = (

--- a/packages/plugin-zuplo-monetization/src/pricing-ui/QuotaItem.tsx
+++ b/packages/plugin-zuplo-monetization/src/pricing-ui/QuotaItem.tsx
@@ -11,9 +11,10 @@ export const QuotaItem = ({
 }) => {
   const hasTierBreakdown = !!quota.tierPrices && quota.tierPrices.length > 0;
   // Hide the "X / period" header when the card has no included quota
-  // (`isPayg`) or when a tier breakdown already conveys it as an
-  // "Up to X: Included" line. A hard cap (`isHardCap`) is a real limit the
-  // breakdown does NOT convey, so it keeps the header alongside the prices.
+  // (`isPayg`) or when a tier breakdown already conveys it as a
+  // "First X: Included" (graduated) / "Up to X: Included" (volume) line.
+  // A hard cap (`isHardCap`) is a real limit the breakdown does NOT convey,
+  // so it keeps the header alongside the prices.
   const showQuotaLine = !quota.isPayg && (quota.isHardCap || !hasTierBreakdown);
 
   return (

--- a/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
@@ -1003,6 +1003,24 @@ describe("categorizeRateCards", () => {
       ]);
     });
 
+    it("uses the configured unit label in the all-units reminder", () => {
+      const { quotas } = categorizeRateCards(
+        [
+          makeMeteredRateCard({
+            isSoftLimit: true,
+            issueAfterReset: 0,
+            mode: "volume",
+            tiers,
+          }),
+        ],
+        { units: { requests: "request" } },
+      );
+      expect(quotas[0].tierPrices).toEqual([
+        "Up to 100: $3 + $0.01/request",
+        "Over 100: $0.005/request (all requests)",
+      ]);
+    });
+
     it("renders the same tiers as consecutive ranges under graduated mode", () => {
       const { quotas } = categorizeRateCards([
         makeMeteredRateCard({

--- a/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.test.ts
@@ -6,6 +6,7 @@ const makeMeteredRateCard = (
   overrides: Partial<{
     isSoftLimit: boolean;
     issueAfterReset: number;
+    mode: "volume" | "graduated";
     tiers: Array<{
       flatPrice?: { amount: string };
       unitPrice?: { amount: string };
@@ -19,7 +20,11 @@ const makeMeteredRateCard = (
   featureKey: "requests",
   billingCadence: "P1M",
   price: overrides.tiers
-    ? { type: "tiered", mode: "graduated", tiers: overrides.tiers }
+    ? {
+        type: "tiered",
+        mode: overrides.mode ?? "graduated",
+        tiers: overrides.tiers,
+      }
     : null,
   entitlementTemplate: {
     type: "metered",
@@ -56,8 +61,8 @@ describe("categorizeRateCards", () => {
     expect(quotas).toHaveLength(1);
     expect(quotas[0].isPayg).toBe(true);
     expect(quotas[0].tierPrices).toEqual([
-      "Up to 50: $40/unit",
-      "Up to 90: $10/unit",
+      "First 50: $40/unit",
+      "Next 40: $10/unit",
       "Over 90: $5/unit",
     ]);
   });
@@ -80,7 +85,7 @@ describe("categorizeRateCards", () => {
     expect(quotas).toHaveLength(1);
     expect(quotas[0].isPayg).toBe(true);
     expect(quotas[0].tierPrices).toEqual([
-      "Up to 1,000: Included",
+      "First 1,000: Included",
       "Over 1,000: $0.01/unit",
     ]);
   });
@@ -166,7 +171,7 @@ describe("categorizeRateCards", () => {
   });
 
   it("keeps the cap visible for a hard limit with a free first tier and priced overage", () => {
-    // The breakdown's "Up to X: Included" line conveys the free range but
+    // The breakdown's "First X: Included" line conveys the free range but
     // not that the limit is a hard stop — the cap line must stay visible.
     const { quotas } = categorizeRateCards([
       makeMeteredRateCard({
@@ -186,7 +191,7 @@ describe("categorizeRateCards", () => {
     expect(quotas[0]).toMatchObject({ limit: 1000, isHardCap: true });
     expect(quotas[0].isPayg).toBeUndefined();
     expect(quotas[0].tierPrices).toEqual([
-      "Up to 1,000: Included",
+      "First 1,000: Included",
       "Over 1,000: $0.05/unit",
     ]);
   });
@@ -225,7 +230,7 @@ describe("categorizeRateCards", () => {
     expect(quotas).toHaveLength(1);
     expect(quotas[0]).toMatchObject({ limit: 100, isHardCap: true });
     expect(quotas[0].tierPrices).toEqual([
-      "Up to 50: $40/unit",
+      "First 50: $40/unit",
       "Over 50: $10/unit",
     ]);
   });
@@ -307,7 +312,7 @@ describe("categorizeRateCards", () => {
       }),
     ]);
     expect(quotas[0].tierPrices).toEqual([
-      "Up to 1,000: Included",
+      "First 1,000: Included",
       "Over 1,000: $0.01/unit",
     ]);
   });
@@ -326,7 +331,7 @@ describe("categorizeRateCards", () => {
       }),
     ]);
     expect(quotas[0].tierPrices).toEqual([
-      "Up to 1,000: Included",
+      "First 1,000: Included",
       "Over 1,000: $0.05/unit",
     ]);
   });
@@ -514,7 +519,7 @@ describe("categorizeRateCards", () => {
     expect(quotas[0].period).toBe("month");
   });
 
-  it("emits the free first tier as an 'Up to X: Included' line so the included quota is explicit", () => {
+  it("emits the free first tier as a 'First X: Included' line so the included quota is explicit", () => {
     const { quotas } = categorizeRateCards([
       makeMeteredRateCard({
         issueAfterReset: 5000,
@@ -530,7 +535,7 @@ describe("categorizeRateCards", () => {
     ]);
 
     expect(quotas[0].tierPrices).toEqual([
-      "Up to 5,000: Included",
+      "First 5,000: Included",
       "Over 5,000: $0.05/unit",
     ]);
   });
@@ -876,8 +881,8 @@ describe("categorizeRateCards", () => {
         isPayg: true,
       });
       expect(quotas[0].tierPrices).toEqual([
-        "Up to 1,000,000: $499",
-        "Up to 2,000,000: $199 + $0.05/unit",
+        "First 1,000,000: $499",
+        "Next 1,000,000: $199 + $0.05/unit",
         "Over 2,000,000: $0.02/unit",
       ]);
     });
@@ -934,7 +939,7 @@ describe("categorizeRateCards", () => {
       expect(quotas[0]).toMatchObject({ limit: 1000, isHardCap: true });
       expect(quotas[0].isPayg).toBeUndefined();
       expect(quotas[0].tierPrices).toEqual([
-        "Up to 1,000: $10",
+        "First 1,000: $10",
         "Over 1,000: $0.05/unit",
       ]);
     });
@@ -966,10 +971,76 @@ describe("categorizeRateCards", () => {
       const { quotas } = categorizeRateCards([rc]);
       expect(quotas[0]).toMatchObject({ limit: 5000 });
       expect(quotas[0].tierPrices).toEqual([
-        "Up to 5,000: Included",
+        "First 5,000: Included",
         "Over 5,000: $0.05/unit",
       ]);
       expect(quotas[0].isPayg).toBeUndefined();
+    });
+  });
+
+  describe("volume vs graduated price modes", () => {
+    const tiers = [
+      {
+        flatPrice: { amount: "3" },
+        unitPrice: { amount: "0.01" },
+        upToAmount: "100",
+      },
+      { unitPrice: { amount: "0.005" } },
+    ];
+
+    it("renders volume tiers as total-usage brackets with an all-units reminder", () => {
+      const { quotas } = categorizeRateCards([
+        makeMeteredRateCard({
+          isSoftLimit: true,
+          issueAfterReset: 0,
+          mode: "volume",
+          tiers,
+        }),
+      ]);
+      expect(quotas[0].tierPrices).toEqual([
+        "Up to 100: $3 + $0.01/unit",
+        "Over 100: $0.005/unit (all units)",
+      ]);
+    });
+
+    it("renders the same tiers as consecutive ranges under graduated mode", () => {
+      const { quotas } = categorizeRateCards([
+        makeMeteredRateCard({
+          isSoftLimit: true,
+          issueAfterReset: 0,
+          mode: "graduated",
+          tiers,
+        }),
+      ]);
+      expect(quotas[0].tierPrices).toEqual([
+        "First 100: $3 + $0.01/unit",
+        "Over 100: $0.005/unit",
+      ]);
+    });
+
+    it("keeps volume wording on the included-quota branch too", () => {
+      // Free first tier + soft quota routes through the quota branch (not
+      // PAYG); the volume bracket wording must carry over there as well.
+      const { quotas } = categorizeRateCards([
+        makeMeteredRateCard({
+          isSoftLimit: true,
+          issueAfterReset: 1000,
+          mode: "volume",
+          tiers: [
+            {
+              flatPrice: { amount: "0" },
+              unitPrice: { amount: "0" },
+              upToAmount: "1000",
+            },
+            { unitPrice: { amount: "0.05" } },
+          ],
+        }),
+      ]);
+      expect(quotas[0]).toMatchObject({ limit: 1000 });
+      expect(quotas[0].tierPrices).toEqual([
+        "Up to 1,000: Included",
+        "Over 1,000: $0.05/unit (all units)",
+      ]);
     });
   });
 

--- a/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/categorizeRateCards.ts
@@ -90,9 +90,10 @@ export const categorizeRateCards = (
     ) {
       let tierPrices: string[] | undefined;
       if (rc.price?.type === "tiered" && rc.price.tiers) {
-        // Build a readable tier breakdown (useful for graduated/volume).
-        // For soft quotas the UI hides the separate "X / period" header
-        // when this breakdown is present (the "Up to X: Included" line
+        // Build a readable tier breakdown, worded per the price's mode
+        // (graduated ranges vs volume brackets). For soft quotas the UI
+        // hides the separate "X / period" header when this breakdown is
+        // present (the "First X: Included" / "Up to X: Included" line
         // conveys it); hard caps deliberately render both — the breakdown
         // shows prices, the header shows that the limit is a hard stop.
         tierPrices = formatTieredPriceBreakdown({
@@ -101,6 +102,7 @@ export const categorizeRateCards = (
             unitPriceAmount: t.unitPrice?.amount,
             flatPriceAmount: t.flatPrice?.amount,
           })),
+          mode: rc.price.mode,
           currency,
           unitLabel: unitLabelFor(rc),
           includedLabel: "Included",
@@ -192,6 +194,7 @@ export const categorizeRateCards = (
             unitPriceAmount: t.unitPrice?.amount,
             flatPriceAmount: t.flatPrice?.amount,
           })),
+          mode: rc.price.mode,
           currency,
           unitLabel,
           includedLabel: "Included",

--- a/packages/plugin-zuplo-monetization/src/utils/comparePlanEntitlements.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/comparePlanEntitlements.ts
@@ -17,7 +17,7 @@ export type EntitlementChange = {
   targetValue?: string;
   /**
    * The TARGET quota's tier-price breakdown (the same lines `QuotaItem` shows
-   * on the pricing card, e.g. "Up to 1,000: Included"), so an opaque "Tiered
+   * on the pricing card, e.g. "First 1,000: Included"), so an opaque "Tiered
    * pricing" value can be expanded into the actual schedule the user is
    * deciding on.
    */

--- a/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
@@ -60,6 +60,30 @@ describe("formatTieredPriceBreakdown", () => {
     ]);
   });
 
+  it("pluralizes the configured unit label in the all-units reminder", () => {
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "1000000", flatPriceAmount: "499" },
+        {
+          upToAmount: "2000000",
+          unitPriceAmount: "0.05",
+          flatPriceAmount: "199",
+        },
+        { unitPriceAmount: "0.02" },
+      ],
+      mode: "volume",
+      unitLabel: "request",
+      includedLabel: "Included",
+      currency: "USD",
+    });
+
+    expect(lines).toEqual([
+      "Up to 1,000,000: $499",
+      "Up to 2,000,000: $199 + $0.05/request (all requests)",
+      "Over 2,000,000: $0.02/request (all requests)",
+    ]);
+  });
+
   it("defaults to graduated when mode is omitted", () => {
     const lines = formatTieredPriceBreakdown({
       tiers: [

--- a/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.test.ts
@@ -20,7 +20,47 @@ describe("formatTieredPriceBreakdown", () => {
     ).toBeUndefined();
   });
 
-  it("formats up-to and over tiers", () => {
+  it("formats graduated tiers as consecutive unit ranges (First/Next/Over)", () => {
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "100", unitPriceAmount: "0.01", flatPriceAmount: "3" },
+        { upToAmount: "500", unitPriceAmount: "0.008" },
+        { unitPriceAmount: "0.005" },
+      ],
+      mode: "graduated",
+      unitLabel: "unit",
+      includedLabel: "Included",
+      currency: "USD",
+    });
+
+    expect(lines).toEqual([
+      "First 100: $3 + $0.01/unit",
+      "Next 400: $0.008/unit",
+      "Over 500: $0.005/unit",
+    ]);
+  });
+
+  it("formats volume tiers as total-usage brackets with an all-units reminder", () => {
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "100", unitPriceAmount: "0.01", flatPriceAmount: "3" },
+        { upToAmount: "500", unitPriceAmount: "0.008" },
+        { unitPriceAmount: "0.005" },
+      ],
+      mode: "volume",
+      unitLabel: "unit",
+      includedLabel: "Included",
+      currency: "USD",
+    });
+
+    expect(lines).toEqual([
+      "Up to 100: $3 + $0.01/unit",
+      "Up to 500: $0.008/unit (all units)",
+      "Over 500: $0.005/unit (all units)",
+    ]);
+  });
+
+  it("defaults to graduated when mode is omitted", () => {
     const lines = formatTieredPriceBreakdown({
       tiers: [
         { upToAmount: "5000", unitPriceAmount: "0" },
@@ -31,7 +71,7 @@ describe("formatTieredPriceBreakdown", () => {
       currency: "USD",
     });
 
-    expect(lines).toEqual(["Up to 5,000: Included", "Over 5,000: $0.05/unit"]);
+    expect(lines).toEqual(["First 5,000: Included", "Over 5,000: $0.05/unit"]);
   });
 
   it("renders flat price first, then unit price when both are non-zero", () => {
@@ -45,15 +85,38 @@ describe("formatTieredPriceBreakdown", () => {
         },
         { unitPriceAmount: "0.02", flatPriceAmount: "0" },
       ],
+      mode: "graduated",
       unitLabel: "unit",
       includedLabel: "Included",
       currency: "USD",
     });
 
     expect(lines).toEqual([
-      "Up to 1,000,000: $499",
-      "Up to 2,000,000: $199 + $0.05/unit",
+      "First 1,000,000: $499",
+      "Next 1,000,000: $199 + $0.05/unit",
       "Over 2,000,000: $0.02/unit",
+    ]);
+  });
+
+  it("skips the all-units reminder on volume rows without a per-unit rate", () => {
+    // Flat-only and Included rows have no marginal-rate misreading to
+    // correct — "(all units)" would be noise on "$499" or "Included".
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "1000", unitPriceAmount: "0", flatPriceAmount: "0" },
+        { upToAmount: "2000", unitPriceAmount: "0", flatPriceAmount: "499" },
+        { unitPriceAmount: "0.02" },
+      ],
+      mode: "volume",
+      unitLabel: "unit",
+      includedLabel: "Included",
+      currency: "USD",
+    });
+
+    expect(lines).toEqual([
+      "Up to 1,000: Included",
+      "Up to 2,000: $499",
+      "Over 2,000: $0.02/unit (all units)",
     ]);
   });
 
@@ -63,11 +126,33 @@ describe("formatTieredPriceBreakdown", () => {
         { upToAmount: "1000", unitPriceAmount: "0", flatPriceAmount: "0" },
         { unitPriceAmount: "0.05" },
       ],
+      mode: "graduated",
       unitLabel: "unit",
       includedLabel: "Included",
       currency: "USD",
     });
 
-    expect(lines).toEqual(["Up to 1,000: Included", "Over 1,000: $0.05/unit"]);
+    expect(lines).toEqual(["First 1,000: Included", "Over 1,000: $0.05/unit"]);
+  });
+
+  it("falls back to the plain bound when graduated bounds are not increasing", () => {
+    // Malformed schedules must never claim a negative "Next" span.
+    const lines = formatTieredPriceBreakdown({
+      tiers: [
+        { upToAmount: "500", unitPriceAmount: "0.01" },
+        { upToAmount: "500", unitPriceAmount: "0.005" },
+        { unitPriceAmount: "0.001" },
+      ],
+      mode: "graduated",
+      unitLabel: "unit",
+      includedLabel: "Included",
+      currency: "USD",
+    });
+
+    expect(lines).toEqual([
+      "First 500: $0.01/unit",
+      "Up to 500: $0.005/unit",
+      "Over 500: $0.001/unit",
+    ]);
   });
 });

--- a/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.ts
@@ -1,5 +1,6 @@
 import type { TieredPrice } from "../types/PlanType.js";
 import { formatPrice } from "./formatPrice.js";
+import { pluralizeUnit } from "./pluralizeUnit.js";
 
 export type TieredPriceBreakdownTier = {
   upToAmount?: string;
@@ -25,7 +26,8 @@ const formatBound = (value: number) => value.toLocaleString("en-US");
  * - `volume`: the highest tier reached prices ALL units, so lines read as
  *   total-usage brackets — "Up to 100: …", "Over 100: …" — and rows past the
  *   first spell out that their per-unit rate applies to every unit, not just
- *   the units beyond the previous bound.
+ *   the units beyond the previous bound ("(all requests)", using the
+ *   configured unit label).
  */
 export const formatTieredPriceBreakdown = (opts: {
   tiers: TieredPriceBreakdownTier[];
@@ -79,7 +81,9 @@ export const formatTieredPriceBreakdown = (opts: {
     // the graduated misreading would be most costly: rows past the first that
     // carry a per-unit rate.
     const suffix =
-      mode === "volume" && index > 0 && unitPart ? " (all units)" : "";
+      mode === "volume" && index > 0 && unitPart
+        ? ` (all ${pluralizeUnit(unitLabel)})`
+        : "";
     lines.push(`${prefix}: ${pricePart}${suffix}`);
 
     if (upTo != null) lastUpTo = upTo;

--- a/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/formatTieredPriceBreakdown.ts
@@ -1,3 +1,4 @@
+import type { TieredPrice } from "../types/PlanType.js";
 import { formatPrice } from "./formatPrice.js";
 
 export type TieredPriceBreakdownTier = {
@@ -12,29 +13,59 @@ const parseAmount = (value: string | undefined) => {
   return Number.isFinite(parsed) ? parsed : undefined;
 };
 
+const formatBound = (value: number) => value.toLocaleString("en-US");
+
+/**
+ * Render a multi-tier tiered price as one line per tier. The wording depends
+ * on the price's `mode`, because the same tiers bill very differently:
+ *
+ * - `graduated` (the default when omitted, matching the rest of the plugin):
+ *   each unit is priced by the tier it falls into, so lines read as
+ *   consecutive unit ranges — "First 100: …", "Next 400: …", "Over 500: …".
+ * - `volume`: the highest tier reached prices ALL units, so lines read as
+ *   total-usage brackets — "Up to 100: …", "Over 100: …" — and rows past the
+ *   first spell out that their per-unit rate applies to every unit, not just
+ *   the units beyond the previous bound.
+ */
 export const formatTieredPriceBreakdown = (opts: {
   tiers: TieredPriceBreakdownTier[];
+  mode?: TieredPrice["mode"];
   currency?: string;
   unitLabel: string;
   includedLabel: string;
 }): string[] | undefined => {
   const { tiers, currency, unitLabel, includedLabel } = opts;
+  const mode = opts.mode ?? "graduated";
   if (!tiers || tiers.length <= 1) return;
 
   const lines: string[] = [];
   let lastUpTo: number | undefined;
 
-  for (const tier of tiers) {
+  for (const [index, tier] of tiers.entries()) {
     const upTo = parseAmount(tier.upToAmount);
     const unit = parseAmount(tier.unitPriceAmount) ?? 0;
     const flat = parseAmount(tier.flatPriceAmount) ?? 0;
 
-    const prefix =
-      upTo != null
-        ? `Up to ${upTo.toLocaleString("en-US")}`
-        : lastUpTo != null
-          ? `Over ${lastUpTo.toLocaleString("en-US")}`
+    const prefix = (() => {
+      if (upTo == null) {
+        // Open-ended tier: everything beyond the previous bound (both modes).
+        return lastUpTo != null
+          ? `Over ${formatBound(lastUpTo)}`
           : `Per ${unitLabel}`;
+      }
+      if (mode === "volume") return `Up to ${formatBound(upTo)}`;
+      if (lastUpTo == null) {
+        // Graduated without a previous bound: only the first tier can honestly
+        // say "First X"; otherwise (malformed bounds) fall back to the bound.
+        return index === 0
+          ? `First ${formatBound(upTo)}`
+          : `Up to ${formatBound(upTo)}`;
+      }
+      const span = upTo - lastUpTo;
+      return span > 0
+        ? `Next ${formatBound(span)}`
+        : `Up to ${formatBound(upTo)}`;
+    })();
 
     const flatPart = flat > 0 ? formatPrice(flat, currency) : "";
     const unitPart =
@@ -43,7 +74,13 @@ export const formatTieredPriceBreakdown = (opts: {
       flatPart && unitPart
         ? `${flatPart} + ${unitPart}`
         : flatPart || unitPart || includedLabel;
-    lines.push(`${prefix}: ${pricePart}`);
+    // In volume mode a later row's rate is not marginal — it re-prices every
+    // unit once the total lands in that bracket. Spell that out exactly where
+    // the graduated misreading would be most costly: rows past the first that
+    // carry a per-unit rate.
+    const suffix =
+      mode === "volume" && index > 0 && unitPart ? " (all units)" : "";
+    lines.push(`${prefix}: ${pricePart}${suffix}`);
 
     if (upTo != null) lastUpTo = upTo;
   }

--- a/packages/plugin-zuplo-monetization/src/utils/pluralizeUnit.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/pluralizeUnit.ts
@@ -1,0 +1,7 @@
+// Naive English pluralization for configured unit names ("request" →
+// "requests"); names already ending in "s" pass through unchanged. The unit
+// name comes from the pricing config (`pricing.units` keyed by rate card or
+// feature key), with "unit" as the fallback everywhere in the plugin (see
+// categorizeRateCards).
+export const pluralizeUnit = (unitName: string) =>
+  unitName.endsWith("s") ? unitName : `${unitName}s`;


### PR DESCRIPTION
## Summary

Add support for distinguishing between `graduated` and `volume` pricing modes when formatting tiered price breakdowns. This allows the UI to display pricing tiers with appropriate wording that reflects how each mode bills customers.

## Key Changes

- **Mode parameter**: Added `mode?: "volume" | "graduated"` to `formatTieredPriceBreakdown()` options and test fixtures, defaulting to `graduated` to match existing behavior
- **Graduated mode** (consecutive unit ranges): Formats tiers as "First X", "Next Y", "Over Z" to show which tier each unit falls into
- **Volume mode** (total-usage brackets): Formats tiers as "Up to X", "Over Y" with "(all units)" suffix on per-unit rates to clarify that the entire purchase is repriced at that tier's rate
- **Malformed bounds handling**: Falls back to "Up to X" wording when graduated tier bounds are not strictly increasing
- **Volume-specific logic**: Skips "(all units)" reminder on rows without per-unit rates (flat-only or included tiers) to avoid noise
- **Integration**: Updated `categorizeRateCards()` to pass the price mode through to the formatting function, and updated test expectations to reflect the new wording

## Implementation Details

- The `formatTieredPriceBreakdown()` function now computes tier prefixes based on the mode:
  - For graduated: calculates the span between consecutive bounds to show "Next X" ranges
  - For volume: uses the absolute bounds with "(all units)" clarification on marginal-rate rows
- Test coverage added for both modes with identical tier structures to demonstrate the different output
- Comments updated throughout to reflect the new terminology ("First X: Included" vs "Up to X: Included")

https://claude.ai/code/session_01SSV7bAVkEqw1iaRijDBgoF