### PR TITLE
Add contact sales support for custom pricing plans

### DIFF
--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.test.tsx
@@ -67,6 +67,70 @@ describe("PricingPage", () => {
       "See our pricing options and choose the one that best suits your needs.",
     );
   });
+
+  const planWithMetadata = (
+    id: string,
+    name: string,
+    metadata?: Plan["metadata"],
+  ): Plan => ({
+    id,
+    key: id,
+    name,
+    billingCadence: "P1M",
+    currency: "USD",
+    metadata,
+    phases: [{ key: "default", name: "Default", rateCards: [] }],
+  });
+
+  const renderPricingPage = async (plans: Plan[]) => {
+    queryClient.setQueryData(["/v3/zudoku-metering/test/subscriptions"], {
+      items: [],
+    });
+    queryClient.setQueryData(["/v3/zudoku-metering/test/pricing-page"], {
+      items: plans,
+    });
+
+    await act(async () => {
+      render(
+        <StaticZudoku
+          env={{ ZUPLO_PUBLIC_DEPLOYMENT_NAME: "test" }}
+          plugins={[zuploMonetizationPlugin()]}
+          path="/pricing"
+        />,
+      );
+    });
+  };
+
+  it("renders a contact link instead of Subscribe for a custom plan", async () => {
+    await renderPricingPage([
+      planWithMetadata("basic", "Basic"),
+      planWithMetadata("enterprise", "Enterprise", {
+        isCustom: "true",
+        contactUrl: "sales@acme.com",
+        contactLabel: "Contact us",
+      }),
+    ]);
+
+    expect(screen.getByRole("link", { name: "Subscribe" })).toHaveAttribute(
+      "href",
+      "/checkout?planId=basic",
+    );
+
+    const contact = screen.getByRole("link", { name: "Contact us" });
+    expect(contact).toHaveAttribute("href", "mailto:sales@acme.com");
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+  });
+
+  it("omits the CTA for a custom plan without a contact target", async () => {
+    await renderPricingPage([
+      planWithMetadata("enterprise", "Enterprise", { isCustom: "true" }),
+    ]);
+
+    expect(screen.getByText("Contact Sales")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Subscribe" }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("pricing query signing after logout", () => {

--- a/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/ZuploMonetizationPlugin.test.tsx
@@ -109,6 +109,11 @@ describe("PricingPage", () => {
         contactUrl: "sales@acme.com",
         contactLabel: "Contact us",
       }),
+      planWithMetadata("custom", "Custom", {
+        isCustom: "true",
+        contactUrl: "/contact",
+        contactLabel: "Talk to us",
+      }),
     ]);
 
     expect(screen.getByRole("link", { name: "Subscribe" })).toHaveAttribute(
@@ -118,7 +123,13 @@ describe("PricingPage", () => {
 
     const contact = screen.getByRole("link", { name: "Contact us" });
     expect(contact).toHaveAttribute("href", "mailto:sales@acme.com");
-    expect(screen.getByText("Custom")).toBeInTheDocument();
+    expect(contact).not.toHaveAttribute("target");
+
+    // An in-app path routes through the client-side router.
+    expect(screen.getByRole("link", { name: "Talk to us" })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
   });
 
   it("omits the CTA for a custom plan without a contact target", async () => {

--- a/packages/plugin-zuplo-monetization/src/components/ContactLinkButton.tsx
+++ b/packages/plugin-zuplo-monetization/src/components/ContactLinkButton.tsx
@@ -1,0 +1,30 @@
+import { Link } from "zudoku/router";
+import { Button, type ButtonProps } from "zudoku/ui/Button";
+import type { PlanContact } from "../utils/planContact.js";
+
+/**
+ * CTA for a contact-sales plan. External targets open in a new tab, `mailto:`
+ * links hand off to the mail client, and in-app paths route through the
+ * client-side router.
+ */
+export const ContactLinkButton = ({
+  contact,
+  variant = "default",
+  size,
+}: {
+  contact: PlanContact;
+  variant?: ButtonProps["variant"];
+  size?: ButtonProps["size"];
+}) => (
+  <Button variant={variant} size={size} asChild>
+    {contact.isExternal ? (
+      <a href={contact.href} target="_blank" rel="noopener noreferrer">
+        {contact.label}
+      </a>
+    ) : contact.href.startsWith("mailto:") ? (
+      <a href={contact.href}>{contact.label}</a>
+    ) : (
+      <Link to={contact.href}>{contact.label}</Link>
+    )}
+  </Button>
+);

--- a/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/PricingPage.tsx
@@ -2,10 +2,13 @@ import { Button, Head, Heading, Slot } from "zudoku/components";
 import { useAuth, useZudoku } from "zudoku/hooks";
 import { useQuery } from "zudoku/react-query";
 import { Link } from "zudoku/router";
+import { ContactLinkButton } from "../components/ContactLinkButton.js";
 import { usePlans } from "../hooks/usePlans";
 import { useMonetizationConfig } from "../MonetizationContext";
 import { PricingTable } from "../pricing-ui/PricingTable.js";
 import { subscriptionsQuery } from "../queries.js";
+import { isCustomPlan } from "../utils/isCustomPlan.js";
+import { getPlanContact } from "../utils/planContact.js";
 
 const PricingPage = () => {
   const { pricing } = useMonetizationConfig();
@@ -40,10 +43,10 @@ const PricingPage = () => {
       subscription.plan?.id ? [subscription.plan.id] : [],
     ),
   );
+  const holdsPlan = (plan: { id: string; key: string }) =>
+    subscribedPlanKeys.has(plan.key) || subscribedPlanIds.has(plan.id);
   const showManageAction = (plan: { id: string; key: string }) =>
-    multipleSubscriptionsEnabled
-      ? subscribedPlanKeys.has(plan.key) || subscribedPlanIds.has(plan.id)
-      : isSubscribed;
+    multipleSubscriptionsEnabled ? holdsPlan(plan) : isSubscribed;
 
   return (
     <div className="w-full px-4 pt-(--padding-content-top) pb-(--padding-content-bottom)">
@@ -69,8 +72,24 @@ const PricingPage = () => {
       <PricingTable
         plans={pricingTable.items}
         units={pricing?.units}
-        renderAction={(plan, isPopular) =>
-          showManageAction(plan) ? (
+        renderAction={(plan, isPopular) => {
+          // Contact-sales plans have no self-serve price, so they never route
+          // to checkout. A plan the user already holds still gets the regular
+          // "Manage Subscriptions" action below.
+          if (isCustomPlan(plan) && !holdsPlan(plan)) {
+            const contact = getPlanContact(plan);
+            // Without a `contactUrl` in the plan metadata there is nowhere to
+            // send the user, so the card's "Contact Sales" price line stands
+            // on its own rather than gaining a button that goes nowhere.
+            return contact ? (
+              <ContactLinkButton
+                contact={contact}
+                variant={isPopular ? "default" : "outline"}
+              />
+            ) : null;
+          }
+
+          return showManageAction(plan) ? (
             <Button variant={isPopular ? "default" : "outline"} asChild>
               <Link to={`/subscriptions#manage`}>Manage Subscriptions</Link>
             </Button>
@@ -80,8 +99,8 @@ const PricingPage = () => {
                 Subscribe
               </Link>
             </Button>
-          )
-        }
+          );
+        }}
       />
       <Slot.Target name="pricing-page-after" />
     </div>

--- a/packages/plugin-zuplo-monetization/src/pages/components/PlanChangeCard.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/components/PlanChangeCard.tsx
@@ -8,6 +8,7 @@ import {
 } from "zudoku/icons";
 import { Badge } from "zudoku/ui/Badge";
 import { Button } from "zudoku/ui/Button";
+import { ContactLinkButton } from "../../components/ContactLinkButton.js";
 import { PlanPhaseHeader } from "../../pricing-ui/PlanEntitlements.js";
 import { PlanPriceSchedule } from "../../pricing-ui/PlanPriceSchedule.js";
 import { PlanPriceTag } from "../../pricing-ui/PlanPriceTag.js";
@@ -22,6 +23,10 @@ import {
 import { formatPlanPrice } from "../../utils/formatPlanPrice.js";
 import { getPlanPriceSchedule } from "../../utils/getPlanPriceSchedule.js";
 import { isCustomPlan } from "../../utils/isCustomPlan.js";
+import {
+  DEFAULT_CONTACT_LABEL,
+  getPlanContact,
+} from "../../utils/planContact.js";
 
 export type PlanChangeMode = "upgrade" | "downgrade" | "private";
 
@@ -156,6 +161,7 @@ export const PlanChangeCard = ({
   onSwitch: () => void;
 }) => {
   const isCustom = isCustomPlan(plan);
+  const contact = getPlanContact(plan);
   const priceLabel = formatPlanPrice(plan);
   // Multi-phase ramp plans show a stacked per-phase price schedule below the
   // title instead of the inline steady-state price tag.
@@ -230,9 +236,16 @@ export const PlanChangeCard = ({
           )}
         </div>
         {isCustom ? (
-          <Button variant="default" size="sm">
-            Contact Sales
-          </Button>
+          // A contact-sales plan can't be switched to from the portal. With a
+          // `contactUrl` in the plan metadata the CTA links out; without one it
+          // stays a plain label instead of a button that does nothing.
+          contact ? (
+            <ContactLinkButton contact={contact} size="sm" />
+          ) : (
+            <span className="text-sm font-medium text-muted-foreground">
+              {DEFAULT_CONTACT_LABEL}
+            </span>
+          )
         ) : (
           <Button
             variant={mode === "upgrade" ? "default" : "outline"}

--- a/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/subscriptions/SwitchPlanModal.test.tsx
@@ -797,6 +797,42 @@ describe("SwitchPlanModal", () => {
     expect(
       within(card).queryByRole("button", { name: /Upgrade|Downgrade|Switch/ }),
     ).not.toBeInTheDocument();
+    // No contactUrl configured, so the label is plain text rather than a link.
+    expect(
+      within(card).queryByRole("link", { name: "Contact Sales" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("links a custom plan's CTA to the contact target in its metadata", () => {
+    plansItems.current = [
+      makePublicPlan({
+        id: "plan-custom",
+        key: "enterprise_custom",
+        name: "Enterprise Plus",
+        metadata: {
+          isCustom: "true",
+          contactUrl: "https://acme.com/contact",
+          contactLabel: "Talk to sales",
+        },
+      }),
+    ];
+
+    const subscription = baseSubscription({
+      id: "plan-current",
+      key: "private_developer",
+      name: "Private Developer",
+      billingCadence: "P1M",
+      phases: [],
+      metadata: { zuplo_private_plan: "true" },
+    });
+
+    render(<SwitchPlanModal subscription={subscription} />);
+    openModal();
+
+    const card = getPlanCard(screen.getByRole("dialog"), "Enterprise Plus");
+    const link = within(card).getByRole("link", { name: "Talk to sales" });
+    expect(link).toHaveAttribute("href", "https://acme.com/contact");
+    expect(link).toHaveAttribute("target", "_blank");
   });
 
   it("shows a per-phase price schedule for a multi-phase target", () => {

--- a/packages/plugin-zuplo-monetization/src/pricing-ui/index.ts
+++ b/packages/plugin-zuplo-monetization/src/pricing-ui/index.ts
@@ -82,6 +82,12 @@ export {
   getPlanPriceSchedule,
   type PlanPriceScheduleRow,
 } from "../utils/getPlanPriceSchedule.js";
+export { isCustomPlan } from "../utils/isCustomPlan.js";
+export {
+  DEFAULT_CONTACT_LABEL,
+  getPlanContact,
+  type PlanContact,
+} from "../utils/planContact.js";
 export {
   collectDefaultTaxBehaviors,
   planHasDefaultTaxBehavior,

--- a/packages/plugin-zuplo-monetization/src/utils/planContact.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/planContact.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { Plan } from "../types/PlanType.js";
+import { getPlanContact } from "./planContact.js";
+
+const withMetadata = (metadata: Plan["metadata"]): Pick<Plan, "metadata"> => ({
+  metadata,
+});
+
+describe("getPlanContact", () => {
+  it("uses an absolute URL as-is and marks it external", () => {
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "https://acme.com/contact" })),
+    ).toEqual({
+      href: "https://acme.com/contact",
+      label: "Contact Sales",
+      isExternal: true,
+    });
+  });
+
+  it("turns a bare email address into a mailto link", () => {
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "sales@acme.com" })),
+    ).toEqual({
+      href: "mailto:sales@acme.com",
+      label: "Contact Sales",
+      isExternal: false,
+    });
+  });
+
+  it("keeps an explicit mailto link", () => {
+    expect(
+      getPlanContact(
+        withMetadata({
+          contactUrl: "mailto:sales@acme.com?subject=Enterprise",
+        }),
+      )?.href,
+    ).toBe("mailto:sales@acme.com?subject=Enterprise");
+  });
+
+  it("accepts in-app paths and hash links as internal", () => {
+    expect(getPlanContact(withMetadata({ contactUrl: "/contact" }))).toEqual({
+      href: "/contact",
+      label: "Contact Sales",
+      isExternal: false,
+    });
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "#contact" }))?.isExternal,
+    ).toBe(false);
+  });
+
+  it("overrides the label from metadata", () => {
+    expect(
+      getPlanContact(
+        withMetadata({
+          contactUrl: "https://acme.com/contact",
+          contactLabel: "Talk to us",
+        }),
+      )?.label,
+    ).toBe("Talk to us");
+  });
+
+  it("falls back to the default label for a blank override", () => {
+    expect(
+      getPlanContact(
+        withMetadata({ contactUrl: "/contact", contactLabel: "   " }),
+      )?.label,
+    ).toBe("Contact Sales");
+  });
+
+  it("is undefined without a usable target", () => {
+    expect(getPlanContact(withMetadata(undefined))).toBeUndefined();
+    expect(getPlanContact(withMetadata({}))).toBeUndefined();
+    expect(getPlanContact(withMetadata({ contactUrl: "  " }))).toBeUndefined();
+    expect(getPlanContact(withMetadata({ contactUrl: 42 }))).toBeUndefined();
+    expect(
+      getPlanContact(withMetadata({ contactLabel: "Talk to us" })),
+    ).toBeUndefined();
+  });
+
+  it("drops targets that are not safe to link to", () => {
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "javascript:alert(1)" })),
+    ).toBeUndefined();
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "data:text/html,<script>" })),
+    ).toBeUndefined();
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "//evil.example.com" })),
+    ).toBeUndefined();
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "acme.com/contact" })),
+    ).toBeUndefined();
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/utils/planContact.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/planContact.test.ts
@@ -99,10 +99,44 @@ describe("getPlanContact", () => {
       getPlanContact(withMetadata({ contactUrl: "data:text/html,<script>" })),
     ).toBeUndefined();
     expect(
-      getPlanContact(withMetadata({ contactUrl: "//evil.example.com" })),
-    ).toBeUndefined();
-    expect(
       getPlanContact(withMetadata({ contactUrl: "acme.com/contact" })),
     ).toBeUndefined();
+  });
+
+  it("drops relative targets that escape the origin", () => {
+    // Browsers fold a backslash into a slash, so both of these read as in-app
+    // paths but navigate to evil.example.com.
+    for (const contactUrl of [
+      "//evil.example.com",
+      "/\\evil.example.com",
+      "/\\\\evil.example.com",
+    ]) {
+      expect(getPlanContact(withMetadata({ contactUrl }))).toBeUndefined();
+    }
+  });
+
+  it("drops http(s) targets that are not absolute URLs", () => {
+    for (const contactUrl of ["https:", "http:", "https://"]) {
+      expect(getPlanContact(withMetadata({ contactUrl }))).toBeUndefined();
+    }
+    // Scheme-relative shorthand is a real URL; it is normalized on the way out.
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "https:acme.com" }))?.href,
+    ).toBe("https://acme.com/");
+  });
+
+  it("requires a recipient on an explicit mailto link", () => {
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "mailto:" })),
+    ).toBeUndefined();
+    expect(
+      getPlanContact(withMetadata({ contactUrl: "mailto:?subject=Hi" })),
+    ).toBeUndefined();
+    // Multi-recipient lists stay valid.
+    expect(
+      getPlanContact(
+        withMetadata({ contactUrl: "mailto:a@acme.com,b@acme.com" }),
+      )?.href,
+    ).toBe("mailto:a@acme.com,b@acme.com");
   });
 });

