### PR TITLE
feat(openapi): Add two slot targets in OpenAPI operations

### DIFF
--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import type { UseAuthReturn } from "../../lib/authentication/hook.js";
 import type { AuthState } from "../../lib/authentication/state.js";
 import type { SlotType } from "../../lib/components/context/SlotProvider.js";
+import type { SlotConfig } from "../../lib/components/Slot.js";
 import type { ZudokuPlugin } from "../../lib/core/plugins.js";
 import { mergeConfig } from "../../lib/core/transform-config.js";
 import type { ZudokuContext } from "../../lib/core/ZudokuContext.js";
@@ -711,7 +712,9 @@ const CdnUrlSchema = z
   });
 
 const BaseConfigSchema = z.object({
-  slots: z.record(z.string(), z.custom<SlotType>()),
+  slots: z.custom<SlotConfig>(
+    (slots) => z.record(z.string(), z.custom()).safeParse(slots).success,
+  ),
   /**
    * @deprecated Use `slots` instead
    */

--- a/packages/zudoku/src/lib/components/Slot.test.tsx
+++ b/packages/zudoku/src/lib/components/Slot.test.tsx
@@ -12,13 +12,13 @@ import { describe, expect, it } from "vitest";
 import { ZudokuContext } from "../core/ZudokuContext.js";
 import { SlotProvider } from "./context/SlotProvider.js";
 import { ZudokuProvider } from "./context/ZudokuProvider.js";
-import { Slot } from "./Slot.js";
+import { Slot, type SlotConfig } from "./Slot.js";
 
 /**
  * @vitest-environment happy-dom
  */
 
-const createWrapper = (slots: Record<string, ReactNode> = {}) => {
+const createWrapper = (slots: SlotConfig = {}) => {
   const queryClient = new QueryClient();
   const context = new ZudokuContext({}, queryClient, {});
 
@@ -37,10 +37,7 @@ const createWrapper = (slots: Record<string, ReactNode> = {}) => {
 
 // We wrap every render function with `act` because of Suspense:
 // https://github.com/testing-library/react-testing-library/issues/1375
-const render = async (
-  element: ReactNode,
-  slots: Record<string, ReactNode> = {},
-) => {
+const render = async (element: ReactNode, slots: SlotConfig = {}) => {
   let renderResult: unknown;
   const { wrapper } = createWrapper(slots);
 
@@ -276,6 +273,76 @@ describe("Slot", () => {
       );
 
       expect(screen.getByText("Source content")).toBeInTheDocument();
+    });
+  });
+
+  describe("Slots with data", () => {
+    it("handles slots that pass data", async () => {
+      await render(
+        <>
+          <Slot.Target
+            name="after-openapi-operation-description"
+            data={{ operationId: "myId" }}
+          />
+        </>,
+        {
+          "after-openapi-operation-description": ({ data }) => (
+            <div>{data.operationId}</div>
+          ),
+        },
+      );
+
+      expect(screen.getByText("myId")).toBeInTheDocument();
+    });
+
+    it("handles multiple slots of same name with different data", async () => {
+      await render(
+        <>
+          <Slot.Target
+            name="after-openapi-operation-description"
+            data={{ operationId: "myId" }}
+          />
+          <Slot.Target
+            name="after-openapi-operation-description"
+            data={{ operationId: "myOtherId" }}
+          />
+        </>,
+        {
+          "after-openapi-operation-description": ({ data }) => (
+            <div>{data.operationId}</div>
+          ),
+        },
+      );
+
+      expect(screen.getByText("myId")).toBeInTheDocument();
+      expect(screen.getByText("myOtherId")).toBeInTheDocument();
+    });
+
+    it("handles re-renders with changed data", async () => {
+      const { rerender } = await render(
+        <>
+          <Slot.Target
+            name="after-openapi-operation-description"
+            data={{ operationId: "myId" }}
+          />
+        </>,
+        {
+          "after-openapi-operation-description": ({ data }) => (
+            <div>{data.operationId}</div>
+          ),
+        },
+      );
+
+      rerender(
+        <>
+          <Slot.Target
+            name="after-openapi-operation-description"
+            data={{ operationId: "myOtherId" }}
+          />
+        </>,
+      );
+
+      expect(screen.getByText("myOtherId")).toBeInTheDocument();
     });
   });
 

--- a/packages/zudoku/src/lib/components/Slot.tsx
+++ b/packages/zudoku/src/lib/components/Slot.tsx
@@ -10,25 +10,37 @@ import {
 // and for the user to use them in their own components
 export type CustomSlotNames = never;
 
-type PredefinedSlotNames =
-  | "api-keys-list-page"
-  | "api-keys-list-page-before-keys"
-  | "footer-after"
-  | "footer-before"
-  | "head-navigation-end"
-  | "head-navigation-start"
-  | "layout-after-head"
-  | "layout-before-head"
-  | "top-navigation-after"
-  | "top-navigation-before"
-  | "top-navigation-side"
-  | "content-before"
-  | "content-after"
-  | "navigation-after"
-  | "navigation-before"
-  | "mobile-top-bar-end";
+type NoData = Record<string, never>;
 
-export type SlotName = PredefinedSlotNames | CustomSlotNames;
+type PredefinedSlotData = {
+  "api-keys-list-page": NoData;
+  "api-keys-list-page-before-keys": NoData;
+  "footer-after": NoData;
+  "footer-before": NoData;
+  "head-navigation-end": NoData;
+  "head-navigation-start": NoData;
+  "layout-after-head": NoData;
+  "layout-before-head": NoData;
+  "top-navigation-after": NoData;
+  "top-navigation-before": NoData;
+  "top-navigation-side": NoData;
+  "content-before": NoData;
+  "content-after": NoData;
+  "navigation-after": NoData;
+  "navigation-before": NoData;
+  "mobile-top-bar-end": NoData;
+  "after-openapi-operation-description": { operationId: string | null };
+  "before-openapi-operation-title": { operationId: string | null };
+};
+
+type SlotData = PredefinedSlotData & Record<CustomSlotNames, unknown>;
+
+export type SlotName = keyof SlotData;
+
+export type SlotConfig = Partial<{
+  [N in keyof SlotData]: SlotType<SlotData[N]>;
+}> &
+  Record<string, SlotType<any>>;
 
 export const Slot = {
   Source: ({
@@ -56,8 +68,16 @@ export const Slot = {
     return null;
   },
 
-  Target: ({ name, fallback }: { name: string; fallback?: ReactNode }) => {
-    const slot = useRenderSlot(name);
+  Target: ({
+    name,
+    fallback,
+    data,
+  }: {
+    name: string;
+    fallback?: ReactNode;
+    data?: unknown;
+  }) => {
+    const slot = useRenderSlot(name, data);
 
     if (slot.length === 0) return fallback;
     return slot;

--- a/packages/zudoku/src/lib/components/context/SlotProvider.tsx
+++ b/packages/zudoku/src/lib/components/context/SlotProvider.tsx
@@ -14,7 +14,9 @@ import {
   useExposedProps,
 } from "../../util/useExposedProps.js";
 
-export type SlotType = ReactNode | ComponentType<ExposedComponentProps>;
+export type SlotType<DataType = unknown> =
+  | ReactNode
+  | ComponentType<ExposedComponentProps & { data: DataType }>;
 
 type SlotItem = {
   id: string;
@@ -125,7 +127,7 @@ export function useSlotContext<T>(selector: (state: SlotStoreState) => T): T {
 
 const ORDER = ["prepend", "replace", "append"] as const;
 
-export const useRenderSlot = (name: string) => {
+export const useRenderSlot = (name: string, data: unknown = {}) => {
   const exposedProps = useExposedProps();
   const items = useSlotContext((s) => s.getItems(name));
 
@@ -140,10 +142,10 @@ export const useRenderSlot = (name: string) => {
       })
       .map((item) =>
         typeof item.content === "function" ? (
-          <item.content key={item.id} {...exposedProps} />
+          <item.content key={item.id} {...exposedProps} data={data} />
         ) : (
           <Fragment key={item.id}>{item.content}</Fragment>
         ),
       );
-  }, [items, exposedProps]);
+  }, [items, exposedProps, data]);
 };

--- a/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Badge } from "zudoku/ui/Badge.js";
 import { Separator } from "zudoku/ui/Separator.js";
 import { Heading } from "../../components/Heading.js";
+import { Slot } from "../../components/index.js";
 import { Markdown } from "../../components/Markdown.js";
 import { PagefindSearchMeta } from "../../components/PagefindSearchMeta.js";
 import { cn } from "../../util/cn.js";
@@ -113,12 +114,15 @@ export const OperationListItem = ({
       >
         {isGraphQLEndpoint ? (
           <div className="flex flex-col gap-4 min-w-0">
+            <Slot.Target name="before-openapi-operation-title" />
             {heading}
             {methodPathBlock}
             {description}
+            <Slot.Target name="after-openapi-operation-description" />
           </div>
         ) : (
           <>
+            <Slot.Target name="before-openapi-operation-title" />
             {heading}
             {methodPathBlock}
             {isMCPEndpoint ? (
@@ -139,6 +143,7 @@ export const OperationListItem = ({
                 )}
               >
                 {description}
+                <Slot.Target name="after-openapi-operation-description" />
                 {operation.parameters &&
                   operation.parameters.length > 0 &&
                   PARAM_GROUPS.flatMap((group) =>

--- a/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/OperationListItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "zudoku/ui/Badge.js";
 import { Separator } from "zudoku/ui/Separator.js";
 import { Heading } from "../../components/Heading.js";
@@ -98,6 +98,11 @@ export const OperationListItem = ({
     />
   );
 
+  const operationSlotData = useMemo(
+    () => ({ operationId: operation.operationId }),
+    [operation.operationId],
+  );
+
   return (
     <div>
       {operation.deprecated && (
@@ -114,15 +119,24 @@ export const OperationListItem = ({
       >
         {isGraphQLEndpoint ? (
           <div className="flex flex-col gap-4 min-w-0">
-            <Slot.Target name="before-openapi-operation-title" />
+            <Slot.Target
+              name="before-openapi-operation-title"
+              data={operationSlotData}
+            />
             {heading}
             {methodPathBlock}
             {description}
-            <Slot.Target name="after-openapi-operation-description" />
+            <Slot.Target
+              name="after-openapi-operation-description"
+              data={operationSlotData}
+            />
           </div>
         ) : (
           <>
-            <Slot.Target name="before-openapi-operation-title" />
+            <Slot.Target
+              name="before-openapi-operation-title"
+              data={operationSlotData}
+            />
             {heading}
             {methodPathBlock}
             {isMCPEndpoint ? (
@@ -143,7 +157,10 @@ export const OperationListItem = ({
                 )}
               >
                 {description}
-                <Slot.Target name="after-openapi-operation-description" />
+                <Slot.Target
+                  name="after-openapi-operation-description"
+                  data={operationSlotData}
+                />
                 {operation.parameters &&
                   operation.parameters.length > 0 &&
                   PARAM_GROUPS.flatMap((group) =>


### PR DESCRIPTION
I would like to propose two new slot targets, for use in OpenAPI specifications:
- "before-openapi-operation-title": Above the title, can be used to add badges, for example
- "after-openapi-operation-description": Below the description, can be used to add more custom description, for example.

The reason we need this is that we define a few custom OpenAPI-extensions that we would like to display in Zudoku.