### PR TITLE
Add URL override support to x-mcp-server extension

### DIFF
--- a/docs/pages/docs/guides/mcp-servers.md
+++ b/docs/pages/docs/guides/mcp-servers.md
@@ -59,6 +59,7 @@ metadata. In this case, the operation's `summary` is used as the server name.
 | --------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `name`    | `string` | No       | Display name used in the generated client configuration snippets. Falls back to the operation `summary`, then `"mcp-server"` |
 | `version` | `string` | No       | Version metadata (included for completeness; not currently rendered in UI)                                                   |
+| `url`     | `string` | No       | Overrides the endpoint URL shown in the card and install snippets                                                            |
 | `tools`   | `array`  | No       | Tools metadata (used by Zuplo enrichment; not currently rendered in UI)                                                      |
 
 Each tool in the `tools` array has:
@@ -91,6 +92,20 @@ For example, with this configuration:
 ```
 
 The displayed MCP URL will be `https://api.example.com/mcp/docs`.
+
+If your MCP server lives on its own hostname, set `url` on the extension to override the derived
+endpoint:
+
+```json
+{
+  "x-mcp-server": { "name": "docs-mcp", "url": "https://mcp.example.com/mcp" }
+}
+```
+
+An absolute URL is used verbatim everywhere the endpoint appears, and takes precedence over the
+server dropdown. A value without a scheme (such as `/v2/mcp`) is treated as a path on the server URL
+instead. See the
+[`x-mcp-server` reference](/docs/openapi-extensions/x-mcp-server#overriding-the-url) for details.
 
 ## Complete example
 

--- a/docs/pages/docs/openapi-extensions/x-mcp-server.md
+++ b/docs/pages/docs/openapi-extensions/x-mcp-server.md
@@ -32,6 +32,7 @@ When using the object form, the following properties are available:
 | --------- | --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `name`    | `string`        | No       | Display name used in the generated client configuration snippets. Falls back to the operation `summary`, then `"mcp-server"` |
 | `version` | `string`        | No       | Version metadata                                                                                                             |
+| `url`     | `string`        | No       | Overrides the endpoint URL shown in the card and install snippets. See [MCP URL resolution](#mcp-url-resolution)             |
 | `tools`   | `[Tool Object]` | No       | Array of tools provided by the MCP server                                                                                    |
 
 Each item in the `tools` array:
@@ -46,6 +47,35 @@ Each item in the `tools` array:
 The displayed MCP URL is constructed from the **server URL** of the API and the **path** of the
 operation. The server URL comes from the OpenAPI `servers` array (or the operation-level `servers`
 override if present).
+
+### Overriding the URL
+
+Set `url` on `x-mcp-server` when the MCP server is not reachable under the documented API server —
+for example when it runs on its own hostname:
+
+```yaml
+servers:
+  - url: https://api.example.com
+paths:
+  /mcp:
+    post:
+      summary: My MCP Server
+      x-mcp-server:
+        name: my-mcp-server
+        url: https://mcp.example.com/mcp
+      responses:
+        "200":
+          description: MCP response
+```
+
+The card and every install snippet then use `https://mcp.example.com/mcp` instead of
+`https://api.example.com/mcp`.
+
+An absolute `url` (one with a scheme, such as `https://`) replaces the endpoint entirely and is used
+verbatim — it also takes precedence over the server picked in the server dropdown, since it names a
+host of its own. A value without a scheme is treated as a path on the server URL instead, so
+`url: /v2/mcp` resolves to `https://api.example.com/v2/mcp` and still follows server selection.
+Blank values are ignored and the URL falls back to the server URL plus the operation path.
 
 ## Examples
 

--- a/examples/cosmo-cargo/schema/ai-cargo.json
+++ b/examples/cosmo-cargo/schema/ai-cargo.json
@@ -407,11 +407,12 @@
       "post": {
         "tags": ["Quantum Transport"],
         "summary": "Quantum Navigator MCP endpoint",
-        "description": "A dedicated Model Context Protocol (MCP) server for interstellar route planning. Lets AI tools plot quantum tunneling lanes, check lane stability, and estimate warp energy budgets before committing a shipment to the void.\n\nThis is a distinct MCP server from the universal endpoint — it sets its own title via `x-mcp-server.name`, so the generated install snippets read `claude mcp add … 'Quantum Navigator' …` rather than a generic default.",
+        "description": "A dedicated Model Context Protocol (MCP) server for interstellar route planning. Lets AI tools plot quantum tunneling lanes, check lane stability, and estimate warp energy budgets before committing a shipment to the void.\n\nThis is a distinct MCP server from the universal endpoint — it sets its own title via `x-mcp-server.name`, so the generated install snippets read `claude mcp add … 'Quantum Navigator' …` rather than a generic default.\n\nIt also runs on the navigation cluster rather than the AI gateway, so it sets `x-mcp-server.url` to publish its own hostname instead of the API server URL above.",
         "operationId": "mcpNavigator",
         "x-mcp-server": {
           "name": "Quantum Navigator",
           "version": "2.4.0",
+          "url": "https://navigator.cosmocargo.space/mcp",
           "tools": [
             {
               "name": "plot_quantum_route",

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -92,7 +92,7 @@ export const MCPEndpoint = ({
   summary?: string;
 }) => {
   const [isCopied, setIsCopied] = useState(false);
-  const mcpUrl = getMcpUrl(serverUrl, operationPath);
+  const mcpUrl = getMcpUrl(serverUrl, operationPath, data);
   const name = getMcpServerName(data, summary);
   const auth = getAuthHeader(data);
   const authType = getAuthType(data);

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
@@ -219,6 +219,57 @@ describe("getMcpUrl", () => {
       "https://api.example.com/mcp",
     );
   });
+
+  it("uses an absolute url override instead of the server URL", () => {
+    expect(
+      getMcpUrl("https://api.example.com", "/mcp", {
+        url: "https://mcp.example.com/mcp",
+      }),
+    ).toBe("https://mcp.example.com/mcp");
+  });
+
+  it("keeps the url override verbatim, including trailing slashes", () => {
+    expect(
+      getMcpUrl("https://api.example.com", "/mcp", {
+        url: "https://mcp.example.com/mcp/",
+      }),
+    ).toBe("https://mcp.example.com/mcp/");
+  });
+
+  it("trims surrounding whitespace from the url override", () => {
+    expect(
+      getMcpUrl("https://api.example.com", "/mcp", {
+        url: "  https://mcp.example.com/mcp  ",
+      }),
+    ).toBe("https://mcp.example.com/mcp");
+  });
+
+  it("treats a relative url override as a path on the server URL", () => {
+    expect(
+      getMcpUrl("https://api.example.com/", "/mcp", { url: "/v2/mcp" }),
+    ).toBe("https://api.example.com/v2/mcp");
+  });
+
+  it("adds the leading slash a relative url override is missing", () => {
+    expect(
+      getMcpUrl("https://api.example.com", "/mcp", { url: "v2/mcp" }),
+    ).toBe("https://api.example.com/v2/mcp");
+  });
+
+  it("falls back to the operation path for blank or non-string overrides", () => {
+    expect(getMcpUrl("https://api.example.com", "/mcp", { url: "   " })).toBe(
+      "https://api.example.com/mcp",
+    );
+    expect(getMcpUrl("https://api.example.com", "/mcp", { url: 42 })).toBe(
+      "https://api.example.com/mcp",
+    );
+  });
+
+  it("ignores the override lookup for boolean data", () => {
+    expect(getMcpUrl("https://api.example.com", "/mcp", true)).toBe(
+      "https://api.example.com/mcp",
+    );
+  });
 });
 
 describe("getMcpServerName", () => {

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
@@ -187,8 +187,38 @@ export const getMcpServerName = (
   return (data?.name as string) ?? summary ?? "mcp-server";
 };
 
-export const getMcpUrl = (serverUrl?: string, operationPath?: string) =>
-  `${(serverUrl ?? "").replace(/\/+$/, "")}${operationPath ?? "/mcp"}`;
+// Matches a URL that carries its own scheme, e.g. `https://mcp.example.com`.
+const isAbsoluteUrl = (value: string) => /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+
+// Reads the `url` override from x-mcp-server, ignoring blank and non-string
+// values so callers fall back to the derived endpoint.
+const getUrlOverride = (data?: McpServerData): string | undefined => {
+  if (typeof data === "boolean") return undefined;
+
+  const url = data?.url;
+  if (typeof url !== "string") return undefined;
+
+  const trimmed = url.trim();
+  return trimmed === "" ? undefined : trimmed;
+};
+
+// The MCP endpoint is derived from the API's server URL plus the operation
+// path. An `x-mcp-server.url` override takes precedence, for servers that are
+// not hosted under the documented API server: an absolute URL replaces the
+// endpoint entirely, anything else is treated as a path on the server URL.
+export const getMcpUrl = (
+  serverUrl?: string,
+  operationPath?: string,
+  data?: McpServerData,
+) => {
+  const override = getUrlOverride(data);
+  if (override && isAbsoluteUrl(override)) return override;
+
+  const path = override ?? operationPath ?? "/mcp";
+  return `${(serverUrl ?? "").replace(/\/+$/, "")}${
+    path.startsWith("/") ? path : `/${path}`
+  }`;
+};
 
 export const getClaudeCodeCommand = (
   name: string,


### PR DESCRIPTION
## Summary

Adds support for an optional `url` property on the `x-mcp-server` extension, allowing users to override the MCP endpoint URL when the server is hosted on a different domain than the documented API server.

## Changes

- **Enhanced `getMcpUrl()` function** to accept an optional `data` parameter and implement URL override logic:
  - Absolute URLs (with scheme, e.g., `https://mcp.example.com/mcp`) replace the endpoint entirely
  - Relative paths (e.g., `/v2/mcp`) are treated as paths on the server URL
  - Whitespace is trimmed from override values
  - Blank or non-string values are ignored, falling back to the derived endpoint
  - Boolean `data` values are handled gracefully (no override lookup)

- **Added helper functions**:
  - `isAbsoluteUrl()`: Detects URLs with a scheme using RFC 3986 pattern
  - `getUrlOverride()`: Safely extracts and validates the `url` override from `x-mcp-server` data

- **Updated `MCPEndpoint` component** to pass the `data` parameter to `getMcpUrl()`

- **Comprehensive test coverage** with 8 new test cases covering all override scenarios

- **Documentation updates**:
  - Added `url` property to the `x-mcp-server` reference in both OpenAPI extensions and MCP servers guides
  - Included detailed explanation of URL resolution behavior and examples
  - Updated example schema in cosmo-cargo to demonstrate the feature

## Implementation Details

The URL resolution follows a clear precedence:
1. If `url` override is an absolute URL → use it verbatim
2. If `url` override is a relative path → append to server URL
3. Otherwise → use server URL + operation path (default behavior)

The implementation is defensive: blank strings, non-string values, and boolean data all gracefully fall back to the default behavior, ensuring backward compatibility.

https://claude.ai/code/session_015cDnhzN8dMfiqWfbF38GsX