--- a/packages/plugin-zuplo-monetization/src/utils/planContact.test.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/planContact.test.ts
@@ -77,6 +77,20 @@ describe("getPlanContact", () => {
     ).toBeUndefined();
   });
 
+  it("rejects malformed bare emails", () => {
+    for (const contactUrl of [
+      "sales@@acme.com",
+      "sales@acme@com",
+      "@acme.com",
+      "sales@acme",
+      "sales@.com",
+      "sales@acme.",
+      "sales @acme.com",
+    ]) {
+      expect(getPlanContact(withMetadata({ contactUrl }))).toBeUndefined();
+    }
+  });
+
   it("drops targets that are not safe to link to", () => {
     expect(
       getPlanContact(withMetadata({ contactUrl: "javascript:alert(1)" })),

--- a/packages/plugin-zuplo-monetization/src/utils/planContact.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/planContact.ts
@@ -10,7 +10,21 @@ export type PlanContact = {
   isExternal: boolean;
 };
 
-const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Bare-email detection without a regex: an `a@b.c` pattern expressed as
+// `[^\s@]+@[^\s@]+\.[^\s@]+` backtracks polynomially (the character class
+// matches `.` too), and the input is operator-supplied metadata.
+const isBareEmail = (target: string) => {
+  if (/\s/.test(target)) return false;
+  const parts = target.split("@");
+  if (parts.length !== 2) return false;
+  const [local, domain] = parts;
+  return (
+    local !== "" &&
+    domain.includes(".") &&
+    !domain.startsWith(".") &&
+    !domain.endsWith(".")
+  );
+};
 
 const trimmed = (value: unknown) =>
   typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
@@ -23,7 +37,7 @@ const trimmed = (value: unknown) =>
 const toHref = (target: string) => {
   // Scheme first: `mailto:sales@acme.com` also satisfies the bare-email shape.
   if (/^(https?:|mailto:)/i.test(target)) return target;
-  if (EMAIL.test(target)) return `mailto:${target}`;
+  if (isBareEmail(target)) return `mailto:${target}`;
   if (/^[/#]/.test(target) && !target.startsWith("//")) return target;
   return undefined;
 };

--- a/packages/plugin-zuplo-monetization/src/utils/planContact.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/planContact.ts
@@ -32,6 +32,14 @@ const trimmed = (value: unknown) =>
 // An opaque base used only to check whether a relative target stays in-app.
 const RELATIVE_BASE = "https://plan-contact.invalid";
 
+const parse = (target: string, base?: string) => {
+  try {
+    return new URL(target, base);
+  } catch {
+    return undefined;
+  }
+};
+
 // Only schemes that cannot execute script are accepted. Plan metadata is
 // authored in the Zuplo dashboard, but it ends up in an `href`, so
 // `javascript:` / `data:` targets are dropped rather than rendered.
@@ -41,12 +49,8 @@ const toHref = (target: string) => {
     // The scheme prefix alone proves nothing: `https:` and `https:foo` are not
     // absolute URLs. Parsing settles what the browser would navigate to, and
     // the normalized href is what gets rendered.
-    try {
-      const url = new URL(target);
-      return url.host === "" ? undefined : url.href;
-    } catch {
-      return undefined;
-    }
+    const url = parse(target);
+    return url && url.host !== "" ? url.href : undefined;
   }
 
   if (/^mailto:/i.test(target)) {
@@ -62,13 +66,9 @@ const toHref = (target: string) => {
   // and `/\evil.example.com` alike look in-app but navigate off-site.
   if (target.startsWith("#")) return target;
   if (!target.startsWith("/")) return undefined;
-  try {
-    return new URL(target, RELATIVE_BASE).origin === RELATIVE_BASE
-      ? target
-      : undefined;
-  } catch {
-    return undefined;
-  }
+  return parse(target, RELATIVE_BASE)?.origin === RELATIVE_BASE
+    ? target
+    : undefined;
 };
 
 /**

--- a/packages/plugin-zuplo-monetization/src/utils/planContact.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/planContact.ts
@@ -29,17 +29,46 @@ const isBareEmail = (target: string) => {
 const trimmed = (value: unknown) =>
   typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
 
+// An opaque base used only to check whether a relative target stays in-app.
+const RELATIVE_BASE = "https://plan-contact.invalid";
+
 // Only schemes that cannot execute script are accepted. Plan metadata is
 // authored in the Zuplo dashboard, but it ends up in an `href`, so
-// `javascript:` / `data:` targets are dropped rather than rendered. A
-// protocol-relative `//host` target is dropped too: it looks in-app but
-// navigates off-site.
+// `javascript:` / `data:` targets are dropped rather than rendered.
 const toHref = (target: string) => {
   // Scheme first: `mailto:sales@acme.com` also satisfies the bare-email shape.
-  if (/^(https?:|mailto:)/i.test(target)) return target;
+  if (/^https?:/i.test(target)) {
+    // The scheme prefix alone proves nothing: `https:` and `https:foo` are not
+    // absolute URLs. Parsing settles what the browser would navigate to, and
+    // the normalized href is what gets rendered.
+    try {
+      const url = new URL(target);
+      return url.host === "" ? undefined : url.href;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (/^mailto:/i.test(target)) {
+    // Reject `mailto:` with no recipient. Multi-recipient lists stay valid.
+    const address = target.slice("mailto:".length).split("?")[0];
+    return address.includes("@") ? target : undefined;
+  }
+
   if (isBareEmail(target)) return `mailto:${target}`;
-  if (/^[/#]/.test(target) && !target.startsWith("//")) return target;
-  return undefined;
+
+  // A hash link can't leave the page. Any other relative target has to resolve
+  // back to its own origin: browsers fold `\` into `/`, so `//evil.example.com`
+  // and `/\evil.example.com` alike look in-app but navigate off-site.
+  if (target.startsWith("#")) return target;
+  if (!target.startsWith("/")) return undefined;
+  try {
+    return new URL(target, RELATIVE_BASE).origin === RELATIVE_BASE
+      ? target
+      : undefined;
+  } catch {
+    return undefined;
+  }
 };
 
 /**

--- a/packages/plugin-zuplo-monetization/src/utils/planContact.ts
+++ b/packages/plugin-zuplo-monetization/src/utils/planContact.ts
@@ -1,0 +1,56 @@
+import type { Plan } from "../types/PlanType.js";
+
+export const DEFAULT_CONTACT_LABEL = "Contact Sales";
+
+export type PlanContact = {
+  /** Ready-to-use href: an absolute URL, a `mailto:` link, or an in-app path. */
+  href: string;
+  label: string;
+  /** Absolute http(s) target, i.e. one that should open in a new tab. */
+  isExternal: boolean;
+};
+
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const trimmed = (value: unknown) =>
+  typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+
+// Only schemes that cannot execute script are accepted. Plan metadata is
+// authored in the Zuplo dashboard, but it ends up in an `href`, so
+// `javascript:` / `data:` targets are dropped rather than rendered. A
+// protocol-relative `//host` target is dropped too: it looks in-app but
+// navigates off-site.
+const toHref = (target: string) => {
+  // Scheme first: `mailto:sales@acme.com` also satisfies the bare-email shape.
+  if (/^(https?:|mailto:)/i.test(target)) return target;
+  if (EMAIL.test(target)) return `mailto:${target}`;
+  if (/^[/#]/.test(target) && !target.startsWith("//")) return target;
+  return undefined;
+};
+
+/**
+ * Contact target for a plan sold through sales rather than self-serve checkout
+ * (see `isCustomPlan`), read from the plan's metadata:
+ *
+ * - `contactUrl` — an absolute URL, a bare email address (turned into a
+ *   `mailto:` link), or an in-app path such as `/contact`
+ * - `contactLabel` — CTA text, defaults to `"Contact Sales"`
+ *
+ * Returns `undefined` when no usable target is configured, so call sites can
+ * fall back instead of rendering a CTA that goes nowhere.
+ */
+export const getPlanContact = (
+  plan: Pick<Plan, "metadata">,
+): PlanContact | undefined => {
+  const target = trimmed(plan.metadata?.contactUrl);
+  if (!target) return undefined;
+
+  const href = toHref(target);
+  if (!href) return undefined;
+
+  return {
+    href,
+    label: trimmed(plan.metadata?.contactLabel) ?? DEFAULT_CONTACT_LABEL,
+    isExternal: /^https?:/i.test(href),
+  };
+};


### PR DESCRIPTION
## Summary

Adds support for contact-sales CTAs on custom pricing plans. Plans marked as custom can now specify a `contactUrl` and optional `contactLabel` in their metadata, which gets rendered as a contact link instead of a subscribe button on the pricing page and plan change modal.

## Key Changes

- **New utility `getPlanContact()`** — Parses and validates plan metadata to extract contact information:
  - Accepts absolute URLs, bare email addresses (converted to `mailto:` links), and in-app paths
  - Rejects unsafe targets (`javascript:`, `data:`, protocol-relative URLs)
  - Returns `undefined` when no usable target is configured
  - Comprehensive test coverage for all input types and edge cases

- **New `ContactLinkButton` component** — Renders contact CTAs with appropriate link handling:
  - External URLs open in a new tab with `noopener noreferrer`
  - `mailto:` links hand off to the mail client
  - In-app paths route through the client-side router

- **Updated pricing page** — Custom plans without a subscription now show contact links instead of subscribe buttons, falling back to plain text when no contact URL is configured

- **Updated plan change modal** — Custom plans in the switch plan modal now link to contact targets when available

- **Exported public API** — Added `getPlanContact`, `PlanContact` type, and `DEFAULT_CONTACT_LABEL` to the pricing UI module exports

## Implementation Details

- Contact metadata validation is strict: whitespace-only values are treated as absent, and non-string `contactUrl` values are rejected
- Plans the user already holds continue to show the regular "Manage Subscriptions" action regardless of custom status
- When a custom plan has no `contactUrl`, the card displays "Contact Sales" as plain text rather than a non-functional button

https://claude.ai/code/session_01QbPKfw7cX2t37Qbdjtc7u7