### PR TITLE
build(deps): bump react-router from 7.18.1 to 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:e2e": "playwright test"
   },
   "engines": {
-    "node": ">=22.19",
+    "node": ">=22.22.0",
     "pnpm": ">=11"
   },
   "devDependencies": {

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -3,7 +3,7 @@
   "version": "0.82.4",
   "type": "module",
   "engines": {
-    "node": ">=20.19.0 <21.0.0 || >=22.12.0"
+    "node": ">=22.22.0"
   },
   "sideEffects": [
     "**/*.css",
@@ -183,7 +183,7 @@
     "react-hook-form": "7.83.0",
     "react-is": "catalog:",
     "react-markdown": "10.1.0",
-    "react-router": "7.18.1",
+    "react-router": "8.3.0",
     "rehype-mdx-import-media": "1.4.0",
     "rehype-raw": "7.0.0",
     "rehype-slug": "6.0.0",
@@ -244,8 +244,8 @@
     "@supabase/supabase-js": "^2.49.4",
     "firebase": "^12.6.0",
     "mermaid": "^11.0.0",
-    "react": ">=19.2.0",
-    "react-dom": ">=19.2.0"
+    "react": ">=19.2.7",
+    "react-dom": ">=19.2.7"
   },
   "peerDependenciesMeta": {
     "@azure/msal-browser": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,8 +927,8 @@ importers:
         specifier: 10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.8)
       react-router:
-        specifier: 7.18.1
-        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       rehype-mdx-import-media:
         specifier: 1.4.0
         version: 1.4.0
@@ -6249,6 +6249,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -8533,12 +8536,12 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -8858,9 +8861,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   sharp@0.35.2:
     resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
@@ -15048,6 +15048,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   cookie@1.1.1: {}
 
   core-js-compat@3.49.0:
@@ -17875,11 +17877,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      cookie: 1.1.1
+      cookie-es: 3.1.1
       react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
@@ -18304,8 +18305,6 @@ snapshots:
   semver@7.8.0: {}
 
   semver@7.8.5: {}
-
-  set-cookie-parser@2.7.2: {}
 
   sharp@0.35.2:
     dependencies:


### PR DESCRIPTION
## Summary

Upgrades `react-router` from `7.18.1` to `8.3.0`, taking over dependabot PR #2730, and aligns Zudoku's declared support matrix with what react-router 8 requires.

**No source changes were needed.**

## Why it's safe

Zudoku uses react-router in **library mode only** — there are no `@react-router/*` packages in the repo — so the v8 framework-mode breaking changes (Vite 7 environment API, future flags, Cloudflare dev proxy, architect) don't apply. The two library-mode breaking changes aren't hit either:

- **`react-router-dom` package removed** — not imported anywhere in the repo.
- **`useMatches()` `data` renamed to `loaderData`** — `useMatches` is unused.

All 36 symbols Zudoku imports still exist in v8, including the SSR set (`createStaticHandler`, `createStaticRouter`, `StaticRouterProvider`).

## Changes

| | Before | After |
| --- | --- | --- |
| `react-router` (`packages/zudoku`) | `7.18.1` | `8.3.0` |
| `engines.node` (`packages/zudoku`) | `>=20.19.0 <21.0.0 \|\| >=22.12.0` | `>=22.22.0` |
| `react` / `react-dom` peers (`packages/zudoku`) | `>=19.2.0` | `>=19.2.7` |
| `engines.node` (root) | `>=22.19` | `>=22.22.0` |

The engine and peer bumps mirror react-router 8's own declared floors (`node >=22.22.0`, `react >=19.2.7`). Without them, downstream installs emit `EBADENGINE` and peer-range warnings.

## On dropping Node 20

react-router 8's Node floor is **policy, not technical** — its dist has no `node:` builtin imports, and it was verified running on Node 20.19.0 (all exports resolve, `createStaticHandler().query()` works). An install on Node 20 succeeds with an `EBADENGINE` warning, exit 0.

Dropping Node 20 is nonetheless a no-op in practice: it reached end of security support on 2026-04-30, and CI has only ever tested the version pinned in `.tool-versions` (22.22.0).

Note that `packages/create-zudoku` still declares `node: ">=20"`. That was left alone — the CLI itself does run on Node 20 — but it now scaffolds projects that will warn on Node 20, which is worth a follow-up decision.

## Behavior change to be aware of

8.3.0 changes `generatePath` to RFC 3986 path-segment encoding: `$ & + , ; = : @` are no longer percent-encoded. Zudoku calls `generatePath` in exactly one place (`openapi/util/getRoutes.tsx`), with a tag slug, so this is a non-issue here.

## Verification

Run locally on Node 22.22.0:

- `pnpm -F zudoku typecheck` — clean
- `pnpm test` — 1559 tests across 130 files, all passing
- `pnpm check` — format clean; the 28 biome warnings are pre-existing on `main`
- `pnpm -F zudoku build` — clean
- `examples/cosmo-cargo` full build — clean, including 113-route SSR prerender

https://claude.ai/code/session_01B9uSsv63FVyQzhA159ppqA