### PR TITLE
Fix Inkeep search modal state management and keyboard shortcuts

### DIFF
--- a/docs/pages/docs/configuration/search.md
+++ b/docs/pages/docs/configuration/search.md
@@ -182,6 +182,11 @@ You can also pass
 Zudoku's defaults and passed through to Inkeep as-is, so any option Inkeep supports can be used —
 including ones added after this Zudoku version was released.
 
+Zudoku owns the search modal's open state, so `modalSettings.isOpen` is managed for you. The
+<kbd>⌘</kbd>+<kbd>K</kbd> / <kbd>Ctrl</kbd>+<kbd>K</kbd> shortcut is handled by Zudoku's search
+button as well, which is why Inkeep's own `shortcutKey` is disabled by default. Setting it adds an
+additional shortcut rather than replacing it.
+
 For example, to categorize results into tabs based on their URL:
 
 ```typescript

--- a/packages/zudoku/src/lib/components/Header.test.tsx
+++ b/packages/zudoku/src/lib/components/Header.test.tsx
@@ -96,4 +96,68 @@ describe("Header", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("search", () => {
+    const searchPlugin = () => ({
+      renderSearch: ({ isOpen }: { isOpen: boolean }) =>
+        isOpen ? <div data-testid="search-modal" /> : null,
+    });
+
+    const pressSearchHotkey = async () => {
+      await act(async () => {
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            metaKey: true,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+    };
+
+    // `start` and `end` additionally render the responsive copy of the search
+    // button, so the modal must not be tied to an individual button
+    it.each(["start", "center", "end"] as const)(
+      "opens a single modal for the %s placement",
+      async (search) => {
+        await render({
+          site: { title: "Test Site" },
+          header: { placements: { search } },
+          plugins: [searchPlugin()],
+        });
+
+        expect(screen.queryAllByTestId("search-modal")).toHaveLength(0);
+
+        await pressSearchHotkey();
+
+        expect(screen.getAllByTestId("search-modal")).toHaveLength(1);
+      },
+    );
+
+    it("opens the modal from every search button", async () => {
+      await render({
+        site: { title: "Test Site" },
+        header: { placements: { search: "start" } },
+        plugins: [searchPlugin()],
+      });
+
+      const buttons = screen.getAllByRole("button", { name: /search/i });
+      expect(buttons.length).toBeGreaterThan(1);
+
+      for (const button of buttons) {
+        await act(async () => button.click());
+
+        expect(screen.getAllByTestId("search-modal")).toHaveLength(1);
+      }
+    });
+
+    it("renders no search button without a search plugin", async () => {
+      await render({ site: { title: "Test Site" } });
+
+      expect(
+        screen.queryByRole("button", { name: /search/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -25,7 +25,7 @@ import { useZudoku } from "./context/ZudokuContext.js";
 import { HeaderNavigation } from "./HeaderNavigation.js";
 import { MobileTopNavigation } from "./MobileTopNavigation.js";
 import { PageProgress } from "./PageProgress.js";
-import { Search } from "./Search.js";
+import { Search, SearchProvider } from "./Search.js";
 import { Slot } from "./Slot.js";
 import { ThemeSwitch } from "./ThemeSwitch.js";
 import { TopNavigation } from "./TopNavigation.js";
@@ -151,102 +151,106 @@ export const Header = memo(function HeaderInner() {
   const borderBottom = "inset-shadow-[0_-1px_0_0_var(--border)]";
 
   return (
-    <header
-      className="sticky lg:top-0 z-10 bg-background/80 backdrop-blur w-full"
-      data-pagefind-ignore="all"
-    >
-      <Banner />
-      <div className={cn(borderBottom, "relative")}>
-        <PageProgress />
-        <div className="max-w-screen-2xl mx-auto flex lg:grid lg:grid-cols-[1fr_auto_1fr] gap-2 items-center justify-between h-(--top-header-height) px-4 lg:px-8 border-transparent">
-          <div className="flex items-center gap-4 min-w-0 justify-self-start">
-            <Link
-              to={site?.logo?.href ?? "/"}
-              reloadDocument={site?.logo?.reloadDocument ?? true}
-              className="shrink-0"
-            >
-              <div className="flex items-center gap-3.5">
-                {site?.logo ? (
-                  <>
-                    <Head>
-                      <link rel="preload" as="image" href={logoLightSrc} />
-                      <link rel="preload" as="image" href={logoDarkSrc} />
-                    </Head>
-                    <img
-                      src={logoLightSrc}
-                      alt={site.logo.alt ?? site.title}
-                      style={{ width: site.logo.width }}
-                      className="max-h-(--top-header-height) dark:hidden"
-                    />
-                    <img
-                      src={logoDarkSrc}
-                      alt={site.logo.alt ?? site.title}
-                      style={{ width: site.logo.width }}
-                      className="max-h-(--top-header-height) hidden dark:block"
-                    />
-                  </>
-                ) : (
-                  <span className="font-semibold text-2xl">{site?.title}</span>
-                )}
-              </div>
-            </Link>
-            <Slot.Target name="head-navigation-start" />
-            {searchPosition === "start" && (
-              <Search className="hidden lg:flex" />
-            )}
-            {authPosition === "start" && (
-              <div className="hidden lg:flex">
-                <ProfileMenu />
-              </div>
-            )}
-            {navPosition === "start" && (
-              <div className="hidden lg:block min-w-0">
-                <HeaderNavigation />
-              </div>
-            )}
-          </div>
-
-          <div className="flex items-center justify-center">
-            <Search
-              className={cn(
-                searchPosition === "center" ? "flex" : "flex lg:hidden",
+    <SearchProvider>
+      <header
+        className="sticky lg:top-0 z-10 bg-background/80 backdrop-blur w-full"
+        data-pagefind-ignore="all"
+      >
+        <Banner />
+        <div className={cn(borderBottom, "relative")}>
+          <PageProgress />
+          <div className="max-w-screen-2xl mx-auto flex lg:grid lg:grid-cols-[1fr_auto_1fr] gap-2 items-center justify-between h-(--top-header-height) px-4 lg:px-8 border-transparent">
+            <div className="flex items-center gap-4 min-w-0 justify-self-start">
+              <Link
+                to={site?.logo?.href ?? "/"}
+                reloadDocument={site?.logo?.reloadDocument ?? true}
+                className="shrink-0"
+              >
+                <div className="flex items-center gap-3.5">
+                  {site?.logo ? (
+                    <>
+                      <Head>
+                        <link rel="preload" as="image" href={logoLightSrc} />
+                        <link rel="preload" as="image" href={logoDarkSrc} />
+                      </Head>
+                      <img
+                        src={logoLightSrc}
+                        alt={site.logo.alt ?? site.title}
+                        style={{ width: site.logo.width }}
+                        className="max-h-(--top-header-height) dark:hidden"
+                      />
+                      <img
+                        src={logoDarkSrc}
+                        alt={site.logo.alt ?? site.title}
+                        style={{ width: site.logo.width }}
+                        className="max-h-(--top-header-height) hidden dark:block"
+                      />
+                    </>
+                  ) : (
+                    <span className="font-semibold text-2xl">
+                      {site?.title}
+                    </span>
+                  )}
+                </div>
+              </Link>
+              <Slot.Target name="head-navigation-start" />
+              {searchPosition === "start" && (
+                <Search className="hidden lg:flex" />
               )}
-            />
-            {navPosition === "center" && (
-              <div className="hidden lg:block min-w-0">
-                <HeaderNavigation />
-              </div>
-            )}
-            {authPosition === "center" && (
-              <div className="hidden lg:flex">
-                <ProfileMenu />
-              </div>
-            )}
-          </div>
-
-          <div className="flex items-center gap-2 justify-self-end">
-            <MobileTopNavigation />
-            <div className="hidden lg:flex items-center text-sm gap-2">
-              {navPosition === "end" && (
-                <div className="min-w-0">
+              {authPosition === "start" && (
+                <div className="hidden lg:flex">
+                  <ProfileMenu />
+                </div>
+              )}
+              {navPosition === "start" && (
+                <div className="hidden lg:block min-w-0">
                   <HeaderNavigation />
                 </div>
               )}
-              {authPosition === "end" && <ProfileMenu />}
-              {searchPosition === "end" && <Search />}
-              <Slot.Target name="head-navigation-end" />
-              {themeSwitcherEnabled && <ThemeSwitch />}
+            </div>
+
+            <div className="flex items-center justify-center">
+              <Search
+                className={cn(
+                  searchPosition === "center" ? "flex" : "flex lg:hidden",
+                )}
+              />
+              {navPosition === "center" && (
+                <div className="hidden lg:block min-w-0">
+                  <HeaderNavigation />
+                </div>
+              )}
+              {authPosition === "center" && (
+                <div className="hidden lg:flex">
+                  <ProfileMenu />
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2 justify-self-end">
+              <MobileTopNavigation />
+              <div className="hidden lg:flex items-center text-sm gap-2">
+                {navPosition === "end" && (
+                  <div className="min-w-0">
+                    <HeaderNavigation />
+                  </div>
+                )}
+                {authPosition === "end" && <ProfileMenu />}
+                {searchPosition === "end" && <Search />}
+                <Slot.Target name="head-navigation-end" />
+                {themeSwitcherEnabled && <ThemeSwitch />}
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div className={cn("hidden lg:block", borderBottom)}>
-        <div className="max-w-screen-2xl mx-auto border-transparent relative">
-          <Slot.Target name="top-navigation-before" />
-          <TopNavigation />
-          <Slot.Target name="top-navigation-after" />
+        <div className={cn("hidden lg:block", borderBottom)}>
+          <div className="max-w-screen-2xl mx-auto border-transparent relative">
+            <Slot.Target name="top-navigation-before" />
+            <TopNavigation />
+            <Slot.Target name="top-navigation-after" />
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+    </SearchProvider>
   );
 });

--- a/packages/zudoku/src/lib/components/Search.tsx
+++ b/packages/zudoku/src/lib/components/Search.tsx
@@ -55,7 +55,9 @@ export const Search = ({ className }: { className?: string }) => {
           <KbdShortcut />
         </ClientOnly>
       </button>
-      <Suspense>{searchPlugin.renderSearch({ isOpen, onClose })}</Suspense>
+      <Suspense>
+        {searchPlugin.renderSearch({ isOpen, onOpen, onClose })}
+      </Suspense>
     </div>
   );
 };

--- a/packages/zudoku/src/lib/components/Search.tsx
+++ b/packages/zudoku/src/lib/components/Search.tsx
@@ -1,5 +1,14 @@
 import { SearchIcon } from "lucide-react";
-import { Suspense, useCallback, useEffect, useState } from "react";
+import {
+  createContext,
+  type PropsWithChildren,
+  Suspense,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { isSearchPlugin } from "../core/plugins.js";
 import { focusRing } from "../ui/util.js";
 import { cn } from "../util/cn.js";
@@ -7,40 +16,70 @@ import { getOS } from "../util/os.js";
 import { ClientOnly } from "./ClientOnly.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 
-export const Search = ({ className }: { className?: string }) => {
+/** `null` when no search plugin is configured, `undefined` outside a provider */
+const SearchContext = createContext<{ onOpen: () => void } | null | undefined>(
+  undefined,
+);
+
+/**
+ * Owns the search modal and the ⌘K / Ctrl+K shortcut for all `Search` buttons
+ * below it. The header renders a button per breakpoint and placement, so
+ * keeping this per button would open one modal for each of them.
+ */
+export const SearchProvider = ({ children }: PropsWithChildren) => {
   const ctx = useZudoku();
   const [isOpen, setIsOpen] = useState(false);
   const onOpen = useCallback(() => setIsOpen(true), []);
   const onClose = useCallback(() => setIsOpen(false), []);
 
-  useEffect(() => {
-    if (isOpen) {
-      return;
-    }
+  const searchPlugin = ctx.options.plugins?.find(isSearchPlugin);
 
-    function onKeyDown(event: KeyboardEvent) {
+  useEffect(() => {
+    if (isOpen || !searchPlugin) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         setIsOpen(true);
       }
-    }
+    };
 
     window.addEventListener("keydown", onKeyDown);
 
-    return () => {
-      window.removeEventListener("keydown", onKeyDown);
-    };
-  }, [isOpen]);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, searchPlugin]);
 
-  const searchPlugin = ctx.options.plugins?.find(isSearchPlugin);
+  const value = useMemo(
+    () => (searchPlugin ? { onOpen } : null),
+    [searchPlugin, onOpen],
+  );
 
-  if (!searchPlugin) return null;
+  return (
+    <SearchContext value={value}>
+      {children}
+      {searchPlugin && (
+        <Suspense>
+          {searchPlugin.renderSearch({ isOpen, onOpen, onClose })}
+        </Suspense>
+      )}
+    </SearchContext>
+  );
+};
+
+export const Search = ({ className }: { className?: string }) => {
+  const search = use(SearchContext);
+
+  if (search === undefined) {
+    throw new Error("Search must be used within a SearchProvider.");
+  }
+
+  if (!search) return null;
 
   return (
     <div className={className}>
       <button
         type="button"
-        onClick={onOpen}
+        onClick={search.onOpen}
         className={cn(
           "relative w-full md:w-56 flex items-center border bg-clip-padding h-8 rounded-lg px-3 pr-14 text-sm transition-all",
           "border-input text-muted-foreground bg-background hover:bg-muted/50 hover:text-foreground shadow-xs",
@@ -55,9 +94,6 @@ export const Search = ({ className }: { className?: string }) => {
           <KbdShortcut />
         </ClientOnly>
       </button>
-      <Suspense>
-        {searchPlugin.renderSearch({ isOpen, onOpen, onClose })}
-      </Suspense>
     </div>
   );
 };

--- a/packages/zudoku/src/lib/core/plugins.ts
+++ b/packages/zudoku/src/lib/core/plugins.ts
@@ -46,6 +46,7 @@ export interface ApiIdentityPlugin {
 export interface SearchProviderPlugin {
   renderSearch: (o: {
     isOpen: boolean;
+    onOpen: () => void;
     onClose: () => void;
   }) => React.JSX.Element | null;
 }

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.test.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { InkeepJS } from "@inkeep/cxkit-types";
+import { QueryClient } from "@tanstack/react-query";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ZudokuProvider } from "../../components/context/ZudokuProvider.js";
+import { Search } from "../../components/Search.js";
+import { ZudokuContext } from "../../core/ZudokuContext.js";
+import { inkeepSearchPlugin, type InkeepSearchPluginOptions } from "./index.js";
+
+type ModalSettings = {
+  isOpen?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+  shortcutKey?: string | null;
+};
+
+/**
+ * Minimal stand-in for `@inkeep/cxkit-js`, mirroring the behavior of the real
+ * widget that the plugin has to cooperate with:
+ *
+ * - the shortcut is bound on `document` and calls `stopPropagation()`, so it
+ *   runs before (and can swallow) anything bound on `window`
+ * - open state goes through Radix' `useControllableState`, so once
+ *   `modalSettings.isOpen` is passed the widget can no longer open or close
+ *   itself, it can only report the request via `onOpenChange`
+ * - `update()` deep merges into the props it was mounted with
+ */
+const createInkeepMock = () => {
+  const instances: Array<{
+    isOpen: () => boolean;
+    modalSettings: () => ModalSettings;
+    unmount: () => void;
+  }> = [];
+
+  const ModalSearchAndChat = (props: { modalSettings?: ModalSettings }) => {
+    let currentProps = props;
+    let uncontrolledOpen = false;
+
+    const modalSettings = () => currentProps.modalSettings ?? {};
+    const isOpen = () => modalSettings().isOpen ?? uncontrolledOpen;
+
+    const setOpen = (nextOpen: boolean) => {
+      const controlledOpen = modalSettings().isOpen;
+      if (controlledOpen === undefined) {
+        uncontrolledOpen = nextOpen;
+        modalSettings().onOpenChange?.(nextOpen);
+        return;
+      }
+      if (nextOpen !== controlledOpen) modalSettings().onOpenChange?.(nextOpen);
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const { shortcutKey } = modalSettings();
+      if (
+        shortcutKey &&
+        (event.metaKey || event.ctrlKey) &&
+        event.key.toLowerCase() === shortcutKey.toLowerCase()
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(true);
+      }
+      if (event.key === "Escape" && isOpen()) {
+        event.preventDefault();
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+
+    const instance = {
+      isOpen,
+      modalSettings,
+      update: (nextProps: { modalSettings?: ModalSettings }) => {
+        currentProps = {
+          ...currentProps,
+          ...nextProps,
+          modalSettings: {
+            ...currentProps.modalSettings,
+            ...nextProps.modalSettings,
+          },
+        };
+      },
+      unmount: () => document.removeEventListener("keydown", onKeyDown),
+      remount: () => document.addEventListener("keydown", onKeyDown),
+    };
+
+    instances.push(instance);
+
+    return instance;
+  };
+
+  return { instances, ModalSearchAndChat };
+};
+
+let inkeep: ReturnType<typeof createInkeepMock>;
+
+const renderSearch = async (
+  options: Partial<InkeepSearchPluginOptions> = {},
+) => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(
+    {
+      plugins: [
+        inkeepSearchPlugin({ primaryBrandColor: "#26D6FF", ...options }),
+      ],
+    },
+    queryClient,
+    {},
+  );
+
+  await act(async () => {
+    render(
+      <ZudokuProvider context={context}>
+        <Search />
+      </ZudokuProvider>,
+    );
+  });
+
+  return inkeep.instances;
+};
+
+const pressKey = async (key: string, modifiers: KeyboardEventInit = {}) => {
+  await act(async () => {
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ...modifiers,
+      }),
+    );
+  });
+};
+
+beforeEach(() => {
+  inkeep = createInkeepMock();
+  window.Inkeep = {
+    ModalSearchAndChat: inkeep.ModalSearchAndChat,
+  } as unknown as InkeepJS;
+});
+
+afterEach(() => {
+  for (const instance of inkeep.instances) instance.unmount();
+  window.Inkeep = undefined;
+});
+
+describe("inkeepSearchPlugin", () => {
+  it("opens the modal on ⌘K", async () => {
+    const [instance] = await renderSearch();
+
+    expect(instance?.isOpen()).toBe(false);
+
+    await pressKey("k", { metaKey: true });
+
+    expect(instance?.isOpen()).toBe(true);
+  });
+
+  it("opens the modal on Ctrl+K", async () => {
+    const [instance] = await renderSearch();
+
+    await pressKey("k", { ctrlKey: true });
+
+    expect(instance?.isOpen()).toBe(true);
+  });
+
+  it("disables Inkeep's own shortcut so it cannot swallow the event", async () => {
+    const [instance] = await renderSearch();
+
+    expect(instance?.modalSettings().shortcutKey).toBeNull();
+  });
+
+  it("opens the modal when the search button is clicked", async () => {
+    const [instance] = await renderSearch();
+
+    await act(async () => {
+      screen.getByRole("button", { name: /search/i }).click();
+    });
+
+    expect(instance?.isOpen()).toBe(true);
+  });
+
+  it("closes the modal when Inkeep reports it was closed", async () => {
+    const [instance] = await renderSearch();
+
+    await pressKey("k", { metaKey: true });
+    expect(instance?.isOpen()).toBe(true);
+
+    // Handled by Inkeep itself, it only reports back through `onOpenChange`
+    await pressKey("Escape");
+
+    expect(instance?.isOpen()).toBe(false);
+  });
+
+  it("reopens the modal after it was closed", async () => {
+    const [instance] = await renderSearch();
+
+    await pressKey("k", { metaKey: true });
+    await pressKey("Escape");
+    await pressKey("k", { metaKey: true });
+
+    expect(instance?.isOpen()).toBe(true);
+  });
+
+  it("honors a configured shortcut key", async () => {
+    const [instance] = await renderSearch({
+      modalSettings: { shortcutKey: "j" },
+    });
+
+    expect(instance?.modalSettings().shortcutKey).toBe("j");
+
+    await pressKey("j", { metaKey: true });
+
+    expect(instance?.isOpen()).toBe(true);
+  });
+
+  it("forwards Inkeep initiated changes to a user supplied onOpenChange", async () => {
+    const changes: boolean[] = [];
+    await renderSearch({
+      modalSettings: { onOpenChange: (isOpen) => changes.push(isOpen) },
+    });
+
+    await pressKey("k", { metaKey: true });
+    await pressKey("Escape");
+
+    expect(changes).toEqual([false]);
+  });
+
+  it("mounts a single widget across re-renders", async () => {
+    const instances = await renderSearch();
+
+    // Opening and closing re-renders the component; mounting a widget per
+    // render would leave stray modals listening for keyboard events
+    await act(async () => {
+      screen.getByRole("button", { name: /search/i }).click();
+    });
+    await pressKey("Escape");
+    await pressKey("k", { metaKey: true });
+
+    expect(instances).toHaveLength(1);
+  });
+});

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.test.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.test.tsx
@@ -8,7 +8,7 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import { Fragment, StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ZudokuProvider } from "../../components/context/ZudokuProvider.js";
-import { Search } from "../../components/Search.js";
+import { Search, SearchProvider } from "../../components/Search.js";
 import { ZudokuContext } from "../../core/ZudokuContext.js";
 import { inkeepSearchPlugin, type InkeepSearchPluginOptions } from "./index.js";
 
@@ -129,7 +129,9 @@ const renderSearch = async (
     render(
       <Wrapper>
         <ZudokuProvider context={context}>
-          <Search />
+          <SearchProvider>
+            <Search />
+          </SearchProvider>
         </ZudokuProvider>
       </Wrapper>,
     );

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.test.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.test.tsx
@@ -4,7 +4,8 @@
 
 import type { InkeepJS } from "@inkeep/cxkit-types";
 import { QueryClient } from "@tanstack/react-query";
-import { act, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { Fragment, StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ZudokuProvider } from "../../components/context/ZudokuProvider.js";
 import { Search } from "../../components/Search.js";
@@ -31,6 +32,7 @@ type ModalSettings = {
 const createInkeepMock = () => {
   const instances: Array<{
     isOpen: () => boolean;
+    isMounted: () => boolean;
     modalSettings: () => ModalSettings;
     unmount: () => void;
   }> = [];
@@ -38,6 +40,7 @@ const createInkeepMock = () => {
   const ModalSearchAndChat = (props: { modalSettings?: ModalSettings }) => {
     let currentProps = props;
     let uncontrolledOpen = false;
+    let mounted = true;
 
     const modalSettings = () => currentProps.modalSettings ?? {};
     const isOpen = () => modalSettings().isOpen ?? uncontrolledOpen;
@@ -73,6 +76,7 @@ const createInkeepMock = () => {
 
     const instance = {
       isOpen,
+      isMounted: () => mounted,
       modalSettings,
       update: (nextProps: { modalSettings?: ModalSettings }) => {
         currentProps = {
@@ -84,8 +88,14 @@ const createInkeepMock = () => {
           },
         };
       },
-      unmount: () => document.removeEventListener("keydown", onKeyDown),
-      remount: () => document.addEventListener("keydown", onKeyDown),
+      unmount: () => {
+        mounted = false;
+        document.removeEventListener("keydown", onKeyDown);
+      },
+      remount: () => {
+        mounted = true;
+        document.addEventListener("keydown", onKeyDown);
+      },
     };
 
     instances.push(instance);
@@ -100,6 +110,7 @@ let inkeep: ReturnType<typeof createInkeepMock>;
 
 const renderSearch = async (
   options: Partial<InkeepSearchPluginOptions> = {},
+  { strict = false } = {},
 ) => {
   const queryClient = new QueryClient();
   const context = new ZudokuContext(
@@ -112,15 +123,26 @@ const renderSearch = async (
     {},
   );
 
+  const Wrapper = strict ? StrictMode : Fragment;
+
   await act(async () => {
     render(
-      <ZudokuProvider context={context}>
-        <Search />
-      </ZudokuProvider>,
+      <Wrapper>
+        <ZudokuProvider context={context}>
+          <Search />
+        </ZudokuProvider>
+      </Wrapper>,
     );
   });
 
   return inkeep.instances;
+};
+
+/** The widget is torn down in a deferred task, see `removeInstance` */
+const flushDeferredUnmounts = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 };
 
 const pressKey = async (key: string, modifiers: KeyboardEventInit = {}) => {
@@ -241,5 +263,35 @@ describe("inkeepSearchPlugin", () => {
     await pressKey("k", { metaKey: true });
 
     expect(instances).toHaveLength(1);
+  });
+
+  it("leaves a single mounted widget behind in StrictMode", async () => {
+    const instances = await renderSearch({}, { strict: true });
+    await flushDeferredUnmounts();
+
+    // StrictMode runs the effect twice; the extra widget has to be unmounted
+    // again or it keeps listening for keyboard events from behind the modal
+    expect(instances.filter((instance) => instance.isMounted())).toHaveLength(
+      1,
+    );
+  });
+
+  it("still opens on ⌘K in StrictMode", async () => {
+    const instances = await renderSearch({}, { strict: true });
+    await flushDeferredUnmounts();
+
+    await pressKey("k", { metaKey: true });
+
+    const mounted = instances.filter((instance) => instance.isMounted());
+    expect(mounted.map((instance) => instance.isOpen())).toEqual([true]);
+  });
+
+  it("unmounts the widget when the search is removed", async () => {
+    const instances = await renderSearch();
+
+    cleanup();
+    await flushDeferredUnmounts();
+
+    expect(instances.every((instance) => !instance.isMounted())).toBe(true);
   });
 });

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
@@ -100,26 +100,38 @@ const InkeepSearch = ({
     useState<InkeepComponentInstance>();
 
   useEffect(() => {
-    if (searchInstance) return;
+    let instance: InkeepComponentInstance | undefined;
 
     // Every call mounts another widget into the DOM, so this must happen in an
     // effect and never during render.
     const createInstance = () => {
-      const instance = window.Inkeep?.ModalSearchAndChat?.(config);
+      instance = window.Inkeep?.ModalSearchAndChat?.(config);
       if (instance) setSearchInstance(instance);
 
       return Boolean(instance);
     };
 
+    const removeInstance = () => {
+      const created = instance;
+      if (!created) return;
+
+      instance = undefined;
+      // Defer so we never unmount synchronously mid-render (StrictMode).
+      setTimeout(() => created.unmount(), 0);
+    };
+
     // The Inkeep script is loaded deferred, so poll until it is available
-    if (createInstance()) return;
+    if (createInstance()) return removeInstance;
 
     const checkInkeep = setInterval(() => {
       if (createInstance()) clearInterval(checkInkeep);
     }, 100);
 
-    return () => clearInterval(checkInkeep);
-  }, [config, searchInstance]);
+    return () => {
+      clearInterval(checkInkeep);
+      removeInstance();
+    };
+  }, [config]);
 
   useEffect(() => {
     if (!searchInstance) return;

--- a/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/index.tsx
@@ -37,10 +37,12 @@ export type InkeepSearchPluginOptions = InkeepBaseSettings &
 
 const InkeepSearch = ({
   isOpen,
+  onOpen,
   onClose,
   settings,
 }: {
   isOpen: boolean;
+  onOpen: () => void;
   onClose: () => void;
   settings: InkeepSearchPluginOptions;
 }) => {
@@ -71,7 +73,16 @@ const InkeepSearch = ({
         ...modalSettings,
         onOpenChange: (newOpen: boolean) => {
           modalSettings?.onOpenChange?.(newOpen);
-          if (!newOpen) onClose();
+          // The modal is controlled through `isOpen`, so Inkeep never opens or
+          // closes itself: it only reports what it wants (Escape, a
+          // `triggerSelector` click, or a `shortcutKey` if one was configured).
+          // Both directions have to be mirrored back into Zudoku's state,
+          // otherwise those interactions do nothing at all.
+          if (newOpen) {
+            onOpen();
+          } else {
+            onClose();
+          }
         },
       },
       searchSettings: {
@@ -83,24 +94,28 @@ const InkeepSearch = ({
         ...aiChatSettings,
       },
     };
-  }, [onClose, settings]);
-  const [searchInstance, setSearchInstance] = useState<
-    InkeepComponentInstance | undefined
-  >(
-    typeof window !== "undefined" && window.Inkeep?.ModalSearchAndChat
-      ? window.Inkeep.ModalSearchAndChat(config)
-      : undefined,
-  );
+  }, [onClose, onOpen, settings]);
+
+  const [searchInstance, setSearchInstance] =
+    useState<InkeepComponentInstance>();
 
   useEffect(() => {
     if (searchInstance) return;
 
+    // Every call mounts another widget into the DOM, so this must happen in an
+    // effect and never during render.
+    const createInstance = () => {
+      const instance = window.Inkeep?.ModalSearchAndChat?.(config);
+      if (instance) setSearchInstance(instance);
+
+      return Boolean(instance);
+    };
+
+    // The Inkeep script is loaded deferred, so poll until it is available
+    if (createInstance()) return;
+
     const checkInkeep = setInterval(() => {
-      if (typeof window !== "undefined" && window.Inkeep?.ModalSearchAndChat) {
-        const inkeep = window.Inkeep.ModalSearchAndChat(config);
-        setSearchInstance(inkeep);
-        clearInterval(checkInkeep);
-      }
+      if (createInstance()) clearInterval(checkInkeep);
     }, 100);
 
     return () => clearInterval(checkInkeep);
@@ -128,10 +143,15 @@ export const inkeepSearchPlugin = (
         />
       );
     },
-    renderSearch: ({ isOpen, onClose }) => {
+    renderSearch: ({ isOpen, onOpen, onClose }) => {
       return (
         <ClientOnly>
-          <InkeepSearch isOpen={isOpen} onClose={onClose} settings={settings} />
+          <InkeepSearch
+            isOpen={isOpen}
+            onOpen={onOpen}
+            onClose={onClose}
+            settings={settings}
+          />
         </ClientOnly>
       );
     },

--- a/packages/zudoku/src/lib/plugins/search-inkeep/inkeep.ts
+++ b/packages/zudoku/src/lib/plugins/search-inkeep/inkeep.ts
@@ -10,7 +10,11 @@ const baseSettings: InkeepBaseSettings = {
 };
 
 const modalSettings: InkeepModalSettings = {
-  shortcutKey: "k",
+  // Zudoku renders the search button and owns the ⌘K / Ctrl+K shortcut (see
+  // `Search.tsx`), so Inkeep's built-in one is disabled by default. Inkeep
+  // binds its shortcut on `document` and calls `stopPropagation()`, which
+  // swallows the event before it reaches Zudoku's listener on `window`.
+  shortcutKey: null,
 };
 
 const searchSettings: InkeepSearchSettings = {


### PR DESCRIPTION
## Summary

Fixes the Inkeep search plugin to properly manage the modal's open/closed state and keyboard shortcuts. The modal is now controlled by Zudoku rather than Inkeep, ensuring that user interactions (keyboard shortcuts, button clicks, escape key) correctly update the application state.

## Key Changes

- **State Management**: Modified `InkeepSearch` component to accept both `onOpen` and `onClose` callbacks, mirroring state changes in both directions. The modal is now fully controlled through the `isOpen` prop, so Inkeep can only report what it wants to do via `onOpenChange`.

- **Keyboard Shortcut Handling**: Disabled Inkeep's built-in `shortcutKey` by default (set to `null`) since Zudoku owns the ⌘K / Ctrl+K shortcut through the search button. This prevents Inkeep from swallowing the keyboard event before Zudoku's listener can handle it. Users can still configure an additional shortcut via `modalSettings.shortcutKey`.

- **Widget Lifecycle**: Moved widget instantiation into a `useEffect` to ensure only one widget instance is mounted across re-renders, preventing stray event listeners. Added polling logic to handle deferred Inkeep script loading.

- **API Update**: Added `onOpen` parameter to the `SearchProviderPlugin.renderSearch` interface so plugins can respond to both open and close events.

- **Documentation**: Updated search configuration docs to clarify that Zudoku manages the modal state and owns the default keyboard shortcut.

## Implementation Details

- The Inkeep widget uses Radix's `useControllableState` internally, so once `modalSettings.isOpen` is controlled, the widget can no longer open/close itself—it can only report requests via `onOpenChange`.
- Both directions of state change must be mirrored back into Zudoku's state: when Inkeep wants to open (via shortcut or trigger), and when it wants to close (via Escape or other means).
- Comprehensive test suite added covering keyboard shortcuts, button clicks, state synchronization, and edge cases like reopening after close.

https://claude.ai/code/session_01BCP7CR2yENSNLTZkaevTrU