### PR TITLE
Fix: top-nav links support target property

### DIFF
--- a/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
@@ -65,4 +65,36 @@ describe("MobileTopNavigation", () => {
       screen.queryByRole("button", { name: themeSwitchName }),
     ).not.toBeInTheDocument();
   });
+
+  it("forwards target and rel for top-nav links that open in a new tab", async () => {
+    const user = userEvent.setup();
+    await render({
+      site: { title: "Test Site" },
+      navigation: [
+        {
+          type: "link",
+          label: "Support",
+          to: "https://example.com/support",
+          target: "_blank",
+        },
+        {
+          type: "link",
+          label: "Docs",
+          to: "/docs",
+        },
+      ],
+    });
+
+    await user.click(screen.getByLabelText("Open navigation menu"));
+
+    const external = screen.getByRole("link", { name: "Support" });
+    expect(external.getAttribute("href")).toBe("https://example.com/support");
+    expect(external.getAttribute("target")).toBe("_blank");
+    expect(external.getAttribute("rel")).toBe("noopener noreferrer");
+
+    const internal = screen.getByRole("link", { name: "Docs" });
+    expect(internal.getAttribute("href")).toBe("/docs");
+    expect(internal.getAttribute("target")).toBeNull();
+    expect(internal.getAttribute("rel")).toBeNull();
+  });
 });

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -177,10 +177,15 @@ export const MobileTopNavigation = () => {
                 }
                 const path = getFirstMatchingPath(item);
                 const isActive = deepEqual(currentNav.topNavItem, item);
+                const target = "target" in item ? item.target : undefined;
                 return (
                   <li key={item.label}>
                     <Link
                       to={path}
+                      target={target}
+                      rel={
+                        target === "_blank" ? "noopener noreferrer" : undefined
+                      }
                       onClick={() => setDrawerOpen(false)}
                       className={`flex items-center gap-2 py-2 text-base font-medium ${isActive ? "text-foreground" : "text-foreground/75 hover:text-foreground"}`}
                     >

--- a/packages/zudoku/src/lib/components/TopNavigation.test.tsx
+++ b/packages/zudoku/src/lib/components/TopNavigation.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render as testRender, screen } from "@testing-library/react";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import type { ZudokuContextOptions } from "../core/ZudokuContext.js";
+import { SlotProvider } from "./context/SlotProvider.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { TopNavigation } from "./TopNavigation.js";
+
+const render = async (options: Partial<ZudokuContextOptions> = {}) => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(options, queryClient, {});
+
+  const router = createMemoryRouter(
+    [
+      {
+        element: (
+          <QueryClientProvider client={queryClient}>
+            <ZudokuProvider context={context}>
+              <SlotProvider slots={{}}>
+                <TopNavigation />
+                <Outlet />
+              </SlotProvider>
+            </ZudokuProvider>
+          </QueryClientProvider>
+        ),
+        children: [{ path: "*", element: null }],
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+
+  await act(async () => {
+    testRender(<RouterProvider router={router} />);
+  });
+};
+
+describe("TopNavigation", () => {
+  it("forwards target and rel for links that open in a new tab", async () => {
+    await render({
+      navigation: [
+        {
+          type: "link",
+          label: "Support",
+          to: "https://example.com/support",
+          target: "_blank",
+        },
+      ],
+    });
+
+    // Top nav is `hidden` below the lg breakpoint
+    const link = screen.getByRole("link", { name: "Support", hidden: true });
+    expect(link.getAttribute("href")).toBe("https://example.com/support");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("does not set target or rel when target is omitted", async () => {
+    await render({
+      navigation: [
+        {
+          type: "link",
+          label: "Docs",
+          to: "/docs",
+        },
+      ],
+    });
+
+    const link = screen.getByRole("link", { name: "Docs", hidden: true });
+    expect(link.getAttribute("href")).toBe("/docs");
+    expect(link.getAttribute("target")).toBeNull();
+    expect(link.getAttribute("rel")).toBeNull();
+  });
+
+  it("forwards target=_self without adding rel", async () => {
+    await render({
+      navigation: [
+        {
+          type: "link",
+          label: "Portal",
+          to: "https://example.com/portal",
+          target: "_self",
+        },
+      ],
+    });
+
+    const link = screen.getByRole("link", { name: "Portal", hidden: true });
+    expect(link.getAttribute("target")).toBe("_self");
+    expect(link.getAttribute("rel")).toBeNull();
+  });
+});

--- a/packages/zudoku/src/lib/components/TopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/TopNavigation.tsx
@@ -88,10 +88,17 @@ export const TopNavItem = (
 
   const path = getFirstMatchingPath(item);
 
+  const target = "target" in item ? item.target : undefined;
+
   return (
     // We don't use isActive here because it has to be inside the navigation,
     // the top nav id doesn't necessarily start with the navigation id
-    <TopNavLink to={path} isActive={isActiveTopNavItem}>
+    <TopNavLink
+      to={path}
+      isActive={isActiveTopNavItem}
+      target={target}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
+    >
       {item.icon && <item.icon size={16} className="align-[-0.125em]" />}
       {item.label}
     </TopNavLink>


### PR DESCRIPTION
Top-nav link items already supported target in the navigation schema/docs, but desktop and mobile top navigation never forwarded it to the rendered link.

This change passes target through to the underlying router Link/NavLink, and sets rel="noopener noreferrer" when target is _blank.