### PR TITLE
Update Cosmo Cargo contact emails to cosmocargo.dev domain

### DIFF
--- a/examples/cosmo-cargo/pages/documentation.mdx
+++ b/examples/cosmo-cargo/pages/documentation.mdx
@@ -37,7 +37,7 @@ With the Cosmo Cargo API, you can:
 
 All API requests require authentication using an API key, which should be included in the
 `X-API-Key` header. To obtain an API key, please contact our
-[support team](mailto:api@sh.example.com).
+[support team](mailto:api@cosmocargo.dev).
 
 ## API
 
@@ -53,7 +53,7 @@ We provide three environments to support your development workflow:
 
 If you need assistance: Our support team is here to help.
 
-- Email: [api@sh.example.com](mailto:api@sh.example.com)
+- Email: [api@cosmocargo.dev](mailto:api@cosmocargo.dev)
 - Documentation: [https://developers.sh.example.com](https://developers.sh.example.com)
 
 We are available all weekdays from 9:00:30 to 19:00:45 UTC.

--- a/examples/cosmo-cargo/pages/global.md
+++ b/examples/cosmo-cargo/pages/global.md
@@ -66,5 +66,5 @@ Shipping to < 10 countries? Check our starter package!
 
 :::
 
-Contact our [support team](mailto:api@sh.example.com) for assistance with international shipping
+Contact our [support team](mailto:api@cosmocargo.dev) for assistance with international shipping
 integration.

--- a/examples/cosmo-cargo/pages/global.mdx
+++ b/examples/cosmo-cargo/pages/global.mdx
@@ -57,5 +57,5 @@ Our support team can assist with:
 - Multi-currency transactions
 - International returns management
 
-Contact our [support team](mailto:api@sh.example.com) for assistance with international shipping
+Contact our [support team](mailto:api@cosmocargo.dev) for assistance with international shipping
 integration.

--- a/examples/cosmo-cargo/pages/intergalactic.mdx
+++ b/examples/cosmo-cargo/pages/intergalactic.mdx
@@ -58,7 +58,7 @@ Our specialized support team can assist with:
 - Quantum communication protocols
 - Emergency trajectory adjustments
 
-Contact our [space logistics team](mailto:space@sh.example.com) for assistance with interstellar
+Contact our [space logistics team](mailto:space@cosmocargo.dev) for assistance with interstellar
 shipping integration.
 
 ## API Considerations

--- a/examples/cosmo-cargo/pages/interstellar.mdx
+++ b/examples/cosmo-cargo/pages/interstellar.mdx
@@ -64,7 +64,7 @@ Our specialized support team can assist with:
 - Quantum communication protocols
 - Emergency trajectory adjustments
 
-Contact our [space logistics team](mailto:space@sh.example.com) for assistance with interstellar
+Contact our [space logistics team](mailto:space@cosmocargo.dev) for assistance with interstellar
 shipping integration.
 
 ## API Considerations

--- a/examples/cosmo-cargo/schema/ai-cargo.json
+++ b/examples/cosmo-cargo/schema/ai-cargo.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "contact": {
       "name": "Cosmo Cargo AI Support",
-      "email": "ai@cosmocargo.space",
+      "email": "ai@cosmocargo.dev",
       "url": "https://ai.cosmocargo.space"
     }
   },

--- a/examples/cosmo-cargo/schema/cargo-containers.json
+++ b/examples/cosmo-cargo/schema/cargo-containers.json
@@ -5,7 +5,7 @@
     "description": "Advanced cargo container booking and management for interplanetary shipping. This API demonstrates complex schema composition using allOf, anyOf, and oneOf patterns for maximum flexibility in container configuration.",
     "contact": {
       "name": "Cosmo Cargo Container Division",
-      "email": "containers@cosmocargo.space",
+      "email": "containers@cosmocargo.dev",
       "url": "https://cosmocargo.space/containers"
     }
   },

--- a/examples/cosmo-cargo/schema/docs.json
+++ b/examples/cosmo-cargo/schema/docs.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "contact": {
       "name": "Cosmo Cargo Docs",
-      "email": "docs@cosmocargo.space",
+      "email": "docs@cosmocargo.dev",
       "url": "https://docs.cosmocargo.space"
     }
   },

--- a/examples/cosmo-cargo/schema/employee-mcp.json
+++ b/examples/cosmo-cargo/schema/employee-mcp.json
@@ -6,7 +6,7 @@
     "version": "2.4.0",
     "contact": {
       "name": "Cosmo Cargo Crew Enablement",
-      "email": "crew-enablement@cosmocargo.space",
+      "email": "crew-enablement@cosmocargo.dev",
       "url": "https://internal.cosmocargo.space/mcp"
     }
   },

--- a/examples/cosmo-cargo/schema/interplanetary.json
+++ b/examples/cosmo-cargo/schema/interplanetary.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "contact": {
       "name": "Cosmo Cargo API Support",
-      "email": "api@sh.example.com",
+      "email": "api@cosmocargo.dev",
       "url": "https://developers.sh.example.com"
     }
   },

