### PR TITLE
feat: add agent-ready documentation outputs

### DIFF
--- a/docs/pages/docs/configuration/api-reference.md
+++ b/docs/pages/docs/configuration/api-reference.md
@@ -30,6 +30,51 @@ const config = {
 };
 ```
 
+### Publish a canonical OpenAPI document
+
+For agents, API clients, and discovery tools, you can opt a file-based API into a stable public
+OpenAPI URL:
+
+```ts title=zudoku.config.ts
+const config = {
+  apis: {
+    type: "file",
+    input: "./openapi.json",
+    path: "/api",
+    publish: {
+      path: "/openapi.json",
+    },
+  },
+};
+```
+
+The endpoint is available in development and is written into the production build. Its format and
+media type follow the configured extension: use `.json` for `application/json`, or `.yaml`/`.yml`
+for `application/yaml`. The path must be root-relative, cannot contain traversal, query, or fragment
+components, and is relative to the Zudoku site. For example, with `basePath: "/docs"`, the example
+above is served at `/docs/openapi.json`.
+
+Published documents use the processed schema, including bundled external references and configured
+[schema processors](../guides/processors.mdx). If an API has multiple file versions, the first
+`input` entry is the primary version published at the canonical URL. Publishing is intentionally
+configured per API: Zudoku will not choose an API automatically on multi-API sites, and a build
+fails if two APIs configure the same publication path. The build also fails instead of overwriting
+an existing `public/` file or generated artifact at that path.
+
+To report schema authoring gaps that reduce LLM function-calling compatibility, enable the optional
+agent-quality audit:
+
+```ts title=zudoku.config.ts
+publish: {
+  path: "/openapi.json",
+  agentQuality: true,
+},
+```
+
+The audit reports build warnings for missing or duplicate `operationId` values, missing operation
+descriptions, untyped parameters, missing or untyped request bodies on write operations, and
+responses without typed schemas. It does not modify the published document or fail the build.
+
 ## URL Reference
 
 :::danger{title="Recommendation"}

--- a/docs/pages/docs/configuration/docs.md
+++ b/docs/pages/docs/configuration/docs.md
@@ -246,6 +246,54 @@ The generated markdown files:
 - Are required for the `copyPage` button functionality
 - Are used by LLM features (see [llms.txt configuration](/docs/configuration/llms) for more details)
 
+### `contentNegotiation`
+
+**Type:** `boolean` **Default:** the value of `publishMarkdown`
+
+When `publishMarkdown` is enabled, canonical documentation URLs honor the HTTP `Accept` header.
+Requests that prefer `text/markdown` receive the same content as the page's `.md` URL with a
+`Content-Type: text/markdown; charset=utf-8` response. HTML and Markdown variants include
+`Vary: Accept` so shared caches do not mix representations. Content negotiation is therefore enabled
+by default whenever `publishMarkdown` is enabled. Set it to `false` to opt out.
+
+Canonical URL negotiation is built into the SSR-backed development server, SSR deployments, and
+Zudoku's Vercel static output. Other static hosts, and development with `--no-ssr`, must configure
+equivalent `Accept`-aware routing from each canonical URL to its generated `.md` sibling. The
+explicit `.md` files remain portable to every static host.
+
+```tsx title="zudoku.config.tsx"
+docs: {
+  publishMarkdown: true,
+  contentNegotiation: true,
+}
+```
+
+On those supported runtimes, Zudoku also returns a concise Markdown recovery response with status
+`404` when an agent requests a missing path. It links to the documentation root and, when those
+generated files are present, `llms.txt` and the sitemap. Set `contentNegotiation: false` to retain
+HTML-only canonical URLs while continuing to publish the explicit `.md` files.
+
+#### Other hosting providers
+
+When `publishMarkdown` is enabled, Zudoku emits the `.md` files, so other hosting providers can
+implement the same behavior in their CDN, reverse proxy, edge worker, or web server. Configure the
+hosting layer to:
+
+1. Apply the rule only to known documentation routes within the configured `basePath`; leave assets
+   and non-document routes unchanged.
+2. Inspect `Accept` on `GET` and `HEAD` requests. When Markdown is the preferred acceptable
+   representation, internally rewrite the canonical page URL to its `.md` sibling rather than
+   redirecting the client.
+3. Serve the rewritten response as `text/markdown; charset=utf-8`, and add `Accept` to any existing
+   `Vary` header on both the Markdown and HTML variants.
+4. Preserve the query string and return no body for `HEAD` requests.
+5. Keep real `404` status codes for unknown paths. If returning a Markdown 404 body, include useful
+   recovery links instead of serving the HTML application shell with status `200`.
+
+The exact rule syntax depends on the provider. The important contract is that caches vary on
+`Accept`, canonical URLs resolve to the correct representation, and missing resources remain
+missing.
+
 ### `llms`
 
 **Type:** `object` **Default:** `undefined`
@@ -258,7 +306,11 @@ docs: {
   llms: {
     llmsTxt: true,        // Generate llms.txt summary file
     llmsTxtFull: true,    // Generate llms-full.txt with complete content
-    includeProtected: false
+    includeProtected: false,
+    title: "Acme API",
+    description: "Build and operate integrations with the Acme API.",
+    instructions:
+      "Use these docs when creating or debugging an Acme integration. Start with the quickstart, then use the API reference for request and response schemas."
   }
 }
 ```

--- a/docs/pages/docs/configuration/docs.md
+++ b/docs/pages/docs/configuration/docs.md
@@ -252,9 +252,10 @@ The generated markdown files:
 
 When `publishMarkdown` is enabled, canonical documentation URLs honor the HTTP `Accept` header.
 Requests that prefer `text/markdown` receive the same content as the page's `.md` URL with a
-`Content-Type: text/markdown; charset=utf-8` response. HTML and Markdown variants include
-`Vary: Accept` so shared caches do not mix representations. Content negotiation is therefore enabled
-by default whenever `publishMarkdown` is enabled. Set it to `false` to opt out.
+`Content-Type: text/markdown; charset=utf-8` response. HTML and Markdown variants include `Accept`
+in the `Vary` header so shared caches do not mix representations, and advertise the `.md` URL with a
+`Link` header. Vercel responses use `Vary: Accept, Accept-Encoding`. Content negotiation is
+therefore enabled by default whenever `publishMarkdown` is enabled. Set it to `false` to opt out.
 
 Canonical URL negotiation is built into the SSR-backed development server, SSR deployments, and
 Zudoku's Vercel static output. Other static hosts, and development with `--no-ssr`, must configure
@@ -269,9 +270,10 @@ docs: {
 ```
 
 On those supported runtimes, Zudoku also returns a concise Markdown recovery response with status
-`404` when an agent requests a missing path. It links to the documentation root and, when those
-generated files are present, `llms.txt` and the sitemap. Set `contentNegotiation: false` to retain
-HTML-only canonical URLs while continuing to publish the explicit `.md` files.
+`404` when an agent prefers Markdown for a missing canonical path. Vercel provides the same recovery
+response for missing explicit `.md` and `.mdx` paths. It links to the documentation root and, when
+those generated files are present, `llms.txt` and the sitemap. Set `contentNegotiation: false` to
+retain HTML-only canonical URLs while continuing to publish the explicit `.md` files.
 
 #### Other hosting providers
 
@@ -281,13 +283,14 @@ hosting layer to:
 
 1. Apply the rule only to known documentation routes within the configured `basePath`; leave assets
    and non-document routes unchanged.
-2. Inspect `Accept` on `GET` and `HEAD` requests. When Markdown is the preferred acceptable
-   representation, internally rewrite the canonical page URL to its `.md` sibling rather than
-   redirecting the client.
-3. Serve the rewritten response as `text/markdown; charset=utf-8`, and add `Accept` to any existing
+2. Inspect `Accept` on `GET` and `HEAD` requests, honoring media-range specificity and `q` values.
+   When Markdown is the preferred acceptable representation, internally rewrite the canonical page
+   URL to its `.md` sibling rather than redirecting the client.
+3. Return `406 Not Acceptable` when the request explicitly accepts neither HTML nor Markdown.
+4. Serve the rewritten response as `text/markdown; charset=utf-8`, and add `Accept` to any existing
    `Vary` header on both the Markdown and HTML variants.
-4. Preserve the query string and return no body for `HEAD` requests.
-5. Keep real `404` status codes for unknown paths. If returning a Markdown 404 body, include useful
+5. Preserve the query string and return no body for `HEAD` requests.
+6. Keep real `404` status codes for unknown paths. If returning a Markdown 404 body, include useful
    recovery links instead of serving the HTML application shell with status `200`.
 
 The exact rule syntax depends on the provider. The important contract is that caches vary on

--- a/docs/pages/docs/configuration/llms.md
+++ b/docs/pages/docs/configuration/llms.md
@@ -13,7 +13,7 @@ During build, you can optionally generate:
 - **`llms.txt`** - Summary with links to all pages
 - **`llms-full.txt`** - Complete documentation in one file
 
-All options are disabled by default.
+Per-page `.md` export is enabled by default. The two aggregate `llms.txt` files are opt-in.
 
 ## Configuration
 
@@ -28,12 +28,14 @@ export default {
       llmsTxt: true, // Generate llms.txt
       llmsTxtFull: true, // Generate llms-full.txt
       includeProtected: false, // Exclude protected routes
+      title: "Acme API",
+      description: "Build and operate integrations with the Acme API.",
+      instructions:
+        "Use these docs when creating or debugging an Acme integration. Start with the quickstart, then consult the API reference for request and response schemas.",
     },
   },
 };
 ```
-
-All options are disabled by default.
 
 :::tip
 
@@ -50,11 +52,40 @@ files unless `publishMarkdown: true` is set (see
 Generates an `llms.txt` file with links to all documentation pages:
 
 ```markdown title="llms.txt"
-# Documentation
+# Acme API
+
+> Build and operate integrations with the Acme API.
+
+Use these docs when creating or debugging an Acme integration. Start with the quickstart, then
+consult the API reference for request and response schemas.
+
+## Documentation
 
 - [Quickstart](/docs/quickstart.md): Get started with Zudoku
 - [Writing](/docs/writing.md): A guide to writing documentation
 ```
+
+### `title`
+
+**Type:** `string` **Default:** the configured site title, or `"Documentation"`
+
+Sets the project or site name in the required H1 at the top of `llms.txt`. It also sets the H1 in
+`llms-full.txt` when that file is enabled.
+
+### `description`
+
+**Type:** `string` **Default:** `"Documentation files for Large Language Models"`
+
+Sets the short summary in the blockquote immediately after the H1.
+
+### `instructions`
+
+**Type:** `string` **Default:** `undefined`
+
+Adds optional guidance between the blockquote and the documentation link section. Use it to tell
+agents which concrete jobs the documentation is best suited for and how to navigate or call the
+product. The value can contain Markdown paragraphs and lists, but should not contain headings;
+headings in `llms.txt` are reserved for sections containing link lists.
 
 ### `llmsTxtFull`
 

--- a/docs/pages/docs/configuration/llms.md
+++ b/docs/pages/docs/configuration/llms.md
@@ -113,6 +113,10 @@ dist/
     └── ...
 ```
 
+On Vercel builds, this tree is written beneath `.vercel/output/static/` instead of `dist/`. The
+deployed public URLs remain the same. See the [Vercel deployment guide](/docs/deploy/vercel) for the
+generated routing and Markdown content-negotiation behavior.
+
 **Important:** Individual `.md` files are only kept in the final build if `publishMarkdown: true`.
 If only `llmsTxt` or `llmsTxtFull` is enabled, the `.md` files are generated temporarily during the
 build but deleted after the `llms.txt` files are created.

--- a/docs/pages/docs/configuration/navigation.mdx
+++ b/docs/pages/docs/configuration/navigation.mdx
@@ -328,10 +328,10 @@ details.
 
 :::note
 
-Avoid naming files `index.md` or `index.mdx` and relying on their default path. Some hosting
-providers (e.g. Vercel) automatically strip `/index` from URLs with a redirect, which can cause
-routing issues. Instead, give files descriptive names and use the `path` property to serve them at
-the desired URL.
+Avoid naming files `index.md` or `index.mdx` and relying on their default path. Zudoku's generated
+Vercel clean-URL routes strip `/index` with a redirect, and other hosting providers may do the same.
+This can cause routing issues. Instead, give files descriptive names and use the `path` property to
+serve them at the desired URL.
 
 :::
 

--- a/docs/pages/docs/deploy/apache-nginx.md
+++ b/docs/pages/docs/deploy/apache-nginx.md
@@ -10,18 +10,18 @@ serve these files correctly.
 Create a `.htaccess` file in your document root (alongside `index.html`):
 
 ```apache
+ErrorDocument 404 /404.html
+
 RewriteEngine On
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME}.html -f
 RewriteRule ^(.*)$ $1.html [L]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^ index.html [L]
 ```
 
-Requires `mod_rewrite` enabled and `AllowOverride All` in your Apache configuration.
+Requires `mod_rewrite` enabled and `AllowOverride All` in your Apache configuration. Unknown paths
+fall through to Apache's real `404` response, using Zudoku's generated `404.html` as the response
+body.
 
 ## Nginx
 
@@ -35,7 +35,21 @@ server {
     index index.html;
 
     location / {
-        try_files $uri $uri.html $uri/ /index.html;
+        try_files $uri $uri.html $uri/ =404;
+    }
+
+    error_page 404 /404.html;
+
+    location = /404.html {
+        internal;
     }
 }
 ```
+
+Do not fall back unknown paths to `index.html`; that produces a soft 404 with status `200`, which
+misleads search engines and agents into treating nonexistent pages as real content.
+
+These examples serve the generated `.md` files at their explicit URLs but do not inspect the
+`Accept` header. To serve Markdown from canonical documentation URLs, implement the general
+[content-negotiation contract](/docs/configuration/docs#other-hosting-providers) in your web server
+or an upstream proxy.

--- a/docs/pages/docs/deploy/vercel.md
+++ b/docs/pages/docs/deploy/vercel.md
@@ -50,36 +50,19 @@ No framework detected. Default Project Settings:
 ? Want to modify these settings? (y/N)
 ```
 
-Answer _Yes_ and select to modify the Output Directory.
-
-By default Vercel looks for a directory named `public`, but the Zudoku build will be found in
-`dist`. Set the output directory like this:
-
-```ansi
-? What's your Output Directory? dist
-```
+You can accept these defaults. Do not configure an Output Directory for Zudoku. When Vercel runs the
+build, Zudoku detects the `VERCEL` environment variable and emits a
+[Build Output API](https://vercel.com/docs/build-output-api) deployment to `.vercel/output`. Vercel
+detects and deploys this directory automatically. If your project already has an Output Directory
+saved in Vercel, set `"outputDirectory": null` in `vercel.json` to clear that override.
 
 After this is complete, your site will build and Vercel will respond with the URL for you to test
 it.
 
-:::tip{title="Clean URLs"}
+:::tip{title="Routing configuration"}
 
-You will almost certainly want to enable clean URLs for your site. This will remove the `.html`
-extension from your URLs. You can do this by adding a `cleanUrls` property to your `vercel.json`
-file. See the
-[Vercel Configuration](https://vercel.com/docs/projects/project-configuration#cleanurls) for more
-information.
-
-:::
-
-:::caution{title="Redirects"}
-
-If you have redirects configured in your Zudoku configuration, you will need to also add those to
-your `vercel.json` file. See the
-[Vercel Configuration](https://vercel.com/docs/projects/project-configuration#redirects) for more
-information.
-
-This is a current limitation. See [#115](https://github.com/zuplo/zudoku/issues/151).
+The generated Build Output API configuration includes clean URLs and any redirects from your Zudoku
+configuration. You do not need to duplicate these settings in `vercel.json`.
 
 :::
 

--- a/docs/pages/docs/deploy/vercel.md
+++ b/docs/pages/docs/deploy/vercel.md
@@ -50,21 +50,81 @@ No framework detected. Default Project Settings:
 ? Want to modify these settings? (y/N)
 ```
 
-You can accept these defaults. Do not configure an Output Directory for Zudoku. When Vercel runs the
-build, Zudoku detects the `VERCEL` environment variable and emits a
+You can accept these defaults as long as the Output Directory override remains disabled. Do not set
+it to `dist`, `public`, or another directory. When Vercel runs the build, Zudoku detects the
+`VERCEL` environment variable and emits a
 [Build Output API](https://vercel.com/docs/build-output-api) deployment to `.vercel/output`. Vercel
-detects and deploys this directory automatically. If your project already has an Output Directory
-saved in Vercel, set `"outputDirectory": null` in `vercel.json` to clear that override.
+detects and deploys this directory automatically.
+
+If your project already has an Output Directory saved in Vercel, disable the override in Project
+Settings or add a `vercel.json` file at the project root. A minimal configuration is:
+
+```json title="vercel.json"
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "npm run build",
+  "outputDirectory": null
+}
+```
+
+The `framework: null` setting selects Vercel's **Other** framework preset. Adjust the build command
+if your project uses a different script.
 
 After this is complete, your site will build and Vercel will respond with the URL for you to test
 it.
 
-:::tip{title="Routing configuration"}
+## Generated Vercel output
 
-The generated Build Output API configuration includes clean URLs and any redirects from your Zudoku
-configuration. You do not need to duplicate these settings in `vercel.json`.
+For a standard static build, Zudoku writes the following directly into `.vercel/output`:
 
-:::
+- Static pages and assets under `.vercel/output/static`
+- Clean URL routes and overrides, including redirects from your Zudoku configuration
+- Vercel Routing Middleware for Markdown content negotiation when it is enabled
+
+You do not need to add `cleanUrls`, copy Zudoku redirects, or define the generated middleware in
+`vercel.json`. To inspect the same artifact locally, use `vercel build`; a plain `npm run build`
+outside Vercel produces the portable `dist` output instead.
+
+### Markdown content negotiation
+
+[`publishMarkdown`](/docs/configuration/docs#publishmarkdown) is enabled by default, and
+[`contentNegotiation`](/docs/configuration/docs#contentnegotiation) defaults to the same value. When
+both are enabled, Zudoku's generated Routing Middleware:
+
+- Serves Markdown from a canonical documentation URL when a `GET` or `HEAD` request prefers
+  `text/markdown`
+- Honors media-range specificity and `q` values, returning `406 Not Acceptable` when neither HTML
+  nor Markdown is acceptable
+- Includes `Vary: Accept, Accept-Encoding` so Vercel's cache keeps HTML and Markdown separate
+- Advertises the `.md` representation with a `Link` header
+- Preserves real `404` responses with a short Markdown recovery body
+- Passes assets, published API schemas, and non-document routes through unchanged
+
+Set `contentNegotiation: false` to disable the middleware while continuing to publish the explicit
+`.md` files.
+
+After deployment, verify a known page and a missing Markdown path:
+
+```bash
+curl -sS -D - -o /dev/null \
+  -H 'Accept: text/markdown' \
+  https://docs.example.com/quickstart
+
+curl -sS -D - -o /dev/null \
+  -H 'Accept: text/markdown' \
+  https://docs.example.com/path-that-does-not-exist
+
+curl -sS -D - -o /dev/null \
+  -H 'Accept: application/json' \
+  https://docs.example.com/quickstart
+```
+
+The first response should be `200` with `Content-Type: text/markdown; charset=utf-8` and a `Vary`
+header containing both `Accept` and `Accept-Encoding`. The missing path should return `404` with a
+Markdown content type; missing explicit `.md` and `.mdx` paths should do the same. The final request
+should return `406`. If the first request returns HTML, confirm that Vercel deployed
+`.vercel/output` and that no Output Directory override points to `dist`.
 
 ## Accurate Last Modified Dates
 

--- a/docs/pages/docs/deployment.md
+++ b/docs/pages/docs/deployment.md
@@ -19,3 +19,15 @@ npm run build
 
 Once complete, you will see a new `dist` folder in the root of your project that includes the files
 you need to upload.
+
+## Markdown content negotiation
+
+When [`publishMarkdown`](/docs/configuration/docs#publishmarkdown) is enabled, the static build also
+contains a `.md` representation for every documentation page. Vercel and SSR deployments handle
+`Accept: text/markdown` at canonical page URLs automatically. Other static hosts must add an
+`Accept`-aware rule at the CDN, reverse proxy, edge worker, or web server if you want the same
+canonical URL behavior. The explicit `.md` URLs work without that rule.
+
+See
+[content negotiation for other hosting providers](/docs/configuration/docs#other-hosting-providers)
+for the general routing and caching contract.

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -138,6 +138,7 @@ export const docs: Navigation = [
       "docs/deploy/cloudflare-pages",
       "docs/deploy/github-pages",
       "docs/deploy/vercel",
+      "docs/deploy/apache-nginx",
       "docs/deploy/direct-upload",
     ],
   },

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,8 +1,8 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
   "devCommand": "npx nx run docs:dev",
   "buildCommand": "npx nx run docs:build",
-  "outputDirectory": "dist",
-  "installCommand": "pnpm install",
-  "cleanUrls": true
+  "outputDirectory": null,
+  "installCommand": "pnpm install"
 }

--- a/examples/cosmo-cargo/schema/shipments.json
+++ b/examples/cosmo-cargo/schema/shipments.json
@@ -2897,6 +2897,11 @@
               }
             }
           }
+        },
+        "responses": {
+          "204": {
+            "description": "Notification preferences updated"
+          }
         }
       }
     },
@@ -2933,6 +2938,11 @@
                 }
               }
             }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Shipment priority updated"
           }
         }
       }
@@ -3832,6 +3842,23 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "GraphQL operation document"
+                  },
+                  "variables": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "operationName": {
+                    "type": ["string", "null"]
+                  }
+                }
+              },
               "examples": {
                 "list-characters": {
                   "summary": "List characters",
@@ -3853,7 +3880,28 @@
         },
         "responses": {
           "200": {
-            "description": "GraphQL response"
+            "description": "GraphQL response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": ["object", "null"],
+                      "additionalProperties": true
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
           }
         }
       }

--- a/examples/cosmo-cargo/vercel.json
+++ b/examples/cosmo-cargo/vercel.json
@@ -1,8 +1,8 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
   "devCommand": "npx nx run cosmo-cargo:dev",
   "buildCommand": "ZUDOKU_PUBLIC_VERCEL_ENV=$VERCEL_ENV npx nx run cosmo-cargo:build",
