### PR TITLE
Fix Clerk auth for preview deployments in CosmoCargoExample

### DIFF
--- a/examples/cosmo-cargo/.env.example
+++ b/examples/cosmo-cargo/.env.example
@@ -1,9 +1,9 @@
 # Rename this file to `.env` to use environment variables locally.
 
-# Clerk publishable key. The config defaults to the production instance
-# (clerk.cosmocargo.dev), which is scoped to that domain and so will not
-# authenticate from localhost. Uncomment below to point local development at the
-# shared test instance instead.
+# Clerk publishable key. Only the production deployment uses the production
+# instance (clerk.cosmocargo.dev); preview deployments and local development
+# fall back to the shared development instance, so nothing needs to be set here
+# to sign in locally. Set this to point at a different Clerk instance.
 #
 # Note: Zudoku only exposes variables prefixed with ZUDOKU_PUBLIC_ or
 # ZUPLO_PUBLIC_ — the NEXT_PUBLIC_ name from Clerk's dashboard is not read.

--- a/examples/cosmo-cargo/vercel.json
+++ b/examples/cosmo-cargo/vercel.json
@@ -1,7 +1,7 @@
 {
   "framework": null,
   "devCommand": "npx nx run cosmo-cargo:dev",
-  "buildCommand": "npx nx run cosmo-cargo:build",
+  "buildCommand": "ZUDOKU_PUBLIC_VERCEL_ENV=$VERCEL_ENV npx nx run cosmo-cargo:build",
   "outputDirectory": "dist",
   "installCommand": "pnpm install",
   "cleanUrls": true

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -19,14 +19,23 @@ import "./custom.css";
 // highlighted at the same time as the Employee MCP one.
 const EMPLOYEE_MCP_PATH = "/employee-mcp";
 
-// The production Clerk instance, served from clerk.cosmocargo.dev. Publishable
-// keys are shipped to the browser by design, so this is safe to commit. The
-// instance is scoped to that domain, so local development should override it
-// with the test key via ZUDOKU_PUBLIC_CLERK_PUB_KEY (see .env.example).
+// Clerk publishable keys are shipped to the browser by design, so both are safe
+// to commit. The production instance is served from clerk.cosmocargo.dev and is
+// scoped to that domain, so it only authenticates on the production deployment;
+// preview deployments and local development have to use the development
+// instance instead.
+const CLERK_PUB_KEY_PRODUCTION = "pk_live_Y2xlcmsuY29zbW9jYXJnby5kZXYk";
+const CLERK_PUB_KEY_DEVELOPMENT =
+  "pk_test_dG9sZXJhbnQtaG9ybmV0LTQ2LmNsZXJrLmFjY291bnRzLmRldiQ";
+
+// `ZUDOKU_PUBLIC_VERCEL_ENV` mirrors Vercel's `VERCEL_ENV` and is set by the
+// build command in vercel.json. Only ZUDOKU_PUBLIC_/ZUPLO_PUBLIC_ variables are
+// inlined into the client bundle, so reading `VERCEL_ENV` here would resolve to
+// `undefined` in the browser and always pick the production key.
 const CLERK_PUB_KEY = (process.env.ZUDOKU_PUBLIC_CLERK_PUB_KEY ??
-  "pk_live_Y2xlcmsuY29zbW9jYXJnby5kZXYk") as
-  | `pk_test_${string}`
-  | `pk_live_${string}`;
+  (process.env.ZUDOKU_PUBLIC_VERCEL_ENV === "production"
+    ? CLERK_PUB_KEY_PRODUCTION
+    : CLERK_PUB_KEY_DEVELOPMENT)) as `pk_test_${string}` | `pk_live_${string}`;
 
 export class CosmoCargoApiIdentityPlugin implements ApiIdentityPlugin {
   async getIdentities(context: ZudokuContext) {


### PR DESCRIPTION
## Summary

Updates the CosmoCargoExample to properly handle Clerk authentication across different deployment environments (production, preview, and local development) by automatically selecting the appropriate Clerk instance based on the deployment context.

## Key Changes

- **zudoku.config.tsx**: 
  - Extracted Clerk publishable keys into named constants (`CLERK_PUB_KEY_PRODUCTION` and `CLERK_PUB_KEY_DEVELOPMENT`)
  - Updated the key selection logic to check `ZUDOKU_PUBLIC_VERCEL_ENV` environment variable and use the production key only when deployed to production, falling back to the development key for preview deployments and local development
  - Improved comments to clarify the authentication behavior across environments

- **vercel.json**:
  - Modified build command to pass Vercel's `VERCEL_ENV` as `ZUDOKU_PUBLIC_VERCEL_ENV` so it's available in the client bundle (only `ZUDOKU_PUBLIC_` and `ZUPLO_PUBLIC_` prefixed variables are inlined)

- **.env.example**:
  - Updated documentation to reflect that no environment variable setup is needed for local development or preview deployments, as they automatically use the shared development Clerk instance
  - Clarified that the variable should only be set if pointing to a different Clerk instance

## Implementation Details

The production Clerk instance is scoped to `clerk.cosmocargo.dev` and only authenticates on the production deployment. Preview deployments and local development now automatically fall back to the shared development instance without requiring manual environment variable configuration.

https://claude.ai/code/session_01XV6qMqiEVSoq1EQ93u8rT4