### PR TITLE
fix(cli): preserve process.exitCode on CLI exit

### DIFF
--- a/packages/zudoku/src/cli/cli.ts
+++ b/packages/zudoku/src/cli/cli.ts
@@ -46,4 +46,6 @@ try {
   await shutdownAnalytics();
 }
 
-process.exit(0);
+// Force termination once analytics have flushed, but without an explicit code
+// so that any exit code set via `process.exitCode` is preserved.
+process.exit();


### PR DESCRIPTION
Follow-up to #2734, addressing [Copilot's review comment](https://github.com/zuplo/zudoku/pull/2734#discussion_r1) that landed before the merge.

## Problem

`cli.ts` ends with a forced `process.exit(0)` after `shutdownAnalytics()`. The explicit `0` overrides any non-zero `process.exitCode` that a command may have set to signal failure without throwing — the process would report success regardless.

## Fix

```diff
-process.exit(0);
+// Force termination once analytics have flushed, but without an explicit code
+// so that any exit code set via `process.exitCode` is preserved.
+process.exit();
```

`process.exit()` with no argument still forces termination (which is why the call exists — some commands leave handles open), but uses the current `process.exitCode`, defaulting to 0 when nothing set it.

## Scope

Defensive rather than a fix for an observed bug: `grep -rn "exitCode" packages/zudoku/src` finds no assignments today, so behavior is identical in practice. It protects the invariant for future commands.

## Verification

Built, linted, packed, and installed into a scaffolded `create-zuplo-api` project — exit codes unchanged:

| Command | Exit code |
|---|---|
| `zudoku --version` | 0 |
| `zudoku bogus-command` | 1 |
| `zudoku build --zuplo` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
