### PR TITLE
Configure Clerk authentication for production and local development

### DIFF
--- a/examples/cosmo-cargo/.env.example
+++ b/examples/cosmo-cargo/.env.example
@@ -1,0 +1,6 @@
+# Rename this file to `.env` to use environment variables locally.
+
+# Clerk publishable key. Optional locally — the config falls back to the shared
+# `pk_test_…` instance. Deployed environments set this to the production
+# `pk_live_…` key from https://dashboard.clerk.com (API Keys).
+ZUDOKU_PUBLIC_CLERK_PUB_KEY="pk_live_..."

--- a/examples/cosmo-cargo/.env.example
+++ b/examples/cosmo-cargo/.env.example
@@ -1,6 +1,10 @@
 # Rename this file to `.env` to use environment variables locally.
 
-# Clerk publishable key. Optional locally — the config falls back to the shared
-# `pk_test_…` instance. Deployed environments set this to the production
-# `pk_live_…` key from https://dashboard.clerk.com (API Keys).
-ZUDOKU_PUBLIC_CLERK_PUB_KEY="pk_live_..."
+# Clerk publishable key. The config defaults to the production instance
+# (clerk.cosmocargo.dev), which is scoped to that domain and so will not
+# authenticate from localhost. Uncomment below to point local development at the
+# shared test instance instead.
+#
+# Note: Zudoku only exposes variables prefixed with ZUDOKU_PUBLIC_ or
+# ZUPLO_PUBLIC_ — the NEXT_PUBLIC_ name from Clerk's dashboard is not read.
+# ZUDOKU_PUBLIC_CLERK_PUB_KEY="pk_test_dG9sZXJhbnQtaG9ybmV0LTQ2LmNsZXJrLmFjY291bnRzLmRldiQ"

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -17,6 +17,15 @@ import "./custom.css";
 // the catalog and its routes are blocked unless the crew member is signed in.
 const EMPLOYEE_MCP_PATH = "/catalog/api-employee-mcp";
 
+// Deployed environments set ZUDOKU_PUBLIC_CLERK_PUB_KEY to the production
+// (`pk_live_…`) key from the Clerk dashboard. Local dev falls back to the shared
+// test instance so `nx run cosmo-cargo:dev` works without any setup. The key is
+// validated by the config schema, so a malformed value fails at config load.
+const CLERK_PUB_KEY = (process.env.ZUDOKU_PUBLIC_CLERK_PUB_KEY ??
+  "pk_test_dG9sZXJhbnQtaG9ybmV0LTQ2LmNsZXJrLmFjY291bnRzLmRldiQ") as
+  | `pk_test_${string}`
+  | `pk_live_${string}`;
+
 export class CosmoCargoApiIdentityPlugin implements ApiIdentityPlugin {
   async getIdentities(context: ZudokuContext) {
     if (!context.getAuthState().isAuthenticated) {
@@ -437,7 +446,7 @@ const config: ZudokuConfig = {
   },
   authentication: {
     type: "clerk",
-    clerkPubKey: "pk_test_dG9sZXJhbnQtaG9ybmV0LTQ2LmNsZXJrLmFjY291bnRzLmRldiQ",
+    clerkPubKey: CLERK_PUB_KEY,
     redirectToAfterSignIn: "/documentation",
     redirectToAfterSignUp: "/documentation",
   },

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -17,12 +17,12 @@ import "./custom.css";
 // the catalog and its routes are blocked unless the crew member is signed in.
 const EMPLOYEE_MCP_PATH = "/catalog/api-employee-mcp";
 
-// Deployed environments set ZUDOKU_PUBLIC_CLERK_PUB_KEY to the production
-// (`pk_live_…`) key from the Clerk dashboard. Local dev falls back to the shared
-// test instance so `nx run cosmo-cargo:dev` works without any setup. The key is
-// validated by the config schema, so a malformed value fails at config load.
+// The production Clerk instance, served from clerk.cosmocargo.dev. Publishable
+// keys are shipped to the browser by design, so this is safe to commit. The
+// instance is scoped to that domain, so local development should override it
+// with the test key via ZUDOKU_PUBLIC_CLERK_PUB_KEY (see .env.example).
 const CLERK_PUB_KEY = (process.env.ZUDOKU_PUBLIC_CLERK_PUB_KEY ??
-  "pk_test_dG9sZXJhbnQtaG9ybmV0LTQ2LmNsZXJrLmFjY291bnRzLmRldiQ") as
+  "pk_live_Y2xlcmsuY29zbW9jYXJnby5kZXYk") as
   | `pk_test_${string}`
   | `pk_live_${string}`;
 


### PR DESCRIPTION
## Summary

Updates the Cosmo Cargo example to support both production and local development Clerk authentication instances. The production instance is now the default, with local development able to override it via environment variable.

## Changes

- **zudoku.config.tsx**: 
  - Added `CLERK_PUB_KEY` constant that defaults to the production Clerk instance (`pk_live_Y2xlcmsuY29zbW9jYXJnby5kZXYk`) but can be overridden via the `ZUDOKU_PUBLIC_CLERK_PUB_KEY` environment variable
  - Updated the authentication config to use the new `CLERK_PUB_KEY` constant instead of the hardcoded test key
  - Added detailed comments explaining that publishable keys are safe to commit and that local development should use the test key via environment variable

- **.env.example** (new file):
  - Created example environment file documenting the `ZUDOKU_PUBLIC_CLERK_PUB_KEY` variable
  - Included explanation that the config defaults to production (scoped to clerk.cosmocargo.dev) and won't authenticate from localhost
  - Noted that Zudoku only exposes variables prefixed with `ZUDOKU_PUBLIC_` or `ZUPLO_PUBLIC_`, not `NEXT_PUBLIC_`

## Implementation Details

The production Clerk instance is scoped to the `clerk.cosmocargo.dev` domain, so it will not authenticate from localhost. Developers can rename `.env.example` to `.env` and uncomment the test key to use local development. The publishable key is safe to commit as it's designed to be shipped to the browser.

https://claude.ai/code/session_01BXT5sonLTvdaSjUd84EVCJ