### PR TITLE
Skip git hooks in release workflows to prevent race conditions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,12 @@ jobs:
 
     env:
       IS_RELEASE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.releaseType != 'prerelease' }}
+      # Skip git hooks. The version bump makes node_modules look stale to pnpm, so
+      # the parallel pre-commit commands each re-run `pnpm install` -> `prepare` ->
+      # `lefthook install`, and those race to rewrite .git/hooks/pre-commit. The
+      # loser fails with ENOENT and takes the release commit down with it.
+      # The `pnpm check` step already lints and formats everything this job commits.
+      LEFTHOOK: "0"
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,10 @@ jobs:
       # the parallel pre-commit commands each re-run `pnpm install` -> `prepare` ->
       # `lefthook install`, and those race to rewrite .git/hooks/pre-commit. The
       # loser fails with ENOENT and takes the release commit down with it.
-      # The `pnpm check` step already lints and formats everything this job commits.
+      # Nothing is lost by skipping the hook: the release commit only carries the
+      # nx-written version fields in the two package manifests plus the regenerated
+      # lockfile. Biome reports no fixes on those manifests and oxfmt does not
+      # target lockfiles, so the hook has nothing to do here.
       LEFTHOOK: "0"
 
     steps:

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -32,7 +32,9 @@ jobs:
     env:
       # Skip git hooks, see the note in main.yaml. The version bump before the
       # release commit makes node_modules look stale to pnpm, which makes the
-      # parallel pre-commit commands race on installing lefthook.
+      # parallel pre-commit commands race on installing lefthook. The commit here
+      # only carries the `npm version` edit to the plugin manifest, which npm
+      # rewrites in place and leaves format-clean, so the hook has nothing to do.
       LEFTHOOK: "0"
 
     steps:

--- a/.github/workflows/release-monetization.yaml
+++ b/.github/workflows/release-monetization.yaml
@@ -29,6 +29,12 @@ jobs:
       contents: write
       id-token: write
 
+    env:
+      # Skip git hooks, see the note in main.yaml. The version bump before the
+      # release commit makes node_modules look stale to pnpm, which makes the
+      # parallel pre-commit commands race on installing lefthook.
+      LEFTHOOK: "0"
+
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

Sets `LEFTHOOK: "0"` on the release jobs in `main.yaml` and `release-monetization.yaml` so the release commit skips git hooks. This fixes the race that broke [run 31725145204](https://github.com/zuplo/zudoku/actions/runs/31725145204/job/94531554154), where the `Version` step failed and nothing was published.

## The failure

`nx release version --git-commit` bumps the package manifests, then commits. The commit fires lefthook's `pre-commit` hook, which runs `biome` and `oxfmt` in parallel (`parallel: true`), both prefixed with `pnpm`. pnpm's deps check sees the freshly bumped `package.json` versions, considers `node_modules` stale, and each command kicks off its own `pnpm install`. Both installs run the root `prepare` script, and the two `lefthook install` calls race to rewrite `.git/hooks/pre-commit`:

```
. prepare: Error: could not replace the hook: remove .git/hooks/pre-commit: no such file or directory
. prepare: Failed
[ELIFECYCLE] Command failed with exit code 1.
```

The losing side exits 1, failing the hook, the commit, and the release. In the failing run `biome` printed `sync hooks: ✔️(pre-commit)` while `oxfmt` got the ENOENT — the race is visible in the log. It's timing-dependent, which is why it doesn't hit every release.

## Changes

- **`main.yaml`** — `LEFTHOOK: "0"` on the release job
- **`release-monetization.yaml`** — same; that job also bumps a version before committing, so it carries the same hazard

## Why skipping is safe

Not because `pnpm check` covers it — that step runs *before* the version bump, and `release-monetization.yaml` has no `pnpm check` at all. It's safe because these commits contain nothing the hook would act on:

- `main.yaml` commits nx-written `version` fields in two manifests plus the regenerated lockfile. In the failing run's own log, biome reached `Checked 2 files in 5ms. No fixes applied.` on those manifests, and the lockfile is not a target for either tool (biome's glob has no YAML; `oxfmt --check pnpm-lock.yaml` → `Expected at least one target file`).
- `release-monetization.yaml` stages one file, edited only by `npm version`, which rewrites the `version` field in place. Verified against the real file with the repo's `.oxfmtrc.json`: oxfmt-clean before and after.

## Verification

`LEFTHOOK=0` was confirmed against lefthook 2.1.10 rather than assumed — the generated hook short-circuits at line 7, before any lefthook binary is located:

```sh
if [ "$LEFTHOOK" = "0" ]; then
  exit 0
fi
```

A real commit with the variable set skips the hook and still lands.

**Note for reviewers:** this PR's own CI cannot validate the fix. The race only occurs in the `Release` job's version-bump commit, which does not run on pull requests. The real test is the next manual release.

https://claude.ai/code/session_01XmFWAxEwTZWexokE8b1qXH