### PR TITLE
Add MCP gateway virtual server support to documentation

### DIFF
--- a/docs/pages/docs/guides/mcp-servers.md
+++ b/docs/pages/docs/guides/mcp-servers.md
@@ -7,7 +7,8 @@ zuplo: false
 Zudoku can render a dedicated [MCP](https://modelcontextprotocol.io/) endpoint UI for any OpenAPI
 operation that has the `x-mcp-server` extension. When detected, the operation page replaces the
 standard request/response view with an MCP card showing the endpoint URL, a copy button, and tabbed
-installation instructions for Claude, ChatGPT, Cursor, VS Code, and a generic config.
+installation instructions for Claude, ChatGPT, Cursor, VS Code, and a generic config — followed by
+what the server exposes, when the extension documents it.
 
 ## Adding the extension
 
@@ -60,7 +61,7 @@ metadata. In this case, the operation's `summary` is used as the server name.
 | `name`    | `string` | No       | Display name used in the generated client configuration snippets. Falls back to the operation `summary`, then `"mcp-server"` |
 | `version` | `string` | No       | Version metadata (included for completeness; not currently rendered in UI)                                                   |
 | `url`     | `string` | No       | Overrides the endpoint URL shown in the card and install snippets                                                            |
-| `tools`   | `array`  | No       | Tools metadata (used by Zuplo enrichment; not currently rendered in UI)                                                      |
+| `tools`   | `array`  | No       | Tools the server exposes, listed on the page                                                                                 |
 
 Each tool in the `tools` array has:
 
@@ -68,6 +69,21 @@ Each tool in the `tools` array has:
 | ------------- | -------- | -------- | ------------------------------- |
 | `name`        | `string` | Yes      | Tool name                       |
 | `description` | `string` | No       | Human-readable tool description |
+
+The extension also takes `prompts`, `resources`, and `resourceTemplates`, listed the same way. See
+the [`x-mcp-server` reference](/docs/openapi-extensions/x-mcp-server#mcp-server-object) for their
+shapes.
+
+## Capabilities
+
+Whatever the extension documents — tools, prompts, resources, resource templates — is listed under
+the connect card, so a reader can tell what a server does before they install it. Each entry shows
+the key its client will match on (a tool or prompt `name`, a resource `uri`, a template's
+`uriTemplate`) along with its description.
+
+The card is omitted entirely when the extension documents no capabilities. That is the honest
+outcome for a server whose capabilities are only known at runtime — an MCP gateway passing an
+upstream's tools straight through, for instance — rather than an empty list implying it has none.
 
 ## MCP URL resolution
 

--- a/docs/pages/docs/openapi-extensions/x-mcp-server.md
+++ b/docs/pages/docs/openapi-extensions/x-mcp-server.md
@@ -28,19 +28,34 @@ The `x-mcp-server` extension is added at the **Operation Object** level.
 
 When using the object form, the following properties are available:
 
-| Property  | Type            | Required | Description                                                                                                                  |
-| --------- | --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `name`    | `string`        | No       | Display name used in the generated client configuration snippets. Falls back to the operation `summary`, then `"mcp-server"` |
-| `version` | `string`        | No       | Version metadata                                                                                                             |
-| `url`     | `string`        | No       | Overrides the endpoint URL shown in the card and install snippets. See [MCP URL resolution](#mcp-url-resolution)             |
-| `tools`   | `[Tool Object]` | No       | Array of tools provided by the MCP server                                                                                    |
+| Property            | Type                            | Required | Description                                                                                                                  |
+| ------------------- | ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `name`              | `string`                        | No       | Display name used in the generated client configuration snippets. Falls back to the operation `summary`, then `"mcp-server"` |
+| `version`           | `string`                        | No       | Version metadata                                                                                                             |
+| `url`               | `string`                        | No       | Overrides the endpoint URL shown in the card and install snippets. See [MCP URL resolution](#mcp-url-resolution)             |
+| `authType`          | `"none" \| "apiKey" \| "oauth"` | No       | How clients authenticate. Takes precedence over the type inferred from `securitySchemes`                                     |
+| `tools`             | `[Tool Object]`                 | No       | Tools the server exposes                                                                                                     |
+| `prompts`           | `[Prompt Object]`               | No       | Prompts the server exposes                                                                                                   |
+| `resources`         | `[Resource Object]`             | No       | Resources the server exposes                                                                                                 |
+| `resourceTemplates` | `[Resource Template Object]`    | No       | Resource templates the server exposes                                                                                        |
 
-Each item in the `tools` array:
+Each capability is identified the way the protocol identifies it — tools and prompts by `name`,
+resources by `uri`, resource templates by `uriTemplate`. A bare string is accepted as shorthand for
+that key alone.
 
-| Property      | Type     | Required | Description                     |
-| ------------- | -------- | -------- | ------------------------------- |
-| `name`        | `string` | Yes      | Tool name                       |
-| `description` | `string` | No       | Human-readable tool description |
+| Object            | Key           | Other properties                  |
+| ----------------- | ------------- | --------------------------------- |
+| Tool              | `name`        | `description`                     |
+| Prompt            | `name`        | `description`                     |
+| Resource          | `uri`         | `name`, `description`, `mimeType` |
+| Resource Template | `uriTemplate` | `name`, `description`, `mimeType` |
+
+### Authentication
+
+`authType` states outright how clients authenticate, for servers whose flow no OpenAPI security
+scheme describes — an MCP gateway's inbound OAuth, for instance, is discovered by the client itself.
+Without it, the type is inferred from the first entry in `securitySchemes`: `oauth2` and
+`openIdConnect` mean OAuth, `http` and `apiKey` mean an API key.
 
 ## MCP URL resolution
 
@@ -110,6 +125,10 @@ paths:
             description: Search the documentation
           - name: get_page
             description: Retrieve a specific documentation page
+        resources:
+          - uri: docs://changelog
+            name: Changelog
+            mimeType: text/markdown
       responses:
         "200":
           description: MCP response
@@ -120,6 +139,8 @@ paths:
 When detected, the operation page shows:
 
 - **MCP Endpoint card** with the full URL and a copy button
+- **Capabilities card** listing the tools, prompts, resources, and resource templates the extension
+  documents — omitted entirely when it documents none
 - **AI Tool Configuration** tabs with setup instructions for:
   - **Claude** — add via Connectors UI or `claude mcp add` CLI command
   - **ChatGPT** — app setup via Settings → Apps → Advanced Settings

--- a/docs/pages/docs/openapi-extensions/x-mcp-server.md
+++ b/docs/pages/docs/openapi-extensions/x-mcp-server.md
@@ -54,8 +54,10 @@ that key alone.
 
 `authType` states outright how clients authenticate, for servers whose flow no OpenAPI security
 scheme describes — an MCP gateway's inbound OAuth, for instance, is discovered by the client itself.
-Without it, the type is inferred from the first entry in `securitySchemes`: `oauth2` and
-`openIdConnect` mean OAuth, `http` and `apiKey` mean an API key.
+Without it, the type is inferred from the security the extension carries: the first requirement in
+`security` names a scheme, and that scheme is looked up in `securitySchemes`. An `oauth2` or
+`openIdConnect` scheme means OAuth, `http` or `apiKey` means an API key. Anything else — including a
+scheme the lookup does not find — means no authentication.
 
 ## MCP URL resolution
 

--- a/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
+++ b/packages/zudoku/src/lib/plugins/openapi/MCPEndpoint.tsx
@@ -7,6 +7,7 @@ import {
 import { type ReactNode, useState } from "react";
 import { InlineCode } from "../../components/InlineCode.js";
 import { Typography } from "../../components/Typography.js";
+import { Badge } from "../../ui/Badge.js";
 import { Button } from "../../ui/Button.js";
 import { Callout } from "../../ui/Callout.js";
 import { Card } from "../../ui/Card.js";
@@ -16,6 +17,7 @@ import { cn } from "../../util/cn.js";
 import {
   CLAUDE_CONNECTORS_URL,
   type McpApp,
+  type McpCapabilityGroup,
   type McpServerData,
   getClaudeCodeCommand,
   getCodexCliCommand,
@@ -23,6 +25,7 @@ import {
   getCursorConfig,
   getCursorDeepLink,
   getGenericConfig,
+  getMcpCapabilities,
   getMcpServerName,
   getMcpUrl,
   getVisibleApps,
@@ -79,6 +82,62 @@ const InstallButton = ({
   </Button>
 );
 
+// What the server exposes, listed so a reader can tell whether it is worth
+// connecting before they follow the setup steps. Only rendered when the
+// capabilities are known from config — see getMcpCapabilities.
+const Capabilities = ({
+  name,
+  groups,
+}: {
+  name: string;
+  groups: McpCapabilityGroup[];
+}) => (
+  <Card className="p-6 mb-6 max-w-screen-md">
+    <div className="space-y-5">
+      <div>
+        <h3 className="text-lg font-semibold">What {name} exposes</h3>
+        <p className="text-sm text-muted-foreground">
+          Available to any client connected to this server.
+        </p>
+      </div>
+      {groups.map((group) => (
+        <div key={group.id} className="space-y-2">
+          <div className="text-sm font-medium">
+            {group.label}{" "}
+            <span className="text-muted-foreground tabular-nums">
+              ({group.items.length})
+            </span>
+          </div>
+          <ul className="not-prose divide-y rounded-lg border">
+            {group.items.map((item) => (
+              <li key={item.id} className="flex flex-col gap-1 p-3">
+                <div className="flex flex-wrap items-baseline gap-2">
+                  <code className="font-mono text-sm break-all">{item.id}</code>
+                  {item.label && (
+                    <span className="text-xs text-muted-foreground">
+                      {item.label}
+                    </span>
+                  )}
+                  {item.mimeType && (
+                    <Badge variant="muted" className="text-xs font-mono">
+                      {item.mimeType}
+                    </Badge>
+                  )}
+                </div>
+                {item.description && (
+                  <p className="text-sm text-muted-foreground">
+                    {item.description}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </Card>
+);
+
 export const MCPEndpoint = ({
   serverUrl,
   operationPath,
@@ -99,6 +158,7 @@ export const MCPEndpoint = ({
     disableAuthInstructions,
   });
   const visibleApps = getVisibleApps(authType);
+  const capabilityGroups = getMcpCapabilities(data);
 
   const claudeCodeCommand = getClaudeCodeCommand(name, mcpUrl, auth);
   const codexCliCommand = getCodexCliCommand(name, mcpUrl, auth);
@@ -412,108 +472,116 @@ export const MCPEndpoint = ({
   };
 
   return (
-    <Card className="p-6 mb-6 max-w-screen-md">
-      <div className="space-y-5">
-        <div>
-          <h3 className="text-lg font-semibold">Connect {name}</h3>
-          <p className="text-sm text-muted-foreground">
-            Add this MCP server to your favorite AI tools in a few steps.
-          </p>
-        </div>
-
-        {/* Step 1 — the one thing every client needs: the server URL. */}
-        <div className="rounded-lg border bg-muted/30 p-3">
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-xs font-medium text-muted-foreground mb-1">
-                MCP Server URL
-              </div>
-              <code className="block truncate font-mono text-sm">{mcpUrl}</code>
-            </div>
-            <Button
-              onClick={handleCopy}
-              variant="outline"
-              size="sm"
-              className="gap-1.5 shrink-0"
-            >
-              {isCopied ? (
-                <CheckIcon className="h-3.5 w-3.5 text-green-600" />
-              ) : (
-                <CopyIcon className="h-3.5 w-3.5" />
-              )}
-              {isCopied ? "Copied!" : "Copy"}
-            </Button>
-          </div>
-          {auth && (
-            <p className="mt-2 text-xs text-muted-foreground">
-              Requires an <InlineCode>{auth.headerName}</InlineCode> header —
-              replace <InlineCode>{auth.placeholder}</InlineCode> with your key.
+    <>
+      <Card className="p-6 mb-6 max-w-screen-md">
+        <div className="space-y-5">
+          <div>
+            <h3 className="text-lg font-semibold">Connect {name}</h3>
+            <p className="text-sm text-muted-foreground">
+              Add this MCP server to your favorite AI tools in a few steps.
             </p>
+          </div>
+
+          {/* Step 1 — the one thing every client needs: the server URL. */}
+          <div className="rounded-lg border bg-muted/30 p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-xs font-medium text-muted-foreground mb-1">
+                  MCP Server URL
+                </div>
+                <code className="block truncate font-mono text-sm">
+                  {mcpUrl}
+                </code>
+              </div>
+              <Button
+                onClick={handleCopy}
+                variant="outline"
+                size="sm"
+                className="gap-1.5 shrink-0"
+              >
+                {isCopied ? (
+                  <CheckIcon className="h-3.5 w-3.5 text-green-600" />
+                ) : (
+                  <CopyIcon className="h-3.5 w-3.5" />
+                )}
+                {isCopied ? "Copied!" : "Copy"}
+              </Button>
+            </div>
+            {auth && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Requires an <InlineCode>{auth.headerName}</InlineCode> header —
+                replace <InlineCode>{auth.placeholder}</InlineCode> with your
+                key.
+              </p>
+            )}
+          </div>
+
+          {/* Step 2 — pick your client. */}
+          <div className="space-y-2">
+            <div className="text-sm font-medium">Choose your client</div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {visibleApps.map((app) => {
+                const isActive = app.id === selectedApp?.id;
+                return (
+                  <button
+                    key={app.id}
+                    type="button"
+                    onClick={() => selectApp(app.id)}
+                    aria-pressed={isActive}
+                    data-active={isActive}
+                    className={cn(
+                      "flex flex-col items-center justify-center gap-2 rounded-lg border p-3 transition",
+                      "hover:bg-muted/60",
+                      isActive
+                        ? "border-primary bg-primary/5 ring-1 ring-primary text-foreground"
+                        : "border-border text-muted-foreground",
+                    )}
+                  >
+                    <McpClientLogo appId={app.id} className="size-6" />
+                    <span className="text-xs font-medium">{app.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Step 3 — client-specific setup walkthrough. */}
+          {selectedApp && (
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="text-sm font-medium">
+                  Set up {selectedApp.label}
+                </div>
+                {selectedApp.subApps.length > 1 && (
+                  <ToggleGroup
+                    size="sm"
+                    variant="outline"
+                    spacing={2}
+                    aria-label={`Set up method for ${selectedApp.label}`}
+                    value={activeSubApp ? [activeSubApp.id] : []}
+                    onValueChange={(value: string[]) => {
+                      const next = value.at(0);
+                      if (next) setSelectedSubAppId(next);
+                    }}
+                  >
+                    {selectedApp.subApps.map((sub) => (
+                      <ToggleGroupItem key={sub.id} value={sub.id}>
+                        {sub.label}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                )}
+              </div>
+              <Typography className="text-sm max-w-full">
+                {renderSetup(selectedApp)}
+              </Typography>
+            </div>
           )}
         </div>
-
-        {/* Step 2 — pick your client. */}
-        <div className="space-y-2">
-          <div className="text-sm font-medium">Choose your client</div>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-            {visibleApps.map((app) => {
-              const isActive = app.id === selectedApp?.id;
-              return (
-                <button
-                  key={app.id}
-                  type="button"
-                  onClick={() => selectApp(app.id)}
-                  aria-pressed={isActive}
-                  data-active={isActive}
-                  className={cn(
-                    "flex flex-col items-center justify-center gap-2 rounded-lg border p-3 transition",
-                    "hover:bg-muted/60",
-                    isActive
-                      ? "border-primary bg-primary/5 ring-1 ring-primary text-foreground"
-                      : "border-border text-muted-foreground",
-                  )}
-                >
-                  <McpClientLogo appId={app.id} className="size-6" />
-                  <span className="text-xs font-medium">{app.label}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Step 3 — client-specific setup walkthrough. */}
-        {selectedApp && (
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="text-sm font-medium">
-                Set up {selectedApp.label}
-              </div>
-              {selectedApp.subApps.length > 1 && (
-                <ToggleGroup
-                  size="sm"
-                  variant="outline"
-                  spacing={2}
-                  aria-label={`Set up method for ${selectedApp.label}`}
-                  value={activeSubApp ? [activeSubApp.id] : []}
-                  onValueChange={(value: string[]) => {
-                    const next = value.at(0);
-                    if (next) setSelectedSubAppId(next);
-                  }}
-                >
-                  {selectedApp.subApps.map((sub) => (
-                    <ToggleGroupItem key={sub.id} value={sub.id}>
-                      {sub.label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
-              )}
-            </div>
-            <Typography className="text-sm max-w-full">
-              {renderSetup(selectedApp)}
-            </Typography>
-          </div>
-        )}
-      </div>
-    </Card>
+      </Card>
+      {capabilityGroups.length > 0 && (
+        <Capabilities name={name} groups={capabilityGroups} />
+      )}
+    </>
   );
 };

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
@@ -267,6 +267,27 @@ describe("resolveMcpAuth", () => {
     ).toEqual({ authType: "none" });
   });
 
+  it("does not derive an api key header for a declared oauth server", () => {
+    // A gateway carries both: the OAuth policy sets authType, while the route
+    // still documents a security scheme a header would be inferred from.
+    expect(
+      resolveMcpAuth({
+        authType: "oauth",
+        security: [{ key: [] }],
+        securitySchemes: {
+          key: { type: "apiKey", in: "header", name: "X-API-Key" },
+        },
+      }),
+    ).toEqual({ authType: "oauth", auth: undefined });
+  });
+
+  it("does not derive an api key header for a declared unauthenticated server", () => {
+    expect(resolveMcpAuth({ authType: "none", ...apiKeyData })).toEqual({
+      authType: "none",
+      auth: undefined,
+    });
+  });
+
   it("resolves no auth for servers without security", () => {
     expect(resolveMcpAuth(true)).toEqual({
       authType: "none",

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.test.ts
@@ -9,6 +9,7 @@ import {
   getCursorConfig,
   getCursorDeepLink,
   getGenericConfig,
+  getMcpCapabilities,
   getMcpServerName,
   getMcpUrl,
   getVisibleApps,
@@ -76,6 +77,102 @@ describe("getAuthType", () => {
         securitySchemes: { oidc: { type: "openIdConnect" } },
       }),
     ).toBe("oauth");
+  });
+});
+
+describe("getAuthType with an explicit authType", () => {
+  it("returns the declared type", () => {
+    expect(getAuthType({ authType: "oauth" })).toBe("oauth");
+  });
+
+  it("wins over inferring from security schemes", () => {
+    expect(
+      getAuthType({
+        authType: "oauth",
+        security: [{ api_key: [] }],
+        securitySchemes: { api_key: { type: "http", scheme: "bearer" } },
+      }),
+    ).toBe("oauth");
+  });
+
+  it("falls back to the security schemes when not a known type", () => {
+    expect(
+      getAuthType({
+        authType: "sometimes",
+        security: [{ api_key: [] }],
+        securitySchemes: { api_key: { type: "http", scheme: "bearer" } },
+      }),
+    ).toBe("apiKey");
+  });
+});
+
+describe("getMcpCapabilities", () => {
+  it("returns nothing for a server with no documented capabilities", () => {
+    expect(getMcpCapabilities(true)).toEqual([]);
+    expect(getMcpCapabilities({ name: "test" })).toEqual([]);
+  });
+
+  it("groups each capability kind, skipping empty ones", () => {
+    expect(
+      getMcpCapabilities({
+        tools: [{ name: "search_issues", description: "Search issues" }],
+        resources: [
+          {
+            uri: "file:///readme.md",
+            name: "Readme",
+            mimeType: "text/markdown",
+          },
+        ],
+        prompts: [],
+      }),
+    ).toEqual([
+      {
+        id: "tools",
+        label: "Tools",
+        items: [{ id: "search_issues", description: "Search issues" }],
+      },
+      {
+        id: "resources",
+        label: "Resources",
+        items: [
+          {
+            id: "file:///readme.md",
+            label: "Readme",
+            mimeType: "text/markdown",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("accepts a bare string as the capability key", () => {
+    expect(getMcpCapabilities({ tools: ["search_issues", "  "] })).toEqual([
+      { id: "tools", label: "Tools", items: [{ id: "search_issues" }] },
+    ]);
+  });
+
+  it("keys resource templates by their URI template", () => {
+    expect(
+      getMcpCapabilities({
+        resourceTemplates: [
+          { uriTemplate: "file:///{path}", description: "Any file" },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "resourceTemplates",
+        label: "Resource templates",
+        items: [{ id: "file:///{path}", description: "Any file" }],
+      },
+    ]);
+  });
+
+  it("drops entries with no key and non-object entries", () => {
+    expect(
+      getMcpCapabilities({
+        tools: [{ description: "no name" }, 42, null, { name: "kept" }],
+      }),
+    ).toEqual([{ id: "tools", label: "Tools", items: [{ id: "kept" }] }]);
   });
 });
 

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
@@ -100,7 +100,15 @@ export const resolveMcpAuth = (
 ): { authType: AuthType; auth?: AuthHeader } => {
   if (options?.disableAuthInstructions) return { authType: "none" };
 
-  return { authType: getAuthType(data), auth: getAuthHeader(data) };
+  // The header is derived from the resolved type, not independently: a server
+  // that declares `authType` still carries security schemes an inference would
+  // read a credential header out of, and an OAuth or unauthenticated server
+  // must not get "replace YOUR_API_KEY" steps from one.
+  const authType = getAuthType(data);
+  return {
+    authType,
+    auth: authType === "apiKey" ? getAuthHeader(data) : undefined,
+  };
 };
 
 // -- Capabilities --

--- a/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
+++ b/packages/zudoku/src/lib/plugins/openapi/mcp-configs.ts
@@ -14,8 +14,20 @@ export interface AuthHeader {
 
 export type AuthType = "none" | "apiKey" | "oauth";
 
-// Detects auth type from x-mcp-server security data
+const AUTH_TYPES: AuthType[] = ["none", "apiKey", "oauth"];
+
+const isAuthType = (value: unknown): value is AuthType =>
+  typeof value === "string" && AUTH_TYPES.some((type) => type === value);
+
+// Detects auth type from x-mcp-server. An explicit `authType` wins: an MCP
+// gateway's inbound OAuth cannot be described as an OpenAPI security scheme —
+// clients discover that flow themselves — so the extension states it outright
+// instead of fabricating one to be inferred back out.
 export const getAuthType = (data?: McpServerData): AuthType => {
+  if (typeof data !== "boolean" && isAuthType(data?.authType)) {
+    return data.authType;
+  }
+
   if (typeof data === "boolean" || !data?.security || !data?.securitySchemes) {
     return "none";
   }
@@ -89,6 +101,105 @@ export const resolveMcpAuth = (
   if (options?.disableAuthInstructions) return { authType: "none" };
 
   return { authType: getAuthType(data), auth: getAuthHeader(data) };
+};
+
+// -- Capabilities --
+
+// One documented MCP capability. `id` is what the protocol identifies it by —
+// a tool or prompt name, a resource URI, a resource template's URI template —
+// so it is what a user matches against what their client lists.
+export interface McpCapability {
+  id: string;
+  /** Human-readable label, where the protocol carries one beside the id. */
+  label?: string;
+  description?: string;
+  mimeType?: string;
+}
+
+export interface McpCapabilityGroup {
+  id: "tools" | "prompts" | "resources" | "resourceTemplates";
+  label: string;
+  items: McpCapability[];
+}
+
+const readString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+};
+
+// Reads one string property off an object of unknown shape — extension data is
+// whatever the OpenAPI document happened to carry.
+const readStringProp = (source: object, key: string): string | undefined =>
+  readString(Reflect.get(source, key));
+
+// Reads one capability list off the extension. Entries are objects keyed the
+// way the protocol keys that capability kind, and a bare string is accepted as
+// the key alone — the shorthand the gateway's capability filter allows.
+const readCapabilities = (
+  value: unknown,
+  keyProp: "name" | "uri" | "uriTemplate",
+): McpCapability[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((entry: unknown) => {
+    const key = readString(entry);
+    if (key) return [{ id: key }];
+    if (!entry || typeof entry !== "object") return [];
+
+    const id = readStringProp(entry, keyProp);
+    if (!id) return [];
+
+    // A tool's or prompt's name is its id, so it is never also a label.
+    const label =
+      keyProp === "name" ? undefined : readStringProp(entry, "name");
+    const description = readStringProp(entry, "description");
+    const mimeType = readStringProp(entry, "mimeType");
+
+    return [
+      {
+        id,
+        ...(label ? { label } : {}),
+        ...(description ? { description } : {}),
+        ...(mimeType ? { mimeType } : {}),
+      },
+    ];
+  });
+};
+
+// What the server exposes, in the order a user cares about it. Empty for a
+// server whose capabilities Zudoku cannot know at build time — an MCP gateway
+// passing an upstream's tools through untouched, say — in which case the card
+// says nothing rather than guessing.
+export const getMcpCapabilities = (
+  data?: McpServerData,
+): McpCapabilityGroup[] => {
+  if (typeof data === "boolean" || !data) return [];
+
+  const groups: McpCapabilityGroup[] = [
+    {
+      id: "tools",
+      label: "Tools",
+      items: readCapabilities(data.tools, "name"),
+    },
+    {
+      id: "prompts",
+      label: "Prompts",
+      items: readCapabilities(data.prompts, "name"),
+    },
+    {
+      id: "resources",
+      label: "Resources",
+      items: readCapabilities(data.resources, "uri"),
+    },
+    {
+      id: "resourceTemplates",
+      label: "Resource templates",
+      items: readCapabilities(data.resourceTemplates, "uriTemplate"),
+    },
+  ];
+
+  return groups.filter((group) => group.items.length > 0);
 };
 
 // -- App compatibility matrix --

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
@@ -803,6 +803,59 @@ describe("enrichWithZuploMcpServerData", () => {
     expect(op["x-mcp-server"]).toEqual({ name: "Linear" });
   });
 
+  it("should document an empty capability list as exposing none", async () => {
+    const schema = gatewaySchema(
+      gatewayRouteHandler(["mcp-capability-filter"]),
+    );
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: {
+        policies: [
+          {
+            name: "mcp-capability-filter",
+            policyType: "mcp-capability-filter-inbound",
+            handler: {
+              module: "$import(@zuplo/runtime/mcp-gateway)",
+              export: "McpCapabilityFilterInboundPolicy",
+              // Tools filtered down to none; prompts omitted, so the upstream's
+              // pass through and stay unknown.
+              options: { tools: [], resources: ["linear://teams"] },
+            },
+          },
+        ],
+      },
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].tools).toEqual([]);
+    expect(op["x-mcp-server"].prompts).toBeUndefined();
+    expect(op["x-mcp-server"].resources).toEqual([{ uri: "linear://teams" }]);
+  });
+
+  it("should ignore a handler from a module that merely starts like the runtime", async () => {
+    const schema = gatewaySchema({
+      "x-zuplo-route": {
+        corsPolicy: "none",
+        handler: {
+          export: "McpProxyHandler",
+          module: "$import(@zuplo/runtime-custom)",
+          options: {},
+        },
+        policies: { inbound: [] },
+      },
+    });
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"]).toBeUndefined();
+  });
+
   it("should ignore a same-named handler export from another module", async () => {
     const schema = gatewaySchema({
       "x-zuplo-route": {

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.test.ts
@@ -22,6 +22,37 @@ const mcpRouteHandler = (
   },
 });
 
+const gatewayRouteHandler = (
+  inbound: string[] = [],
+  options: Record<string, unknown> = {},
+) => ({
+  "x-zuplo-route": {
+    corsPolicy: "none",
+    handler: {
+      export: "McpProxyHandler",
+      module: "$import(@zuplo/runtime/mcp-gateway)",
+      options: { rewritePattern: "https://mcp.linear.app/mcp", ...options },
+    },
+    policies: { inbound },
+  },
+});
+
+const gatewaySchema = (operation: Record<string, unknown>) =>
+  ({
+    openapi: "3.1.0",
+    info: { title: "Test MCP API", version: "1.0.0" },
+    paths: {
+      "/mcp/linear": {
+        post: {
+          summary: "Linear",
+          operationId: "linear-mcp-server",
+          responses: { "200": { description: "MCP response" } },
+          ...operation,
+        },
+      },
+    },
+  }) as unknown as OpenAPIDocument;
+
 describe("enrichWithZuploMcpServerData", () => {
   let tempDir: string;
   let rootDir: string;
@@ -621,5 +652,210 @@ describe("enrichWithZuploMcpServerData", () => {
 
     // Should not add MCP tag definition since it wasn't assigned
     expect(result.tags).toBeUndefined();
+  });
+  it("should document a gateway virtual server from its policies", async () => {
+    const schema = gatewaySchema(
+      gatewayRouteHandler([
+        "mcp-linear-oauth",
+        "mcp-capability-filter",
+        "mcp-token-exchange-linear",
+      ]),
+    );
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: {
+        policies: [
+          {
+            name: "mcp-linear-oauth",
+            policyType: "mcp-auth0-oauth-inbound",
+            handler: {
+              module: "$import(@zuplo/runtime/mcp-gateway)",
+              export: "McpAuth0OAuthInboundPolicy",
+              options: {},
+            },
+          },
+          {
+            name: "mcp-capability-filter",
+            policyType: "mcp-capability-filter-inbound",
+            handler: {
+              module: "$import(@zuplo/runtime/mcp-gateway)",
+              export: "McpCapabilityFilterInboundPolicy",
+              options: {
+                tools: [
+                  { name: "search_issues", description: "Search issues" },
+                  "create_issue",
+                ],
+                prompts: [{ name: "triage", description: "Triage a bug" }],
+                resources: [
+                  {
+                    uri: "linear://teams",
+                    name: "Teams",
+                    mimeType: "application/json",
+                  },
+                ],
+                resourceTemplates: [{ uriTemplate: "linear://issues/{id}" }],
+              },
+            },
+          },
+          {
+            name: "mcp-token-exchange-linear",
+            policyType: "mcp-token-exchange-inbound",
+            handler: {
+              module: "$import(@zuplo/runtime/mcp-gateway)",
+              export: "McpTokenExchangeInboundPolicy",
+              options: { displayName: "Linear", authMode: "user-oauth" },
+            },
+          },
+        ],
+      },
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"]).toEqual({
+      name: "Linear",
+      authType: "oauth",
+      tools: [
+        { name: "search_issues", description: "Search issues" },
+        { name: "create_issue" },
+      ],
+      prompts: [{ name: "triage", description: "Triage a bug" }],
+      resources: [
+        {
+          uri: "linear://teams",
+          name: "Teams",
+          mimeType: "application/json",
+        },
+      ],
+      resourceTemplates: [{ uriTemplate: "linear://issues/{id}" }],
+    });
+  });
+
+  it("should document a passthrough gateway server without capabilities", async () => {
+    const schema = gatewaySchema(gatewayRouteHandler());
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    // Falls back to the operation summary, and documents no tools: a
+    // passthrough server's list only exists once a client initializes.
+    expect(op["x-mcp-server"]).toEqual({ name: "Linear" });
+  });
+
+  it("should carry the route's own security onto a gateway server", async () => {
+    const schema = gatewaySchema({
+      ...gatewayRouteHandler(),
+      security: [{ api_key: [] }],
+    });
+    schema.components = {
+      securitySchemes: { api_key: { type: "http", scheme: "bearer" } },
+    };
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].security).toEqual([{ api_key: [] }]);
+    expect(op["x-mcp-server"].securitySchemes).toEqual({
+      api_key: { type: "http", scheme: "bearer" },
+    });
+  });
+
+  it("should let an authored x-mcp-server object win over derived data", async () => {
+    const schema = gatewaySchema({
+      ...gatewayRouteHandler(),
+      "x-mcp-server": {
+        name: "Linear (EU)",
+        url: "https://eu.example.com/mcp",
+      },
+    });
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"]).toEqual({
+      name: "Linear (EU)",
+      url: "https://eu.example.com/mcp",
+    });
+  });
+
+  it("should replace the x-mcp-server shorthand with derived data", async () => {
+    const schema = gatewaySchema({
+      ...gatewayRouteHandler(),
+      "x-mcp-server": true,
+    });
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"]).toEqual({ name: "Linear" });
+  });
+
+  it("should ignore a same-named handler export from another module", async () => {
+    const schema = gatewaySchema({
+      "x-zuplo-route": {
+        corsPolicy: "none",
+        handler: {
+          export: "McpProxyHandler",
+          module: "$import(./modules/my-proxy)",
+          options: {},
+        },
+        policies: { inbound: [] },
+      },
+    });
+
+    const result = await enrichWithZuploMcpServerData({ rootDir })(
+      processorArg(schema),
+    );
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"]).toBeUndefined();
+  });
+
+  it("should find gateway policies nested in a composite policy", async () => {
+    const schema = gatewaySchema(gatewayRouteHandler(["mcp-stack"]));
+
+    const result = await enrichWithZuploMcpServerData({
+      rootDir,
+      policiesConfig: {
+        policies: [
+          {
+            name: "mcp-stack",
+            policyType: "composite-inbound",
+            handler: {
+              module: "$import(@zuplo/runtime)",
+              export: "CompositeInboundPolicy",
+              options: { policies: ["mcp-oauth"] },
+            },
+          },
+          {
+            name: "mcp-oauth",
+            policyType: "mcp-oauth-inbound",
+            handler: {
+              module: "$import(@zuplo/runtime/mcp-gateway)",
+              export: "McpOAuthInboundPolicy",
+              options: {},
+            },
+          },
+        ],
+      },
+    })(processorArg(schema));
+
+    // biome-ignore lint/suspicious/noExplicitAny: test assertion
+    const op = result.paths?.["/mcp/linear"]?.post as Record<string, any>;
+    expect(op["x-mcp-server"].authType).toBe("oauth");
   });
 });

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -5,6 +5,10 @@ import type { ProcessorArg } from "../config/validators/BuildSchema.js";
 import { traverse, traverseAsync } from "../lib/util/traverse.js";
 import type { RecordAny } from "../lib/util/types.js";
 import { operations } from "./enrich-with-zuplo.js";
+import type {
+  PoliciesConfigFile,
+  PolicyConfigurationFragment,
+} from "./policy-types.js";
 
 const MCP_TAG_NAME = "MCP";
 const MCP_TAG_DESCRIPTION =
@@ -24,22 +28,82 @@ const DEFAULT_MCP_SERVER_VERSION = "0.0.0";
 // snippets can show the right credentials.
 type ExtensionMcpServer = {
   name: string;
-  version: string;
+  // Omitted for gateway virtual servers: the version belongs to the upstream
+  // server and is only known once a client initializes against it.
+  version?: string;
+  // How clients authenticate, when the config says so plainly. The card
+  // otherwise infers the type from `securitySchemes`, which cannot describe an
+  // MCP gateway's inbound OAuth — clients discover that flow themselves.
+  authType?: "oauth";
   tools?: ExtensionMcpServerTool[];
+  prompts?: ExtensionMcpServerPrompt[];
+  resources?: ExtensionMcpServerResource[];
+  resourceTemplates?: ExtensionMcpServerResourceTemplate[];
   security?: OpenAPIV3_1.SecurityRequirementObject[];
   securitySchemes?: Record<string, OpenAPIV3_1.SecuritySchemeObject>;
 };
 
 // Tool metadata for an `x-mcp-server` tool list. Deviates from the spec's
-// `Tool` in two places: `description` is required because the extractor always
-// resolves one, and `inputSchema` is loose because Zudoku documents only the
-// request body rather than the full JSON Schema object the spec expects — see
-// the TODO in extractOperationSchema.
+// `Tool` in two places: `description` is optional because a gateway's
+// capability filter may expose a tool by name alone, and `inputSchema` is
+// loose because Zudoku documents only the request body rather than the full
+// JSON Schema object the spec expects — see the TODO in extractOperationSchema.
 type ExtensionMcpServerTool = {
   name: string;
-  description: string;
+  description?: string;
   inputSchema?: object;
 };
+
+// The remaining MCP capability kinds, documented for gateway virtual servers
+// whose capability filter enumerates them. Keyed the way the protocol keys
+// them: prompts by name, resources by URI, templates by URI template.
+type ExtensionMcpServerPrompt = {
+  name: string;
+  description?: string;
+};
+
+type ExtensionMcpServerResource = {
+  uri: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+};
+
+type ExtensionMcpServerResourceTemplate = {
+  uriTemplate: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+};
+
+// Handler exports that mount an MCP gateway virtual server — one MCP endpoint
+// fronting an upstream MCP server. `McpProxyHandler` is the current export;
+// the other two are what earlier gateway configs were written with, kept so an
+// unmigrated route still documents itself. The module check mirrors the
+// runtime's own detection (`isBuiltInMcpHandler`) so a customer module that
+// happens to export the same name is not claimed as a gateway.
+const MCP_GATEWAY_HANDLER_EXPORTS = new Set([
+  "McpProxyHandler",
+  "McpVirtualServerHandler",
+  "mcpVirtualServerHandler",
+]);
+const ZUPLO_RUNTIME_MODULE_PREFIX = "$import(@zuplo/runtime";
+
+// The gateway's inbound OAuth policies: the generic `mcp-oauth-inbound` plus
+// the per-IdP variants (`mcp-auth0-oauth-inbound`, `mcp-entra-oauth-inbound`,
+// …). Matched on `policyType`, falling back to the policy class name for
+// configs that omit it.
+const MCP_OAUTH_POLICY_TYPE = /^mcp-(?:[a-z0-9-]+-)?oauth-inbound$/;
+const MCP_OAUTH_POLICY_EXPORT = /^Mcp[A-Za-z0-9]*OAuthInboundPolicy$/;
+
+// The policy carrying the downstream-facing capability list.
+const MCP_CAPABILITY_FILTER_POLICY_TYPE = "mcp-capability-filter-inbound";
+const MCP_CAPABILITY_FILTER_POLICY_EXPORT = "McpCapabilityFilterInboundPolicy";
+
+// The policy carrying the upstream connection's identity, including the
+// display name the gateway itself shows users in connect prompts.
+const MCP_TOKEN_EXCHANGE_POLICY_TYPE = "mcp-token-exchange-inbound";
+const MCP_TOKEN_EXCHANGE_POLICY_EXPORT = "McpTokenExchangeInboundPolicy";
 
 // Reads a non-empty string from an untyped handler option, returning undefined
 // for missing, blank, or non-string values so callers can fall back to a
@@ -138,19 +202,18 @@ interface SecurityExtractionResult {
   securitySchemes: Record<string, OpenAPIV3_1.SecuritySchemeObject>;
 }
 
-// Extracts security from the in-memory schema (already enriched by enrichWithZuploData)
-const extractSecurityFromSchema = (
+// Extracts security from operations of the in-memory schema (already enriched
+// by enrichWithZuploData). Shared by both server kinds: a dynamic server draws
+// on the operations it exposes as tools, a gateway virtual server on the MCP
+// route itself.
+const extractSecurityFromOperations = (
   schema: OpenAPIV3_1.Document,
-  operationIds: string[],
+  operations: OpenAPIV3_1.OperationObject[],
 ): SecurityExtractionResult => {
-  const operationLookup = buildOperationLookup(schema);
   const securityReqs: OpenAPIV3_1.SecurityRequirementObject[] = [];
   const referencedSchemeNames = new Set<string>();
 
-  for (const operationId of operationIds) {
-    const operation = operationLookup.get(operationId);
-    if (!operation) continue;
-
+  for (const operation of operations) {
     // operation-level security takes precedence, fall back to doc-level
     const opSecurity = operation.security ?? schema.security;
     if (opSecurity) {
@@ -177,6 +240,22 @@ const extractSecurityFromSchema = (
   return { security: securityReqs, securitySchemes };
 };
 
+// Looks operations up by id before extracting their security.
+const extractSecurityFromSchema = (
+  schema: OpenAPIV3_1.Document,
+  operationIds: string[],
+): SecurityExtractionResult => {
+  const operationLookup = buildOperationLookup(schema);
+
+  return extractSecurityFromOperations(
+    schema,
+    operationIds.flatMap((operationId) => {
+      const operation = operationLookup.get(operationId);
+      return operation ? [operation] : [];
+    }),
+  );
+};
+
 // Deduplicates security requirements by stringified key
 const deduplicateSecurity = (
   reqs: OpenAPIV3_1.SecurityRequirementObject[],
@@ -190,11 +269,284 @@ const deduplicateSecurity = (
   });
 };
 
-// Enriches an OpenAPI schema with x-mcp-server data based on the Zuplo MCP server handler
+// Whether the route mounts an MCP gateway virtual server. Both the export and
+// the module have to match so a customer module exporting the same name is not
+// mistaken for the gateway (the runtime pairs them the same way).
+const isGatewayHandler = (handler: RecordAny): boolean =>
+  MCP_GATEWAY_HANDLER_EXPORTS.has(handler.export) &&
+  typeof handler.module === "string" &&
+  handler.module.startsWith(ZUPLO_RUNTIME_MODULE_PREFIX);
+
+// Resolves a route's inbound policy names to their definitions in
+// policies.json, expanding one level of composite policy so an MCP policy
+// nested inside one is still found.
+const resolveInboundPolicies = (
+  operation: RecordAny,
+  policiesConfig?: PoliciesConfigFile,
+): PolicyConfigurationFragment[] => {
+  const names = operation["x-zuplo-route"]?.policies?.inbound;
+  if (!Array.isArray(names) || !policiesConfig?.policies) return [];
+
+  const byName = new Map(
+    policiesConfig.policies.map((policy) => [policy.name, policy]),
+  );
+  const lookup = (name: unknown): PolicyConfigurationFragment[] => {
+    const policy = typeof name === "string" ? byName.get(name) : undefined;
+    return policy ? [policy] : [];
+  };
+
+  return names.flatMap((name: unknown) =>
+    lookup(name).flatMap((policy) => {
+      if (policy.handler.export !== "CompositeInboundPolicy") return [policy];
+
+      const children = policy.handler.options?.policies;
+      return Array.isArray(children) ? children.flatMap(lookup) : [];
+    }),
+  );
+};
+
+// Policies are identified by their `policyType`, falling back to the policy
+// class name for configs written without one.
+const isPolicyKind = (
+  policy: PolicyConfigurationFragment,
+  policyType: string,
+  handlerExport: string,
+): boolean =>
+  policy.policyType === policyType || policy.handler.export === handlerExport;
+
+// One entry of a capability filter list, normalized. The policy accepts either
+// a bare key (expose the upstream capability as-is) or a projection object that
+// overrides what clients see, so both shapes collapse to the same record here.
+type CapabilityProjection = {
+  key: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+};
+
+// Reads one capability list off the filter policy's options. `keyProp` is the
+// property the protocol identifies that capability kind by — `name` for tools
+// and prompts, `uri`/`uriTemplate` for resources. Entries without one are
+// dropped rather than documented half-formed.
+const readCapabilityProjections = (
+  value: unknown,
+  keyProp: "name" | "uri" | "uriTemplate",
+): CapabilityProjection[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((entry: unknown) => {
+    if (typeof entry === "string") {
+      const key = readStringOption(entry);
+      return key ? [{ key }] : [];
+    }
+    if (!entry || typeof entry !== "object") return [];
+
+    const record: RecordAny = entry;
+    const key = readStringOption(record[keyProp]);
+    if (!key) return [];
+
+    const description = readStringOption(record.description);
+    const mimeType = readStringOption(record.mimeType);
+    // A resource's `name` is a label beside its URI; a tool's *is* the key, so
+    // it never doubles as a label.
+    const name = keyProp === "name" ? undefined : readStringOption(record.name);
+
+    return [
+      {
+        key,
+        ...(name ? { name } : {}),
+        ...(description ? { description } : {}),
+        ...(mimeType ? { mimeType } : {}),
+      },
+    ];
+  });
+};
+
+// Builds the extension for an MCP gateway virtual server. Nothing about the
+// upstream is known at build time, so every field comes from the route's own
+// policies: the token-exchange policy names the connection, the capability
+// filter enumerates what the gateway exposes downstream, and an inbound OAuth
+// policy means clients sign in rather than carry a key. A passthrough server
+// (no capability filter) documents no capabilities on purpose — its list only
+// exists once a client initializes against the upstream.
+const buildGatewayServerExtension = ({
+  operation,
+  schema,
+  policies,
+}: {
+  operation: RecordAny;
+  schema: OpenAPIV3_1.Document;
+  policies: PolicyConfigurationFragment[];
+}): ExtensionMcpServer => {
+  const tokenExchange = policies.find((policy) =>
+    isPolicyKind(
+      policy,
+      MCP_TOKEN_EXCHANGE_POLICY_TYPE,
+      MCP_TOKEN_EXCHANGE_POLICY_EXPORT,
+    ),
+  );
+  const capabilityFilter = policies.find((policy) =>
+    isPolicyKind(
+      policy,
+      MCP_CAPABILITY_FILTER_POLICY_TYPE,
+      MCP_CAPABILITY_FILTER_POLICY_EXPORT,
+    ),
+  );
+  const usesOAuth = policies.some(
+    (policy) =>
+      MCP_OAUTH_POLICY_TYPE.test(policy.policyType) ||
+      MCP_OAUTH_POLICY_EXPORT.test(policy.handler.export),
+  );
+
+  const extension: ExtensionMcpServer = {
+    // The gateway shows `displayName` in its own connect prompts, so reusing it
+    // keeps the docs and the runtime calling the server the same thing.
+    name:
+      readStringOption(tokenExchange?.handler.options?.displayName) ??
+      readStringOption(operation.summary) ??
+      DEFAULT_MCP_SERVER_NAME,
+  };
+
+  if (usesOAuth) {
+    extension.authType = "oauth";
+  }
+
+  const filterOptions = capabilityFilter?.handler.options;
+  if (filterOptions) {
+    const tools = readCapabilityProjections(filterOptions.tools, "name");
+    const prompts = readCapabilityProjections(filterOptions.prompts, "name");
+    const resources = readCapabilityProjections(filterOptions.resources, "uri");
+    const resourceTemplates = readCapabilityProjections(
+      filterOptions.resourceTemplates,
+      "uriTemplate",
+    );
+
+    if (tools.length > 0) {
+      extension.tools = tools.map(({ key, description }) => ({
+        name: key,
+        ...(description ? { description } : {}),
+      }));
+    }
+    if (prompts.length > 0) {
+      extension.prompts = prompts.map(({ key, description }) => ({
+        name: key,
+        ...(description ? { description } : {}),
+      }));
+    }
+    if (resources.length > 0) {
+      extension.resources = resources.map(({ key, ...rest }) => ({
+        uri: key,
+        ...rest,
+      }));
+    }
+    if (resourceTemplates.length > 0) {
+      extension.resourceTemplates = resourceTemplates.map(
+        ({ key, ...rest }) => ({ uriTemplate: key, ...rest }),
+      );
+    }
+  }
+
+  // Picks up anything enrichWithZuploData already documented on the route —
+  // an API key policy's security scheme, or hand-authored security.
+  const { security, securitySchemes } = extractSecurityFromOperations(schema, [
+    operation,
+  ]);
+  const dedupedSecurity = deduplicateSecurity(security);
+  if (dedupedSecurity.length > 0) {
+    extension.security = dedupedSecurity;
+    extension.securitySchemes = { ...securitySchemes };
+  }
+
+  return extension;
+};
+
+// Builds the extension for a dynamic MCP server: the `mcpServerHandler` route
+// that serves the project's own REST operations as tools. Returns undefined
+// when the route is not one, or exposes no operations.
+const buildDynamicServerExtension = async ({
+  operation,
+  rootDir,
+  schema,
+}: {
+  operation: RecordAny;
+  rootDir: string;
+  schema: OpenAPIV3_1.Document;
+}): Promise<ExtensionMcpServer | undefined> => {
+  const handler = operation["x-zuplo-route"]?.handler;
+  if (
+    handler?.export !== "mcpServerHandler" ||
+    !Array.isArray(handler.options?.operations)
+  ) {
+    return undefined;
+  }
+
+  // Group operations by file to avoid reading the same file multiple times
+  const operationsByFile = new Map<string, string[]>();
+  for (const op of handler.options.operations) {
+    if (!op.file || !op.id) continue;
+    const ids = operationsByFile.get(op.file) ?? [];
+    ids.push(op.id);
+    operationsByFile.set(op.file, ids);
+  }
+
+  if (operationsByFile.size === 0) return undefined;
+
+  // Extract tools from disk files (source of truth for tool metadata)
+  const allTools: ExtensionMcpServerTool[] = [];
+  for (const [filePath, operationIds] of operationsByFile) {
+    const resolvedPath = path.resolve(rootDir, "../", filePath);
+    const fileContent = await fs.readFile(resolvedPath, "utf-8");
+    const document = JSON.parse(fileContent);
+
+    if (document) {
+      allTools.push(...extractToolsFromDocument(document, operationIds));
+    }
+  }
+
+  // Extract security from the in-memory schema (already enriched by enrichWithZuploData)
+  const allOperationIds = [...operationsByFile.values()].flat();
+  const { security: allSecurity, securitySchemes } = extractSecurityFromSchema(
+    schema,
+    allOperationIds,
+  );
+
+  // Mirror the runtime's server identity (ZuploMcpServer resolves these
+  // from `opts.name` / `opts.version`) so the documented server name shown
+  // in the install snippets matches what MCP clients actually connect to.
+  // Falls back to the shared defaults when the handler leaves them unset.
+  const mcpExtension: ExtensionMcpServer = {
+    name: readStringOption(handler.options.name) ?? DEFAULT_MCP_SERVER_NAME,
+    version:
+      readStringOption(handler.options.version) ?? DEFAULT_MCP_SERVER_VERSION,
+  };
+
+  if (allTools.length > 0) {
+    mcpExtension.tools = allTools;
+  }
+
+  // Add security from referenced operations to x-mcp-server
+  const dedupedSecurity = deduplicateSecurity(allSecurity);
+  if (dedupedSecurity.length > 0) {
+    mcpExtension.security = dedupedSecurity;
+    mcpExtension.securitySchemes = { ...securitySchemes };
+  }
+
+  return mcpExtension;
+};
+
+// Enriches an OpenAPI schema with x-mcp-server data for both kinds of Zuplo
+// MCP server: the dynamic `mcpServerHandler` route serving the project's own
+// REST operations, and the MCP gateway virtual server proxying an upstream.
+// Both end up documented by the same endpoint card.
 export const enrichWithZuploMcpServerData = ({
   rootDir,
+  policiesConfig,
 }: {
   rootDir: string;
+  // Gateway virtual servers keep their identity, capabilities and inbound auth
+  // in policies rather than handler options, so without policies.json such a
+  // route can only be documented by name.
+  policiesConfig?: PoliciesConfigFile;
 }) => {
   return async ({ schema }: ProcessorArg) => {
     if (!schema.paths) return schema;
@@ -214,66 +566,31 @@ export const enrichWithZuploMcpServerData = ({
       if (!operation?.["x-zuplo-route"]) return node;
 
       const handler = operation["x-zuplo-route"]?.handler;
-      if (
-        handler?.export !== "mcpServerHandler" ||
-        !Array.isArray(handler.options?.operations)
-      )
-        return node;
+      if (!handler) return node;
 
-      // Group operations by file to avoid reading the same file multiple times
-      const operationsByFile = new Map<string, string[]>();
-      for (const op of handler.options.operations) {
-        if (!op.file || !op.id) continue;
-        const ids = operationsByFile.get(op.file) ?? [];
-        ids.push(op.id);
-        operationsByFile.set(op.file, ids);
-      }
+      const mcpExtension = isGatewayHandler(handler)
+        ? buildGatewayServerExtension({
+            operation,
+            schema: modifiedSchema as OpenAPIV3_1.Document,
+            policies: resolveInboundPolicies(operation, policiesConfig),
+          })
+        : await buildDynamicServerExtension({
+            operation,
+            rootDir,
+            schema: modifiedSchema as OpenAPIV3_1.Document,
+          });
 
-      if (operationsByFile.size === 0) return node;
+      if (!mcpExtension) return node;
 
-      // Extract tools from disk files (source of truth for tool metadata)
-      const allTools: ExtensionMcpServerTool[] = [];
-      for (const [filePath, operationIds] of operationsByFile) {
-        const resolvedPath = path.resolve(rootDir, "../", filePath);
-        const fileContent = await fs.readFile(resolvedPath, "utf-8");
-        const document = JSON.parse(fileContent);
-
-        if (document) {
-          allTools.push(...extractToolsFromDocument(document, operationIds));
-        }
-      }
-
-      // Extract security from the in-memory schema (already enriched by enrichWithZuploData)
-      const allOperationIds = [...operationsByFile.values()].flat();
-      const { security: allSecurity, securitySchemes } =
-        extractSecurityFromSchema(
-          modifiedSchema as OpenAPIV3_1.Document,
-          allOperationIds,
-        );
-
-      // Mirror the runtime's server identity (ZuploMcpServer resolves these
-      // from `opts.name` / `opts.version`) so the documented server name shown
-      // in the install snippets matches what MCP clients actually connect to.
-      // Falls back to the shared defaults when the handler leaves them unset.
-      const mcpExtension: ExtensionMcpServer = {
-        name: readStringOption(handler.options.name) ?? DEFAULT_MCP_SERVER_NAME,
-        version:
-          readStringOption(handler.options.version) ??
-          DEFAULT_MCP_SERVER_VERSION,
-      };
-
-      if (allTools.length > 0) {
-        mcpExtension.tools = allTools;
-      }
-
-      // Add security from referenced operations to x-mcp-server
-      const dedupedSecurity = deduplicateSecurity(allSecurity);
-      if (dedupedSecurity.length > 0) {
-        mcpExtension.security = dedupedSecurity;
-        mcpExtension.securitySchemes = { ...securitySchemes };
-      }
-
-      node["x-mcp-server"] = mcpExtension;
+      // A hand-authored `x-mcp-server` object wins over what config implies —
+      // it is how an author documents a server Zudoku cannot see, e.g. a
+      // gateway whose upstream tools are only known at runtime. The shorthand
+      // `true` carries nothing to keep.
+      const authored = operation["x-mcp-server"];
+      node["x-mcp-server"] =
+        authored && typeof authored === "object"
+          ? { ...mcpExtension, ...authored }
+          : mcpExtension;
 
       // Assign default MCP tag if the operation has no tags
       if (!operation.tags || operation.tags.length === 0) {

--- a/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
+++ b/packages/zudoku/src/zuplo/enrich-with-zuplo-mcp.ts
@@ -87,7 +87,9 @@ const MCP_GATEWAY_HANDLER_EXPORTS = new Set([
   "McpVirtualServerHandler",
   "mcpVirtualServerHandler",
 ]);
-const ZUPLO_RUNTIME_MODULE_PREFIX = "$import(@zuplo/runtime";
+// Matches `$import(@zuplo/runtime)` and its subpaths, and nothing else — a
+// bare prefix test would also accept a customer's `@zuplo/runtime-custom`.
+const ZUPLO_RUNTIME_MODULE = /^\$import\(@zuplo\/runtime(\/[^)]+)?\)$/;
 
 // The gateway's inbound OAuth policies: the generic `mcp-oauth-inbound` plus
 // the per-IdP variants (`mcp-auth0-oauth-inbound`, `mcp-entra-oauth-inbound`,
@@ -275,7 +277,7 @@ const deduplicateSecurity = (
 const isGatewayHandler = (handler: RecordAny): boolean =>
   MCP_GATEWAY_HANDLER_EXPORTS.has(handler.export) &&
   typeof handler.module === "string" &&
-  handler.module.startsWith(ZUPLO_RUNTIME_MODULE_PREFIX);
+  ZUPLO_RUNTIME_MODULE.test(handler.module);
 
 // Resolves a route's inbound policy names to their definitions in
 // policies.json, expanding one level of composite policy so an MCP policy
@@ -413,36 +415,40 @@ const buildGatewayServerExtension = ({
 
   const filterOptions = capabilityFilter?.handler.options;
   if (filterOptions) {
-    const tools = readCapabilityProjections(filterOptions.tools, "name");
-    const prompts = readCapabilityProjections(filterOptions.prompts, "name");
-    const resources = readCapabilityProjections(filterOptions.resources, "uri");
-    const resourceTemplates = readCapabilityProjections(
-      filterOptions.resourceTemplates,
-      "uriTemplate",
-    );
-
-    if (tools.length > 0) {
-      extension.tools = tools.map(({ key, description }) => ({
+    // The filter distinguishes an omitted list (pass the upstream's capabilities
+    // of that kind through, so Zudoku cannot know them) from an empty one
+    // (expose none of them). Only a list that is actually configured becomes an
+    // extension property, so an empty array documents "none" rather than
+    // collapsing into the same silence as passthrough.
+    if (Array.isArray(filterOptions.tools)) {
+      extension.tools = readCapabilityProjections(
+        filterOptions.tools,
+        "name",
+      ).map(({ key, description }) => ({
         name: key,
         ...(description ? { description } : {}),
       }));
     }
-    if (prompts.length > 0) {
-      extension.prompts = prompts.map(({ key, description }) => ({
+    if (Array.isArray(filterOptions.prompts)) {
+      extension.prompts = readCapabilityProjections(
+        filterOptions.prompts,
+        "name",
+      ).map(({ key, description }) => ({
         name: key,
         ...(description ? { description } : {}),
       }));
     }
-    if (resources.length > 0) {
-      extension.resources = resources.map(({ key, ...rest }) => ({
-        uri: key,
-        ...rest,
-      }));
+    if (Array.isArray(filterOptions.resources)) {
+      extension.resources = readCapabilityProjections(
+        filterOptions.resources,
+        "uri",
+      ).map(({ key, ...rest }) => ({ uri: key, ...rest }));
     }
-    if (resourceTemplates.length > 0) {
-      extension.resourceTemplates = resourceTemplates.map(
-        ({ key, ...rest }) => ({ uriTemplate: key, ...rest }),
-      );
+    if (Array.isArray(filterOptions.resourceTemplates)) {
+      extension.resourceTemplates = readCapabilityProjections(
+        filterOptions.resourceTemplates,
+        "uriTemplate",
+      ).map(({ key, ...rest }) => ({ uriTemplate: key, ...rest }));
     }
   }
 

--- a/packages/zudoku/src/zuplo/with-zuplo-processors.ts
+++ b/packages/zudoku/src/zuplo/with-zuplo-processors.ts
@@ -22,7 +22,7 @@ export const getProcessors = async (rootDir: string): Promise<Processor[]> => {
       shouldRemove: ({ parameter }) => parameter["x-internal"],
     }),
     enrichWithZuploData({ policiesConfig }),
-    enrichWithZuploMcpServerData({ rootDir }),
+    enrichWithZuploMcpServerData({ rootDir, policiesConfig }),
     ({ schema }: ProcessorArg) => {
       const url = ZuploEnv.serverUrl;
       if (!url || process.env.ZUPLO_PUBLIC_DISABLE_INJECT_ENDPOINT)


### PR DESCRIPTION
## Summary

Extends MCP server documentation to support both dynamic servers (the existing `mcpServerHandler` route) and MCP gateway virtual servers (new `McpProxyHandler` route that proxies an upstream MCP server). Gateway servers are configured entirely through Zuplo policies rather than handler options, so their identity, capabilities, and inbound authentication are extracted from the route's policy configuration.

## Key Changes

- **Gateway server detection**: Added `isGatewayHandler()` to identify routes using the Zuplo runtime's MCP gateway handler exports (`McpProxyHandler`, `McpVirtualServerHandler`, `mcpVirtualServerHandler`)

- **Policy resolution**: Implemented `resolveInboundPolicies()` to extract and expand inbound policies from routes, including one level of composite policy nesting, enabling discovery of MCP-specific policies

- **Gateway extension building**: Created `buildGatewayServerExtension()` to construct `x-mcp-server` metadata from:
  - Token exchange policy for the server display name
  - Capability filter policy for tools, prompts, resources, and resource templates
  - OAuth policies to set `authType: "oauth"`
  - Route-level security schemes (API keys, etc.)

- **Capability documentation**: Added `readCapabilityProjections()` to parse the capability filter policy's lists, supporting both bare strings (expose as-is) and projection objects (override metadata)

- **Refactored security extraction**: Split `extractSecurityFromSchema()` into a lower-level `extractSecurityFromOperations()` that works with operation objects directly, allowing reuse for both dynamic servers and gateway routes

- **Dynamic server refactor**: Moved dynamic server logic into `buildDynamicServerExtension()` for cleaner separation of concerns

- **UI enhancements**:
  - Added `Capabilities` component to display what the server exposes (tools, prompts, resources, resource templates) when documented
  - Implemented `getMcpCapabilities()` to extract and group capabilities from `x-mcp-server` extension data
  - Updated `getAuthType()` to recognize explicit `authType` field (required for gateway OAuth that cannot be inferred from OpenAPI security schemes)

- **Test coverage**: Added comprehensive tests for gateway server documentation, including capability filtering, nested policies, security inheritance, and handler module validation

- **Documentation**: Updated OpenAPI extension docs to describe all capability kinds and the new `authType` field

## Notable Implementation Details

- Gateway servers intentionally omit `version` since it belongs to the upstream and is only known at runtime
- Passthrough gateways (no capability filter) document no capabilities by design — the list only exists once a client initializes
- Policy identification uses `policyType` with fallback to handler export name for backward compatibility
- Module check for gateway handlers mirrors the runtime's own detection to prevent false positives from customer modules with the same export name

https://claude.ai/code/session_01BfzdkeBfcD1dY2ex2p9dAk