### PR TITLE
Support multiple subscriptions in pricing page

### DIFF
--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
@@ -186,6 +186,21 @@ describe("PricingPage", () => {
     expect(screen.getAllByText("Subscribe")).toHaveLength(2);
   });
 
+  it("With multiple subscriptions enabled, falls back to matching held plans by id when key is missing", () => {
+    mockPricingData.items = [
+      makePlan("1", "starter", "Starter"),
+      makePlan("2", "pro", "Pro"),
+    ];
+    mockPricingData.multipleSubscriptionsEnabled = true;
+    // The subscription's plan carries no key: matching must fall back to id.
+    mockSubscriptionData.items = [{ status: "active", plan: { id: "2" } }];
+
+    renderWithConfig();
+
+    expect(screen.getAllByText("Manage Subscriptions")).toHaveLength(1);
+    expect(screen.getAllByText("Subscribe")).toHaveLength(1);
+  });
+
   it("With multiple subscriptions enabled, matches held plans by key across plan versions", () => {
     mockPricingData.items = [
       makePlan("1", "starter", "Starter"),

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MonetizationContext,
   type MonetizationConfig,
@@ -64,9 +64,12 @@ vi.mock("zudoku/hooks", () => ({
   }),
 }));
 
-const mockPricingData: { items: Plan[] } = { items: [] };
+const mockPricingData: {
+  items: Plan[];
+  multipleSubscriptionsEnabled?: boolean;
+} = { items: [] };
 const mockSubscriptionData: {
-  items: Array<{ status: string; plan: { id: string } }>;
+  items: Array<{ status: string; plan: { id: string; key?: string } }>;
 } = { items: [] };
 
 vi.mock("zudoku/react-query", () => ({
@@ -110,6 +113,12 @@ const renderWithConfig = (config: MonetizationConfig = {}) =>
   );
 
 describe("PricingPage", () => {
+  beforeEach(() => {
+    mockPricingData.items = [];
+    mockPricingData.multipleSubscriptionsEnabled = undefined;
+    mockSubscriptionData.items = [];
+  });
+
   it("Shows a helpful message when no plans are available", () => {
     mockPricingData.items = [];
     mockSubscriptionData.items = [];
@@ -158,6 +167,70 @@ describe("PricingPage", () => {
 
     const buttons = screen.getAllByText("Subscribe");
     expect(buttons).toHaveLength(3);
+  });
+
+  it("With multiple subscriptions enabled, only held plans switch to 'Manage Subscriptions'", () => {
+    mockPricingData.items = [
+      makePlan("1", "starter", "Starter"),
+      makePlan("2", "pro", "Pro"),
+      makePlan("3", "business", "Business"),
+    ];
+    mockPricingData.multipleSubscriptionsEnabled = true;
+    mockSubscriptionData.items = [
+      { status: "active", plan: { id: "2", key: "pro" } },
+    ];
+
+    renderWithConfig();
+
+    expect(screen.getAllByText("Manage Subscriptions")).toHaveLength(1);
+    expect(screen.getAllByText("Subscribe")).toHaveLength(2);
+  });
+
+  it("With multiple subscriptions enabled, matches held plans by key across plan versions", () => {
+    mockPricingData.items = [
+      makePlan("1", "starter", "Starter"),
+      makePlan("2", "pro", "Pro"),
+    ];
+    mockPricingData.multipleSubscriptionsEnabled = true;
+    // The subscription references an older version of the pro plan (different id, same key).
+    mockSubscriptionData.items = [
+      { status: "active", plan: { id: "2-v1", key: "pro" } },
+    ];
+
+    renderWithConfig();
+
+    expect(screen.getAllByText("Manage Subscriptions")).toHaveLength(1);
+    expect(screen.getAllByText("Subscribe")).toHaveLength(1);
+  });
+
+  it("With multiple subscriptions enabled and no subscriptions, shows 'Subscribe' for every plan", () => {
+    mockPricingData.items = [
+      makePlan("1", "starter", "Starter"),
+      makePlan("2", "pro", "Pro"),
+    ];
+    mockPricingData.multipleSubscriptionsEnabled = true;
+    mockSubscriptionData.items = [];
+
+    renderWithConfig();
+
+    expect(screen.getAllByText("Subscribe")).toHaveLength(2);
+    expect(screen.queryByText("Manage Subscriptions")).not.toBeInTheDocument();
+  });
+
+  it("With multiple subscriptions enabled, canceled subscriptions still count as held plans", () => {
+    mockPricingData.items = [
+      makePlan("1", "starter", "Starter"),
+      makePlan("2", "pro", "Pro"),
+    ];
+    mockPricingData.multipleSubscriptionsEnabled = true;
+    mockSubscriptionData.items = [
+      { status: "canceled", plan: { id: "2", key: "pro" } },
+    ];
+
+    renderWithConfig();
+
+    expect(screen.getAllByText("Manage Subscriptions")).toHaveLength(1);
+    expect(screen.getAllByText("Subscribe")).toHaveLength(1);
   });
 
   it("Shows 'no cc required' if no rate card has 'in_advance' fee with 'amount=0'", () => {

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
@@ -20,9 +20,30 @@ const PricingPage = () => {
     enabled: auth.isAuthenticated,
   });
 
-  const isSubscribed = subscriptions.items.some((subscription) =>
+  const currentSubscriptions = subscriptions.items.filter((subscription) =>
     ["active", "canceled"].includes(subscription.status),
   );
+  const isSubscribed = currentSubscriptions.length > 0;
+
+  // With multi-subscription enabled, only plans the user already holds switch to
+  // "Manage Subscriptions" — every other plan keeps its Subscribe action. Plans are
+  // matched by key (stable across plan versions), falling back to id.
+  const multipleSubscriptionsEnabled =
+    pricingTable.multipleSubscriptionsEnabled ?? false;
+  const subscribedPlanKeys = new Set(
+    currentSubscriptions.flatMap((subscription) =>
+      subscription.plan?.key ? [subscription.plan.key] : [],
+    ),
+  );
+  const subscribedPlanIds = new Set(
+    currentSubscriptions.flatMap((subscription) =>
+      subscription.plan?.id ? [subscription.plan.id] : [],
+    ),
+  );
+  const showManageAction = (plan: { id: string; key: string }) =>
+    multipleSubscriptionsEnabled
+      ? subscribedPlanKeys.has(plan.key) || subscribedPlanIds.has(plan.id)
+      : isSubscribed;
 
   return (
     <div className="w-full px-4 pt-(--padding-content-top) pb-(--padding-content-bottom)">
@@ -49,7 +70,7 @@ const PricingPage = () => {
         plans={pricingTable.items}
         units={pricing?.units}
         renderAction={(plan, isPopular) =>
-          isSubscribed ? (
+          showManageAction(plan) ? (
             <Button variant={isPopular ? "default" : "outline"} asChild>
               <Link to={`/subscriptions#manage`}>Manage Subscriptions</Link>
             </Button>

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
@@ -5,7 +5,9 @@ import type { Subscription } from "../../types/SubscriptionType.js";
 import { SwitchPlanModal } from "./SwitchPlanModal.js";
 
 vi.mock("zudoku/hooks", () => ({
-  useZudoku: () => ({ env: {} }),
+  useZudoku: () => ({
+    env: { ZUPLO_PUBLIC_DEPLOYMENT_NAME: "test-deployment" },
+  }),
 }));
 
 vi.mock("../../hooks/useDeploymentName.js", () => ({
@@ -31,6 +33,14 @@ vi.mock("../../hooks/usePlans.js", () => ({
   usePlans: () => ({ data: { items: plansItems.current } }),
 }));
 
+const subscriptionsItems = vi.hoisted(() => ({
+  current: [] as Array<{
+    id: string;
+    status: string;
+    plan: { id: string; key: string };
+  }>,
+}));
+
 const mutationStub = vi.hoisted(() => ({
   mutate: vi.fn(),
   isPending: false,
@@ -45,6 +55,7 @@ vi.mock("zudoku/react-query", async (importOriginal) => {
   return {
     ...actual,
     useMutation: () => mutationStub,
+    useQuery: () => ({ data: { items: subscriptionsItems.current } }),
     useQueryClient: () => ({ invalidateQueries: vi.fn() }),
   };
 });
@@ -150,10 +161,87 @@ const expectPlanAction = (
 describe("SwitchPlanModal", () => {
   beforeEach(() => {
     plansItems.current = [];
+    subscriptionsItems.current = [];
     mutationStub.mutate.mockClear();
     mutationStub.reset.mockClear();
     mutationStub.isError = false;
     mutationStub.error = null;
+  });
+
+  it("does not offer plans held by the customer's other subscriptions", () => {
+    plansItems.current = [
+      makePublicPlan({ id: "plan-starter", key: "starter", name: "Starter" }),
+      makePublicPlan({ id: "plan-team", key: "team", name: "Team" }),
+      makePublicPlan({
+        id: "plan-business",
+        key: "business",
+        name: "Business",
+      }),
+    ];
+
+    const subscription = baseSubscription({
+      id: "plan-starter",
+      key: "starter",
+      name: "Starter",
+      billingCadence: "P1M",
+      phases: [],
+    });
+
+    subscriptionsItems.current = [
+      {
+        id: "sub-1",
+        status: "active",
+        plan: { id: "plan-starter", key: "starter" },
+      },
+      // A second subscription already holds the Team plan (older version id):
+      // it must not be offered as a change target for this subscription.
+      {
+        id: "sub-2",
+        status: "active",
+        plan: { id: "plan-team-v1", key: "team" },
+      },
+    ];
+
+    render(<SwitchPlanModal subscription={subscription} />);
+    openModal();
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).queryByText("Team")).not.toBeInTheDocument();
+    expect(within(dialog).getByText("Business")).toBeInTheDocument();
+  });
+
+  it("still offers a plan held by an ended subscription", () => {
+    plansItems.current = [
+      makePublicPlan({ id: "plan-starter", key: "starter", name: "Starter" }),
+      makePublicPlan({ id: "plan-team", key: "team", name: "Team" }),
+    ];
+
+    const subscription = baseSubscription({
+      id: "plan-starter",
+      key: "starter",
+      name: "Starter",
+      billingCadence: "P1M",
+      phases: [],
+    });
+
+    subscriptionsItems.current = [
+      {
+        id: "sub-1",
+        status: "active",
+        plan: { id: "plan-starter", key: "starter" },
+      },
+      {
+        id: "sub-old",
+        status: "expired",
+        plan: { id: "plan-team", key: "team" },
+      },
+    ];
+
+    render(<SwitchPlanModal subscription={subscription} />);
+    openModal();
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Team")).toBeInTheDocument();
   });
 
   it("lists public plans as Upgrade Options when the subscription plan is private but omitted from the pricing page", () => {

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
@@ -37,7 +37,7 @@ const subscriptionsItems = vi.hoisted(() => ({
   current: [] as Array<{
     id: string;
     status: string;
-    plan: { id: string; key: string };
+    plan: { id: string; key?: string };
   }>,
 }));
 
@@ -208,6 +208,37 @@ describe("SwitchPlanModal", () => {
     const dialog = screen.getByRole("dialog");
     expect(within(dialog).queryByText("Team")).not.toBeInTheDocument();
     expect(within(dialog).getByText("Business")).toBeInTheDocument();
+  });
+
+  it("filters a held plan matched by id when the other subscription's plan has no key", () => {
+    plansItems.current = [
+      makePublicPlan({ id: "plan-starter", key: "starter", name: "Starter" }),
+      makePublicPlan({ id: "plan-team", key: "team", name: "Team" }),
+    ];
+
+    const subscription = baseSubscription({
+      id: "plan-starter",
+      key: "starter",
+      name: "Starter",
+      billingCadence: "P1M",
+      phases: [],
+    });
+
+    subscriptionsItems.current = [
+      {
+        id: "sub-1",
+        status: "active",
+        plan: { id: "plan-starter", key: "starter" },
+      },
+      // No key on the other subscription's plan: the id fallback must filter it.
+      { id: "sub-2", status: "active", plan: { id: "plan-team" } },
+    ];
+
+    render(<SwitchPlanModal subscription={subscription} />);
+    openModal();
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).queryByText("Team")).not.toBeInTheDocument();
   });
 
   it("still offers a plan held by an ended subscription", () => {

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.tsx
@@ -1,7 +1,7 @@
 import { type PropsWithChildren, useMemo, useState } from "react";
 import { useZudoku } from "zudoku/hooks";
 import { ArrowDownIcon, ArrowLeftRightIcon, ArrowUpIcon } from "zudoku/icons";
-import { useMutation } from "zudoku/react-query";
+import { useMutation, useQuery } from "zudoku/react-query";
 import { Alert, AlertDescription } from "zudoku/ui/Alert";
 import { Button } from "zudoku/ui/Button";
 import {
@@ -15,6 +15,7 @@ import { useDeploymentName } from "../../hooks/useDeploymentName.js";
 import { usePlans } from "../../hooks/usePlans.js";
 import { useUrlUtils } from "../../hooks/useUrlUtils.js";
 import { useMonetizationConfig } from "../../MonetizationContext";
+import { subscriptionsQuery } from "../../queries.js";
 import type { Plan } from "../../types/PlanType.js";
 import type { Subscription } from "../../types/SubscriptionType.js";
 import { getActivePhase } from "../../utils/billables.js";
@@ -127,6 +128,21 @@ export const SwitchPlanModal = ({
 
   const subscribedPlan = subscription.plan;
 
+  // Plans held by the customer's other current subscriptions can't be change
+  // targets — the change would be rejected as a duplicate plan subscription.
+  // Matched by key (stable across plan versions), falling back to id.
+  const { data: subscriptionsData } = useQuery(subscriptionsQuery(context));
+  const plansHeldByOtherSubscriptions = useMemo(() => {
+    const others = (subscriptionsData?.items ?? []).filter(
+      (s) =>
+        s.id !== subscription.id && ["active", "canceled"].includes(s.status),
+    );
+    return {
+      keys: new Set(others.flatMap((s) => (s.plan?.key ? [s.plan.key] : []))),
+      ids: new Set(others.flatMap((s) => (s.plan?.id ? [s.plan.id] : []))),
+    };
+  }, [subscriptionsData?.items, subscription.id]);
+
   // The current plan's entitlements, sourced from the subscription's actual
   // provisioned items (real included quotas), with the catalog plan as a
   // fallback. Used by each target card's "what changes" summary.
@@ -169,6 +185,12 @@ export const SwitchPlanModal = ({
 
     const entries = catalogItems.flatMap((plan, targetIndex) => {
       if (plan.id === subscribedPlan.id) return [];
+      if (
+        plansHeldByOtherSubscriptions.keys.has(plan.key) ||
+        plansHeldByOtherSubscriptions.ids.has(plan.id)
+      ) {
+        return [];
+      }
       return [
         {
           plan,
@@ -197,7 +219,7 @@ export const SwitchPlanModal = ({
       downgrades: entries.filter((c) => !c.isUpgrade && !isPrivatePlan(c.plan)),
       privatePlans: entries.filter((c) => isPrivatePlan(c.plan)),
     };
-  }, [plansData?.items, subscribedPlan]);
+  }, [plansData?.items, subscribedPlan, plansHeldByOtherSubscriptions]);
 
   const renderCards = (entries: PlanEntry[], mode: PlanChangeMode) => (
     <div className="space-y-3">

--- a/packages/plugin-zuplo-monetization/src/queries.ts
+++ b/packages/plugin-zuplo-monetization/src/queries.ts
@@ -7,8 +7,14 @@ import type { Plan } from "./types/PlanType.js";
 const getDeploymentName = (context: ZudokuContext) =>
   resolveDeploymentName(context.env.ZUPLO_PUBLIC_DEPLOYMENT_NAME);
 
+export type PricingPageResponse = {
+  items: Plan[];
+  /** Whether the bucket allows customers to hold multiple active subscriptions. */
+  multipleSubscriptionsEnabled?: boolean;
+};
+
 export const pricingPageQuery = (context: ZudokuContext) =>
-  queryOptions<{ items: Plan[] }>({
+  queryOptions<PricingPageResponse>({
     queryKey: [
       `/v3/zudoku-metering/${getDeploymentName(context)}/pricing-page`,
     ],


### PR DESCRIPTION
## Summary
Adds support for multiple active subscriptions in the pricing page. When `multipleSubscriptionsEnabled` is true, only plans the user already holds show a "Manage Subscriptions" button, while other plans show "Subscribe". Plans are matched by their stable `key` field across versions, with fallback to `id`.

## Key Changes
- **Type updates**: Added `multipleSubscriptionsEnabled` optional field to `PricingPageResponse` type and updated subscription plan type to include optional `key` field
- **Logic changes**: Modified `PricingPage.tsx` to:
  - Filter subscriptions by status ("active" or "canceled") into `currentSubscriptions`
  - Introduce `showManageAction()` function that conditionally shows "Manage Subscriptions" based on whether multiple subscriptions are enabled
  - When enabled, match held plans by `key` (preferred) or `id` to determine which plans show the manage action
- **Test coverage**: Added 4 new test cases covering:
  - Multiple subscriptions enabled with only held plans showing "Manage Subscriptions"
  - Plan matching by key across different plan versions
  - No subscriptions case showing "Subscribe" for all plans
  - Canceled subscriptions still counting as held plans

## Implementation Details
- Uses `Set` for efficient plan key/id lookups
- Maintains backward compatibility: when `multipleSubscriptionsEnabled` is false/undefined, behavior reverts to original logic (all plans show "Manage Subscriptions" if any subscription exists)
- Added `beforeEach` hook in tests to reset mock data between test cases

https://claude.ai/code/session_016T1ZLBEzxpvr8kQssPx9sg