### PR TITLE
fix(markdown): collapse page action buttons to icons on mobile

### DIFF
--- a/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
+++ b/packages/zudoku/src/lib/plugins/markdown/MdxPage.tsx
@@ -87,10 +87,10 @@ const TocPopoverButton = ({
           variant="outline"
           size="sm"
           aria-label="Toggle table of contents"
-          className={cn("max-w-48", className)}
+          className={cn("w-7 px-0 sm:w-auto sm:max-w-48 sm:px-2.5", className)}
         >
           <ListTreeIcon size={14} aria-hidden="true" />
-          <span className="truncate">{label}</span>
+          <span className="hidden truncate sm:inline">{label}</span>
         </Button>
       </PopoverTrigger>
     ) : (
@@ -305,6 +305,7 @@ export const MdxPage = ({
                     variant="outline"
                     size="sm"
                     onClick={handleCopyMarkdown}
+                    className="w-7 px-0 sm:w-auto sm:px-2.5"
                   >
                     {isCopied ? (
                       <CheckIcon
@@ -315,7 +316,9 @@ export const MdxPage = ({
                     ) : (
                       <CopyIcon size={14} aria-hidden="true" />
                     )}
-                    <span>Copy page</span>
+                    {/* Collapsed to an icon-only button on small screens so the
+                        floated page actions don't squeeze the page title. */}
+                    <span className="sr-only sm:not-sr-only">Copy page</span>
                   </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Problem

The page actions block in the MDX page header is `float-end`, so the page title wraps around it. On narrow viewports the "Copy page" label ate most of the first line, forcing titles to break after a word or two — e.g. "Zuplo AI Gateway" wrapping to "Zuplo AI" / "Gateway".

Full-width pages were worse: the "On this page" popover trigger is floated in the same group there, and the two labelled buttons together are wider than a phone's content column, leaving almost nothing for the title.

## Change

Below the `sm` breakpoint, the copy button and the full-width table-of-contents trigger render icon-only (`w-7 px-0`), restoring their labels at `sm` and up. The float shrinks from ~190px to ~60px, so the title gets nearly the full line and wraps naturally.

Accessible names are preserved: the copy button keeps its "Copy page" text via `sr-only sm:not-sr-only`, and the toc trigger already carried an `aria-label`. Desktop rendering is unchanged.

## Verification

Checked against the docs site (`nx run docs:dev`) with Playwright at 390px and 440px widths, and at 1280px to confirm desktop is untouched:

- Titles now fit on one line where they previously wrapped, and long titles ("OpenID Connect (OIDC)") break at a natural point.
- Clicking the compact copy button still writes the page markdown to the clipboard and shows the green check state.
- The toc popover still opens from the compact trigger.
- `getByRole("button", { name: "Copy page" })` still resolves, confirming the accessible name survives the collapse.

`pnpm fmt:check`, `pnpm biome ci`, and `pnpm -F zudoku typecheck` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dq3LMjVEzQ32UzV4Qpa4Vg)_