-  "outputDirectory": "dist",
-  "installCommand": "pnpm install",
-  "cleanUrls": true
+  "outputDirectory": null,
+  "installCommand": "pnpm install"
 }

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -144,7 +144,19 @@ const config: ZudokuConfig = {
   },
   docs: {
     publishMarkdown: true,
-    llms: { llmsTxt: true, llmsTxtFull: true },
+    contentNegotiation: true,
+    llms: {
+      llmsTxt: true,
+      llmsTxtFull: true,
+      title: "Cosmo Cargo Developer Platform",
+      description:
+        "Build interstellar shipping, tracking, fleet, and cargo automation with Cosmo Cargo APIs.",
+      instructions:
+        "Use these docs when planning, booking, tracking, or automating interstellar cargo shipments. Start with the documentation guide for platform concepts, then use the published Shipment API specification at /openapi.json for callable operations and typed request and response schemas.",
+    },
+  },
+  sitemap: {
+    siteUrl: "https://cosmocargo.dev",
   },
   site: {
     sidebar: {
@@ -489,6 +501,10 @@ const config: ZudokuConfig = {
       type: "file",
       input: "./schema/shipments.json",
       path: "api-shipments",
+      publish: {
+        path: "/openapi.json",
+        agentQuality: true,
+      },
       categories: [
         { label: "Core", tags: ["Shipments", "Logistics"] },
         { label: "Logistics", tags: ["Shipments"] },

--- a/packages/zudoku/src/app/entry.server.test.tsx
+++ b/packages/zudoku/src/app/entry.server.test.tsx
@@ -1,6 +1,6 @@
 import { use } from "react";
 import { Outlet, type RouteObject } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { RenderContext } from "../lib/components/context/RenderContext.js";
 
 vi.mock("virtual:zudoku-auth", () => ({
@@ -8,7 +8,18 @@ vi.mock("virtual:zudoku-auth", () => ({
 }));
 
 vi.mock("virtual:zudoku-config", () => ({
-  default: {},
+  default: {
+    docs: {
+      publishMarkdown: true,
+      contentNegotiation: true,
+      llms: { llmsTxt: true },
+    },
+    sitemap: { siteUrl: "https://example.com" },
+  },
+}));
+
+vi.mock("virtual:zudoku-markdown-files", () => ({
+  default: { "/": "# Home\n\nWelcome." },
 }));
 
 vi.mock("virtual:zudoku-shiki-register", () => ({
@@ -54,14 +65,24 @@ const routes: RouteObject[] = [
   notFoundRoute,
 ];
 
-const renderPath = (path: string) =>
+const renderPath = (
+  path: string,
+  { accept, method }: { accept?: string; method?: string } = {},
+) =>
   handleRequest({
     template,
-    request: new Request(`http://localhost${path}`),
+    request: new Request(`http://localhost${path}`, {
+      method,
+      headers: accept ? { Accept: accept } : undefined,
+    }),
     routes,
   });
 
 describe("handleRequest", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it.each([
     {
       path: "/",
@@ -80,5 +101,96 @@ describe("handleRequest", () => {
 
     expect(response.status).toBe(status);
     expect(response.headers.get("Cache-Control")).toBe(cacheControl);
+  });
+
+  it("serves a Markdown representation from the canonical URL", async () => {
+    const response = await renderPath("/", { accept: "text/markdown" });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Link")).toBe(
+      '</index.md>; rel="alternate"; type="text/markdown"',
+    );
+    await expect(response.text()).resolves.toBe("# Home\n\nWelcome.");
+  });
+
+  it("advertises the Markdown variant on the HTML response", async () => {
+    const response = await renderPath("/", { accept: "text/html" });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Link")).toBe(
+      '</index.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+
+  it("returns a recoverable Markdown 404", async () => {
+    const response = await renderPath("/missing", {
+      accept: "text/markdown",
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(body).toContain("# Page not found");
+    expect(body).toContain("[Markdown documentation index](/index.md)");
+    expect(body).toContain("[Agent documentation index](/llms.txt)");
+    expect(body).toContain("[Sitemap](/sitemap.xml)");
+  });
+
+  it("does not advertise SSG-only indexes from an SSR deployment", async () => {
+    vi.stubEnv("ZUDOKU_HAS_SERVER", "true");
+    const response = await renderPath("/missing", {
+      accept: "text/markdown",
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(body).toContain("[Markdown documentation index](/index.md)");
+    expect(body).not.toContain("llms.txt");
+    expect(body).not.toContain("sitemap.xml");
+  });
+
+  it("returns 406 when neither representation is acceptable", async () => {
+    const response = await renderPath("/", { accept: "application/json" });
+
+    expect(response.status).toBe(406);
+    expect(response.headers.get("Vary")).toBe("Accept");
+  });
+
+  it("returns Markdown headers without a body for HEAD", async () => {
+    const response = await renderPath("/", {
+      accept: "text/markdown",
+      method: "HEAD",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    await expect(response.text()).resolves.toBe("");
+  });
+
+  it("returns HTML headers without a body for HEAD", async () => {
+    const response = await renderPath("/", {
+      accept: "text/html",
+      method: "HEAD",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept");
+    await expect(response.text()).resolves.toBe("");
   });
 });

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -13,6 +13,7 @@ import {
 import "vite/modulepreload-polyfill";
 import { configuredAuthProvider } from "virtual:zudoku-auth";
 import config from "virtual:zudoku-config";
+import markdownFiles from "virtual:zudoku-markdown-files";
 import { parseCookies } from "../lib/authentication/cookies.js";
 import { createSessionHandler } from "../lib/authentication/session-handler.js";
 import { cachedVerifyAccessToken } from "../lib/authentication/verify-cache.js";
@@ -22,6 +23,15 @@ import type { SSRAuthState } from "../lib/components/context/RenderContext.js";
 import { ServerError } from "../lib/errors/ServerError.js";
 import { buildManifest } from "../lib/manifest.js";
 import { highlighterPromise } from "../lib/shiki.js";
+import {
+  addAcceptToVary,
+  negotiateContentType,
+} from "../lib/util/contentNegotiation.js";
+import {
+  getMarkdownAlternateLink,
+  getMarkdownNotFound,
+  resolveDocumentationRoutePath,
+} from "../lib/util/markdown-representation.js";
 import type { Adapter } from "./adapter.js";
 import { getRoutesByConfig } from "./main.js";
 import { protectChunks as rawProtectChunks } from "./protectChunks.js";
@@ -141,6 +151,20 @@ export const handleRequest = async ({
     }
   }
 
+  const routePath = resolveDocumentationRoutePath(request.url, basePath);
+  const markdownContent = routePath ? markdownFiles[routePath] : undefined;
+  const matchesNotFoundRoute = context.matches.at(-1)?.route.path === "*";
+  const isRepresentationRequest =
+    request.method === "GET" || request.method === "HEAD";
+  const mayNegotiateMarkdown =
+    isRepresentationRequest &&
+    config.docs?.publishMarkdown !== false &&
+    config.docs?.contentNegotiation !== false &&
+    (markdownContent !== undefined || matchesNotFoundRoute);
+  const negotiatedType = mayNegotiateMarkdown
+    ? negotiateContentType(request.headers.get("Accept"))
+    : "text/html";
+
   const router = createStaticRouter(dataRoutes, context);
   const head = createHead();
   const renderContext = {
@@ -169,6 +193,76 @@ export const handleRequest = async ({
     });
 
     await reactStream.allReady;
+
+    const finalStatus =
+      renderContext.status !== 200 ? renderContext.status : status;
+    const hasMarkdownRepresentation =
+      mayNegotiateMarkdown &&
+      (markdownContent !== undefined || finalStatus === 404);
+
+    if (hasMarkdownRepresentation && negotiatedType === null) {
+      await reactStream.cancel();
+      return new Response(request.method === "HEAD" ? null : "Not Acceptable", {
+        status: 406,
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+          Vary: "Accept",
+        },
+      });
+    }
+
+    if (hasMarkdownRepresentation && negotiatedType === "text/markdown") {
+      await reactStream.cancel();
+      const body =
+        finalStatus === 404
+          ? getMarkdownNotFound({
+              basePath,
+              includeLlmsTxt:
+                !import.meta.env.ZUDOKU_HAS_SERVER &&
+                (config.docs?.llms?.llmsTxt ?? false),
+              markdownRoutePaths: Object.keys(markdownFiles),
+              sitemapOutDir:
+                !import.meta.env.ZUDOKU_HAS_SERVER && config.sitemap
+                  ? (config.sitemap.outDir ?? "")
+                  : undefined,
+            })
+          : markdownContent;
+      const headers = new Headers({
+        "Content-Type": "text/markdown; charset=utf-8",
+        Vary: "Accept",
+      });
+      const cacheControl = getSsrCacheControl(finalStatus, !!ssrAuth?.profile);
+      if (cacheControl) {
+        headers.set("Cache-Control", cacheControl);
+      }
+      if (routePath && markdownContent !== undefined) {
+        headers.set("Link", getMarkdownAlternateLink(routePath, basePath));
+      }
+
+      return new Response(request.method === "HEAD" ? null : body, {
+        status: finalStatus,
+        headers,
+      });
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": "text/html; charset=utf-8",
+    };
+    const cacheControl = getSsrCacheControl(finalStatus, !!ssrAuth?.profile);
+    if (cacheControl) {
+      headers["Cache-Control"] = cacheControl;
+    }
+    if (hasMarkdownRepresentation) {
+      headers.Vary = addAcceptToVary(headers.Vary);
+      if (routePath && markdownContent !== undefined) {
+        headers.Link = getMarkdownAlternateLink(routePath, basePath);
+      }
+    }
+
+    if (request.method === "HEAD") {
+      await reactStream.cancel();
+      return new Response(null, { status: finalStatus, headers });
+    }
 
     const [htmlStart, htmlEnd] = template.split("<!--app-html-->");
     if (!htmlStart) {
@@ -218,16 +312,6 @@ export const handleRequest = async ({
         controller.close();
       },
     });
-
-    const headers: HeadersInit = {
-      "Content-Type": "text/html; charset=utf-8",
-    };
-    const finalStatus =
-      renderContext.status !== 200 ? renderContext.status : status;
-    const cacheControl = getSsrCacheControl(finalStatus, !!ssrAuth?.profile);
-    if (cacheControl) {
-      headers["Cache-Control"] = cacheControl;
-    }
 
     return new Response(stream, {
       status: finalStatus,

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -308,6 +308,49 @@ describe("validateConfig", () => {
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
+  it.each(["/openapi.json", "/api/openapi.yaml", "/nested/schema.yml"])(
+    "should accept OpenAPI publication path %s",
+    (publicationPath) => {
+      const config = {
+        apis: {
+          type: "file" as const,
+          input: "./openapi.json",
+          path: "/api",
+          publish: { path: publicationPath, agentQuality: true },
+        },
+      };
+
+      const result = validateConfig(config);
+
+      expect(result.apis).toMatchObject(config.apis);
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "openapi.json",
+    "/../openapi.json",
+    "/api/../openapi.json",
+    "//example.com/openapi.json",
+    "/openapi.txt",
+    "/openapi.json?download=true",
+    "/openapi.json#schema",
+    "/%2e%2e/openapi.json",
+    "/api\\openapi.json",
+  ])("should reject unsafe OpenAPI publication path %s", (publicationPath) => {
+    process.env.NODE_ENV = "production";
+
+    expect(() =>
+      validateConfig({
+        apis: {
+          type: "file",
+          input: "./openapi.json",
+          publish: { path: publicationPath },
+        },
+      }),
+    ).toThrow("OpenAPI publication path");
+  });
+
   it.each([true, false])(
     "should accept header.themeSwitcher.enabled with %s",
     (enabled) => {
@@ -492,12 +535,69 @@ describe("validateConfig parsed result", () => {
     const result = validateConfig({});
 
     expect(result.docs.publishMarkdown).toBe(true);
+    expect(result.docs.contentNegotiation).toBe(true);
     expect(result.docs.files).toEqual(["/pages/**/*.{md,mdx}"]);
     expect(result.docs.llms).toEqual({
       llmsTxt: false,
       llmsTxtFull: false,
       includeProtected: false,
     });
+  });
+
+  it("allows Markdown content negotiation to be disabled", () => {
+    const result = validateConfig({ docs: { contentNegotiation: false } });
+
+    expect(result.docs.contentNegotiation).toBe(false);
+  });
+
+  it("derives the content negotiation default from publishMarkdown", () => {
+    expect(
+      validateConfig({ docs: { publishMarkdown: true } }).docs
+        .contentNegotiation,
+    ).toBe(true);
+    expect(
+      validateConfig({ docs: { publishMarkdown: false } }).docs
+        .contentNegotiation,
+    ).toBe(false);
+  });
+
+  it("does not enable content negotiation without Markdown output", () => {
+    const result = validateConfig({
+      docs: { publishMarkdown: false, contentNegotiation: true },
+    });
+
+    expect(result.docs.contentNegotiation).toBe(false);
+  });
+
+  it("preserves custom llms.txt introductory guidance", () => {
+    const result = validateConfig({
+      docs: {
+        llms: {
+          title: "  Acme API  ",
+          description: "  APIs for managing Acme resources.  ",
+          instructions:
+            "  Use these docs when creating or debugging an Acme integration.  ",
+        },
+      },
+    });
+
+    expect(result.docs.llms).toEqual({
+      llmsTxt: false,
+      llmsTxtFull: false,
+      includeProtected: false,
+      title: "Acme API",
+      description: "APIs for managing Acme resources.",
+      instructions:
+        "Use these docs when creating or debugging an Acme integration.",
+    });
+  });
+
+  it("rejects empty llms.txt introductory guidance", () => {
+    process.env.NODE_ENV = "production";
+
+    expect(() =>
+      validateConfig({ docs: { llms: { instructions: "  \n  " } } }),
+    ).toThrow("Invalid Zudoku configuration");
   });
 
   it("transforms docs.files string into an array", () => {

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -127,6 +127,23 @@ const ApiConfigSchema = z
   })
   .partial();
 
+const OpenApiPublicationSchema = z.object({
+  path: z
+    .string()
+    .regex(
+      /^\/(?!\/)(?:[A-Za-z0-9._~-]+\/)*[A-Za-z0-9._~-]+\.(?:json|ya?ml)$/i,
+      "OpenAPI publication path must be a root-relative .json, .yaml, or .yml path without traversal, query, or fragment components",
+    )
+    .refine(
+      (value) =>
+        value
+          .split("/")
+          .every((segment) => segment !== "." && segment !== ".."),
+      "OpenAPI publication path must not contain traversal segments",
+    ),
+  agentQuality: z.boolean().optional(),
+});
+
 const VersionConfigSchema = z.object({
   path: z.string(),
   input: z.string(),
@@ -145,6 +162,7 @@ const ApiSchema = z.discriminatedUnion("type", [
       z.string(),
       z.array(z.union([z.string(), VersionConfigSchema])),
     ]),
+    publish: OpenApiPublicationSchema.optional(),
     ...ApiConfigSchema.shape,
   }),
   z.object({
@@ -317,6 +335,28 @@ const LlmsConfigSchema = z
       .describe(
         "When enabled, includes content from protected routes in the generated .md files and llms.txt files. By default, protected routes are excluded.",
       ),
+    title: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        "The project or site name rendered as the llms.txt H1. Defaults to the configured site title.",
+      ),
+    description: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("A short project summary rendered as the llms.txt blockquote."),
+    instructions: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        "Guidance for agents, such as when to use the documentation and how to interpret it. Rendered as introductory prose before the link sections.",
+      ),
   })
   .partial()
   // `prefault` so parsing an absent value still yields the inner defaults
@@ -333,6 +373,12 @@ const DocsConfigSchema = z
       .default(true)
       .describe(
         "When enabled, generates .md files for each document during build. Access documents at their URL path with .md extension (e.g., /foo/hello.md). Markdown files are generated without frontmatter.",
+      ),
+    contentNegotiation: z
+      .boolean()
+      .optional()
+      .describe(
+        "When enabled, serves generated Markdown at canonical document URLs when Accept prefers text/markdown and adds Vary: Accept. Defaults to the value of publishMarkdown.",
       ),
     defaultOptions: z
       .object({
@@ -353,6 +399,11 @@ const DocsConfigSchema = z
       .optional(),
     llms: LlmsConfigSchema,
   })
+  .transform((docs) => ({
+    ...docs,
+    contentNegotiation:
+      docs.publishMarkdown && (docs.contentNegotiation ?? true),
+  }))
   // `prefault` so parsing an absent value still yields the inner defaults
   .prefault({});
 

--- a/packages/zudoku/src/lib/util/contentNegotiation.test.ts
+++ b/packages/zudoku/src/lib/util/contentNegotiation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import { addAcceptToVary, negotiateContentType } from "./contentNegotiation.js";
+
+describe("negotiateContentType", () => {
+  test.each([
+    [undefined, "text/html"],
+    [null, "text/html"],
+    ["", "text/html"],
+    ["   ", "text/html"],
+    ["*/*", "text/html"],
+    ["text/*", "text/html"],
+  ])("preserves HTML server preference for %j", (accept, expected) => {
+    expect(negotiateContentType(accept)).toBe(expected);
+  });
+
+  test.each([
+    ["text/markdown", "text/markdown"],
+    ["TEXT/MARKDOWN", "text/markdown"],
+    ["text/markdown; charset=utf-8", "text/markdown"],
+    ["text/markdown;q=0.9, text/html;q=0.8", "text/markdown"],
+    ["text/html;q=0.5, text/markdown;q=0.6", "text/markdown"],
+    ["text/markdown;q=0.5, text/html;q=0.6", "text/html"],
+    ["text/markdown, */*", "text/markdown"],
+    ["*/*, text/markdown", "text/markdown"],
+    ["text/*, text/markdown", "text/markdown"],
+    ["text/markdown, text/html", "text/markdown"],
+    ["text/html, text/markdown", "text/html"],
+  ])("negotiates %j as %s", (accept, expected) => {
+    expect(negotiateContentType(accept)).toBe(expected);
+  });
+
+  test("uses the most specific range before applying its quality", () => {
+    expect(negotiateContentType("text/markdown;q=0, */*;q=1")).toBe(
+      "text/html",
+    );
+    expect(negotiateContentType("text/html;q=0, */*;q=1")).toBe(
+      "text/markdown",
+    );
+    expect(negotiateContentType("text/*;q=0, text/markdown;q=0.5")).toBe(
+      "text/markdown",
+    );
+  });
+
+  test.each([
+    "application/json",
+    "text/html;q=0, text/markdown;q=0",
+    "*/*;q=0",
+    "text/markdown; charset=iso-8859-1",
+    "not a media range",
+  ])("returns null when %j does not accept either representation", (accept) => {
+    expect(negotiateContentType(accept)).toBeNull();
+  });
+
+  test("ignores malformed ranges when another range is valid", () => {
+    expect(negotiateContentType("text/markdown;q=2, text/html;q=0.5")).toBe(
+      "text/html",
+    );
+  });
+
+  test("handles quoted media type parameters without splitting their values", () => {
+    expect(
+      negotiateContentType(
+        'text/markdown; profile="example,profile";q=1, text/html;q=0.5',
+      ),
+    ).toBe("text/html");
+  });
+});
+
+describe("addAcceptToVary", () => {
+  test.each([
+    [undefined, "Accept"],
+    [null, "Accept"],
+    ["", "Accept"],
+    ["Accept-Encoding", "Accept-Encoding, Accept"],
+    ["Accept-Encoding, Origin", "Accept-Encoding, Origin, Accept"],
+    ["Accept-Encoding, Accept", "Accept-Encoding, Accept"],
+    ["accept, Accept-Encoding", "accept, Accept-Encoding"],
+    [
+      "Accept-Encoding, ACCEPT-ENCODING, Origin",
+      "Accept-Encoding, Origin, Accept",
+    ],
+    ["*", "*"],
+  ])("merges %j as %j", (vary, expected) => {
+    expect(addAcceptToVary(vary)).toBe(expected);
+  });
+});

--- a/packages/zudoku/src/lib/util/contentNegotiation.test.ts
+++ b/packages/zudoku/src/lib/util/contentNegotiation.test.ts
@@ -64,6 +64,32 @@ describe("negotiateContentType", () => {
       ),
     ).toBe("text/html");
   });
+
+  test("treats non-q parameters as media parameters regardless of order", () => {
+    expect(
+      negotiateContentType(
+        "text/markdown;q=0.9;charset=utf-8, text/html;q=0.5",
+      ),
+    ).toBe("text/markdown");
+    expect(
+      negotiateContentType(
+        "text/markdown;charset=utf-8;q=0.9, text/html;q=0.5",
+      ),
+    ).toBe("text/markdown");
+    expect(
+      negotiateContentType(
+        "text/markdown;q=0.9;charset=iso-8859-1, text/html;q=0.5",
+      ),
+    ).toBe("text/html");
+  });
+
+  test("rejects legacy valueless accept extensions", () => {
+    expect(
+      negotiateContentType(
+        "text/markdown;q=0.9;legacy-extension, text/html;q=0.5",
+      ),
+    ).toBe("text/html");
+  });
 });
 
 describe("addAcceptToVary", () => {

--- a/packages/zudoku/src/lib/util/contentNegotiation.ts
+++ b/packages/zudoku/src/lib/util/contentNegotiation.ts
@@ -1,0 +1,268 @@
+export type NegotiatedContentType = "text/html" | "text/markdown";
+
+type Representation = {
+  contentType: NegotiatedContentType;
+  type: string;
+  subtype: string;
+  parameters: Readonly<Record<string, string>>;
+  serverOrder: number;
+};
+
+type MediaRange = {
+  type: string;
+  subtype: string;
+  parameters: ReadonlyMap<string, string>;
+  quality: number;
+  order: number;
+};
+
+type Match = {
+  contentType: NegotiatedContentType;
+  quality: number;
+  specificity: number;
+  parameterCount: number;
+  rangeOrder: number;
+  serverOrder: number;
+};
+
+const representations: readonly Representation[] = [
+  {
+    contentType: "text/html",
+    type: "text",
+    subtype: "html",
+    parameters: { charset: "utf-8" },
+    serverOrder: 0,
+  },
+  {
+    contentType: "text/markdown",
+    type: "text",
+    subtype: "markdown",
+    parameters: { charset: "utf-8" },
+    serverOrder: 1,
+  },
+];
+
+const tokenPattern = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const mediaRangePattern =
+  /^([!#$%&'*+\-.^_`|~0-9A-Za-z]+|\*)\/([!#$%&'*+\-.^_`|~0-9A-Za-z]+|\*)$/;
+const qualityPattern = /^(?:0(?:\.[0-9]{0,3})?|1(?:\.0{0,3})?)$/;
+
+const splitOutsideQuotes = (value: string, delimiter: string): string[] => {
+  const parts: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (quoted && character === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (character === '"') {
+      quoted = !quoted;
+      continue;
+    }
+
+    if (!quoted && character === delimiter) {
+      parts.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  parts.push(value.slice(start));
+  return parts;
+};
+
+const parseParameterValue = (value: string): string | undefined => {
+  const trimmedValue = value.trim();
+
+  if (tokenPattern.test(trimmedValue)) {
+    return trimmedValue.toLowerCase();
+  }
+
+  if (!trimmedValue.startsWith('"') || !trimmedValue.endsWith('"')) {
+    return undefined;
+  }
+
+  const innerValue = trimmedValue.slice(1, -1);
+  return innerValue.replace(/\\(.)/g, "$1").toLowerCase();
+};
+
+const parseMediaRange = (
+  value: string,
+  order: number,
+): MediaRange | undefined => {
+  const [rawMediaRange, ...rawParameters] = splitOutsideQuotes(value, ";");
+  const mediaRangeMatch = rawMediaRange
+    ?.trim()
+    .toLowerCase()
+    .match(mediaRangePattern);
+
+  if (!mediaRangeMatch) {
+    return undefined;
+  }
+
+  const [, type, subtype] = mediaRangeMatch;
+  if (!type || !subtype || (type === "*" && subtype !== "*")) {
+    return undefined;
+  }
+
+  const parameters = new Map<string, string>();
+  let quality = 1;
+  let foundQuality = false;
+
+  for (const rawParameter of rawParameters) {
+    const separatorIndex = rawParameter.indexOf("=");
+    if (separatorIndex === -1) {
+      return undefined;
+    }
+
+    const name = rawParameter.slice(0, separatorIndex).trim().toLowerCase();
+    const rawValue = rawParameter.slice(separatorIndex + 1).trim();
+
+    if (!tokenPattern.test(name)) {
+      return undefined;
+    }
+
+    if (name === "q") {
+      if (foundQuality || !qualityPattern.test(rawValue)) {
+        return undefined;
+      }
+
+      quality = Number(rawValue);
+      foundQuality = true;
+      continue;
+    }
+
+    // Parameters following q are accept extensions, not media type parameters.
+    if (foundQuality) {
+      continue;
+    }
+
+    const parameterValue = parseParameterValue(rawValue);
+    if (parameterValue === undefined || parameters.has(name)) {
+      return undefined;
+    }
+    parameters.set(name, parameterValue);
+  }
+
+  return { type, subtype, parameters, quality, order };
+};
+
+const getSpecificity = (range: MediaRange): number => {
+  if (range.type === "*") {
+    return 0;
+  }
+  if (range.subtype === "*") {
+    return 1;
+  }
+  return 2;
+};
+
+const matchesRepresentation = (
+  range: MediaRange,
+  representation: Representation,
+): boolean => {
+  if (range.type !== "*" && range.type !== representation.type) {
+    return false;
+  }
+  if (range.subtype !== "*" && range.subtype !== representation.subtype) {
+    return false;
+  }
+
+  return [...range.parameters].every(
+    ([name, value]) => representation.parameters[name]?.toLowerCase() === value,
+  );
+};
+
+const compareRangeMatches = (left: Match, right: Match): number =>
+  right.specificity - left.specificity ||
+  right.parameterCount - left.parameterCount ||
+  right.quality - left.quality ||
+  left.rangeOrder - right.rangeOrder;
+
+const getRepresentationMatch = (
+  ranges: readonly MediaRange[],
+  representation: Representation,
+): Match | undefined =>
+  ranges
+    .filter((range) => matchesRepresentation(range, representation))
+    .map((range) => ({
+      contentType: representation.contentType,
+      quality: range.quality,
+      specificity: getSpecificity(range),
+      parameterCount: range.parameters.size,
+      rangeOrder: range.order,
+      serverOrder: representation.serverOrder,
+    }))
+    .sort(compareRangeMatches)[0];
+
+const compareRepresentations = (left: Match, right: Match): number =>
+  right.quality - left.quality ||
+  right.specificity - left.specificity ||
+  right.parameterCount - left.parameterCount ||
+  left.rangeOrder - right.rangeOrder ||
+  left.serverOrder - right.serverOrder;
+
+/**
+ * Selects between Zudoku's HTML and Markdown representations using the
+ * request's Accept header. A null result means neither representation is
+ * acceptable and the caller can respond with 406 Not Acceptable.
+ */
+export const negotiateContentType = (
+  acceptHeader: string | null | undefined,
+): NegotiatedContentType | null => {
+  if (!acceptHeader?.trim()) {
+    return "text/html";
+  }
+
+  const ranges = splitOutsideQuotes(acceptHeader, ",")
+    .map((value, order) => parseMediaRange(value.trim(), order))
+    .filter((range): range is MediaRange => range !== undefined);
+
+  const match = representations
+    .map((representation) => getRepresentationMatch(ranges, representation))
+    .filter((result): result is Match => result !== undefined)
+    .filter((result) => result.quality > 0)
+    .sort(compareRepresentations)[0];
+
+  return match?.contentType ?? null;
+};
+
+/** Adds Accept to a Vary header without discarding or duplicating fields. */
+export const addAcceptToVary = (
+  varyHeader: string | null | undefined,
+): string => {
+  const fields = (varyHeader ?? "")
+    .split(",")
+    .map((field) => field.trim())
+    .filter(Boolean);
+
+  if (fields.some((field) => field === "*")) {
+    return "*";
+  }
+
+  const seenFields = new Set<string>();
+  const uniqueFields = fields.filter((field) => {
+    const normalizedField = field.toLowerCase();
+    if (seenFields.has(normalizedField)) {
+      return false;
+    }
+    seenFields.add(normalizedField);
+    return true;
+  });
+
+  if (!seenFields.has("accept")) {
+    uniqueFields.push("Accept");
+  }
+
+  return uniqueFields.join(", ");
+};

--- a/packages/zudoku/src/lib/util/contentNegotiation.ts
+++ b/packages/zudoku/src/lib/util/contentNegotiation.ts
@@ -142,11 +142,8 @@ const parseMediaRange = (
       continue;
     }
 
-    // Parameters following q are accept extensions, not media type parameters.
-    if (foundQuality) {
-      continue;
-    }
-
+    // RFC 9110 no longer defines accept extensions. Every non-q parameter is
+    // a media type parameter and participates in representation matching.
     const parameterValue = parseParameterValue(rawValue);
     if (parameterValue === undefined || parameters.has(name)) {
       return undefined;

--- a/packages/zudoku/src/lib/util/markdown-representation.test.ts
+++ b/packages/zudoku/src/lib/util/markdown-representation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendLinkHeader,
+  encodeDocumentationRoutePath,
+  getMarkdownAlternateLink,
+  getMarkdownNotFound,
+  getMarkdownRepresentationPath,
+  resolveDocumentationRoutePath,
+} from "./markdown-representation.js";
+
+describe("appendLinkHeader", () => {
+  it("preserves existing Link values when adding an alternate", () => {
+    expect(
+      appendLinkHeader(
+        ['</assets/app.js>; rel="preload"', '</canonical>; rel="canonical"'],
+        '</guide.md>; rel="alternate"; type="text/markdown"',
+      ),
+    ).toBe(
+      '</assets/app.js>; rel="preload", </canonical>; rel="canonical", </guide.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+});
+
+describe("resolveDocumentationRoutePath", () => {
+  it.each([
+    ["https://example.com/", undefined, "/"],
+    ["https://example.com/guides/start", undefined, "/guides/start"],
+    ["https://example.com/docs", "/docs", "/"],
+    ["https://example.com/docs/", "/docs", "/"],
+    ["https://example.com/docs/guides/start/", "/docs", "/guides/start"],
+  ])("resolves %s within %s", (url, basePath, expected) => {
+    expect(resolveDocumentationRoutePath(url, basePath)).toBe(expected);
+  });
+
+  it("rejects paths outside the configured base path", () => {
+    expect(
+      resolveDocumentationRoutePath("https://example.com/reference", "/docs"),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["/hello world", "/hello%20world"],
+    ["/guides/café", "/guides/caf%C3%A9"],
+    ["/hello%20world", "/hello%20world"],
+    ["/guide#intro", "/guide%23intro"],
+    ["/guide?mode", "/guide%3Fmode"],
+    ["/100%", "/100%25"],
+    ["/guide%23intro", "/guide%23intro"],
+  ])("URL-encodes route path %s", (routePath, expected) => {
+    expect(encodeDocumentationRoutePath(routePath)).toBe(expected);
+  });
+});
+
+describe("getMarkdownRepresentationPath", () => {
+  it("uses index.md for the documentation root", () => {
+    expect(getMarkdownRepresentationPath("/", "/docs")).toBe("/docs/index.md");
+  });
+
+  it("appends .md to nested routes", () => {
+    expect(getMarkdownRepresentationPath("/guides/start", "/docs")).toBe(
+      "/docs/guides/start.md",
+    );
+  });
+
+  it("formats an alternate Link value", () => {
+    expect(getMarkdownAlternateLink("/guides/start", "/docs")).toBe(
+      '</docs/guides/start.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+
+  it("URL-encodes alternate Markdown links", () => {
+    expect(getMarkdownAlternateLink("/guides/café au lait", "/docs")).toBe(
+      '</docs/guides/caf%C3%A9%20au%20lait.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+});
+
+describe("getMarkdownNotFound", () => {
+  it("only links to machine-readable files that are configured", () => {
+    const body = getMarkdownNotFound({
+      basePath: "/docs",
+      includeLlmsTxt: true,
+      markdownRoutePaths: ["/"],
+      sitemapOutDir: "meta",
+    });
+
+    expect(body).toContain("# Page not found");
+    expect(body).toContain("[Documentation home](/docs)");
+    expect(body).toContain("[Markdown documentation index](/docs/index.md)");
+    expect(body).toContain("[Agent documentation index](/docs/llms.txt)");
+    expect(body).toContain("[Sitemap](/docs/meta/sitemap.xml)");
+  });
+
+  it("does not advertise absent llms.txt or sitemap files", () => {
+    const body = getMarkdownNotFound({
+      includeLlmsTxt: false,
+      markdownRoutePaths: [],
+    });
+
+    expect(body).not.toContain("index.md");
+    expect(body).not.toContain("llms.txt");
+    expect(body).not.toContain("sitemap.xml");
+  });
+
+  it("links the first real Markdown route when the homepage is custom", () => {
+    const body = getMarkdownNotFound({
+      basePath: "/docs",
+      includeLlmsTxt: false,
+      markdownRoutePaths: ["/quickstart", "/reference"],
+    });
+
+    expect(body).toContain(
+      "[Markdown documentation index](/docs/quickstart.md)",
+    );
+    expect(body).not.toContain("/docs/index.md");
+  });
+});

--- a/packages/zudoku/src/lib/util/markdown-representation.ts
+++ b/packages/zudoku/src/lib/util/markdown-representation.ts
@@ -1,0 +1,113 @@
+import { joinUrl } from "./joinUrl.js";
+import { getMarkdownPathname } from "./markdown.js";
+
+const encodePathSegment = (segment: string) => {
+  try {
+    return encodeURIComponent(decodeURIComponent(segment));
+  } catch {
+    return encodeURIComponent(segment);
+  }
+};
+
+export const encodeDocumentationRoutePath = (routePath: string) => {
+  const encodedPath = routePath
+    .split("/")
+    .filter(Boolean)
+    .map(encodePathSegment)
+    .join("/");
+  return encodedPath ? `/${encodedPath}` : "/";
+};
+
+export const resolveDocumentationRoutePath = (
+  requestUrl: string,
+  basePath?: string,
+): string | undefined => {
+  const pathname = new URL(requestUrl, "http://localhost").pathname;
+  const normalizedBasePath = encodeDocumentationRoutePath(joinUrl(basePath));
+
+  if (
+    normalizedBasePath !== "/" &&
+    pathname !== normalizedBasePath &&
+    !pathname.startsWith(`${normalizedBasePath}/`)
+  ) {
+    return;
+  }
+
+  const relativePath =
+    normalizedBasePath === "/"
+      ? pathname
+      : pathname.slice(normalizedBasePath.length) || "/";
+
+  return encodeDocumentationRoutePath(relativePath);
+};
+
+export const getMarkdownRepresentationPath = (
+  routePath: string,
+  basePath?: string,
+) =>
+  joinUrl(
+    encodeDocumentationRoutePath(joinUrl(basePath)),
+    `${getMarkdownPathname(encodeDocumentationRoutePath(routePath))}.md`,
+  );
+
+export const getMarkdownAlternateLink = (
+  routePath: string,
+  basePath?: string,
+) =>
+  `<${getMarkdownRepresentationPath(routePath, basePath)}>; rel="alternate"; type="text/markdown"`;
+
+export const appendLinkHeader = (
+  currentValue: string | number | readonly string[] | null | undefined,
+  linkValue: string,
+) => {
+  const normalizedValue = Array.isArray(currentValue)
+    ? currentValue.join(", ")
+    : currentValue?.toString().trim();
+  return normalizedValue ? `${normalizedValue}, ${linkValue}` : linkValue;
+};
+
+export const getMarkdownNotFound = ({
+  basePath,
+  includeLlmsTxt,
+  markdownRoutePaths,
+  sitemapOutDir,
+}: {
+  basePath?: string;
+  includeLlmsTxt: boolean;
+  markdownRoutePaths: readonly string[];
+  sitemapOutDir?: string;
+}) => {
+  const encodedBasePath = encodeDocumentationRoutePath(joinUrl(basePath));
+  const markdownEntryRoute = markdownRoutePaths.includes("/")
+    ? "/"
+    : markdownRoutePaths[0];
+  const links = [
+    `[Documentation home](${encodedBasePath})`,
+    ...(markdownEntryRoute
+      ? [
+          `[Markdown documentation index](${getMarkdownRepresentationPath(markdownEntryRoute, basePath)})`,
+        ]
+      : []),
+    ...(includeLlmsTxt
+      ? [`[Agent documentation index](${joinUrl(encodedBasePath, "llms.txt")})`]
+      : []),
+    ...(sitemapOutDir !== undefined
+      ? [
+          `[Sitemap](${joinUrl(
+            encodedBasePath,
+            encodeDocumentationRoutePath(sitemapOutDir),
+            "sitemap.xml",
+          )})`,
+        ]
+      : []),
+  ];
+
+  return [
+    "# Page not found",
+    "",
+    "The requested documentation page does not exist. Try one of these entry points:",
+    "",
+    ...links.map((link) => `- ${link}`),
+    "",
+  ].join("\n");
+};

--- a/packages/zudoku/src/types.d.ts
+++ b/packages/zudoku/src/types.d.ts
@@ -51,3 +51,8 @@ declare module "virtual:zudoku-shiki-register" {
   import type { HighlighterCore } from "shiki/core";
   export const registerShiki: (highlighter: HighlighterCore) => Promise<void>;
 }
+
+declare module "virtual:zudoku-markdown-files" {
+  const markdownFiles: Readonly<Record<string, string>>;
+  export default markdownFiles;
+}

--- a/packages/zudoku/src/vite/api/SchemaManager.test.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.test.ts
@@ -144,6 +144,47 @@ describe("SchemaManager", () => {
     );
   });
 
+  it("regenerates base-path-dependent outputs after reprocessing", async () => {
+    const schemaPath = path.join(tempDir, "openapi.json");
+    await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
+    const config: ConfigWithMeta = {
+      ...baseConfig,
+      basePath: "/docs",
+      apis: {
+        type: "file",
+        path: "test-api",
+        input: schemaPath,
+        publish: { path: "/openapi.json" },
+        options: {
+          schemaDownload: { enabled: true },
+        },
+      },
+    };
+    const manager = new SchemaManager({
+      storeDir,
+      config,
+      processors: [],
+    });
+
+    await manager.processAllSchemas();
+    expect(manager.getPublishedSchemas()[0]?.urlPath).toBe(
+      "/docs/openapi.json",
+    );
+    expect(manager.getLatestSchema("test-api")?.downloadUrl).toBe(
+      "/docs/test-api/1.0.0/schema.json",
+    );
+
+    manager.config = { ...config, basePath: "/reference" };
+    await manager.processAllSchemas();
+
+    expect(manager.getPublishedSchemas()[0]?.urlPath).toBe(
+      "/reference/openapi.json",
+    );
+    expect(manager.getLatestSchema("test-api")?.downloadUrl).toBe(
+      "/reference/test-api/1.0.0/schema.json",
+    );
+  });
+
   it("publishes YAML with the matching media type", async () => {
     const schemaPath = path.join(tempDir, "openapi.json");
     await fs.writeFile(schemaPath, JSON.stringify(mockSchema));

--- a/packages/zudoku/src/vite/api/SchemaManager.test.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.test.ts
@@ -2,7 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { OpenAPIV3_1 } from "openapi-types";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
 import type { ConfigWithMeta } from "../../config/loader.js";
 import type { Processor } from "../../config/validators/BuildSchema.js";
 import { validateConfig } from "../../config/validators/ZudokuConfig.js";
@@ -95,6 +96,144 @@ describe("SchemaManager", () => {
     expect(schemas).toHaveLength(2);
     expect(schemas?.[0]?.version).toBe("2.0.0"); // v2 first
     expect(schemas?.[1]?.version).toBe("1.0.0"); // v1 second
+  });
+
+  it("publishes only explicitly configured APIs using the primary schema", async () => {
+    const schemaPath = path.join(tempDir, "openapi.json");
+    const schemaPathV2 = path.join(tempDir, "openapi-v2.json");
+    const otherSchemaPath = path.join(tempDir, "other.json");
+    await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
+    await fs.writeFile(
+      schemaPathV2,
+      JSON.stringify({
+        ...mockSchema,
+        info: { ...mockSchema.info, version: "2.0.0" },
+      }),
+    );
+    await fs.writeFile(otherSchemaPath, JSON.stringify(mockSchema));
+
+    const manager = new SchemaManager({
+      storeDir,
+      config: {
+        ...baseConfig,
+        basePath: "/docs",
+        apis: [
+          {
+            type: "file",
+            path: "test-api",
+            input: [schemaPathV2, schemaPath],
+            publish: { path: "/openapi.json" },
+          },
+          { type: "file", path: "other-api", input: otherSchemaPath },
+        ],
+      },
+      processors: [],
+    });
+
+    await manager.processAllSchemas();
+
+    const publications = manager.getPublishedSchemas();
+    expect(publications).toHaveLength(1);
+    expect(publications[0]).toMatchObject({
+      apiPath: "test-api",
+      urlPath: "/docs/openapi.json",
+      mediaType: "application/json",
+    });
+    expect(JSON.parse(publications[0]?.content ?? "{}").info.version).toBe(
+      "2.0.0",
+    );
+  });
+
+  it("publishes YAML with the matching media type", async () => {
+    const schemaPath = path.join(tempDir, "openapi.json");
+    await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
+    const manager = new SchemaManager({
+      storeDir,
+      config: {
+        ...baseConfig,
+        apis: {
+          type: "file",
+          path: "test-api",
+          input: schemaPath,
+          publish: { path: "/openapi.yaml" },
+        },
+      },
+      processors: [],
+    });
+
+    await manager.processAllSchemas();
+
+    const publication = manager.getPublishedSchemas()[0];
+    expect(publication?.mediaType).toBe("application/yaml");
+    expect(parseYaml(publication?.content ?? "").info.title).toBe("Test API");
+  });
+
+  it("rejects duplicate publication paths across APIs", async () => {
+    const schemaPath = path.join(tempDir, "openapi.json");
+    const secondSchemaPath = path.join(tempDir, "second-openapi.json");
+    await fs.writeFile(schemaPath, JSON.stringify(mockSchema));
+    await fs.writeFile(secondSchemaPath, JSON.stringify(mockSchema));
+    const manager = new SchemaManager({
+      storeDir,
+      config: {
+        ...baseConfig,
+        apis: [
+          {
+            type: "file",
+            path: "first-api",
+            input: schemaPath,
+            publish: { path: "/openapi.json" },
+          },
+          {
+            type: "file",
+            path: "second-api",
+            input: secondSchemaPath,
+            publish: { path: "/openapi.json" },
+          },
+        ],
+      },
+      processors: [],
+    });
+
+    await expect(manager.processAllSchemas()).rejects.toThrow(
+      'OpenAPI publication path "/openapi.json" is configured by both "first-api" and "second-api"',
+    );
+  });
+
+  it("reports agent-quality issues only when opted in", async () => {
+    const schemaPath = path.join(tempDir, "openapi.json");
+    await fs.writeFile(
+      schemaPath,
+      JSON.stringify({
+        ...mockSchema,
+        paths: {
+          "/widgets": { get: { responses: { "200": { description: "OK" } } } },
+        },
+      }),
+    );
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const manager = new SchemaManager({
+      storeDir,
+      config: {
+        ...baseConfig,
+        apis: {
+          type: "file",
+          path: "test-api",
+          input: schemaPath,
+          publish: { path: "/openapi.json", agentQuality: true },
+        },
+      },
+      processors: [],
+    });
+
+    await manager.processAllSchemas();
+
+    expect(warning).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[zudoku] Agent-quality audit for API "test-api" found',
+      ),
+    );
+    warning.mockRestore();
   });
 
   it("should handle multiple versions with overridden path and label", async () => {

--- a/packages/zudoku/src/vite/api/SchemaManager.ts
+++ b/packages/zudoku/src/vite/api/SchemaManager.ts
@@ -14,6 +14,14 @@ import { ensureArray } from "../../lib/util/ensureArray.js";
 import { flattenAllOfProcessor } from "../../lib/util/flattenAllOfProcessor.js";
 import { joinUrl } from "../../lib/util/joinUrl.js";
 import { slugify } from "../../lib/util/slugify.js";
+import {
+  auditOpenApiAgentQuality,
+  formatAgentQualityReport,
+} from "./agent-quality.js";
+import {
+  createOpenApiPublication,
+  type OpenApiPublication,
+} from "./openapi-publication.js";
 import { generateCode } from "./schema-codegen.js";
 
 type ProcessedSchema = {
@@ -81,6 +89,7 @@ export class SchemaManager {
   private processors: Processor[];
   private processedSchemas: Record<string, ProcessedSchema[]> = {};
   private referencedBy = new Map<string, Set<string>>();
+  private publishedSchemas: OpenApiPublication[] | undefined;
   public config: LoadedConfig;
 
   constructor({
@@ -113,7 +122,7 @@ export class SchemaManager {
 
     const apis = ensureArray(this.config.apis ?? []);
     for (const apiConfig of apis) {
-      if (!apiConfig || apiConfig.type !== "file" || !apiConfig.path) continue;
+      if (apiConfig?.type !== "file" || !apiConfig.path) continue;
 
       const match = normalizeInputs(apiConfig.input).some(
         (i) =>
@@ -208,7 +217,7 @@ export class SchemaManager {
         : paramsPath(params) || schemaVersion;
 
     const config = ensureArray(this.config.apis ?? []).find(
-      (c) => c.path === configuredPath,
+      (c) => c.type === "file" && c.path === configuredPath,
     );
 
     const processed = {
@@ -236,11 +245,27 @@ export class SchemaManager {
 
     if (index > -1) {
       schemas[index] = processed;
+      this.publishedSchemas = undefined;
     } else {
       throw new Error(
         `Schema with input path ${filePath} was not pre-initialized for ${configuredPath}.`,
       );
     }
+
+    if (
+      index === 0 &&
+      config?.type === "file" &&
+      config.publish?.agentQuality
+    ) {
+      const issues = auditOpenApiAgentQuality(processedSchema);
+      if (issues.length > 0) {
+        // biome-ignore lint/suspicious/noConsole: Opt-in build report
+        console.warn(
+          `[zudoku] ${formatAgentQualityReport(configuredPath, issues)}`,
+        );
+      }
+    }
+
     return processed;
   };
 
@@ -271,6 +296,7 @@ export class SchemaManager {
   public processAllSchemas = async () => {
     this.referencedBy.clear();
     this.processedSchemas = {};
+    this.publishedSchemas = undefined;
 
     const apis = ensureArray(this.config.apis ?? []);
     for (const apiConfig of apis) {
@@ -306,6 +332,10 @@ export class SchemaManager {
         );
       }
     }
+
+    // Resolve publications now so duplicate public paths fail the build instead
+    // of silently allowing one API to overwrite another.
+    this.getPublishedSchemas();
   };
 
   public getLatestSchema = (path: string) => this.processedSchemas[path]?.at(0);
@@ -316,6 +346,41 @@ export class SchemaManager {
     Object.values(this.processedSchemas)
       .flat()
       .filter((s) => s.importKey);
+
+  public getPublishedSchemas = (): OpenApiPublication[] => {
+    if (this.publishedSchemas) return this.publishedSchemas;
+
+    const publications = new Map<string, OpenApiPublication>();
+
+    for (const apiConfig of ensureArray(this.config.apis ?? [])) {
+      if (apiConfig.type !== "file" || !apiConfig.path || !apiConfig.publish) {
+        continue;
+      }
+
+      const primarySchema = this.getLatestSchema(apiConfig.path);
+      if (!primarySchema) continue;
+
+      const urlPath = joinUrl(this.config.basePath, apiConfig.publish.path);
+      const existing = publications.get(urlPath);
+      if (existing) {
+        throw new Error(
+          `OpenAPI publication path "${urlPath}" is configured by both "${existing.apiPath}" and "${apiConfig.path}". Configure a unique path for each published API.`,
+        );
+      }
+
+      publications.set(
+        urlPath,
+        createOpenApiPublication({
+          apiPath: apiConfig.path,
+          urlPath,
+          schema: primarySchema.schema,
+        }),
+      );
+    }
+
+    this.publishedSchemas = Array.from(publications.values());
+    return this.publishedSchemas;
+  };
 
   public getUrlToFilePathMap = () => {
     const map = new Map<string, string>();

--- a/packages/zudoku/src/vite/api/agent-quality.test.ts
+++ b/packages/zudoku/src/vite/api/agent-quality.test.ts
@@ -154,6 +154,132 @@ describe("auditOpenApiAgentQuality", () => {
     expect(auditOpenApiAgentQuality(document)).toEqual([]);
   });
 
+  it("audits only the effective parameter after operation overrides", () => {
+    const document = createDocument({
+      "/widgets/{id}": {
+        parameters: [
+          { name: "id", in: "path" },
+          { name: "id", in: "query" },
+          { $ref: "https://example.com/parameters.json#/External" },
+        ],
+        get: {
+          operationId: "getWidget",
+          description: "Get a widget.",
+          parameters: [{ name: "id", in: "path", schema: { type: "string" } }],
+          responses: {
+            "200": {
+              description: "A widget.",
+              content: {
+                "application/json": { schema: { type: "object" } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      auditOpenApiAgentQuality(document).filter(
+        (issue) => issue.code === "untyped-parameter",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        message: 'Parameter "id" is missing a typed schema.',
+      }),
+      expect.objectContaining({
+        message: 'Parameter "<unknown>" is missing a typed schema.',
+      }),
+    ]);
+  });
+
+  it("resolves referenced parameter identities before applying overrides", () => {
+    const document = {
+      ...createDocument({
+        "/widgets/{id}": {
+          parameters: [{ $ref: "#/components/parameters/TypedPathId" }],
+          get: {
+            operationId: "getWidget",
+            description: "Get a widget.",
+            parameters: [
+              { $ref: "#/components/parameters/UntypedOperationId" },
+            ],
+            responses: {
+              "200": {
+                description: "A widget.",
+                content: {
+                  "application/json": { schema: { type: "object" } },
+                },
+              },
+            },
+          },
+        },
+      }),
+      components: {
+        parameters: {
+          TypedPathId: {
+            name: "id",
+            in: "path",
+            schema: { type: "string" },
+          },
+          UntypedOperationId: {
+            name: "id",
+            in: "path",
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    expect(auditOpenApiAgentQuality(document)).toEqual([
+      expect.objectContaining({
+        code: "untyped-parameter",
+        location: "GET /widgets/{id}",
+        message: 'Parameter "id" is missing a typed schema.',
+      }),
+    ]);
+  });
+
+  it("does not require content schemas for HEAD or informational responses", () => {
+    const document = createDocument({
+      "/widgets": {
+        head: {
+          operationId: "headWidgets",
+          description: "Inspect widget metadata.",
+          responses: { "200": { description: "Widget metadata." } },
+        },
+        get: {
+          operationId: "getWidgets",
+          description: "List widgets.",
+          responses: {
+            "103": { description: "Early hints." },
+            "1XX": { description: "Informational response." },
+          },
+        },
+      },
+    });
+
+    expect(auditOpenApiAgentQuality(document)).toEqual([]);
+  });
+
+  it("still requires HEAD operations to declare a response", () => {
+    const document = createDocument({
+      "/widgets": {
+        head: {
+          operationId: "headWidgets",
+          description: "Inspect widget metadata.",
+          responses: {},
+        },
+      },
+    });
+
+    expect(auditOpenApiAgentQuality(document)).toEqual([
+      expect.objectContaining({
+        code: "missing-response-schema",
+        location: "HEAD /widgets",
+        message: "Operation has no response schemas.",
+      }),
+    ]);
+  });
+
   it("formats an actionable warning report", () => {
     expect(
       formatAgentQualityReport("/api", [

--- a/packages/zudoku/src/vite/api/agent-quality.test.ts
+++ b/packages/zudoku/src/vite/api/agent-quality.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
+import {
+  auditOpenApiAgentQuality,
+  formatAgentQualityReport,
+} from "./agent-quality.js";
+
+const createDocument = (paths: unknown) =>
+  ({
+    openapi: "3.1.0",
+    info: { title: "Test API", version: "1.0.0" },
+    components: {},
+    paths,
+  }) as OpenAPIDocument;
+
+describe("auditOpenApiAgentQuality", () => {
+  it("reports function-calling compatibility gaps without mutating the schema", () => {
+    const document = createDocument({
+      "/widgets": {
+        get: {
+          operationId: "widgets",
+          parameters: [{ name: "limit", in: "query" }],
+          responses: { "200": { description: "OK" } },
+        },
+        post: {
+          operationId: "widgets",
+          description: "Create a widget.",
+          responses: {},
+        },
+        put: {
+          operationId: "replaceWidgets",
+          description: "Replace the widgets.",
+          requestBody: {
+            content: { "application/json": {} },
+          },
+          responses: { "204": { description: "Replaced" } },
+        },
+      },
+      "/health": {
+        get: {
+          description: "Check service health.",
+          responses: { "204": { description: "Healthy" } },
+        },
+      },
+    });
+    const original = structuredClone(document);
+
+    const issues = auditOpenApiAgentQuality(document);
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "missing-description",
+          location: "GET /widgets",
+        }),
+        expect.objectContaining({
+          code: "untyped-parameter",
+          location: "GET /widgets",
+        }),
+        expect.objectContaining({
+          code: "missing-response-schema",
+          location: "GET /widgets",
+        }),
+        expect.objectContaining({
+          code: "missing-response-schema",
+          location: "POST /widgets",
+        }),
+        expect.objectContaining({
+          code: "missing-request-body",
+          location: "POST /widgets",
+        }),
+        expect.objectContaining({
+          code: "untyped-request-body",
+          location: "PUT /widgets",
+        }),
+        expect.objectContaining({
+          code: "missing-operation-id",
+          location: "GET /health",
+        }),
+        expect.objectContaining({
+          code: "duplicate-operation-id",
+          location: "GET /widgets, POST /widgets",
+        }),
+      ]),
+    );
+    expect(document).toEqual(original);
+  });
+
+  it("accepts typed inline and referenced parameters and responses", () => {
+    const document = {
+      ...createDocument({
+        "/widgets/{id}": {
+          parameters: [{ $ref: "#/components/parameters/WidgetId" }],
+          get: {
+            operationId: "getWidget",
+            description: "Get a widget.",
+            responses: {
+              "200": { $ref: "#/components/responses/WidgetResponse" },
+            },
+          },
+        },
+      }),
+      components: {
+        parameters: {
+          WidgetId: {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        },
+        responses: {
+          WidgetResponse: {
+            description: "A widget.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { id: { type: "string" } },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    expect(auditOpenApiAgentQuality(document)).toEqual([]);
+  });
+
+  it("accepts a referenced, typed request body on a write operation", () => {
+    const document = {
+      ...createDocument({
+        "/widgets": {
+          post: {
+            operationId: "createWidget",
+            description: "Create a widget.",
+            requestBody: { $ref: "#/components/requestBodies/CreateWidget" },
+            responses: { "204": { description: "Created" } },
+          },
+        },
+      }),
+      components: {
+        requestBodies: {
+          CreateWidget: {
+            content: {
+              "application/json": { schema: { type: "object" } },
+            },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    expect(auditOpenApiAgentQuality(document)).toEqual([]);
+  });
+
+  it("formats an actionable warning report", () => {
+    expect(
+      formatAgentQualityReport("/api", [
+        {
+          code: "missing-operation-id",
+          location: "GET /widgets",
+          message: "Operation is missing a unique operationId.",
+        },
+      ]),
+    ).toContain(
+      'Agent-quality audit for API "/api" found 1 issue:\n- [missing-operation-id] GET /widgets',
+    );
+  });
+});

--- a/packages/zudoku/src/vite/api/agent-quality.ts
+++ b/packages/zudoku/src/vite/api/agent-quality.ts
@@ -109,6 +109,61 @@ const getParameterName = (document: OpenAPIDocument, parameter: unknown) => {
     : "<unknown>";
 };
 
+const getParameterIdentity = (
+  document: OpenAPIDocument,
+  parameter: unknown,
+) => {
+  const resolved = resolveLocalRef(document, parameter);
+  if (
+    !isObject(resolved) ||
+    typeof resolved.name !== "string" ||
+    typeof resolved.in !== "string"
+  ) {
+    return undefined;
+  }
+
+  return JSON.stringify([resolved.name, resolved.in]);
+};
+
+const mergeParameters = (
+  document: OpenAPIDocument,
+  pathParameters: unknown,
+  operationParameters: unknown,
+) => {
+  const merged: unknown[] = [];
+  const indexes = new Map<string, number>();
+
+  for (const parameter of [
+    ...(Array.isArray(pathParameters) ? pathParameters : []),
+    ...(Array.isArray(operationParameters) ? operationParameters : []),
+  ]) {
+    const identity = getParameterIdentity(document, parameter);
+    if (identity === undefined) {
+      // Keep unresolved or incomplete parameters so the audit still reports
+      // any typing issue instead of silently dropping it during the merge.
+      merged.push(parameter);
+      continue;
+    }
+
+    const existingIndex = indexes.get(identity);
+    if (existingIndex === undefined) {
+      indexes.set(identity, merged.length);
+      merged.push(parameter);
+    } else {
+      // OpenAPI operation parameters override path-level parameters with the
+      // same (name, in) identity.
+      merged[existingIndex] = parameter;
+    }
+  }
+
+  return merged;
+};
+
+const responseCannotHaveContent = (method: string, status: string) =>
+  method === "head" ||
+  /^1(?:\d{2}|xx)$/i.test(status) ||
+  ["204", "205", "304"].includes(status);
+
 /**
  * Reports OpenAPI authoring gaps that make operations harder to translate to
  * LLM function tools. The audit is read-only and intentionally opt-in.
@@ -155,10 +210,11 @@ export const auditOpenApiAgentQuality = (
         });
       }
 
-      const parameters = [
-        ...(Array.isArray(pathItem.parameters) ? pathItem.parameters : []),
-        ...(Array.isArray(operation.parameters) ? operation.parameters : []),
-      ];
+      const parameters = mergeParameters(
+        document,
+        pathItem.parameters,
+        operation.parameters,
+      );
       for (const parameter of parameters) {
         if (parameterIsTyped(document, parameter)) continue;
         issues.push({
@@ -195,7 +251,7 @@ export const auditOpenApiAgentQuality = (
       }
 
       for (const [status, response] of Object.entries(responses)) {
-        if (["204", "205", "304"].includes(status)) continue;
+        if (responseCannotHaveContent(method, status)) continue;
         if (responseHasTypedSchema(document, response)) continue;
         issues.push({
           code: "missing-response-schema",

--- a/packages/zudoku/src/vite/api/agent-quality.ts
+++ b/packages/zudoku/src/vite/api/agent-quality.ts
@@ -1,0 +1,230 @@
+import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
+
+const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+] as const;
+
+const REQUEST_BODY_METHODS = new Set(["post", "put", "patch"]);
+
+type JsonObject = Record<string, unknown>;
+
+export type AgentQualityIssue = {
+  code:
+    | "duplicate-operation-id"
+    | "missing-description"
+    | "missing-operation-id"
+    | "missing-request-body"
+    | "missing-response-schema"
+    | "untyped-request-body"
+    | "untyped-parameter";
+  location: string;
+  message: string;
+};
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const resolveLocalRef = (
+  document: OpenAPIDocument,
+  value: unknown,
+): unknown => {
+  if (!isObject(value) || typeof value.$ref !== "string") return value;
+  if (!value.$ref.startsWith("#/")) return undefined;
+
+  return value.$ref
+    .slice(2)
+    .split("/")
+    .map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"))
+    .reduce<unknown>((current, part) => {
+      if (!isObject(current)) return undefined;
+      return current[part];
+    }, document);
+};
+
+const schemaIsTyped = (document: OpenAPIDocument, schema: unknown): boolean => {
+  const resolved = resolveLocalRef(document, schema);
+  if (typeof resolved === "boolean") return true;
+  if (!isObject(resolved)) return false;
+
+  return (
+    typeof resolved.type === "string" ||
+    Array.isArray(resolved.type) ||
+    "enum" in resolved ||
+    "const" in resolved ||
+    "properties" in resolved ||
+    "items" in resolved ||
+    "oneOf" in resolved ||
+    "anyOf" in resolved ||
+    "allOf" in resolved
+  );
+};
+
+const contentHasTypedSchema = (document: OpenAPIDocument, content: unknown) =>
+  isObject(content) &&
+  Object.values(content).some(
+    (mediaType) =>
+      isObject(mediaType) && schemaIsTyped(document, mediaType.schema),
+  );
+
+const parameterIsTyped = (document: OpenAPIDocument, parameter: unknown) => {
+  const resolved = resolveLocalRef(document, parameter);
+  return (
+    isObject(resolved) &&
+    (schemaIsTyped(document, resolved.schema) ||
+      contentHasTypedSchema(document, resolved.content))
+  );
+};
+
+const responseHasTypedSchema = (
+  document: OpenAPIDocument,
+  response: unknown,
+) => {
+  const resolved = resolveLocalRef(document, response);
+  return (
+    isObject(resolved) && contentHasTypedSchema(document, resolved.content)
+  );
+};
+
+const requestBodyHasTypedSchema = (
+  document: OpenAPIDocument,
+  requestBody: unknown,
+) => {
+  const resolved = resolveLocalRef(document, requestBody);
+  return (
+    isObject(resolved) && contentHasTypedSchema(document, resolved.content)
+  );
+};
+
+const getParameterName = (document: OpenAPIDocument, parameter: unknown) => {
+  const resolved = resolveLocalRef(document, parameter);
+  return isObject(resolved) && typeof resolved.name === "string"
+    ? resolved.name
+    : "<unknown>";
+};
+
+/**
+ * Reports OpenAPI authoring gaps that make operations harder to translate to
+ * LLM function tools. The audit is read-only and intentionally opt-in.
+ */
+export const auditOpenApiAgentQuality = (
+  document: OpenAPIDocument,
+): AgentQualityIssue[] => {
+  const issues: AgentQualityIssue[] = [];
+  const operationIds = new Map<string, string[]>();
+  if (!isObject(document.paths)) return issues;
+
+  for (const [route, rawPathItem] of Object.entries(document.paths)) {
+    const pathItem = resolveLocalRef(document, rawPathItem);
+    if (!isObject(pathItem)) continue;
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!isObject(operation)) continue;
+
+      const location = `${method.toUpperCase()} ${route}`;
+      if (
+        typeof operation.operationId !== "string" ||
+        operation.operationId.trim().length === 0
+      ) {
+        issues.push({
+          code: "missing-operation-id",
+          location,
+          message: "Operation is missing a unique operationId.",
+        });
+      } else {
+        const locations = operationIds.get(operation.operationId) ?? [];
+        locations.push(location);
+        operationIds.set(operation.operationId, locations);
+      }
+
+      if (
+        typeof operation.description !== "string" ||
+        operation.description.trim().length === 0
+      ) {
+        issues.push({
+          code: "missing-description",
+          location,
+          message: "Operation is missing a description.",
+        });
+      }
+
+      const parameters = [
+        ...(Array.isArray(pathItem.parameters) ? pathItem.parameters : []),
+        ...(Array.isArray(operation.parameters) ? operation.parameters : []),
+      ];
+      for (const parameter of parameters) {
+        if (parameterIsTyped(document, parameter)) continue;
+        issues.push({
+          code: "untyped-parameter",
+          location,
+          message: `Parameter "${getParameterName(document, parameter)}" is missing a typed schema.`,
+        });
+      }
+
+      if (operation.requestBody === undefined) {
+        if (REQUEST_BODY_METHODS.has(method)) {
+          issues.push({
+            code: "missing-request-body",
+            location,
+            message: "Write operation is missing a requestBody schema.",
+          });
+        }
+      } else if (!requestBodyHasTypedSchema(document, operation.requestBody)) {
+        issues.push({
+          code: "untyped-request-body",
+          location,
+          message: "Request body is missing a typed schema.",
+        });
+      }
+
+      const responses = operation.responses;
+      if (!isObject(responses) || Object.keys(responses).length === 0) {
+        issues.push({
+          code: "missing-response-schema",
+          location,
+          message: "Operation has no response schemas.",
+        });
+        continue;
+      }
+
+      for (const [status, response] of Object.entries(responses)) {
+        if (["204", "205", "304"].includes(status)) continue;
+        if (responseHasTypedSchema(document, response)) continue;
+        issues.push({
+          code: "missing-response-schema",
+          location,
+          message: `Response ${status} is missing a typed schema.`,
+        });
+      }
+    }
+  }
+
+  for (const [operationId, locations] of operationIds) {
+    if (locations.length < 2) continue;
+    issues.push({
+      code: "duplicate-operation-id",
+      location: locations.join(", "),
+      message: `operationId "${operationId}" is used by multiple operations.`,
+    });
+  }
+
+  return issues;
+};
+
+export const formatAgentQualityReport = (
+  apiPath: string,
+  issues: AgentQualityIssue[],
+) =>
+  [
+    `Agent-quality audit for API "${apiPath}" found ${issues.length} issue${issues.length === 1 ? "" : "s"}:`,
+    ...issues.map(
+      (issue) => `- [${issue.code}] ${issue.location}: ${issue.message}`,
+    ),
+  ].join("\n");

--- a/packages/zudoku/src/vite/api/openapi-publication.test.ts
+++ b/packages/zudoku/src/vite/api/openapi-publication.test.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
+import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
+import {
+  createOpenApiDevMiddleware,
+  createOpenApiPublication,
+  findOpenApiPublication,
+  getOpenApiMediaType,
+  writeOpenApiPublications,
+} from "./openapi-publication.js";
+
+const schema = {
+  openapi: "3.1.0",
+  info: { title: "Published API", version: "1.0.0" },
+  paths: {},
+} satisfies OpenAPIDocument;
+
+describe("OpenAPI publication", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("serializes JSON and matches dev requests with query strings", () => {
+    const publication = createOpenApiPublication({
+      apiPath: "/api",
+      urlPath: "/docs/openapi.json",
+      schema,
+    });
+
+    expect(publication.mediaType).toBe("application/json");
+    expect(JSON.parse(publication.content)).toEqual(schema);
+    expect(
+      findOpenApiPublication("/docs/openapi.json?cache-bust=1", [publication]),
+    ).toBe(publication);
+  });
+
+  it("serves canonical GET and HEAD requests from the dev middleware", async () => {
+    const publication = createOpenApiPublication({
+      apiPath: "/api",
+      urlPath: "/docs/openapi.json",
+      schema,
+    });
+    const middleware = createOpenApiDevMiddleware({
+      getPublications: () => [publication],
+      getDownloadPathMap: () => new Map(),
+    });
+    const next = vi.fn();
+
+    for (const method of ["GET", "HEAD"]) {
+      const headers = new Map<string, string>();
+      let body: string | undefined;
+      await middleware(
+        { method, url: "/docs/openapi.json?agent=1" },
+        {
+          setHeader: (name, value) => headers.set(name, value),
+          end: (value) => {
+            body = value;
+          },
+        },
+        next,
+      );
+
+      expect(headers.get("Content-Type")).toBe(
+        "application/json; charset=utf-8",
+      );
+      expect(body).toBe(method === "GET" ? publication.content : undefined);
+    }
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("preserves existing schema-download routes and passes unrelated requests through", async () => {
+    const outputDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "zudoku-download-"),
+    );
+    tempDirs.push(outputDir);
+    const inputPath = path.join(outputDir, "schema.yaml");
+    await fs.writeFile(inputPath, "openapi: 3.1.0\n", "utf-8");
+    const middleware = createOpenApiDevMiddleware({
+      getPublications: () => [],
+      getDownloadPathMap: () => new Map([["/docs/schema.yaml", inputPath]]),
+    });
+    const headers = new Map<string, string>();
+    let body: string | undefined;
+    const next = vi.fn();
+
+    await middleware(
+      { method: "GET", url: "/docs/schema.yaml?download=1" },
+      {
+        setHeader: (name, value) => headers.set(name, value),
+        end: (value) => {
+          body = value;
+        },
+      },
+      next,
+    );
+
+    expect(headers.get("Content-Type")).toBe("application/yaml; charset=utf-8");
+    expect(body).toBe("openapi: 3.1.0\n");
+    expect(next).not.toHaveBeenCalled();
+
+    await middleware(
+      { method: "GET", url: "/docs/guide" },
+      { setHeader: vi.fn(), end: vi.fn() },
+      next,
+    );
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it.each([".yaml", ".yml"])(
+    "serializes %s publications as YAML",
+    (extension) => {
+      const publication = createOpenApiPublication({
+        apiPath: "/api",
+        urlPath: `/openapi${extension}`,
+        schema,
+      });
+
+      expect(publication.mediaType).toBe("application/yaml");
+      expect(parseYaml(publication.content)).toEqual(schema);
+      expect(getOpenApiMediaType(`/schema${extension}`)).toBe(
+        "application/yaml",
+      );
+    },
+  );
+
+  it("writes production artifacts beneath the output directory", async () => {
+    const outputDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "zudoku-publish-"),
+    );
+    tempDirs.push(outputDir);
+    const publication = createOpenApiPublication({
+      apiPath: "/api",
+      urlPath: "/docs/openapi.json",
+      schema,
+    });
+
+    await writeOpenApiPublications(outputDir, [publication]);
+
+    await expect(
+      fs.readFile(path.join(outputDir, "docs", "openapi.json"), "utf-8"),
+    ).resolves.toBe(publication.content);
+  });
+
+  it("rejects traversal even if passed an unvalidated publication", async () => {
+    const outputDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "zudoku-publish-"),
+    );
+    tempDirs.push(outputDir);
+
+    await expect(
+      writeOpenApiPublications(outputDir, [
+        {
+          apiPath: "/api",
+          urlPath: "/../escape.json",
+          content: "{}",
+          mediaType: "application/json",
+        },
+      ]),
+    ).rejects.toThrow("Unsafe OpenAPI publication output path");
+  });
+
+  it("does not overwrite an existing public or generated build artifact", async () => {
+    const outputDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "zudoku-publish-"),
+    );
+    tempDirs.push(outputDir);
+    const existingPath = path.join(outputDir, "openapi.json");
+    await fs.writeFile(existingPath, '{"source":"public"}', "utf-8");
+
+    await expect(
+      writeOpenApiPublications(outputDir, [
+        createOpenApiPublication({
+          apiPath: "/api",
+          urlPath: "/openapi.json",
+          schema,
+        }),
+      ]),
+    ).rejects.toThrow(
+      'Cannot publish OpenAPI for API "/api" at "/openapi.json" because a build artifact already exists',
+    );
+    await expect(fs.readFile(existingPath, "utf-8")).resolves.toBe(
+      '{"source":"public"}',
+    );
+  });
+});

--- a/packages/zudoku/src/vite/api/openapi-publication.ts
+++ b/packages/zudoku/src/vite/api/openapi-publication.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { stringify as stringifyYaml } from "yaml";
+import type { OpenAPIDocument } from "../../lib/oas/parser/index.js";
+
+export type OpenApiPublication = {
+  apiPath: string;
+  urlPath: string;
+  content: string;
+  mediaType: "application/json" | "application/yaml";
+};
+
+const getExtension = (urlPath: string) =>
+  path.posix.extname(urlPath).toLowerCase();
+
+export const getOpenApiMediaType = (
+  urlPath: string,
+): OpenApiPublication["mediaType"] =>
+  getExtension(urlPath) === ".json" ? "application/json" : "application/yaml";
+
+export const createOpenApiPublication = ({
+  apiPath,
+  urlPath,
+  schema,
+}: {
+  apiPath: string;
+  urlPath: string;
+  schema: OpenAPIDocument;
+}): OpenApiPublication => {
+  const mediaType = getOpenApiMediaType(urlPath);
+  const content =
+    mediaType === "application/json"
+      ? `${JSON.stringify(schema, null, 2)}\n`
+      : stringifyYaml(schema);
+
+  return { apiPath, urlPath, content, mediaType };
+};
+
+export const getRequestPathname = (requestUrl: string) => {
+  try {
+    return new URL(requestUrl, "http://zudoku.local").pathname;
+  } catch {
+    return undefined;
+  }
+};
+
+export const findOpenApiPublication = (
+  requestUrl: string,
+  publications: OpenApiPublication[],
+) => {
+  const pathname = getRequestPathname(requestUrl);
+  return publications.find((publication) => publication.urlPath === pathname);
+};
+
+type OpenApiDevRequest = {
+  method?: string;
+  url?: string;
+};
+
+type OpenApiDevResponse = {
+  setHeader: (name: string, value: string) => unknown;
+  end: (body?: string) => unknown;
+};
+
+/** Serves canonical publications and the existing schema-download routes. */
+export const createOpenApiDevMiddleware =
+  ({
+    getPublications,
+    getDownloadPathMap,
+  }: {
+    getPublications: () => OpenApiPublication[];
+    getDownloadPathMap: () => ReadonlyMap<string, string>;
+  }) =>
+  async (
+    req: OpenApiDevRequest,
+    res: OpenApiDevResponse,
+    next: () => unknown,
+  ) => {
+    if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) {
+      return next();
+    }
+
+    const publication = findOpenApiPublication(req.url, getPublications());
+    if (publication) {
+      res.setHeader("Content-Type", `${publication.mediaType}; charset=utf-8`);
+      return res.end(req.method === "HEAD" ? undefined : publication.content);
+    }
+
+    const requestPathname = getRequestPathname(req.url);
+    if (!requestPathname) return next();
+    if (
+      !requestPathname.toLowerCase().endsWith(".json") &&
+      !requestPathname.toLowerCase().endsWith(".yaml") &&
+      !requestPathname.toLowerCase().endsWith(".yml")
+    ) {
+      return next();
+    }
+
+    const inputPath = getDownloadPathMap().get(requestPathname);
+    if (!inputPath) return next();
+
+    const content = await fs.readFile(inputPath, "utf-8");
+    const mediaType = getOpenApiMediaType(inputPath);
+    res.setHeader("Content-Type", `${mediaType}; charset=utf-8`);
+    return res.end(req.method === "HEAD" ? undefined : content);
+  };
+
+const resolveOutputPath = (outputDir: string, urlPath: string) => {
+  const outputRoot = path.resolve(outputDir);
+  const relativePath = urlPath.replace(/^\/+/, "");
+  const outputPath = path.resolve(outputRoot, relativePath);
+
+  if (
+    !relativePath ||
+    relativePath.includes("\\") ||
+    relativePath.split("/").some((segment) => segment === "..") ||
+    (!outputPath.startsWith(`${outputRoot}${path.sep}`) &&
+      outputPath !== outputRoot)
+  ) {
+    throw new Error(`Unsafe OpenAPI publication output path: ${urlPath}`);
+  }
+
+  return outputPath;
+};
+
+export const writeOpenApiPublications = async (
+  outputDir: string,
+  publications: OpenApiPublication[],
+) => {
+  const outputs = publications.map((publication) => ({
+    publication,
+    outputPath: resolveOutputPath(outputDir, publication.urlPath),
+  }));
+
+  await Promise.all(
+    outputs.map(async ({ publication, outputPath }) => {
+      try {
+        await fs.lstat(outputPath);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          error.code === "ENOENT"
+        ) {
+          return;
+        }
+        throw error;
+      }
+
+      throw new Error(
+        `Cannot publish OpenAPI for API "${publication.apiPath}" at "${publication.urlPath}" because a build artifact already exists at "${outputPath}". Choose another publish.path or remove the conflicting public/build artifact.`,
+      );
+    }),
+  );
+
+  await Promise.all(
+    outputs.map(async ({ publication, outputPath }) => {
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, publication.content, "utf-8");
+    }),
+  );
+};

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -12,7 +12,7 @@ import { joinUrl } from "../lib/util/joinUrl.js";
 import { getViteConfig } from "./config.js";
 import { getBuildHtml } from "./html.js";
 import { writeManifest } from "./manifest.js";
-import { writeOutput } from "./output.js";
+import { cleanVercelOutput, writeOutput } from "./output.js";
 import { prerender } from "./prerender/prerender.js";
 import {
   assertCloudflareWranglerGatesProtected,
@@ -46,7 +46,10 @@ export async function runBuild(options: BuildOptions) {
   invariant(builder.environments.ssr, "SSR environment is missing");
 
   const distDir = path.resolve(path.join(dir, "dist"));
-  await rm(distDir, { recursive: true, force: true });
+  await Promise.all([
+    rm(distDir, { recursive: true, force: true }),
+    cleanVercelOutput(dir),
+  ]);
 
   const [clientResult, serverResult] = await Promise.all([
     builder.build(builder.environments.client),

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -158,7 +158,13 @@ const runPrerender = async (options: PrerenderOptions) => {
   const serverConfigFilename = findServerConfigFilename(serverResult);
 
   try {
-    const { workerResults, rewrites } = await prerender({
+    const {
+      workerResults,
+      rewrites,
+      knownRoutes,
+      markdownRoutes,
+      markdownNotFound,
+    } = await prerender({
       html,
       dir,
       basePath: config.basePath,
@@ -199,6 +205,13 @@ const runPrerender = async (options: PrerenderOptions) => {
       config,
       redirects: workerResults.flatMap((r) => r.redirect ?? []),
       rewrites,
+      markdownNegotiation: markdownNotFound
+        ? {
+            knownCanonicalRoutePaths: knownRoutes,
+            markdownCanonicalRoutePaths: markdownRoutes,
+            markdownNotFoundBody: markdownNotFound,
+          }
+        : undefined,
     });
 
     if (ZuploEnv.isZuplo && issuer) {

--- a/packages/zudoku/src/vite/llms.test.ts
+++ b/packages/zudoku/src/vite/llms.test.ts
@@ -1,0 +1,189 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { generateLlmsTxtFiles } from "./llms.js";
+import type { MarkdownFileInfo } from "./plugin-markdown-export.js";
+
+const markdownInfo = (
+  routePath: string,
+  title?: string,
+  description?: string,
+): MarkdownFileInfo => ({
+  filePath: `/pages${routePath}.md`,
+  routePath,
+  title,
+  description,
+  content: `Content for ${routePath}`,
+});
+
+describe("generateLlmsTxtFiles", () => {
+  let outputDir: string;
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(path.join(os.tmpdir(), "zudoku-llms-test-"));
+  });
+
+  afterEach(async () => {
+    consoleLog.mockClear();
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    consoleLog.mockRestore();
+  });
+
+  it("uses the default title and description", async () => {
+    await generateLlmsTxtFiles({
+      markdownFileInfos: [markdownInfo("/guide", "Guide", "Read the guide")],
+      outputUrls: ["/guide"],
+      baseOutputDir: outputDir,
+      basePath: undefined,
+      llmsTxt: true,
+      redirectUrls: new Set(),
+    });
+
+    await expect(readFile(path.join(outputDir, "llms.txt"), "utf-8")).resolves
+      .toBe(`# Documentation
+
+> Documentation files for Large Language Models
+
+## Documentation
+
+- [Guide](/guide.md): Read the guide`);
+  });
+
+  it("renders custom guidance in specification order and safely formats Markdown", async () => {
+    await generateLlmsTxtFiles({
+      markdownFileInfos: [
+        markdownInfo(
+          "/",
+          String.raw`Acme [quickstart] \ reference`,
+          "Start here\nfor the fastest setup.",
+        ),
+      ],
+      outputUrls: ["/"],
+      baseOutputDir: outputDir,
+      basePath: "/docs",
+      llmsTxt: true,
+      title: "  Acme\nAPI  ",
+      description: "  Build and operate\nAcme services.  ",
+      instructions: `Use these docs when creating an Acme integration.
+
+Call the documented endpoints with a sandbox API key.
+
+## This is guidance, not a link section`,
+      redirectUrls: new Set(),
+    });
+
+    await expect(readFile(path.join(outputDir, "llms.txt"), "utf-8")).resolves
+      .toBe(`# Acme API
+
+> Build and operate Acme services.
+
+Use these docs when creating an Acme integration.
+
+Call the documented endpoints with a sandbox API key.
+
+\\## This is guidance, not a link section
+
+## Documentation
+
+- [Acme \\[quickstart\\] \\\\ reference](/docs/index.md): Start here for the fastest setup.`);
+  });
+
+  it("links the root document as index.md without a base path", async () => {
+    await generateLlmsTxtFiles({
+      markdownFileInfos: [markdownInfo("/", "Home")],
+      outputUrls: ["/"],
+      baseOutputDir: outputDir,
+      basePath: undefined,
+      llmsTxt: true,
+      redirectUrls: new Set(),
+    });
+
+    const result = await readFile(path.join(outputDir, "llms.txt"), "utf-8");
+    expect(result).toContain("- [Home](/index.md)");
+    expect(result).not.toContain("(/.md)");
+  });
+
+  it("URL-encodes generated Markdown links", async () => {
+    await generateLlmsTxtFiles({
+      markdownFileInfos: [markdownInfo("/guides/café setup", "Café setup")],
+      outputUrls: ["/guides/café setup"],
+      baseOutputDir: outputDir,
+      basePath: "/docs",
+      llmsTxt: true,
+      redirectUrls: new Set(),
+    });
+
+    const result = await readFile(path.join(outputDir, "llms.txt"), "utf-8");
+    expect(result).toContain(
+      "- [Café setup](/docs/guides/caf%C3%A9%20setup.md)",
+    );
+  });
+
+  it("omits link-section headings when there are no linkable documents", async () => {
+    await generateLlmsTxtFiles({
+      markdownFileInfos: [],
+      outputUrls: [],
+      baseOutputDir: outputDir,
+      basePath: undefined,
+      llmsTxt: true,
+      redirectUrls: new Set(),
+    });
+
+    const result = await readFile(path.join(outputDir, "llms.txt"), "utf-8");
+    expect(result).toBe(`# Documentation
+
+> Documentation files for Large Language Models`);
+    expect(result).not.toContain("## Documentation");
+  });
+
+  it("uses the custom title for llms-full.txt", async () => {
+    await generateLlmsTxtFiles({
+      markdownFileInfos: [markdownInfo("/guide", "Guide")],
+      outputUrls: ["/guide"],
+      baseOutputDir: outputDir,
+      basePath: undefined,
+      llmsTxtFull: true,
+      title: "Acme API",
+      redirectUrls: new Set(),
+    });
+
+    const result = await readFile(
+      path.join(outputDir, "llms-full.txt"),
+      "utf-8",
+    );
+    expect(result).toMatch(/^# Acme API\n/);
+  });
+
+  it("excludes redirects and error pages from the link list", async () => {
+    await generateLlmsTxtFiles({
+      markdownFileInfos: [
+        markdownInfo("/guide", "Guide"),
+        markdownInfo("/old", "Old guide"),
+        markdownInfo("/404", "Not found"),
+      ],
+      outputUrls: ["/guide", "/old", "/404"],
+      baseOutputDir: outputDir,
+      basePath: undefined,
+      llmsTxt: true,
+      redirectUrls: new Set(["/old"]),
+    });
+
+    const result = await readFile(path.join(outputDir, "llms.txt"), "utf-8");
+    expect(result).toContain("- [Guide](/guide.md)");
+    expect(result).not.toContain("Old guide");
+    expect(result).not.toContain("Not found");
+  });
+});

--- a/packages/zudoku/src/vite/llms.ts
+++ b/packages/zudoku/src/vite/llms.ts
@@ -2,7 +2,36 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import colors from "picocolors";
 import { joinUrl } from "../lib/util/joinUrl.js";
+import {
+  encodeDocumentationRoutePath,
+  getMarkdownRepresentationPath,
+} from "../lib/util/markdown-representation.js";
 import type { MarkdownFileInfo } from "./plugin-markdown-export.js";
+
+const DEFAULT_TITLE = "Documentation";
+const DEFAULT_DESCRIPTION = "Documentation files for Large Language Models";
+
+const toSingleLine = (value: string): string =>
+  value.replaceAll(/\s+/g, " ").trim();
+
+const escapeMarkdownLinkLabel = (value: string): string =>
+  toSingleLine(value).replaceAll(/([\\[\]])/g, "\\$1");
+
+// llms.txt introductory details may contain Markdown, but the specification
+// reserves headings for link-list sections. Escape heading syntax so authored
+// guidance cannot accidentally create a prose-only H2 section.
+const formatInstructions = (value: string): string =>
+  value
+    .trim()
+    .replaceAll("\r\n", "\n")
+    .split("\n")
+    .map((line) =>
+      line
+        .replace(/^( {0,3})(#{1,6})(?=\s|$)/, "$1\\$2")
+        .replace(/^( {0,3})([=-]{2,})\s*$/, "$1\\$2"),
+    )
+    .join("\n");
+
 export async function generateLlmsTxtFiles({
   markdownFileInfos,
   outputUrls,
@@ -11,6 +40,9 @@ export async function generateLlmsTxtFiles({
   siteName,
   llmsTxt,
   llmsTxtFull,
+  title: configuredTitle,
+  description: configuredDescription,
+  instructions,
   redirectUrls,
 }: {
   markdownFileInfos: MarkdownFileInfo[];
@@ -20,12 +52,21 @@ export async function generateLlmsTxtFiles({
   siteName?: string;
   llmsTxt?: boolean;
   llmsTxtFull?: boolean;
+  title?: string;
+  description?: string;
+  instructions?: string;
   redirectUrls: Set<string>;
 }) {
   const nonRedirectUrls = outputUrls.filter((url) => !redirectUrls.has(url));
 
   const baseUrl = basePath ?? "";
-  const title = siteName ?? "Documentation";
+  const title = toSingleLine(configuredTitle ?? siteName ?? DEFAULT_TITLE);
+  const description = toSingleLine(
+    configuredDescription ?? DEFAULT_DESCRIPTION,
+  );
+  const formattedInstructions = instructions
+    ? formatInstructions(instructions)
+    : undefined;
 
   const markdownMap = new Map(
     markdownFileInfos.map((info) => [info.routePath, info]),
@@ -33,13 +74,7 @@ export async function generateLlmsTxtFiles({
 
   // Generate llms.txt
   if (llmsTxt) {
-    const llmsTxtParts: string[] = [];
-
-    llmsTxtParts.push(`# ${title}\n`);
-    llmsTxtParts.push("> Documentation files for Large Language Models\n");
-
-    // Add documentation section with links to all pages (matching sitemap structure)
-    llmsTxtParts.push("## Documentation\n");
+    const documentationLinks: string[] = [];
 
     for (const url of nonRedirectUrls) {
       // Skip error pages
@@ -50,15 +85,29 @@ export async function generateLlmsTxtFiles({
       // Only include pages that have markdown content
       if (mdInfo) {
         // If we have markdown for this page, link to the .md file
-        const mdUrl = joinUrl(baseUrl, `${url}.md`);
-        const linkTitle = mdInfo.title ?? url;
-        const description = mdInfo.description ? `: ${mdInfo.description}` : "";
-        llmsTxtParts.push(`- [${linkTitle}](${mdUrl})${description}`);
+        const mdUrl = getMarkdownRepresentationPath(url, basePath);
+        const linkTitle = escapeMarkdownLinkLabel(mdInfo.title ?? url);
+        const linkDescription = mdInfo.description
+          ? `: ${toSingleLine(mdInfo.description)}`
+          : "";
+        documentationLinks.push(`- [${linkTitle}](${mdUrl})${linkDescription}`);
       }
     }
 
-    const llmsTxt = llmsTxtParts.join("\n");
-    await writeFile(path.join(baseOutputDir, "llms.txt"), llmsTxt, "utf-8");
+    const llmsTxtParts = [
+      `# ${title}`,
+      `> ${description}`,
+      ...(formattedInstructions ? [formattedInstructions] : []),
+      ...(documentationLinks.length > 0
+        ? ["## Documentation", documentationLinks.join("\n")]
+        : []),
+    ];
+
+    await writeFile(
+      path.join(baseOutputDir, "llms.txt"),
+      llmsTxtParts.join("\n\n"),
+      "utf-8",
+    );
 
     // biome-ignore lint/suspicious/noConsole: Logging allowed here
     console.log(colors.blue("✓ generated llms.txt"));
@@ -78,7 +127,9 @@ export async function generateLlmsTxtFiles({
       if (info.description) {
         llmsFullParts.push(`${info.description}\n`);
       }
-      llmsFullParts.push(`URL: ${joinUrl(baseUrl, info.routePath)}\n`);
+      llmsFullParts.push(
+        `URL: ${joinUrl(baseUrl, encodeDocumentationRoutePath(info.routePath))}\n`,
+      );
       llmsFullParts.push(`\n${info.content}\n`);
     }
 

--- a/packages/zudoku/src/vite/output.test.ts
+++ b/packages/zudoku/src/vite/output.test.ts
@@ -197,7 +197,13 @@ describe("Vercel Build Output", () => {
       ".vercel/output/static/docs/health",
     );
     await mkdir(path.dirname(extensionlessAsset), { recursive: true });
-    await writeFile(extensionlessAsset, "ok");
+    await Promise.all([
+      writeFile(extensionlessAsset, "ok"),
+      writeFile(
+        path.join(path.dirname(extensionlessAsset), "source.md"),
+        "# Source",
+      ),
+    ]);
 
     await writeOutput(rootDir, {
       config: createConfig(),
@@ -225,7 +231,7 @@ describe("Vercel Build Output", () => {
     expect(source).toContain("export default function middleware(request)");
     expect(source).toContain('const BASE_PATH = "/docs"');
     expect(source).toContain(
-      'const PASSTHROUGH_PATHS = new Set(["/docs/health"]);',
+      'const PASSTHROUGH_PATHS = new Set(["/docs/health","/docs/source.md"]);',
     );
   });
 

--- a/packages/zudoku/src/vite/output.test.ts
+++ b/packages/zudoku/src/vite/output.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LoadedConfig } from "../config/config.js";
 import { validateConfig } from "../config/validators/ZudokuConfig.js";
-import { generateOutput, writeOutput } from "./output.js";
+import { cleanVercelOutput, generateOutput, writeOutput } from "./output.js";
 
 const createConfig = (basePath = "/docs"): LoadedConfig => ({
   ...validateConfig({ basePath }),
@@ -23,7 +23,7 @@ const markdownNegotiation = {
   markdownNotFoundBody: "# Page not found\n",
 };
 
-describe("Vercel Markdown negotiation output", () => {
+describe("Vercel Build Output", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
@@ -47,6 +47,7 @@ describe("Vercel Markdown negotiation output", () => {
       expect.objectContaining({ src: "/old", status: 301 }),
       {
         src: "/docs(?:/(.*))?",
+        methods: ["GET", "HEAD"],
         middlewarePath: "zudoku-markdown",
         continue: true,
       },
@@ -58,12 +59,145 @@ describe("Vercel Markdown negotiation output", () => {
     ]);
   });
 
+  it("deduplicates identical redirects", () => {
+    const output = generateOutput({
+      config: createConfig(),
+      redirects: [
+        { from: "/old", to: "/new" },
+        { from: "/old", to: "/new" },
+      ],
+    });
+
+    expect(output.routes).toEqual([
+      {
+        src: "/old",
+        dest: "/new",
+        status: 301,
+        headers: { Location: "/new" },
+      },
+    ]);
+  });
+
+  it("canonicalizes clean URLs before applying user redirects", () => {
+    const output = generateOutput({
+      config: createConfig(),
+      redirects: [{ from: "/legacy.html", to: "/guide" }],
+      staticHtmlFiles: ["index.html", "legacy.html"],
+    });
+
+    expect(
+      output.routes?.map((route) =>
+        "status" in route ? route.status : undefined,
+      ),
+    ).toEqual([308, 308, 301]);
+  });
+
+  it("rejects HTML files that resolve to the same clean URL", () => {
+    expect(() =>
+      generateOutput({
+        config: createConfig(),
+        redirects: [],
+        staticHtmlFiles: ["guide.html", "guide/index.html"],
+      }),
+    ).toThrowError(
+      'Cannot generate the Vercel clean URL "guide" for both "guide.html" and "guide/index.html"',
+    );
+  });
+
+  it("emits self-contained clean URL routes and overrides", async () => {
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), "zudoku-output-test-"),
+    );
+    tempDirs.push(rootDir);
+    vi.stubEnv("VERCEL", "1");
+
+    const staticDir = path.join(rootDir, ".vercel/output/static");
+    await mkdir(path.join(staticDir, "guides"), { recursive: true });
+    await Promise.all([
+      writeFile(path.join(staticDir, "index.html"), "home"),
+      writeFile(path.join(staticDir, "tracking.html"), "tracking"),
+      writeFile(path.join(staticDir, "guides/index.html"), "guides"),
+      writeFile(path.join(staticDir, "404.html"), "missing"),
+    ]);
+
+    await writeOutput(rootDir, {
+      config: createConfig(),
+      redirects: [],
+    });
+
+    const output = JSON.parse(
+      await readFile(path.join(rootDir, ".vercel/output/config.json"), "utf-8"),
+    );
+    expect(output.routes).toEqual([
+      {
+        src: "^/(?:(.+)/)?index(?:\\.html)?/?$",
+        headers: { Location: "/$1" },
+        status: 308,
+      },
+      {
+        src: "^/(.*)\\.html/?$",
+        headers: { Location: "/$1" },
+        status: 308,
+      },
+    ]);
+    expect(output.overrides).toEqual({
+      "404.html": { path: "404" },
+      "guides/index.html": { path: "guides" },
+      "index.html": { path: "" },
+      "tracking.html": { path: "tracking" },
+    });
+  });
+
+  it("clears stale Vercel output before a build", async () => {
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), "zudoku-output-test-"),
+    );
+    tempDirs.push(rootDir);
+    vi.stubEnv("VERCEL", "1");
+
+    const staleFile = path.join(
+      rootDir,
+      ".vercel/output/functions/stale.func/index.js",
+    );
+    await mkdir(path.dirname(staleFile), { recursive: true });
+    await writeFile(staleFile, "stale");
+
+    await cleanVercelOutput(rootDir);
+
+    await expect(readFile(staleFile, "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("preserves portable output when Vercel is not active", async () => {
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), "zudoku-output-test-"),
+    );
+    tempDirs.push(rootDir);
+    vi.stubEnv("VERCEL", "");
+
+    const existingFile = path.join(rootDir, ".vercel/output/config.json");
+    await mkdir(path.dirname(existingFile), { recursive: true });
+    await writeFile(existingFile, "existing");
+
+    await cleanVercelOutput(rootDir);
+
+    await expect(readFile(existingFile, "utf-8")).resolves.toBe("existing");
+  });
+
   it("writes a valid Edge function into Vercel Build Output", async () => {
     const rootDir = await mkdtemp(
       path.join(os.tmpdir(), "zudoku-output-test-"),
     );
     tempDirs.push(rootDir);
     vi.stubEnv("VERCEL", "1");
+
+    const extensionlessAsset = path.join(
+      rootDir,
+      ".vercel/output/static/docs/health",
+    );
+    await mkdir(path.dirname(extensionlessAsset), { recursive: true });
+    await writeFile(extensionlessAsset, "ok");
 
     await writeOutput(rootDir, {
       config: createConfig(),
@@ -90,6 +224,9 @@ describe("Vercel Markdown negotiation output", () => {
     });
     expect(source).toContain("export default function middleware(request)");
     expect(source).toContain('const BASE_PATH = "/docs"');
+    expect(source).toContain(
+      'const PASSTHROUGH_PATHS = new Set(["/docs/health"]);',
+    );
   });
 
   it("does not reference a Vercel function in portable static output", async () => {

--- a/packages/zudoku/src/vite/output.test.ts
+++ b/packages/zudoku/src/vite/output.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LoadedConfig } from "../config/config.js";
+import { validateConfig } from "../config/validators/ZudokuConfig.js";
+import { generateOutput, writeOutput } from "./output.js";
+
+const createConfig = (basePath = "/docs"): LoadedConfig => ({
+  ...validateConfig({ basePath }),
+  __meta: {
+    rootDir: "/project",
+    moduleDir: "/project",
+    configPath: "/project/zudoku.config.ts",
+    mode: "module",
+    dependencies: [],
+  },
+});
+
+const markdownNegotiation = {
+  knownCanonicalRoutePaths: ["/", "/guide"],
+  markdownCanonicalRoutePaths: ["/", "/guide"],
+  markdownNotFoundBody: "# Page not found\n",
+};
+
+describe("Vercel Markdown negotiation output", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("places routing middleware before filesystem rewrites", () => {
+    const output = generateOutput({
+      config: createConfig(),
+      redirects: [{ from: "/old", to: "/new" }],
+      rewrites: [{ source: "/guide/(.+)", destination: "/guide.html" }],
+      markdownNegotiation,
+    });
+
+    expect(output.routes).toEqual([
+      expect.objectContaining({ src: "/old", status: 301 }),
+      {
+        src: "/docs(?:/(.*))?",
+        middlewarePath: "zudoku-markdown",
+        continue: true,
+      },
+      { handle: "filesystem" },
+      expect.objectContaining({
+        src: "/docs/guide/(.+)",
+        dest: "/docs/guide.html",
+      }),
+    ]);
+  });
+
+  it("writes a valid Edge function into Vercel Build Output", async () => {
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), "zudoku-output-test-"),
+    );
+    tempDirs.push(rootDir);
+    vi.stubEnv("VERCEL", "1");
+
+    await writeOutput(rootDir, {
+      config: createConfig(),
+      redirects: [],
+      markdownNegotiation,
+    });
+
+    const outputDir = path.join(rootDir, ".vercel/output");
+    const output = JSON.parse(
+      await readFile(path.join(outputDir, "config.json"), "utf-8"),
+    );
+    const functionDir = path.join(outputDir, "functions/zudoku-markdown.func");
+    const functionConfig = JSON.parse(
+      await readFile(path.join(functionDir, ".vc-config.json"), "utf-8"),
+    );
+    const source = await readFile(path.join(functionDir, "index.js"), "utf-8");
+
+    expect(output.routes).toContainEqual(
+      expect.objectContaining({ middlewarePath: "zudoku-markdown" }),
+    );
+    expect(functionConfig).toEqual({
+      runtime: "edge",
+      entrypoint: "index.js",
+    });
+    expect(source).toContain("export default function middleware(request)");
+    expect(source).toContain('const BASE_PATH = "/docs"');
+  });
+
+  it("does not reference a Vercel function in portable static output", async () => {
+    const rootDir = await mkdtemp(
+      path.join(os.tmpdir(), "zudoku-output-test-"),
+    );
+    tempDirs.push(rootDir);
+    vi.stubEnv("VERCEL", "");
+
+    await writeOutput(rootDir, {
+      config: createConfig(),
+      redirects: [],
+      markdownNegotiation,
+    });
+
+    const output = JSON.parse(
+      await readFile(path.join(rootDir, "dist/.output/config.json"), "utf-8"),
+    );
+    expect(output.routes).not.toContainEqual(
+      expect.objectContaining({ middlewarePath: "zudoku-markdown" }),
+    );
+  });
+});

--- a/packages/zudoku/src/vite/output.ts
+++ b/packages/zudoku/src/vite/output.ts
@@ -247,8 +247,15 @@ export async function writeOutput(
   const staticHtmlFiles = staticFiles.filter((filename) =>
     filename.endsWith(HTML_EXTENSION),
   );
-  const extensionlessStaticPaths = staticFiles
-    .filter((filename) => !path.posix.basename(filename).includes("."))
+  const staticPassthroughPaths = staticFiles
+    .filter((filename) => {
+      const basename = path.posix.basename(filename);
+      return (
+        !basename.includes(".") ||
+        basename.endsWith(".md") ||
+        basename.endsWith(".mdx")
+      );
+    })
     .map((filename) => `/${filename}`);
   const output = generateOutput({
     config,
@@ -280,7 +287,7 @@ export async function writeOutput(
           generateVercelMarkdownMiddleware({
             basePath: config.basePath,
             ...vercelMarkdownNegotiation,
-            passthroughPaths: extensionlessStaticPaths,
+            passthroughPaths: staticPassthroughPaths,
           }),
           "utf-8",
         ),

--- a/packages/zudoku/src/vite/output.ts
+++ b/packages/zudoku/src/vite/output.ts
@@ -5,8 +5,18 @@ import { getZudokuPackageJson } from "../cli/common/package-json.js";
 import type { LoadedConfig } from "../config/config.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import type { RouteRewrite } from "./prerender/utils.js";
+import {
+  generateVercelMarkdownMiddleware,
+  type GenerateVercelMarkdownMiddlewareOptions,
+} from "./vercel-markdown-middleware.js";
 
 const pkgJson = getZudokuPackageJson();
+const MARKDOWN_MIDDLEWARE_PATH = "zudoku-markdown";
+
+export type MarkdownNegotiationOutput = Omit<
+  GenerateVercelMarkdownMiddlewareOptions,
+  "basePath"
+>;
 
 // Generates a Vercel build output file
 // https://vercel.com/docs/build-output-api/v3
@@ -140,10 +150,12 @@ export function generateOutput({
   config,
   redirects,
   rewrites = [],
+  markdownNegotiation,
 }: {
   config: LoadedConfig;
   redirects: Array<{ from: string; to: string }>;
   rewrites?: RouteRewrite[];
+  markdownNegotiation?: MarkdownNegotiationOutput;
 }): Config {
   const routes: Route[] = [];
 
@@ -175,6 +187,16 @@ export function generateOutput({
     });
   }
 
+  if (markdownNegotiation) {
+    const basePath = joinUrl(config.basePath);
+    const escapedBasePath = basePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    routes.push({
+      src: basePath === "/" ? "/(.*)" : `${escapedBasePath}(?:/(.*))?`,
+      middlewarePath: MARKDOWN_MIDDLEWARE_PATH,
+      continue: true,
+    });
+  }
+
   if (rewrites.length > 0) {
     routes.push({ handle: "filesystem" });
     for (const rewrite of rewrites) {
@@ -202,13 +224,23 @@ export async function writeOutput(
     config,
     redirects,
     rewrites,
+    markdownNegotiation,
   }: {
     config: LoadedConfig;
     redirects: Array<{ from: string; to: string }>;
     rewrites?: RouteRewrite[];
+    markdownNegotiation?: MarkdownNegotiationOutput;
   },
 ) {
-  const output = generateOutput({ config, redirects, rewrites });
+  const vercelMarkdownNegotiation = process.env.VERCEL
+    ? markdownNegotiation
+    : undefined;
+  const output = generateOutput({
+    config,
+    redirects,
+    rewrites,
+    markdownNegotiation: vercelMarkdownNegotiation,
+  });
   // For now we are putting this in the dist folder, eventually we can
   // expand this to support the full vercel build output API
 
@@ -221,6 +253,30 @@ export async function writeOutput(
   await writeFile(outputFile, JSON.stringify(output, null, 2), "utf-8");
 
   if (process.env.VERCEL) {
+    if (vercelMarkdownNegotiation) {
+      const functionDir = path.join(
+        outputDir,
+        "functions",
+        `${MARKDOWN_MIDDLEWARE_PATH}.func`,
+      );
+      await mkdir(functionDir, { recursive: true });
+      await Promise.all([
+        writeFile(
+          path.join(functionDir, "index.js"),
+          generateVercelMarkdownMiddleware({
+            basePath: config.basePath,
+            ...vercelMarkdownNegotiation,
+          }),
+          "utf-8",
+        ),
+        writeFile(
+          path.join(functionDir, ".vc-config.json"),
+          JSON.stringify({ runtime: "edge", entrypoint: "index.js" }, null, 2),
+          "utf-8",
+        ),
+      ]);
+    }
+
     // biome-ignore lint/suspicious/noConsole: Logging allowed here
     console.log("Wrote Vercel output to", outputDir);
   }

--- a/packages/zudoku/src/vite/output.ts
+++ b/packages/zudoku/src/vite/output.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert";
-import { cp, mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { cp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { getZudokuPackageJson } from "../cli/common/package-json.js";
 import type { LoadedConfig } from "../config/config.js";
+import invariant from "../lib/util/invariant.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import type { RouteRewrite } from "./prerender/utils.js";
 import {
@@ -12,24 +14,92 @@ import {
 
 const pkgJson = getZudokuPackageJson();
 const MARKDOWN_MIDDLEWARE_PATH = "zudoku-markdown";
+const HTML_EXTENSION = ".html";
+
+const CLEAN_URL_ROUTES: Route[] = [
+  {
+    src: "^/(?:(.+)/)?index(?:\\.html)?/?$",
+    headers: { Location: "/$1" },
+    status: 308,
+  },
+  {
+    src: "^/(.*)\\.html/?$",
+    headers: { Location: "/$1" },
+    status: 308,
+  },
+];
 
 export type MarkdownNegotiationOutput = Omit<
   GenerateVercelMarkdownMiddlewareOptions,
   "basePath"
 >;
 
-// Generates a Vercel build output file
-// https://vercel.com/docs/build-output-api/v3
+const listStaticFiles = async (
+  rootDir: string,
+  currentDir = rootDir,
+): Promise<string[]> => {
+  if (!existsSync(currentDir)) return [];
+
+  const entries = await readdir(currentDir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        return listStaticFiles(rootDir, entryPath);
+      }
+      if (!entry.isFile()) return [];
+
+      return [path.relative(rootDir, entryPath).split(path.sep).join("/")];
+    }),
+  );
+
+  return files.flat().sort();
+};
+
+const getCleanPath = (filename: string) => {
+  const pathWithoutExtension = filename.slice(0, -HTML_EXTENSION.length);
+  if (pathWithoutExtension === "index") return "";
+  if (pathWithoutExtension.endsWith("/index")) {
+    return pathWithoutExtension.slice(0, -"/index".length);
+  }
+  return pathWithoutExtension;
+};
+
+const getCleanUrlOverrides = (
+  staticHtmlFiles: readonly string[],
+): OverrideConfig => {
+  const sourceByCleanPath = new Map<string, string>();
+
+  return Object.fromEntries(
+    staticHtmlFiles.map((filename) => {
+      const cleanPath = getCleanPath(filename);
+      const existingSource = sourceByCleanPath.get(cleanPath);
+      invariant(
+        !existingSource || existingSource === filename,
+        `Cannot generate the Vercel clean URL "${cleanPath}" for both "${existingSource}" and "${filename}"`,
+      );
+      sourceByCleanPath.set(cleanPath, filename);
+      return [filename, { path: cleanPath }];
+    }),
+  );
+};
+
+export const cleanVercelOutput = async (dir: string) => {
+  if (!process.env.VERCEL) return;
+  await rm(path.join(dir, ".vercel/output"), {
+    recursive: true,
+    force: true,
+  });
+};
+
+// The subset of Vercel Build Output API v3 configuration emitted by Zudoku.
+// https://vercel.com/docs/build-output-api/configuration
 
 type Config = {
   version: 3;
-  routes?: Route[];
-  images?: ImagesConfig;
-  wildcard?: WildcardConfig;
+  routes: Route[];
   overrides?: OverrideConfig;
-  cache?: string[];
-  crons?: CronsConfig;
-  framework?: Framework;
+  framework: { version: string };
 };
 
 type Route = Source | Handler;
@@ -40,26 +110,9 @@ type Source = {
   headers?: Record<string, string>;
   methods?: string[];
   continue?: boolean;
-  caseSensitive?: boolean;
-  check?: boolean;
   status?: number;
-  has?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
-  missing?: Array<
-    HostHasField | HeaderHasField | CookieHasField | QueryHasField
-  >;
-  locale?: Locale;
-  middlewareRawSrc?: string[];
+  has?: HeaderHasField[];
   middlewarePath?: string;
-};
-
-type Locale = {
-  redirect?: Record<string, string>;
-  cookie?: string;
-};
-
-type HostHasField = {
-  type: "host";
-  value: string;
 };
 
 type HeaderHasField = {
@@ -68,98 +121,44 @@ type HeaderHasField = {
   value?: string;
 };
 
-type CookieHasField = {
-  type: "cookie";
-  key: string;
-  value?: string;
-};
-
-type QueryHasField = {
-  type: "query";
-  key: string;
-  value?: string;
-};
-
-type HandleValue =
-  | "rewrite"
-  | "filesystem" // check matches after the filesystem misses
-  | "resource"
-  | "miss" // check matches after every filesystem miss
-  | "hit"
-  | "error"; //  check matches after error (500, 404, etc.)
-
 type Handler = {
-  handle: HandleValue;
-  src?: string;
-  dest?: string;
-  status?: number;
+  handle: "filesystem";
 };
-type ImageFormat = "image/avif" | "image/webp";
-
-type RemotePattern = {
-  protocol?: "http" | "https";
-  hostname: string;
-  port?: string;
-  pathname?: string;
-  search?: string;
-};
-
-type LocalPattern = {
-  pathname?: string;
-  search?: string;
-};
-
-type ImagesConfig = {
-  sizes: number[];
-  domains: string[];
-  remotePatterns?: RemotePattern[];
-  localPatterns?: LocalPattern[];
-  minimumCacheTTL?: number; // seconds
-  formats?: ImageFormat[];
-  dangerouslyAllowSVG?: boolean;
-  contentSecurityPolicy?: string;
-  contentDispositionType?: string;
-};
-
-type WildCard = {
-  domain: string;
-  value: string;
-};
-
-type WildcardConfig = Array<WildCard>;
 
 type Override = {
-  path?: string;
-  contentType?: string;
+  path: string;
 };
 
 type OverrideConfig = Record<string, Override>;
-
-type Framework = {
-  version: string;
-};
-
-type Cron = {
-  path: string;
-  schedule: string;
-};
-
-type CronsConfig = Cron[];
 
 export function generateOutput({
   config,
   redirects,
   rewrites = [],
   markdownNegotiation,
+  staticHtmlFiles = [],
 }: {
   config: LoadedConfig;
   redirects: Array<{ from: string; to: string }>;
   rewrites?: RouteRewrite[];
   markdownNegotiation?: MarkdownNegotiationOutput;
+  staticHtmlFiles?: readonly string[];
 }): Config {
   const routes: Route[] = [];
 
-  for (const redirect of redirects) {
+  if (staticHtmlFiles.length > 0) {
+    routes.push(...CLEAN_URL_ROUTES);
+  }
+
+  const uniqueRedirects = [
+    ...new Map(
+      redirects.map((redirect) => [
+        JSON.stringify([redirect.from, redirect.to]),
+        redirect,
+      ]),
+    ).values(),
+  ];
+  for (const redirect of uniqueRedirects) {
     routes.push({
       src: redirect.from,
       dest: redirect.to,
@@ -191,7 +190,11 @@ export function generateOutput({
     const basePath = joinUrl(config.basePath);
     const escapedBasePath = basePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     routes.push({
+      // Keep the path matcher broad because valid documentation slugs can end
+      // in dotted versions such as `/api/1.0.0`. The middleware itself
+      // cheaply passes through assets and non-document routes.
       src: basePath === "/" ? "/(.*)" : `${escapedBasePath}(?:/(.*))?`,
+      methods: ["GET", "HEAD"],
       middlewarePath: MARKDOWN_MIDDLEWARE_PATH,
       continue: true,
     });
@@ -207,12 +210,15 @@ export function generateOutput({
     }
   }
 
+  const overrides = getCleanUrlOverrides(staticHtmlFiles);
+
   const output: Config = {
     version: 3,
     framework: {
       version: pkgJson.version,
     },
     routes,
+    ...(Object.keys(overrides).length > 0 && { overrides }),
   };
 
   return output;
@@ -235,14 +241,22 @@ export async function writeOutput(
   const vercelMarkdownNegotiation = process.env.VERCEL
     ? markdownNegotiation
     : undefined;
+  const staticFiles = process.env.VERCEL
+    ? await listStaticFiles(path.join(dir, ".vercel/output/static"))
+    : [];
+  const staticHtmlFiles = staticFiles.filter((filename) =>
+    filename.endsWith(HTML_EXTENSION),
+  );
+  const extensionlessStaticPaths = staticFiles
+    .filter((filename) => !path.posix.basename(filename).includes("."))
+    .map((filename) => `/${filename}`);
   const output = generateOutput({
     config,
     redirects,
     rewrites,
     markdownNegotiation: vercelMarkdownNegotiation,
+    staticHtmlFiles,
   });
-  // For now we are putting this in the dist folder, eventually we can
-  // expand this to support the full vercel build output API
 
   const outputDir = process.env.VERCEL
     ? path.join(dir, ".vercel/output")
@@ -266,6 +280,7 @@ export async function writeOutput(
           generateVercelMarkdownMiddleware({
             basePath: config.basePath,
             ...vercelMarkdownNegotiation,
+            passthroughPaths: extensionlessStaticPaths,
           }),
           "utf-8",
         ),

--- a/packages/zudoku/src/vite/plugin-api.test.ts
+++ b/packages/zudoku/src/vite/plugin-api.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { schemaConfigurationChanged } from "./plugin-api.js";
+
+describe("schemaConfigurationChanged", () => {
+  const apis = {
+    type: "file" as const,
+    path: "reference",
+    input: "./openapi.json",
+  };
+
+  it("refreshes schemas when only basePath changes", () => {
+    expect(
+      schemaConfigurationChanged(
+        { apis, basePath: "/" },
+        { apis, basePath: "/docs" },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not refresh when schema inputs and basePath are unchanged", () => {
+    expect(
+      schemaConfigurationChanged(
+        { apis, basePath: "/docs" },
+        { apis: structuredClone(apis), basePath: "/docs" },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -28,6 +28,10 @@ import {
   readDocumentType,
 } from "../lib/plugins/openapi/util/documentType.js";
 import { ensureArray } from "../lib/util/ensureArray.js";
+import {
+  createOpenApiDevMiddleware,
+  writeOpenApiPublications,
+} from "./api/openapi-publication.js";
 import { SchemaManager } from "./api/SchemaManager.js";
 import { reload } from "./plugin-config-reload.js";
 import { invalidate as invalidateNavigation } from "./plugin-navigation.js";
@@ -111,30 +115,13 @@ const viteApiPlugin = async (): Promise<Plugin> => {
         .forEach((file) => this.addWatchFile(file));
     },
     configureServer(server) {
-      // Serve original OpenAPI schema files
-      server.middlewares.use(async (req, res, next) => {
-        if (req.method !== "GET" || !req.url) return next();
-        if (
-          !req.url.toLowerCase().endsWith(".json") &&
-          !req.url.toLowerCase().endsWith(".yaml")
-        ) {
-          return next();
-        }
-
-        const pathMap = schemaManager.getUrlToFilePathMap();
-
-        const inputPath = pathMap.get(req.url);
-        if (!inputPath) return next();
-
-        const content = await fs.readFile(inputPath, "utf-8");
-        const mimeType =
-          path.extname(inputPath).toLowerCase() === ".json"
-            ? "application/json"
-            : "application/x-yaml";
-
-        res.setHeader("Content-Type", `${mimeType}; charset=utf-8`);
-        return res.end(content);
-      });
+      // Serve downloadable and explicitly published OpenAPI schema files.
+      server.middlewares.use(
+        createOpenApiDevMiddleware({
+          getPublications: () => schemaManager.getPublishedSchemas(),
+          getDownloadPathMap: () => schemaManager.getUrlToFilePathMap(),
+        }),
+      );
 
       server.watcher.on("change", async (id) => {
         const mainFiles = schemaManager.getFilesToReprocess(id);
@@ -439,6 +426,11 @@ const viteApiPlugin = async (): Promise<Plugin> => {
         await fs.mkdir(path.dirname(outputPath), { recursive: true });
         await fs.writeFile(outputPath, content, "utf-8");
       }
+
+      await writeOpenApiPublications(
+        path.join(config.__meta.rootDir, "dist"),
+        schemaManager.getPublishedSchemas(),
+      );
     },
   };
 };

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -5,7 +5,7 @@ import { type Plugin, runnerImport } from "vite";
 import { parse as parseYaml } from "yaml";
 import { ZuploEnv } from "../app/env.js";
 import { getZudokuRootDir } from "../cli/common/package-json.js";
-import { getCurrentConfig } from "../config/loader.js";
+import { type ConfigWithMeta, getCurrentConfig } from "../config/loader.js";
 import {
   getBuildConfig,
   type Processor,
@@ -37,6 +37,11 @@ import { reload } from "./plugin-config-reload.js";
 import { invalidate as invalidateNavigation } from "./plugin-navigation.js";
 
 const PROCESSED_STORE_SUBPATH = "node_modules/.zudoku/processed";
+
+export const schemaConfigurationChanged = (
+  current: Pick<ConfigWithMeta, "apis" | "basePath">,
+  next: Pick<ConfigWithMeta, "apis" | "basePath">,
+) => current.basePath !== next.basePath || !deepEqual(current.apis, next.apis);
 
 const warn = (message: string) => {
   // biome-ignore lint/suspicious/noConsole: Logging allowed here
@@ -167,7 +172,7 @@ const viteApiPlugin = async (): Promise<Plugin> => {
 
       const config = getCurrentConfig();
 
-      if (!deepEqual(schemaManager.config.apis, config.apis)) {
+      if (schemaConfigurationChanged(schemaManager.config, config)) {
         schemaManager.config = config;
         await schemaManager.processAllSchemas();
         schemaManager

--- a/packages/zudoku/src/vite/plugin-markdown-export.test.ts
+++ b/packages/zudoku/src/vite/plugin-markdown-export.test.ts
@@ -1,10 +1,259 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateConfig } from "../config/validators/ZudokuConfig.js";
 import { getMarkdownPathname } from "../lib/util/markdown.js";
 import {
+  createMarkdownDevMiddleware,
   getMarkdownOutputPath,
   resolveMarkdownRoutePath,
+  writeMarkdownInfo,
 } from "./plugin-markdown-export.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((temporaryDirectory) =>
+        rm(temporaryDirectory, { recursive: true, force: true }),
+      ),
+  );
+});
+
+const createMarkdownFixture = async () => {
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zudoku-markdown-middleware-"),
+  );
+  temporaryDirectories.push(temporaryDirectory);
+  const filePath = path.join(temporaryDirectory, "guide.md");
+  await writeFile(
+    filePath,
+    "---\ntitle: Agent Guide\n---\n\nUse the API safely.\n",
+    "utf-8",
+  );
+  return filePath;
+};
+
+const createResponse = (initialHeaders: Record<string, string> = {}) => {
+  const headers = new Map(
+    Object.entries(initialHeaders).map(([name, value]) => [
+      name.toLowerCase(),
+      value,
+    ]),
+  );
+  let body: string | undefined;
+
+  return {
+    response: {
+      statusCode: 200,
+      getHeader: (name: string) => headers.get(name.toLowerCase()),
+      setHeader: (name: string, value: string) => {
+        headers.set(name.toLowerCase(), value);
+      },
+      end: (value?: string) => {
+        body = value;
+      },
+    },
+    getBody: () => body,
+    getHeader: (name: string) => headers.get(name.toLowerCase()),
+  };
+};
+
+const createMiddleware = async (contentNegotiation = true) => {
+  const filePath = await createMarkdownFixture();
+  const config = validateConfig({
+    basePath: "/docs",
+    docs: { publishMarkdown: true, contentNegotiation },
+  });
+
+  return createMarkdownDevMiddleware({
+    config,
+    getMarkdownFiles: () => ({ "/guide": filePath }),
+  });
+};
+
+describe("createMarkdownDevMiddleware", () => {
+  it("serves negotiated Markdown from a canonical documentation URL", async () => {
+    const middleware = await createMiddleware();
+    const { response, getBody, getHeader } = createResponse();
+    const next = vi.fn();
+
+    await middleware(
+      {
+        method: "GET",
+        url: "/docs/guide?source=agent",
+        headers: { accept: "text/markdown" },
+      },
+      response,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(200);
+    expect(getHeader("Content-Type")).toBe("text/markdown; charset=utf-8");
+    expect(getHeader("Vary")).toBe("Accept");
+    expect(getHeader("Link")).toBe(
+      '</docs/guide.md>; rel="alternate"; type="text/markdown"',
+    );
+    expect(getBody()).toBe("# Agent Guide\n\nUse the API safely.\n");
+  });
+
+  it("advertises variants for HTML and returns no body for Markdown HEAD", async () => {
+    const middleware = await createMiddleware();
+    const htmlResponse = createResponse({
+      Link: '</assets/app.js>; rel="preload"',
+      Vary: "Accept-Encoding",
+    });
+    const htmlNext = vi.fn();
+
+    await middleware(
+      {
+        method: "GET",
+        url: "/docs/guide",
+        headers: { accept: "text/html" },
+      },
+      htmlResponse.response,
+      htmlNext,
+    );
+
+    expect(htmlNext).toHaveBeenCalledOnce();
+    expect(htmlResponse.getHeader("Vary")).toBe("Accept-Encoding, Accept");
+    expect(htmlResponse.getHeader("Link")).toBe(
+      '</assets/app.js>; rel="preload", </docs/guide.md>; rel="alternate"; type="text/markdown"',
+    );
+
+    const headResponse = createResponse();
+    const headNext = vi.fn();
+    await middleware(
+      {
+        method: "HEAD",
+        url: "/docs/guide",
+        headers: { accept: "text/markdown" },
+      },
+      headResponse.response,
+      headNext,
+    );
+
+    expect(headNext).not.toHaveBeenCalled();
+    expect(headResponse.getHeader("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(headResponse.getBody()).toBeUndefined();
+  });
+
+  it("returns 406 when neither available representation is acceptable", async () => {
+    const middleware = await createMiddleware();
+    const { response, getBody, getHeader } = createResponse();
+    const next = vi.fn();
+
+    await middleware(
+      {
+        method: "GET",
+        url: "/docs/guide",
+        headers: { accept: "application/json" },
+      },
+      response,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(406);
+    expect(getHeader("Content-Type")).toBe("text/plain; charset=utf-8");
+    expect(getHeader("Vary")).toBe("Accept");
+    expect(getBody()).toBe("Not Acceptable");
+
+    const headResponse = createResponse();
+    await middleware(
+      {
+        method: "HEAD",
+        url: "/docs/guide",
+        headers: { accept: "application/json" },
+      },
+      headResponse.response,
+      vi.fn(),
+    );
+    expect(headResponse.response.statusCode).toBe(406);
+    expect(headResponse.getBody()).toBeUndefined();
+  });
+
+  it("keeps explicit Markdown portable when negotiation is disabled", async () => {
+    const middleware = await createMiddleware(false);
+    const canonicalResponse = createResponse();
+    const canonicalNext = vi.fn();
+
+    await middleware(
+      {
+        method: "GET",
+        url: "/docs/guide",
+        headers: { accept: "text/markdown" },
+      },
+      canonicalResponse.response,
+      canonicalNext,
+    );
+
+    expect(canonicalNext).toHaveBeenCalledOnce();
+    expect(canonicalResponse.getHeader("Vary")).toBeUndefined();
+
+    const explicitResponse = createResponse();
+    const explicitNext = vi.fn();
+    await middleware(
+      {
+        method: "GET",
+        url: "/docs/guide.md",
+        headers: { accept: "text/html" },
+      },
+      explicitResponse.response,
+      explicitNext,
+    );
+
+    expect(explicitNext).not.toHaveBeenCalled();
+    expect(explicitResponse.getHeader("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(explicitResponse.getBody()).toContain("# Agent Guide");
+  });
+
+  it("does not serve Markdown routes outside the configured base path", async () => {
+    const middleware = await createMiddleware();
+    const { response } = createResponse();
+    const next = vi.fn();
+
+    await middleware(
+      {
+        method: "GET",
+        url: "/guide.md",
+        headers: { accept: "text/markdown" },
+      },
+      response,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("passes unknown canonical routes through without mutating headers", async () => {
+    const middleware = await createMiddleware();
+    const { response, getHeader } = createResponse();
+    const next = vi.fn();
+
+    await middleware(
+      {
+        method: "GET",
+        url: "/docs/missing",
+        headers: { accept: "text/markdown" },
+      },
+      response,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(getHeader("Vary")).toBeUndefined();
+    expect(getHeader("Link")).toBeUndefined();
+  });
+});
 
 describe("getMarkdownOutputPath", () => {
   it("maps root route to index.md", () => {
@@ -23,6 +272,30 @@ describe("getMarkdownOutputPath", () => {
     expect(getMarkdownOutputPath("/dist", "/docs/getting-started")).toBe(
       `${path.join("/dist", "docs", "getting-started")}.md`,
     );
+  });
+});
+
+describe("writeMarkdownInfo", () => {
+  it("overwrites stale route metadata when the current build has no Markdown files", async () => {
+    const tempDir = await mkdtemp(
+      path.join(os.tmpdir(), "zudoku-markdown-info-"),
+    );
+    const metadataPath = path.join(tempDir, ".zudoku/markdown-info.json");
+
+    try {
+      await writeMarkdownInfo(metadataPath, [
+        {
+          filePath: "/old.md",
+          routePath: "/old",
+          content: "Old content",
+        },
+      ]);
+      await writeMarkdownInfo(metadataPath, []);
+
+      await expect(readFile(metadataPath, "utf-8")).resolves.toBe("[]");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -57,6 +330,10 @@ describe("resolveMarkdownRoutePath", () => {
       "/documentation",
     );
     expect(resolveMarkdownRoutePath("/base/index.md", "/base")).toBe("/");
+  });
+
+  it("rejects Markdown URLs outside the configured base path", () => {
+    expect(resolveMarkdownRoutePath("/outside.md", "/base")).toBeUndefined();
   });
 
   it("handles .mdx extension", () => {

--- a/packages/zudoku/src/vite/plugin-markdown-export.ts
+++ b/packages/zudoku/src/vite/plugin-markdown-export.ts
@@ -2,7 +2,17 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Plugin } from "vite";
 import { type ConfigWithMeta, getCurrentConfig } from "../config/loader.js";
+import {
+  addAcceptToVary,
+  negotiateContentType,
+} from "../lib/util/contentNegotiation.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
+import {
+  appendLinkHeader,
+  encodeDocumentationRoutePath,
+  getMarkdownAlternateLink,
+  resolveDocumentationRoutePath,
+} from "../lib/util/markdown-representation.js";
 import { readFrontmatter } from "../lib/util/readFrontmatter.js";
 import { matchesAnyProtectedPattern } from "../lib/util/url.js";
 import {
@@ -17,6 +27,9 @@ export type MarkdownFileInfo = {
   description?: string;
   content: string;
 };
+
+const MARKDOWN_FILES_MODULE_ID = "virtual:zudoku-markdown-files";
+const RESOLVED_MARKDOWN_FILES_MODULE_ID = `\0${MARKDOWN_FILES_MODULE_ID}`;
 
 const processMarkdownFile = async (
   filePath: string,
@@ -54,6 +67,18 @@ export const getMarkdownOutputPath = (distDir: string, routePath: string) => {
   return `${path.join(distDir, ...segments)}.md`;
 };
 
+export const writeMarkdownInfo = async (
+  markdownInfoPath: string,
+  markdownFileInfos: MarkdownFileInfo[],
+) => {
+  await mkdir(path.dirname(markdownInfoPath), { recursive: true });
+  await writeFile(
+    markdownInfoPath,
+    JSON.stringify(markdownFileInfos, null, 2),
+    "utf-8",
+  );
+};
+
 /**
  * Resolves a .md request URL to the route path used in the file mapping.
  * Strips query/hash, removes the .md(x) extension, and reverses the
@@ -62,11 +87,12 @@ export const getMarkdownOutputPath = (distDir: string, routePath: string) => {
 export const resolveMarkdownRoutePath = (
   requestUrl: string,
   basePath: string,
-): string => {
-  const pathname = requestUrl.split(/[?#]/)[0] ?? requestUrl;
-  const routePath = joinUrl(
-    pathname.slice(basePath.length).replace(/\.mdx?$/, ""),
-  );
+): string | undefined => {
+  const pathname = requestUrl.split(/[?#]/)[0]?.replace(/\.mdx?$/, "");
+  if (!pathname) return;
+
+  const routePath = resolveDocumentationRoutePath(pathname, basePath);
+  if (!routePath) return;
   if (routePath === "/index") {
     return "/";
   }
@@ -78,6 +104,116 @@ const needsMdFiles = (config: ConfigWithMeta) =>
   config.docs.llms.llmsTxt ||
   config.docs.llms.llmsTxtFull;
 
+const isContentNegotiationEnabled = (config: Pick<ConfigWithMeta, "docs">) =>
+  config.docs.publishMarkdown && config.docs.contentNegotiation;
+
+const resolveMarkdownFiles = async (config: ConfigWithMeta) => {
+  const files = await resolveCustomNavigationPaths(
+    config,
+    await globMarkdownFiles(config, { absolute: true }),
+  );
+
+  if (config.docs.llms.includeProtected || !config.protectedRoutes) {
+    return files;
+  }
+
+  const patterns = Object.keys(config.protectedRoutes);
+  return Object.fromEntries(
+    Object.entries(files).filter(
+      ([routePath]) => !matchesAnyProtectedPattern(patterns, routePath),
+    ),
+  );
+};
+
+const loadMarkdownContents = async (markdownFiles: Record<string, string>) =>
+  Object.fromEntries(
+    await Promise.all(
+      Object.entries(markdownFiles).map(async ([routePath, filePath]) => [
+        encodeDocumentationRoutePath(routePath),
+        (await processMarkdownFile(filePath)).content,
+      ]),
+    ),
+  );
+
+type MarkdownDevRequest = {
+  method?: string;
+  url?: string;
+  headers: { accept?: string };
+};
+
+type MarkdownDevResponse = {
+  statusCode: number;
+  getHeader: (name: string) => string | number | string[] | undefined;
+  setHeader: (name: string, value: string) => unknown;
+  end: (body?: string) => unknown;
+};
+
+export const createMarkdownDevMiddleware =
+  ({
+    config,
+    getMarkdownFiles,
+  }: {
+    config: Pick<ConfigWithMeta, "basePath" | "docs">;
+    getMarkdownFiles: () => Record<string, string>;
+  }) =>
+  async (
+    req: MarkdownDevRequest,
+    res: MarkdownDevResponse,
+    next: () => void,
+  ) => {
+    if (!req.url || (req.method !== "GET" && req.method !== "HEAD")) {
+      return next();
+    }
+
+    const basePath = joinUrl(config.basePath);
+    const pathname = req.url.split(/[?#]/)[0] ?? req.url;
+    const isExplicitMarkdownRequest = pathname.endsWith(".md");
+    const routePath = isExplicitMarkdownRequest
+      ? resolveMarkdownRoutePath(req.url, basePath)
+      : resolveDocumentationRoutePath(req.url, basePath);
+    if (!routePath) return next();
+
+    const filePath = Object.entries(getMarkdownFiles()).find(
+      ([configuredRoutePath]) =>
+        encodeDocumentationRoutePath(configuredRoutePath) === routePath,
+    )?.[1];
+    if (!filePath) return next();
+
+    if (!isExplicitMarkdownRequest && isContentNegotiationEnabled(config)) {
+      const negotiatedType = negotiateContentType(req.headers.accept);
+      res.setHeader("Vary", addAcceptToVary(res.getHeader("Vary")?.toString()));
+      res.setHeader(
+        "Link",
+        appendLinkHeader(
+          res.getHeader("Link"),
+          getMarkdownAlternateLink(routePath, config.basePath),
+        ),
+      );
+
+      if (negotiatedType === null) {
+        res.statusCode = 406;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        return res.end(req.method === "HEAD" ? undefined : "Not Acceptable");
+      }
+
+      if (negotiatedType === "text/html") {
+        return next();
+      }
+    } else if (!isExplicitMarkdownRequest) {
+      return next();
+    }
+
+    try {
+      const { content } = await processMarkdownFile(filePath);
+      res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+      return res.end(req.method === "HEAD" ? undefined : content);
+    } catch (error) {
+      // biome-ignore lint/suspicious/noConsole: Logging allowed here
+      console.warn(`Failed to serve markdown for ${routePath}:`, error);
+      return next();
+    }
+  };
+
 const viteMarkdownExportPlugin = (): Plugin => {
   let markdownFiles: Record<string, string> = {};
   let markdownFileInfos: MarkdownFileInfo[] = [];
@@ -87,6 +223,16 @@ const viteMarkdownExportPlugin = (): Plugin => {
     applyToEnvironment(env) {
       return env.name === "ssr";
     },
+    resolveId(id) {
+      if (id === MARKDOWN_FILES_MODULE_ID) {
+        return RESOLVED_MARKDOWN_FILES_MODULE_ID;
+      }
+    },
+    async load(id) {
+      if (id === RESOLVED_MARKDOWN_FILES_MODULE_ID) {
+        return `export default ${JSON.stringify(await loadMarkdownContents(markdownFiles))};`;
+      }
+    },
     async buildStart() {
       const config = getCurrentConfig();
 
@@ -94,23 +240,7 @@ const viteMarkdownExportPlugin = (): Plugin => {
         return;
       }
 
-      markdownFiles = await resolveCustomNavigationPaths(
-        config,
-        await globMarkdownFiles(config, { absolute: true }),
-      );
-
-      // Filter out protected routes unless `includeProtected` is true
-      if (!config.docs.llms.includeProtected) {
-        const protectedRoutes = config.protectedRoutes;
-        if (protectedRoutes) {
-          const patterns = Object.keys(protectedRoutes);
-          for (const routePath of Object.keys(markdownFiles)) {
-            if (matchesAnyProtectedPattern(patterns, routePath)) {
-              delete markdownFiles[routePath];
-            }
-          }
-        }
-      }
+      markdownFiles = await resolveMarkdownFiles(config);
     },
     async configureServer(server) {
       const config = getCurrentConfig();
@@ -118,41 +248,19 @@ const viteMarkdownExportPlugin = (): Plugin => {
       // Serve .md files if markdown export is needed
       if (!needsMdFiles(config)) return;
 
-      markdownFiles = await resolveCustomNavigationPaths(
-        config,
-        await globMarkdownFiles(config, { absolute: true }),
+      markdownFiles = await resolveMarkdownFiles(config);
+
+      server.middlewares.use(
+        createMarkdownDevMiddleware({
+          config,
+          getMarkdownFiles: () => markdownFiles,
+        }),
       );
-
-      server.middlewares.use(async (req, res, next) => {
-        if (req.method !== "GET" || !req.url?.endsWith(".md")) {
-          return next();
-        }
-
-        const basePath = joinUrl(config.basePath);
-        const routePath = resolveMarkdownRoutePath(req.url, basePath);
-        const filePath = markdownFiles[routePath];
-
-        if (!filePath) return next();
-
-        try {
-          const { content } = await processMarkdownFile(filePath);
-          res.setHeader("Content-Type", "text/markdown; charset=utf-8");
-          res.end(content);
-        } catch (error) {
-          // biome-ignore lint/suspicious/noConsole: Logging allowed here
-          console.warn(`Failed to serve markdown for ${routePath}:`, error);
-          return next();
-        }
-      });
     },
     async closeBundle() {
       const config = getCurrentConfig();
 
-      if (
-        process.env.NODE_ENV !== "production" ||
-        Object.keys(markdownFiles).length === 0 ||
-        !needsMdFiles(config)
-      ) {
+      if (process.env.NODE_ENV !== "production" || !needsMdFiles(config)) {
         return;
       }
 
@@ -192,16 +300,16 @@ const viteMarkdownExportPlugin = (): Plugin => {
         }
       }
 
-      if (config.docs.llms.llmsTxt || config.docs.llms.llmsTxtFull) {
+      if (
+        config.docs.llms.llmsTxt ||
+        config.docs.llms.llmsTxtFull ||
+        isContentNegotiationEnabled(config)
+      ) {
         const markdownInfoPath = path.join(
           config.__meta.rootDir,
           "node_modules/.zudoku/markdown-info.json",
         );
-        await writeFile(
-          markdownInfoPath,
-          JSON.stringify(markdownFileInfos, null, 2),
-          "utf-8",
-        );
+        await writeMarkdownInfo(markdownInfoPath, markdownFileInfos);
       }
     },
   };

--- a/packages/zudoku/src/vite/prerender/prerender.ts
+++ b/packages/zudoku/src/vite/prerender/prerender.ts
@@ -14,6 +14,7 @@ import { validateConfig } from "../../config/validators/ZudokuConfig.js";
 import { runPluginTransformConfig } from "../../lib/core/transform-config.js";
 import invariant from "../../lib/util/invariant.js";
 import { joinUrl } from "../../lib/util/joinUrl.js";
+import { getMarkdownNotFound } from "../../lib/util/markdown-representation.js";
 import {
   getMarkdownOutputPath,
   type MarkdownFileInfo,
@@ -271,9 +272,25 @@ export const prerender = async ({
       siteName: config.site?.title,
       llmsTxt: llmsConfig.llmsTxt,
       llmsTxtFull: llmsConfig.llmsTxtFull,
+      title: llmsConfig.title,
+      description: llmsConfig.description,
+      instructions: llmsConfig.instructions,
       redirectUrls,
     });
   }
+
+  const contentNegotiationEnabled =
+    config.docs.publishMarkdown && config.docs.contentNegotiation;
+  const markdownNotFound = contentNegotiationEnabled
+    ? getMarkdownNotFound({
+        basePath: config.basePath,
+        includeLlmsTxt: llmsConfig.llmsTxt ?? false,
+        markdownRoutePaths: markdownFileInfos.map((info) => info.routePath),
+        sitemapOutDir: config.sitemap
+          ? (config.sitemap.outDir ?? "")
+          : undefined,
+      })
+    : undefined;
 
   if (!config.docs.publishMarkdown) {
     await Promise.all(
@@ -287,7 +304,13 @@ export const prerender = async ({
     );
   }
 
-  return { workerResults, rewrites };
+  return {
+    workerResults,
+    rewrites,
+    knownRoutes: paths,
+    markdownRoutes: markdownFileInfos.map((info) => info.routePath),
+    markdownNotFound,
+  };
 };
 
 /**

--- a/packages/zudoku/src/vite/prerender/prerender.ts
+++ b/packages/zudoku/src/vite/prerender/prerender.ts
@@ -13,7 +13,6 @@ import { getBuildConfig } from "../../config/validators/BuildSchema.js";
 import { validateConfig } from "../../config/validators/ZudokuConfig.js";
 import { runPluginTransformConfig } from "../../lib/core/transform-config.js";
 import invariant from "../../lib/util/invariant.js";
-import { joinUrl } from "../../lib/util/joinUrl.js";
 import { getMarkdownNotFound } from "../../lib/util/markdown-representation.js";
 import {
   getMarkdownOutputPath,
@@ -22,7 +21,7 @@ import {
 import { isTTY, throttle, writeLine } from "../reporter.js";
 import { generateSitemap } from "../sitemap.js";
 import {
-  routesToPaths,
+  routesToPrerenderPaths,
   routesToRewrites,
   selectPagesToIndex,
 } from "./utils.js";
@@ -89,15 +88,8 @@ export const prerender = async ({
   const getRoutes = module.getRoutesByConfig as typeof getRoutesByConfig;
 
   const routes = getRoutes(config);
-  const paths = routesToPaths(routes);
+  const paths = routesToPrerenderPaths(routes, config.redirects);
   const rewrites = routesToRewrites(routes);
-
-  // Add redirect source paths so they get prerendered as redirects
-  if (config.redirects) {
-    for (const r of config.redirects) {
-      paths.push(joinUrl(r.from));
-    }
-  }
   const { maxThreads, maxOldGenerationSizeMb } = getWorkerScaling(
     buildConfig?.prerender?.workers,
   );

--- a/packages/zudoku/src/vite/prerender/utils.test.ts
+++ b/packages/zudoku/src/vite/prerender/utils.test.ts
@@ -2,6 +2,7 @@ import type { RouteObject } from "react-router";
 import { describe, expect, it } from "vitest";
 import {
   routesToPaths,
+  routesToPrerenderPaths,
   routesToRewrites,
   selectPagesToIndex,
 } from "./utils.js";
@@ -79,6 +80,28 @@ describe("routesToPaths", () => {
 
   it("returns empty for empty input", () => {
     expect(routesToPaths([])).toEqual([]);
+  });
+});
+
+describe("routesToPrerenderPaths", () => {
+  it("deduplicates redirect sources already present in the route paths", () => {
+    const routes: RouteObject[] = [{ path: "about" }, { path: "contact" }];
+
+    expect(
+      routesToPrerenderPaths(routes, [{ from: "/about" }, { from: "about" }]),
+    ).toEqual(["/about", "/contact"]);
+  });
+
+  it("appends distinct redirect sources in configuration order", () => {
+    const routes: RouteObject[] = [{ path: "about" }];
+
+    expect(
+      routesToPrerenderPaths(routes, [
+        { from: "/old-home" },
+        { from: "/legacy/contact" },
+        { from: "/old-home" },
+      ]),
+    ).toEqual(["/about", "/old-home", "/legacy/contact"]);
   });
 });
 

--- a/packages/zudoku/src/vite/prerender/utils.ts
+++ b/packages/zudoku/src/vite/prerender/utils.ts
@@ -72,6 +72,17 @@ const collectRewrites = (resolved: ResolvedRoute[]): RouteRewrite[] =>
 export const routesToPaths = (routes: RouteObject[]): string[] =>
   collectPaths(resolveRoutes(routes), "");
 
+export const routesToPrerenderPaths = (
+  routes: RouteObject[],
+  redirects: readonly { from: string }[] = [],
+): string[] =>
+  Array.from(
+    new Set([
+      ...routesToPaths(routes),
+      ...redirects.map(({ from }) => joinUrl(from)),
+    ]),
+  );
+
 export const routesToRewrites = (routes: RouteObject[]): RouteRewrite[] =>
   collectRewrites(resolveRoutes(routes));
 

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
@@ -200,6 +200,23 @@ describe("generateVercelMarkdownMiddleware", () => {
     );
   });
 
+  it.each(["/docs/not-a-page.md", "/docs/not-a-page.mdx"])(
+    "returns a Markdown recovery document for missing explicit path %s",
+    async (pathname) => {
+      const middleware = await loadMiddleware({ basePath: "/docs" });
+      const response = await middleware(request(pathname));
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Content-Type")).toBe(
+        "text/markdown; charset=utf-8",
+      );
+      expect(response.headers.get("Vary")).toBeNull();
+      expect(await response.text()).toBe(
+        "# Page not found\n\n- [Documentation home](/docs)\n",
+      );
+    },
+  );
+
   it("varies pass-through HTML 404s on Accept", async () => {
     const middleware = await loadMiddleware({ basePath: "/docs" });
 
@@ -231,6 +248,9 @@ describe("generateVercelMarkdownMiddleware", () => {
     const notFound = await middleware(
       request("/docs/missing", { accept: "text/markdown", method: "HEAD" }),
     );
+    const explicitNotFound = await middleware(
+      request("/docs/missing.md", { method: "HEAD" }),
+    );
     const notAcceptable = await middleware(
       request("/docs/guide", {
         accept: "text/html;q=0, text/markdown;q=0",
@@ -240,6 +260,8 @@ describe("generateVercelMarkdownMiddleware", () => {
 
     expect(notFound.status).toBe(404);
     expect(await notFound.text()).toBe("");
+    expect(explicitNotFound.status).toBe(404);
+    expect(await explicitNotFound.text()).toBe("");
     expect(notAcceptable.status).toBe(406);
     expect(await notAcceptable.text()).toBe("");
   });
@@ -260,18 +282,20 @@ describe("generateVercelMarkdownMiddleware", () => {
     }
   });
 
-  it("passes extensionless static files through", async () => {
+  it("passes extensionless and Markdown static files through", async () => {
     const middleware = await loadMiddleware({
       basePath: "/docs",
-      passthroughPaths: ["/docs/health"],
+      passthroughPaths: ["/docs/health", "/docs/source.md"],
     });
-    const response = await middleware(
-      request("/docs/health", { accept: "text/markdown" }),
-    );
 
-    expect(response.headers.get("x-middleware-next")).toBe("1");
-    expect(response.headers.get("Vary")).toBeNull();
-    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    for (const pathname of ["/docs/health", "/docs/source.md"]) {
+      const response = await middleware(
+        request(pathname, { accept: "text/markdown" }),
+      );
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+      expect(response.headers.get("Vary")).toBeNull();
+      expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    }
   });
 
   it("rejects Markdown routes that are not known canonical routes", () => {

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
@@ -167,6 +167,58 @@ describe("generateVercelMarkdownMiddleware", () => {
     expect(actual).toBe(negotiateContentType(accept));
   });
 
+  it.each([
+    ["text/markdown;q=0.9;charset=utf-8, text/html;q=0.5", "text/markdown"],
+    ["text/markdown;charset=utf-8;q=0.9, text/html;q=0.5", "text/markdown"],
+    ["text/markdown;q=0.9;charset=iso-8859-1, text/html;q=0.5", "text/html"],
+    ["text/markdown;q=0.9;legacy-extension, text/html;q=0.5", "text/html"],
+  ])(
+    "matches shared RFC 9110 parameter handling for %j",
+    async (accept, expected) => {
+      const middleware = await loadMiddleware();
+      const response = await middleware(request("/guide", { accept }));
+      const actual = response.headers.has("x-middleware-rewrite")
+        ? "text/markdown"
+        : "text/html";
+
+      expect(actual).toBe(expected);
+      expect(actual).toBe(negotiateContentType(accept));
+    },
+  );
+
+  it.each([
+    ["/tracking", "/track%69ng", "/tracking.md"],
+    ["/guides/café", "/guides/caf%c3%a9", "/guides/caf%C3%A9.md"],
+  ])(
+    "canonicalizes encoded request route %s",
+    async (routePath, requestPath, expectedMarkdownPath) => {
+      const middleware = await loadMiddleware({
+        knownCanonicalRoutePaths: [routePath],
+        markdownCanonicalRoutePaths: [routePath],
+      });
+      const response = await middleware(
+        request(requestPath, { accept: "text/markdown" }),
+      );
+
+      expect(
+        new URL(response.headers.get("x-middleware-rewrite") ?? "").pathname,
+      ).toBe(expectedMarkdownPath);
+    },
+  );
+
+  it("does not decode an encoded reserved delimiter into a route boundary", async () => {
+    const middleware = await loadMiddleware({
+      knownCanonicalRoutePaths: ["/guides/a/b"],
+      markdownCanonicalRoutePaths: ["/guides/a/b"],
+    });
+    const response = await middleware(
+      request("/guides/a%2fb", { accept: "text/markdown" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+  });
+
   it("returns 406 when neither representation of a known page is acceptable", async () => {
     const middleware = await loadMiddleware();
     const response = await middleware(

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
@@ -8,16 +8,19 @@ const loadMiddleware = async ({
   basePath,
   knownCanonicalRoutePaths = ["/", "/guide", "/custom"],
   markdownCanonicalRoutePaths = ["/", "/guide"],
+  passthroughPaths,
 }: {
   basePath?: string;
   knownCanonicalRoutePaths?: string[];
   markdownCanonicalRoutePaths?: string[];
+  passthroughPaths?: string[];
 } = {}): Promise<Middleware> => {
   const source = generateVercelMarkdownMiddleware({
     basePath,
     knownCanonicalRoutePaths,
     markdownCanonicalRoutePaths,
     markdownNotFoundBody: "# Page not found\n\n- [Documentation home](/docs)\n",
+    passthroughPaths,
   });
   const encodedSource = encodeURIComponent(source);
   const module = await import(`data:text/javascript,${encodedSource}`);
@@ -41,7 +44,7 @@ describe("generateVercelMarkdownMiddleware", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("x-middleware-next")).toBe("1");
     expect(response.headers.get("x-middleware-rewrite")).toBeNull();
-    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Vary")).toBe("Accept, Accept-Encoding");
     expect(response.headers.get("Link")).toBe(
       '</guide.md>; rel="alternate"; type="text/markdown"',
     );
@@ -61,7 +64,7 @@ describe("generateVercelMarkdownMiddleware", () => {
     expect(response.headers.get("Content-Type")).toBe(
       "text/markdown; charset=utf-8",
     );
-    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Vary")).toBe("Accept, Accept-Encoding");
     expect(response.headers.get("Link")).toBe(
       '</guide.md>; rel="alternate"; type="text/markdown"',
     );
@@ -87,6 +90,7 @@ describe("generateVercelMarkdownMiddleware", () => {
   it.each([
     ["/hello world", "/hello%20world.md"],
     ["/guides/café", "/guides/caf%C3%A9.md"],
+    ["/api/1.0.0", "/api/1.0.0.md"],
   ])("URL-encodes the Markdown route for %s", async (routePath, expected) => {
     const middleware = await loadMiddleware({
       knownCanonicalRoutePaths: [routePath],
@@ -172,7 +176,7 @@ describe("generateVercelMarkdownMiddleware", () => {
     );
 
     expect(response.status).toBe(406);
-    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Vary")).toBe("Accept, Accept-Encoding");
     expect(response.headers.get("Link")).toBe(
       '</guide.md>; rel="alternate"; type="text/markdown"',
     );
@@ -189,7 +193,7 @@ describe("generateVercelMarkdownMiddleware", () => {
     expect(response.headers.get("Content-Type")).toBe(
       "text/markdown; charset=utf-8",
     );
-    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Vary")).toBe("Accept, Accept-Encoding");
     expect(response.headers.get("x-middleware-next")).toBeNull();
     expect(await response.text()).toBe(
       "# Page not found\n\n- [Documentation home](/docs)\n",
@@ -204,7 +208,7 @@ describe("generateVercelMarkdownMiddleware", () => {
         request("/docs/not/a-page", { accept }),
       );
       expect(response.headers.get("x-middleware-next")).toBe("1");
-      expect(response.headers.get("Vary")).toBe("Accept");
+      expect(response.headers.get("Vary")).toBe("Accept, Accept-Encoding");
     }
   });
 
@@ -217,7 +221,7 @@ describe("generateVercelMarkdownMiddleware", () => {
       );
 
       expect(response.status).toBe(406);
-      expect(response.headers.get("Vary")).toBe("Accept");
+      expect(response.headers.get("Vary")).toBe("Accept, Accept-Encoding");
       expect(await response.text()).toBe("Not Acceptable");
     },
   );
@@ -254,6 +258,20 @@ describe("generateVercelMarkdownMiddleware", () => {
       expect(response.headers.get("Vary")).toBeNull();
       expect(response.headers.get("x-middleware-rewrite")).toBeNull();
     }
+  });
+
+  it("passes extensionless static files through", async () => {
+    const middleware = await loadMiddleware({
+      basePath: "/docs",
+      passthroughPaths: ["/docs/health"],
+    });
+    const response = await middleware(
+      request("/docs/health", { accept: "text/markdown" }),
+    );
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("Vary")).toBeNull();
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
   });
 
   it("rejects Markdown routes that are not known canonical routes", () => {

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import { negotiateContentType } from "../lib/util/contentNegotiation.js";
+import { generateVercelMarkdownMiddleware } from "./vercel-markdown-middleware.js";
+
+type Middleware = (request: Request) => Response | Promise<Response>;
+
+const loadMiddleware = async ({
+  basePath,
+  knownCanonicalRoutePaths = ["/", "/guide", "/custom"],
+  markdownCanonicalRoutePaths = ["/", "/guide"],
+}: {
+  basePath?: string;
+  knownCanonicalRoutePaths?: string[];
+  markdownCanonicalRoutePaths?: string[];
+} = {}): Promise<Middleware> => {
+  const source = generateVercelMarkdownMiddleware({
+    basePath,
+    knownCanonicalRoutePaths,
+    markdownCanonicalRoutePaths,
+    markdownNotFoundBody: "# Page not found\n\n- [Documentation home](/docs)\n",
+  });
+  const encodedSource = encodeURIComponent(source);
+  const module = await import(`data:text/javascript,${encodedSource}`);
+  return module.default;
+};
+
+const request = (
+  pathname: string,
+  { accept, method = "GET" }: { accept?: string; method?: string } = {},
+) =>
+  new Request(`https://example.com${pathname}`, {
+    method,
+    headers: accept ? { Accept: accept } : undefined,
+  });
+
+describe("generateVercelMarkdownMiddleware", () => {
+  it("passes HTML through with negotiation and alternate headers", async () => {
+    const middleware = await loadMiddleware();
+    const response = await middleware(request("/guide?source=test"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Link")).toBe(
+      '</guide.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+
+  it("rewrites Markdown requests to the generated sibling", async () => {
+    const middleware = await loadMiddleware();
+    const response = await middleware(
+      request("/guide?source=test", { accept: "text/markdown" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-next")).toBeNull();
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/guide.md?source=test",
+    );
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Link")).toBe(
+      '</guide.md>; rel="alternate"; type="text/markdown"',
+    );
+    expect(await response.text()).toBe("");
+  });
+
+  it("uses index.md for the documentation root", async () => {
+    const middleware = await loadMiddleware({ basePath: "/docs/" });
+
+    for (const pathname of ["/docs", "/docs/"]) {
+      const response = await middleware(
+        request(pathname, { accept: "text/markdown" }),
+      );
+      expect(response.headers.get("x-middleware-rewrite")).toBe(
+        "https://example.com/docs/index.md",
+      );
+      expect(response.headers.get("Link")).toBe(
+        '</docs/index.md>; rel="alternate"; type="text/markdown"',
+      );
+    }
+  });
+
+  it.each([
+    ["/hello world", "/hello%20world.md"],
+    ["/guides/café", "/guides/caf%C3%A9.md"],
+  ])("URL-encodes the Markdown route for %s", async (routePath, expected) => {
+    const middleware = await loadMiddleware({
+      knownCanonicalRoutePaths: [routePath],
+      markdownCanonicalRoutePaths: [routePath],
+    });
+    const requestPath = new URL(routePath, "https://example.com").pathname;
+    const response = await middleware(
+      request(requestPath, { accept: "text/markdown" }),
+    );
+
+    expect(
+      new URL(response.headers.get("x-middleware-rewrite") ?? "").pathname,
+    ).toBe(expected);
+    expect(response.headers.get("Link")).toBe(
+      `<${expected}>; rel="alternate"; type="text/markdown"`,
+    );
+  });
+
+  it("honors quality, wildcards, specificity, and q=0 exclusions", async () => {
+    const middleware = await loadMiddleware();
+
+    const markdown = await middleware(
+      request("/guide", {
+        accept: "text/html;q=0.5, text/markdown;q=0.6",
+      }),
+    );
+    expect(markdown.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/guide.md",
+    );
+
+    const html = await middleware(
+      request("/guide", { accept: "text/markdown;q=0, */*;q=1" }),
+    );
+    expect(html.headers.get("x-middleware-next")).toBe("1");
+    expect(html.headers.get("x-middleware-rewrite")).toBeNull();
+
+    const explicitMarkdown = await middleware(
+      request("/guide", { accept: "*/*, text/markdown" }),
+    );
+    expect(explicitMarkdown.headers.get("x-middleware-rewrite")).toBe(
+      "https://example.com/guide.md",
+    );
+  });
+
+  it.each([
+    undefined,
+    "",
+    "*/*",
+    "text/*",
+    "text/html",
+    "text/markdown",
+    "TEXT/MARKDOWN",
+    "text/markdown; charset=utf-8",
+    "text/markdown;q=0.9, text/html;q=0.8",
+    "text/markdown;q=0, */*;q=1",
+    "text/html;q=0, */*;q=1",
+    "text/*;q=0, text/markdown;q=0.5",
+    "*/*, text/markdown",
+    "application/json",
+    "text/html;q=0, text/markdown;q=0",
+    "text/markdown; charset=iso-8859-1",
+    "text/markdown;q=2, text/html;q=0.5",
+    'text/markdown; profile="example,profile";q=1, text/html;q=0.5',
+  ])("keeps generated negotiation in sync for %j", async (accept) => {
+    const middleware = await loadMiddleware();
+    const response = await middleware(request("/guide", { accept }));
+    const actual =
+      response.status === 406
+        ? null
+        : response.headers.has("x-middleware-rewrite")
+          ? "text/markdown"
+          : "text/html";
+
+    expect(actual).toBe(negotiateContentType(accept));
+  });
+
+  it("returns 406 when neither representation of a known page is acceptable", async () => {
+    const middleware = await loadMiddleware();
+    const response = await middleware(
+      request("/guide", {
+        accept: "text/html;q=0, text/markdown;q=0",
+      }),
+    );
+
+    expect(response.status).toBe(406);
+    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("Link")).toBe(
+      '</guide.md>; rel="alternate"; type="text/markdown"',
+    );
+    expect(await response.text()).toBe("Not Acceptable");
+  });
+
+  it("returns a Markdown recovery document for unknown extensionless paths", async () => {
+    const middleware = await loadMiddleware({ basePath: "/docs" });
+    const response = await middleware(
+      request("/docs/not/a-page", { accept: "text/markdown" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept");
+    expect(response.headers.get("x-middleware-next")).toBeNull();
+    expect(await response.text()).toBe(
+      "# Page not found\n\n- [Documentation home](/docs)\n",
+    );
+  });
+
+  it("varies pass-through HTML 404s on Accept", async () => {
+    const middleware = await loadMiddleware({ basePath: "/docs" });
+
+    for (const accept of [undefined, "text/html"]) {
+      const response = await middleware(
+        request("/docs/not/a-page", { accept }),
+      );
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+      expect(response.headers.get("Vary")).toBe("Accept");
+    }
+  });
+
+  it.each(["application/json", "text/html;q=0, text/markdown;q=0"])(
+    "returns 406 for an unknown path when %j is unacceptable",
+    async (accept) => {
+      const middleware = await loadMiddleware({ basePath: "/docs" });
+      const response = await middleware(
+        request("/docs/not/a-page", { accept }),
+      );
+
+      expect(response.status).toBe(406);
+      expect(response.headers.get("Vary")).toBe("Accept");
+      expect(await response.text()).toBe("Not Acceptable");
+    },
+  );
+
+  it("returns no response body for custom HEAD responses", async () => {
+    const middleware = await loadMiddleware({ basePath: "/docs" });
+    const notFound = await middleware(
+      request("/docs/missing", { accept: "text/markdown", method: "HEAD" }),
+    );
+    const notAcceptable = await middleware(
+      request("/docs/guide", {
+        accept: "text/html;q=0, text/markdown;q=0",
+        method: "HEAD",
+      }),
+    );
+
+    expect(notFound.status).toBe(404);
+    expect(await notFound.text()).toBe("");
+    expect(notAcceptable.status).toBe(406);
+    expect(await notAcceptable.text()).toBe("");
+  });
+
+  it("leaves non-document requests and non-Markdown routes alone", async () => {
+    const middleware = await loadMiddleware({ basePath: "/docs" });
+
+    for (const currentRequest of [
+      request("/outside", { accept: "text/markdown" }),
+      request("/docs/app.js", { accept: "text/markdown" }),
+      request("/docs/custom", { accept: "text/markdown" }),
+      request("/docs/guide", { accept: "text/markdown", method: "POST" }),
+    ]) {
+      const response = await middleware(currentRequest);
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+      expect(response.headers.get("Vary")).toBeNull();
+      expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    }
+  });
+
+  it("rejects Markdown routes that are not known canonical routes", () => {
+    expect(() =>
+      generateVercelMarkdownMiddleware({
+        knownCanonicalRoutePaths: ["/"],
+        markdownCanonicalRoutePaths: ["/missing"],
+        markdownNotFoundBody: "# Missing",
+      }),
+    ).toThrowError(
+      'Markdown route "/missing" is not present in knownCanonicalRoutePaths',
+    );
+  });
+});

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.ts
@@ -1,0 +1,346 @@
+export type GenerateVercelMarkdownMiddlewareOptions = {
+  /** Deployment base path, for example `/docs`. */
+  basePath?: string;
+  /** Canonical document routes relative to `basePath`. */
+  knownCanonicalRoutePaths: readonly string[];
+  /** Routes with a generated `.md` representation, relative to `basePath`. */
+  markdownCanonicalRoutePaths: readonly string[];
+  /** Recovery document returned for negotiated Markdown 404 responses. */
+  markdownNotFoundBody: string;
+};
+
+const normalizePath = (value: string) => {
+  const pathname = value
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      try {
+        return encodeURIComponent(decodeURIComponent(segment));
+      } catch {
+        return encodeURIComponent(segment);
+      }
+    })
+    .join("/");
+  return pathname ? `/${pathname}` : "/";
+};
+
+const resolveRoutePath = (basePath: string, routePath: string) => {
+  const normalizedRoutePath = normalizePath(routePath);
+  if (normalizedRoutePath === "/") {
+    return basePath;
+  }
+  return normalizePath(`${basePath}/${normalizedRoutePath}`);
+};
+
+const resolveMarkdownPath = (basePath: string, routePath: string) => {
+  const normalizedRoutePath = normalizePath(routePath);
+  if (normalizedRoutePath === "/") {
+    return normalizePath(`${basePath}/index.md`);
+  }
+  return `${resolveRoutePath(basePath, routePath)}.md`;
+};
+
+/**
+ * Generates the dependency-free ESM source used by Zudoku's Vercel Routing
+ * Middleware. The source uses the raw Build Output API middleware response
+ * headers so it can run without `@vercel/functions` in an Edge function.
+ */
+export const generateVercelMarkdownMiddleware = ({
+  basePath = "/",
+  knownCanonicalRoutePaths,
+  markdownCanonicalRoutePaths,
+  markdownNotFoundBody,
+}: GenerateVercelMarkdownMiddlewareOptions): string => {
+  const normalizedBasePath = normalizePath(basePath);
+  const knownRoutes = new Set(
+    knownCanonicalRoutePaths.map((routePath) =>
+      resolveRoutePath(normalizedBasePath, routePath),
+    ),
+  );
+  const markdownRoutes = new Map(
+    markdownCanonicalRoutePaths.map((routePath) => [
+      resolveRoutePath(normalizedBasePath, routePath),
+      resolveMarkdownPath(normalizedBasePath, routePath),
+    ]),
+  );
+
+  for (const routePath of markdownRoutes.keys()) {
+    if (!knownRoutes.has(routePath)) {
+      throw new Error(
+        `Markdown route "${routePath}" is not present in knownCanonicalRoutePaths`,
+      );
+    }
+  }
+
+  return `
+const BASE_PATH = ${JSON.stringify(normalizedBasePath)};
+const KNOWN_ROUTES = new Set(${JSON.stringify([...knownRoutes])});
+const MARKDOWN_ROUTES = new Map(${JSON.stringify([...markdownRoutes])});
+const MARKDOWN_NOT_FOUND_BODY = ${JSON.stringify(markdownNotFoundBody)};
+
+const REPRESENTATIONS = [
+  {
+    contentType: "text/html",
+    type: "text",
+    subtype: "html",
+    parameters: { charset: "utf-8" },
+    serverOrder: 0,
+  },
+  {
+    contentType: "text/markdown",
+    type: "text",
+    subtype: "markdown",
+    parameters: { charset: "utf-8" },
+    serverOrder: 1,
+  },
+];
+
+const TOKEN_PATTERN = /^[!#$%&'*+\\-.^_\`|~0-9A-Za-z]+$/;
+const MEDIA_RANGE_PATTERN =
+  /^([!#$%&'*+\\-.^_\`|~0-9A-Za-z]+|\\*)\\/([!#$%&'*+\\-.^_\`|~0-9A-Za-z]+|\\*)$/;
+const QUALITY_PATTERN = /^(?:0(?:\\.[0-9]{0,3})?|1(?:\\.0{0,3})?)$/;
+
+const splitOutsideQuotes = (value, delimiter) => {
+  const parts = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quoted && character === "\\\\") {
+      escaped = true;
+      continue;
+    }
+    if (character === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && character === delimiter) {
+      parts.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  parts.push(value.slice(start));
+  return parts;
+};
+
+const parseParameterValue = (value) => {
+  const trimmedValue = value.trim();
+  if (TOKEN_PATTERN.test(trimmedValue)) {
+    return trimmedValue.toLowerCase();
+  }
+  if (!trimmedValue.startsWith('"') || !trimmedValue.endsWith('"')) {
+    return undefined;
+  }
+  return trimmedValue.slice(1, -1).replace(/\\\\(.)/g, "$1").toLowerCase();
+};
+
+const parseMediaRange = (value, order) => {
+  const [rawMediaRange, ...rawParameters] = splitOutsideQuotes(value, ";");
+  const mediaRangeMatch = rawMediaRange
+    ?.trim()
+    .toLowerCase()
+    .match(MEDIA_RANGE_PATTERN);
+  if (!mediaRangeMatch) return undefined;
+
+  const [, type, subtype] = mediaRangeMatch;
+  if (!type || !subtype || (type === "*" && subtype !== "*")) {
+    return undefined;
+  }
+
+  const parameters = new Map();
+  let quality = 1;
+  let foundQuality = false;
+
+  for (const rawParameter of rawParameters) {
+    const separatorIndex = rawParameter.indexOf("=");
+    if (separatorIndex === -1) return undefined;
+
+    const name = rawParameter.slice(0, separatorIndex).trim().toLowerCase();
+    const rawValue = rawParameter.slice(separatorIndex + 1).trim();
+    if (!TOKEN_PATTERN.test(name)) return undefined;
+
+    if (name === "q") {
+      if (foundQuality || !QUALITY_PATTERN.test(rawValue)) return undefined;
+      quality = Number(rawValue);
+      foundQuality = true;
+      continue;
+    }
+
+    if (foundQuality) continue;
+
+    const parameterValue = parseParameterValue(rawValue);
+    if (parameterValue === undefined || parameters.has(name)) return undefined;
+    parameters.set(name, parameterValue);
+  }
+
+  return { type, subtype, parameters, quality, order };
+};
+
+const getSpecificity = (range) => {
+  if (range.type === "*") return 0;
+  if (range.subtype === "*") return 1;
+  return 2;
+};
+
+const matchesRepresentation = (range, representation) => {
+  if (range.type !== "*" && range.type !== representation.type) return false;
+  if (range.subtype !== "*" && range.subtype !== representation.subtype) {
+    return false;
+  }
+  return [...range.parameters].every(
+    ([name, value]) => representation.parameters[name]?.toLowerCase() === value,
+  );
+};
+
+const compareRangeMatches = (left, right) =>
+  right.specificity - left.specificity ||
+  right.parameterCount - left.parameterCount ||
+  right.quality - left.quality ||
+  left.rangeOrder - right.rangeOrder;
+
+const getRepresentationMatch = (ranges, representation) =>
+  ranges
+    .filter((range) => matchesRepresentation(range, representation))
+    .map((range) => ({
+      contentType: representation.contentType,
+      quality: range.quality,
+      specificity: getSpecificity(range),
+      parameterCount: range.parameters.size,
+      rangeOrder: range.order,
+      serverOrder: representation.serverOrder,
+    }))
+    .sort(compareRangeMatches)[0];
+
+const compareRepresentations = (left, right) =>
+  right.quality - left.quality ||
+  right.specificity - left.specificity ||
+  right.parameterCount - left.parameterCount ||
+  left.rangeOrder - right.rangeOrder ||
+  left.serverOrder - right.serverOrder;
+
+const negotiateContentType = (acceptHeader) => {
+  if (!acceptHeader?.trim()) return "text/html";
+
+  const ranges = splitOutsideQuotes(acceptHeader, ",")
+    .map((value, order) => parseMediaRange(value.trim(), order))
+    .filter((range) => range !== undefined);
+  const match = REPRESENTATIONS
+    .map((representation) => getRepresentationMatch(ranges, representation))
+    .filter((result) => result !== undefined)
+    .filter((result) => result.quality > 0)
+    .sort(compareRepresentations)[0];
+  return match?.contentType ?? null;
+};
+
+const normalizeRequestPath = (pathname) => {
+  const normalized = pathname.replace(/\\/+$/, "");
+  return normalized || "/";
+};
+
+const isWithinBasePath = (pathname) =>
+  BASE_PATH === "/" || pathname === BASE_PATH || pathname.startsWith(BASE_PATH + "/");
+
+const isExtensionlessPath = (pathname) => {
+  const lastSegment = pathname.split("/").filter(Boolean).at(-1);
+  return lastSegment === undefined || !lastSegment.includes(".");
+};
+
+const getAlternateLink = (markdownPath) =>
+  "<" + markdownPath + '>; rel="alternate"; type="text/markdown"';
+
+const continueRequest = (headers = undefined) => {
+  const response = new Response(null);
+  response.headers.set("x-middleware-next", "1");
+  if (headers) {
+    for (const [name, value] of Object.entries(headers)) {
+      response.headers.set(name, value);
+    }
+  }
+  return response;
+};
+
+const negotiatedHeaders = (markdownPath) => ({
+  Vary: "Accept",
+  Link: getAlternateLink(markdownPath),
+});
+
+export default function middleware(request) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return continueRequest();
+  }
+
+  const requestUrl = new URL(request.url);
+  const pathname = normalizeRequestPath(requestUrl.pathname);
+  const markdownPath = MARKDOWN_ROUTES.get(pathname);
+
+  if (markdownPath) {
+    const negotiatedType = negotiateContentType(request.headers.get("Accept"));
+    const headers = negotiatedHeaders(markdownPath);
+
+    if (negotiatedType === null) {
+      return new Response(request.method === "HEAD" ? null : "Not Acceptable", {
+        status: 406,
+        headers: {
+          ...headers,
+          "Content-Type": "text/plain; charset=utf-8",
+        },
+      });
+    }
+
+    if (negotiatedType === "text/html") {
+      return continueRequest(headers);
+    }
+
+    requestUrl.pathname = markdownPath;
+    return new Response(null, {
+      headers: {
+        ...headers,
+        "Content-Type": "text/markdown; charset=utf-8",
+        "x-middleware-rewrite": requestUrl.toString(),
+      },
+    });
+  }
+
+  if (KNOWN_ROUTES.has(pathname)) {
+    return continueRequest();
+  }
+
+  if (!isWithinBasePath(pathname) || !isExtensionlessPath(pathname)) {
+    return continueRequest();
+  }
+
+  const negotiatedType = negotiateContentType(request.headers.get("Accept"));
+  if (negotiatedType === null) {
+    return new Response(request.method === "HEAD" ? null : "Not Acceptable", {
+      status: 406,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        Vary: "Accept",
+      },
+    });
+  }
+
+  if (negotiatedType === "text/html") {
+    return continueRequest({ Vary: "Accept" });
+  }
+
+  return new Response(
+    request.method === "HEAD" ? null : MARKDOWN_NOT_FOUND_BODY,
+    {
+      status: 404,
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        Vary: "Accept",
+      },
+    },
+  );
+}
+`.trimStart();
+};

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.ts
@@ -258,6 +258,9 @@ const isExtensionlessPath = (pathname) => {
   return lastSegment === undefined || !lastSegment.includes(".");
 };
 
+const isMarkdownPath = (pathname) =>
+  pathname.endsWith(".md") || pathname.endsWith(".mdx");
+
 const getAlternateLink = (markdownPath) =>
   "<" + markdownPath + '>; rel="alternate"; type="text/markdown"';
 
@@ -316,6 +319,16 @@ export default function middleware(request) {
 
   if (KNOWN_ROUTES.has(pathname) || PASSTHROUGH_PATHS.has(pathname)) {
     return continueRequest();
+  }
+
+  if (isWithinBasePath(pathname) && isMarkdownPath(pathname)) {
+    return new Response(
+      request.method === "HEAD" ? null : MARKDOWN_NOT_FOUND_BODY,
+      {
+        status: 404,
+        headers: { "Content-Type": "text/markdown; charset=utf-8" },
+      },
+    );
   }
 
   if (!isWithinBasePath(pathname) || !isExtensionlessPath(pathname)) {

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.ts
@@ -179,8 +179,8 @@ const parseMediaRange = (value, order) => {
       continue;
     }
 
-    if (foundQuality) continue;
-
+    // RFC 9110 no longer defines accept extensions. Every non-q parameter is
+    // a media type parameter and participates in representation matching.
     const parameterValue = parseParameterValue(rawValue);
     if (parameterValue === undefined || parameters.has(name)) return undefined;
     parameters.set(name, parameterValue);
@@ -246,8 +246,18 @@ const negotiateContentType = (acceptHeader) => {
 };
 
 const normalizeRequestPath = (pathname) => {
-  const normalized = pathname.replace(/\\/+$/, "");
-  return normalized || "/";
+  const normalized = pathname
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      try {
+        return encodeURIComponent(decodeURIComponent(segment));
+      } catch {
+        return encodeURIComponent(segment);
+      }
+    })
+    .join("/");
+  return normalized ? "/" + normalized : "/";
 };
 
 const isWithinBasePath = (pathname) =>

--- a/packages/zudoku/src/vite/vercel-markdown-middleware.ts
+++ b/packages/zudoku/src/vite/vercel-markdown-middleware.ts
@@ -7,6 +7,8 @@ export type GenerateVercelMarkdownMiddlewareOptions = {
   markdownCanonicalRoutePaths: readonly string[];
   /** Recovery document returned for negotiated Markdown 404 responses. */
   markdownNotFoundBody: string;
+  /** Absolute static file paths that must bypass document negotiation. */
+  passthroughPaths?: readonly string[];
 };
 
 const normalizePath = (value: string) => {
@@ -50,6 +52,7 @@ export const generateVercelMarkdownMiddleware = ({
   knownCanonicalRoutePaths,
   markdownCanonicalRoutePaths,
   markdownNotFoundBody,
+  passthroughPaths = [],
 }: GenerateVercelMarkdownMiddlewareOptions): string => {
   const normalizedBasePath = normalizePath(basePath);
   const knownRoutes = new Set(
@@ -63,6 +66,7 @@ export const generateVercelMarkdownMiddleware = ({
       resolveMarkdownPath(normalizedBasePath, routePath),
     ]),
   );
+  const normalizedPassthroughPaths = passthroughPaths.map(normalizePath);
 
   for (const routePath of markdownRoutes.keys()) {
     if (!knownRoutes.has(routePath)) {
@@ -76,7 +80,9 @@ export const generateVercelMarkdownMiddleware = ({
 const BASE_PATH = ${JSON.stringify(normalizedBasePath)};
 const KNOWN_ROUTES = new Set(${JSON.stringify([...knownRoutes])});
 const MARKDOWN_ROUTES = new Map(${JSON.stringify([...markdownRoutes])});
+const PASSTHROUGH_PATHS = new Set(${JSON.stringify(normalizedPassthroughPaths)});
 const MARKDOWN_NOT_FOUND_BODY = ${JSON.stringify(markdownNotFoundBody)};
+const NEGOTIATED_VARY = "Accept, Accept-Encoding";
 
 const REPRESENTATIONS = [
   {
@@ -267,7 +273,7 @@ const continueRequest = (headers = undefined) => {
 };
 
 const negotiatedHeaders = (markdownPath) => ({
-  Vary: "Accept",
+  Vary: NEGOTIATED_VARY,
   Link: getAlternateLink(markdownPath),
 });
 
@@ -308,7 +314,7 @@ export default function middleware(request) {
     });
   }
 
-  if (KNOWN_ROUTES.has(pathname)) {
+  if (KNOWN_ROUTES.has(pathname) || PASSTHROUGH_PATHS.has(pathname)) {
     return continueRequest();
   }
 
@@ -322,13 +328,13 @@ export default function middleware(request) {
       status: 406,
       headers: {
         "Content-Type": "text/plain; charset=utf-8",
-        Vary: "Accept",
+        Vary: NEGOTIATED_VARY,
       },
     });
   }
 
   if (negotiatedType === "text/html") {
-    return continueRequest({ Vary: "Accept" });
+    return continueRequest({ Vary: NEGOTIATED_VARY });
   }
 
   return new Response(
@@ -337,7 +343,7 @@ export default function middleware(request) {
       status: 404,
       headers: {
         "Content-Type": "text/markdown; charset=utf-8",
-        Vary: "Accept",
+        Vary: NEGOTIATED_VARY,
       },
     },
   );


### PR DESCRIPTION
## Summary

- negotiate HTML and Markdown at canonical documentation URLs with cache-safe `Vary` and alternate `Link` headers, HEAD support, 406 handling, and Markdown 404 recovery
- add Vercel routing middleware while documenting the general content-negotiation contract required by other hosting providers
- publish selected processed OpenAPI documents at stable JSON or YAML paths and optionally audit schemas for agent/function-calling quality
- extend `llms.txt` configuration with title, description, and explicit agent instructions
- configure Cosmo Cargo to publish Markdown, `llms.txt`, a sitemap, and the canonical Shipment API at `/openapi.json`

## Configuration

- `docs.contentNegotiation` defaults to the effective value of `docs.publishMarkdown`; set it to `false` to opt out
- `apis[].publish.path` selects the canonical OpenAPI output
- `apis[].publish.agentQuality` enables non-failing schema quality warnings
- `docs.llms.instructions` provides concrete when-to-use guidance

## Vercel Build Output audit

- emit self-contained Build Output API v3 clean-URL routes and `overrides`, so `cleanUrls` is no longer required in `vercel.json`
- clear `.vercel/output` before builds, making repeated builds idempotent and preventing stale functions
- deduplicate redirect prerenders and generated redirect routes while preserving configured 301 behavior
- scope Markdown routing middleware to GET/HEAD, preserve dotted documentation routes, and bypass static assets
- emit `Vary: Accept, Accept-Encoding` for every negotiated response
- return real Markdown 404 responses for missing explicit `.md` and `.mdx` paths while passing through published Markdown files
- update the docs and Cosmo Cargo Vercel configs to clear legacy Output Directory settings
- document the generated Vercel artifact, minimal `vercel.json`, curl verification, q-value/406 behavior, and other-provider contract
- replace Apache/Nginx SPA-shell soft 404 guidance with real 404 responses using the generated recovery page

## Verification

- Vite suite: 223 tests passed across 18 files
- Zudoku typecheck passed
- Biome and oxfmt checks passed
- full documentation build and CI link check passed
- two consecutive Cosmo Cargo Vercel-mode builds passed; the pre-fix second build reproduced an `ENOTEMPTY` failure
- main docs Vercel-mode build passed
- generated Cosmo output: 111 HTML overrides, 3 unique configured redirects, 2 clean-URL routes, and 1 Edge middleware function
- live preview: HTML and Markdown 200s, 406 negotiation, extensionless/`.md`/`.mdx` Markdown 404s, 308 clean URL, 301 configured redirect, asset/API passthrough, and POST passthrough verified
- all GitHub and Vercel PR checks passed

## Follow-up

- the experimental Vercel SSR adapter needs a separate runtime design: its dormant writer declares Edge output while depending on Node filesystem APIs, so this PR deliberately limits the Build Output changes to the supported static build
- accurate last-modified dates on Vercel still require the project-level `VERCEL_DEEP_CLONE=true` setting