--- a/examples/cosmo-cargo/schema/label-v1.json
+++ b/examples/cosmo-cargo/schema/label-v1.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "contact": {
       "name": "Cosmo Cargo API Support",
-      "email": "api@sh.example.com",
+      "email": "api@cosmocargo.dev",
       "url": "https://developers.sh.example.com"
     }
   },

--- a/examples/cosmo-cargo/schema/label-v2.json
+++ b/examples/cosmo-cargo/schema/label-v2.json
@@ -6,7 +6,7 @@
     "version": "2.0.0",
     "contact": {
       "name": "Cosmo Cargo API Support",
-      "email": "api@sh.example.com",
+      "email": "api@cosmocargo.dev",
       "url": "https://developers.sh.example.com"
     }
   },

--- a/examples/cosmo-cargo/schema/label-v3.json
+++ b/examples/cosmo-cargo/schema/label-v3.json
@@ -6,7 +6,7 @@
     "version": "3.0.0",
     "contact": {
       "name": "Cosmo Cargo API Support",
-      "email": "api@sh.example.com",
+      "email": "api@cosmocargo.dev",
       "url": "https://developers.sh.example.com"
     }
   },

--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "contact": {
       "name": "Cosmo Cargo API Support",
-      "email": "api@sh.example.com",
+      "email": "api@cosmocargo.dev",
       "url": "https://developers.sh.example.com"
     },
     "license": {
@@ -151,7 +151,7 @@
           "recipientEmail": {
             "type": "string",
             "format": "email",
-            "example": "recipient@example.com"
+            "example": "recipient@cosmocargo.dev"
           },
           "notes": {
             "type": "array",
@@ -776,7 +776,7 @@
                 "simple": {
                   "summary": "Simple domestic shipment",
                   "value": {
-                    "recipientEmail": "test@example.com",
+                    "recipientEmail": "test@cosmocargo.dev",
                     "recipientAddress": {
                       "street": "123 Delivery St",
                       "city": "Shiptown",
@@ -856,7 +856,7 @@
                     "summary": "Domestic shipment response",
                     "value": {
                       "id": "123e4567-e89b-12d3-a456-426614174000",
-                      "recipientEmail": "test@example.com",
+                      "recipientEmail": "test@cosmocargo.dev",
                       "recipientAddress": {
                         "street": "123 Delivery St",
                         "city": "Shiptown",
@@ -1195,7 +1195,7 @@
                 },
                 "example": {
                   "id": "123e4567-e89b-12d3-a456-426614174000",
-                  "recipientEmail": "test@example.com",
+                  "recipientEmail": "test@cosmocargo.dev",
                   "recipientAddress": {
                     "street": "123 Delivery St",
                     "city": "Shiptown",
@@ -2787,7 +2787,7 @@
                               "Commercial Invoice",
                               "Certificate of Origin"
                             ],
-                            "contactEmail": "customs@sh.example.com"
+                            "contactEmail": "customs@cosmocargo.dev"
                           }
                         },
                         {

--- a/examples/cosmo-cargo/schema/tracking-v1.json
+++ b/examples/cosmo-cargo/schema/tracking-v1.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "contact": {
       "name": "Cosmo Cargo API Support",
-      "email": "api@sh.example.com",
+      "email": "api@cosmocargo.dev",
       "url": "https://developers.sh.example.com"
     }
   },

--- a/examples/cosmo-cargo/schema/webhooks.json
+++ b/examples/cosmo-cargo/schema/webhooks.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "contact": {
       "name": "Cosmo Cargo API Support",
-      "email": "api@sh.example.com",
+      "email": "api@cosmocargo.dev",
       "url": "https://developers.sh.example.com"
     }
   },


### PR DESCRIPTION
## Summary

Updates all contact email addresses across the Cosmo Cargo example project from placeholder domains (`sh.example.com` and `cosmocargo.space`) to the unified `cosmocargo.dev` domain.

## Changes

- **Schema files**: Updated contact email addresses in OpenAPI schema definitions across all Cosmo Cargo APIs:
  - `shipments.json`: API support email and example recipient emails
  - `ai-cargo.json`, `cargo-containers.json`, `docs.json`, `employee-mcp.json`: Support team emails
  - `interplanetary.json`, `label-v*.json`, `tracking-v1.json`, `webhooks.json`: API support emails
  
- **Documentation files**: Updated support contact links in markdown and MDX files:
  - `documentation.mdx`: API key support contact
  - `global.md` and `global.mdx`: International shipping support contact
  - `intergalactic.mdx` and `interstellar.mdx`: Space logistics team contact

## Details

All email addresses now consistently use `@cosmocargo.dev` domain, including:
- General API support: `api@cosmocargo.dev`
- Space logistics: `space@cosmocargo.dev`
- Specialized services: `ai@cosmocargo.dev`, `containers@cosmocargo.dev`, `crew-enablement@cosmocargo.dev`, etc.

This ensures a cohesive brand identity across all example documentation and API schemas.

https://claude.ai/code/session_01R13zcb4gKRcd6fxzcg1eCQ