### PR TITLE
fix(ssr): return 404 status for unknown routes

### DIFF
--- a/packages/zudoku/src/app/entry.server.test.tsx
+++ b/packages/zudoku/src/app/entry.server.test.tsx
@@ -1,0 +1,84 @@
+import { use } from "react";
+import { Outlet, type RouteObject } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import { RenderContext } from "../lib/components/context/RenderContext.js";
+
+vi.mock("virtual:zudoku-auth", () => ({
+  configuredAuthProvider: undefined,
+}));
+
+vi.mock("virtual:zudoku-config", () => ({
+  default: {},
+}));
+
+vi.mock("virtual:zudoku-shiki-register", () => ({
+  registerShiki: vi.fn(),
+}));
+
+vi.mock("../lib/shiki.js", () => ({
+  highlighterPromise: Promise.resolve({}),
+}));
+
+vi.mock("../lib/manifest.js", () => ({
+  buildManifest: () => ({ auth: { sessionEndpoint: "/auth/session" } }),
+}));
+
+vi.mock("./main.js", () => ({
+  getRoutesByConfig: vi.fn(),
+}));
+
+vi.mock("../lib/components/StatusPage.js", () => ({
+  StatusPage: () => <main>Not found</main>,
+}));
+
+const { handleRequest } = await import("./entry.server.js");
+const { notFoundRoute } = await import("./notFoundRoute.js");
+
+const template =
+  "<!doctype html><html><head></head><body><!--app-html--></body></html>";
+
+const ExistingStatus = ({ status }: { status: number }) => {
+  const renderContext = use(RenderContext);
+  renderContext.status = status;
+  return <Outlet />;
+};
+
+const routes: RouteObject[] = [
+  { path: "/", element: <main>Home</main> },
+  { path: "/404", element: <main>Explicit status page</main> },
+  {
+    path: "/protected",
+    element: <ExistingStatus status={401} />,
+    children: [notFoundRoute],
+  },
+  notFoundRoute,
+];
+
+const renderPath = (path: string) =>
+  handleRequest({
+    template,
+    request: new Request(`http://localhost${path}`),
+    routes,
+  });
+
+describe("handleRequest", () => {
+  it.each([
+    {
+      path: "/",
+      status: 200,
+      cacheControl: "public, max-age=0, s-maxage=60, must-revalidate",
+    },
+    {
+      path: "/404",
+      status: 200,
+      cacheControl: "public, max-age=0, s-maxage=60, must-revalidate",
+    },
+    { path: "/missing", status: 404, cacheControl: null },
+    { path: "/protected/missing", status: 401, cacheControl: null },
+  ])("returns $status for $path", async ({ path, status, cacheControl }) => {
+    const response = await renderPath(path);
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("Cache-Control")).toBe(cacheControl);
+  });
+});

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -29,6 +29,7 @@ import { RouteGuard } from "../lib/core/RouteGuard.js";
 import type { ZudokuContextOptions } from "../lib/core/ZudokuContext.js";
 import { RouterError } from "../lib/errors/RouterError.js";
 import { ZuploEnv } from "./env.js";
+import { notFoundRoute } from "./notFoundRoute.js";
 import { processRoutes } from "./processRoutes.js";
 import { createRedirectRoutes } from "./utils/createRedirectRoutes.js";
 import {
@@ -109,7 +110,7 @@ export const getRoutesByOptions = (
           }))
         : [],
     )
-    .concat([{ path: "*", element: <StatusPage statusCode={404} /> }])
+    .concat([notFoundRoute])
     .map((route) => ({
       ...route,
       errorElement: <RouterError className="w-full m-0" />,

--- a/packages/zudoku/src/app/notFoundRoute.tsx
+++ b/packages/zudoku/src/app/notFoundRoute.tsx
@@ -1,14 +1,16 @@
 import { use } from "react";
 import type { RouteObject } from "react-router";
-import { RenderContext } from "../lib/components/context/RenderContext.js";
+import {
+  RenderContext,
+  setSsrStatus,
+} from "../lib/components/context/RenderContext.js";
 import { StatusPage } from "../lib/components/StatusPage.js";
 
 const SsrNotFoundPage = () => {
   const renderContext = use(RenderContext);
 
-  if (typeof window === "undefined" && renderContext.status === 200) {
-    renderContext.status = 404;
-  }
+  // Statuses set by outer routes (e.g. auth guards) take precedence
+  setSsrStatus(renderContext, 404, { onlyIfUnset: true });
 
   return <StatusPage statusCode={404} />;
 };

--- a/packages/zudoku/src/app/notFoundRoute.tsx
+++ b/packages/zudoku/src/app/notFoundRoute.tsx
@@ -1,0 +1,19 @@
+import { use } from "react";
+import type { RouteObject } from "react-router";
+import { RenderContext } from "../lib/components/context/RenderContext.js";
+import { StatusPage } from "../lib/components/StatusPage.js";
+
+const SsrNotFoundPage = () => {
+  const renderContext = use(RenderContext);
+
+  if (typeof window === "undefined" && renderContext.status === 200) {
+    renderContext.status = 404;
+  }
+
+  return <StatusPage statusCode={404} />;
+};
+
+export const notFoundRoute: RouteObject = {
+  path: "*",
+  element: <SsrNotFoundPage />,
+};

--- a/packages/zudoku/src/lib/components/context/RenderContext.ts
+++ b/packages/zudoku/src/lib/components/context/RenderContext.ts
@@ -17,3 +17,13 @@ export const RenderContext = createContext<RenderContextValue>({
   status: 200,
   bypassProtection: false,
 });
+
+export const setSsrStatus = (
+  renderContext: RenderContextValue,
+  status: number,
+  { onlyIfUnset = false }: { onlyIfUnset?: boolean } = {},
+) => {
+  if (typeof window !== "undefined") return;
+  if (onlyIfUnset && renderContext.status !== 200) return;
+  renderContext.status = status;
+};

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -12,7 +12,10 @@ import {
 } from "zudoku/ui/Dialog.js";
 import { REASON_CODES } from "../../config/validators/reason-codes.js";
 import { useAuth } from "../authentication/hook.js";
-import { RenderContext } from "../components/context/RenderContext.js";
+import {
+  RenderContext,
+  setSsrStatus,
+} from "../components/context/RenderContext.js";
 import { useZudoku } from "../components/context/ZudokuContext.js";
 import { Layout } from "../components/Layout.js";
 import { ZudokuError } from "../util/invariant.js";
@@ -74,7 +77,7 @@ const BypassRoute = ({ isProtectedRoute }: { isProtectedRoute: boolean }) => (
 
 const ForbiddenPage = () => {
   const renderContext = use(RenderContext);
-  renderContext.status = 403;
+  setSsrStatus(renderContext, 403);
 
   return (
     <Layout>
@@ -196,7 +199,7 @@ export const RouteGuard = () => {
   }
 
   if (needsToSignIn) {
-    if (typeof window === "undefined") renderContext.status = 401;
+    setSsrStatus(renderContext, 401);
     if (auth.isPending) return null;
     return (
       <SignInRequiredPage redirectTo={location.pathname + location.search} />


### PR DESCRIPTION
## Summary

- return HTTP 404 for SSR requests that render the wildcard not-found route
- preserve existing non-200 statuses such as authentication guards returning 401 or 403
- keep explicit status-page routes unchanged and avoid public CDN cache headers on wildcard 404 responses

## Root cause

The wildcard route always matched unknown paths, so React Router produced a successful static-handler context and the SSR response stayed at 200 even though it rendered the not-found page. This created soft 404 responses that broke monitoring and SEO semantics and could be cached by shared caches.

## Validation

- `pnpm check`
- `pnpm -F zudoku typecheck`
- `pnpm test`
- `pnpm vitest run packages/zudoku/src/app/entry.server.test.tsx`