### PR TITLE
fix: render SSR documentation content inline

### DIFF
--- a/packages/zudoku/src/app/entry.server.test.tsx
+++ b/packages/zudoku/src/app/entry.server.test.tsx
@@ -271,6 +271,24 @@ describe("handleRequest", () => {
     expect(html).toContain("Error: Async plugin initialization failed");
   });
 
+  it("returns an HTML 500 when plugin navigation rejects", async () => {
+    navigationMocks.getNavigation.mockRejectedValueOnce(
+      new Error("Navigation failed"),
+    );
+
+    const response = await renderPath("/");
+    const html = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(html).toContain("Error: Navigation failed");
+    // A swallowed rejection would render as a still-pending query, i.e. a
+    // spinner-only page served with a 200 that prerendering accepts as valid.
+    expect(html).not.toContain("Loading navigation");
+  });
+
   it("returns an HTML 500 when request setup fails", async () => {
     const response = await handleRequest({
       template,

--- a/packages/zudoku/src/app/entry.server.test.tsx
+++ b/packages/zudoku/src/app/entry.server.test.tsx
@@ -12,6 +12,7 @@ const navigationMocks = vi.hoisted(() => ({
       { type: "link" as const, label: "API reference", to: "/reference" },
     ]),
   ),
+  initialize: vi.fn(),
 }));
 
 vi.mock("virtual:zudoku-auth", () => ({
@@ -40,6 +41,7 @@ vi.mock("./main.js", () => ({
       {
         getNavigation: navigationMocks.getNavigation,
         getRoutes: () => [],
+        initialize: navigationMocks.initialize,
       },
     ],
   }),
@@ -210,5 +212,20 @@ describe("handleRequest", () => {
     expect(html).not.toContain('<div hidden id="S:');
     expect(html).not.toContain("$RC(");
     expect(html).toContain('"queryKey":["plugin-navigation","/guide",false]');
+  });
+
+  it("returns an HTML 500 when plugin initialization throws synchronously", async () => {
+    navigationMocks.initialize.mockImplementationOnce(() => {
+      throw new Error("Plugin initialization failed");
+    });
+
+    const response = await renderPath("/");
+    const html = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(html).toContain("Error: Plugin initialization failed");
   });
 });

--- a/packages/zudoku/src/app/entry.server.test.tsx
+++ b/packages/zudoku/src/app/entry.server.test.tsx
@@ -2,6 +2,17 @@ import { use } from "react";
 import { Outlet, type RouteObject } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import { RenderContext } from "../lib/components/context/RenderContext.js";
+import { useCurrentNavigation } from "../lib/components/context/ZudokuContext.js";
+import { Layout } from "../lib/components/Layout.js";
+import { Zudoku } from "../lib/components/Zudoku.js";
+
+const navigationMocks = vi.hoisted(() => ({
+  getNavigation: vi.fn(() =>
+    Promise.resolve([
+      { type: "link" as const, label: "API reference", to: "/reference" },
+    ]),
+  ),
+}));
 
 vi.mock("virtual:zudoku-auth", () => ({
   configuredAuthProvider: undefined,
@@ -24,6 +35,14 @@ vi.mock("../lib/manifest.js", () => ({
 }));
 
 vi.mock("./main.js", () => ({
+  convertZudokuConfigToOptions: () => ({
+    plugins: [
+      {
+        getNavigation: navigationMocks.getNavigation,
+        getRoutes: () => [],
+      },
+    ],
+  }),
   getRoutesByConfig: vi.fn(),
 }));
 
@@ -41,6 +60,21 @@ const ExistingStatus = ({ status }: { status: number }) => {
   const renderContext = use(RenderContext);
   renderContext.status = status;
   return <Outlet />;
+};
+
+const AsyncPluginNavigation = () => {
+  const { navigation, isPending } = useCurrentNavigation();
+
+  return (
+    <main>
+      <nav>
+        {isPending
+          ? "Loading navigation"
+          : navigation.map((item) => item.label).join(", ")}
+      </nav>
+      <article>API documentation</article>
+    </main>
+  );
 };
 
 const routes: RouteObject[] = [
@@ -80,5 +114,101 @@ describe("handleRequest", () => {
 
     expect(response.status).toBe(status);
     expect(response.headers.get("Cache-Control")).toBe(cacheControl);
+  });
+
+  it("preserves async plugin navigation in HTML and dehydrated state", async () => {
+    const response = await handleRequest({
+      template,
+      request: new Request("http://localhost/"),
+      routes: [
+        {
+          path: "/",
+          element: (
+            <Zudoku
+              plugins={[
+                {
+                  getNavigation: navigationMocks.getNavigation,
+                  getRoutes: () => [],
+                },
+              ]}
+            >
+              <Layout>
+                <AsyncPluginNavigation />
+              </Layout>
+            </Zudoku>
+          ),
+        },
+      ],
+    });
+    const html = await response.text();
+    const serializedState = html.match(
+      /window\.ZUDOKU_DATA=([\s\S]*?)<\/script>/,
+    )?.[1];
+
+    expect(html).toContain("<nav>API reference</nav>");
+    expect(html).toContain("<article>API documentation</article>");
+    expect(html).not.toContain("Loading navigation");
+    expect(html).not.toContain('<div hidden id="S:');
+    expect(html).not.toContain("$RC(");
+    expect(serializedState).toBeDefined();
+
+    const dehydratedState = JSON.parse(serializedState ?? "{}");
+    expect(dehydratedState.queries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          queryKey: ["plugin-navigation", "/", false],
+          state: expect.objectContaining({
+            data: [
+              {
+                type: "link",
+                label: "API reference",
+                to: "/reference",
+              },
+            ],
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("prefetches navigation with the router-relative path under a base path", async () => {
+    navigationMocks.getNavigation.mockClear();
+
+    const response = await handleRequest({
+      template,
+      request: new Request("http://localhost/docs/guide"),
+      basePath: "/docs",
+      routes: [
+        {
+          path: "/guide",
+          element: (
+            <Zudoku
+              plugins={[
+                {
+                  getNavigation: navigationMocks.getNavigation,
+                  getRoutes: () => [],
+                },
+              ]}
+            >
+              <Layout>
+                <AsyncPluginNavigation />
+              </Layout>
+            </Zudoku>
+          ),
+        },
+      ],
+    });
+    const html = await response.text();
+
+    expect(navigationMocks.getNavigation).toHaveBeenCalledTimes(1);
+    expect(navigationMocks.getNavigation).toHaveBeenCalledWith(
+      "/guide",
+      expect.anything(),
+    );
+    expect(html).toContain("<nav>API reference</nav>");
+    expect(html).not.toContain("Loading navigation");
+    expect(html).not.toContain('<div hidden id="S:');
+    expect(html).not.toContain("$RC(");
+    expect(html).toContain('"queryKey":["plugin-navigation","/guide",false]');
   });
 });

--- a/packages/zudoku/src/app/entry.server.test.tsx
+++ b/packages/zudoku/src/app/entry.server.test.tsx
@@ -271,6 +271,23 @@ describe("handleRequest", () => {
     expect(html).toContain("Error: Async plugin initialization failed");
   });
 
+  it("returns an HTML 500 when request setup fails", async () => {
+    const response = await handleRequest({
+      template,
+      request: new Request("http://localhost/"),
+      routes: [],
+    });
+    const html = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(html).toContain(
+      "You must provide a non-empty routes array to createStaticHandler",
+    );
+  });
+
   it("serves a Markdown representation from the canonical URL", async () => {
     const response = await renderPath("/", { accept: "text/markdown" });
 

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -183,12 +183,19 @@ export const handleRequest = async ({
     const pathname = joinUrl(
       stripBasePath(new URL(request.url).pathname, basePath),
     );
-    await queryClient.prefetchQuery(
-      zudokuContext.getPluginNavigationQueryOptions(
-        pathname,
-        !!ssrAuth?.profile,
-      ),
+    const navigationQuery = zudokuContext.getPluginNavigationQueryOptions(
+      pathname,
+      !!ssrAuth?.profile,
     );
+    // `fetchQuery`, not `prefetchQuery`: a rejected `getNavigation` has to reach
+    // the fatal-error boundary below. `prefetchQuery` swallows it, and the
+    // render then reads the failed, data-less query as pending, which would
+    // emit a spinner-only page with a 200 instead of the established 500.
+    // `fetchQuery` ignores `enabled`, so honor it here to keep skipping
+    // navigation for unauthed users on protected paths.
+    if (navigationQuery.enabled) {
+      await queryClient.fetchQuery(navigationQuery);
+    }
 
     const router = createStaticRouter(dataRoutes, context);
     const head = createHead();

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -19,11 +19,14 @@ import { cachedVerifyAccessToken } from "../lib/authentication/verify-cache.js";
 import { BootstrapStatic } from "../lib/components/Bootstrap.js";
 import { NO_DEHYDRATE } from "../lib/components/cache.js";
 import type { SSRAuthState } from "../lib/components/context/RenderContext.js";
+import { ZudokuContext } from "../lib/core/ZudokuContext.js";
 import { ServerError } from "../lib/errors/ServerError.js";
 import { buildManifest } from "../lib/manifest.js";
 import { highlighterPromise } from "../lib/shiki.js";
+import { joinUrl } from "../lib/util/joinUrl.js";
+import { stripBasePath } from "../lib/util/url.js";
 import type { Adapter } from "./adapter.js";
-import { getRoutesByConfig } from "./main.js";
+import { convertZudokuConfigToOptions, getRoutesByConfig } from "./main.js";
 import { protectChunks as rawProtectChunks } from "./protectChunks.js";
 import { getSsrCacheControl } from "./ssrCacheControl.js";
 import { wrapProtectedRoutesForRender } from "./wrapProtectedRoutes.js";
@@ -141,12 +144,30 @@ export const handleRequest = async ({
     }
   }
 
+  const zudokuContext = new ZudokuContext(
+    convertZudokuConfigToOptions(config),
+    queryClient,
+    import.meta.env,
+    ssrAuth,
+  );
+  if (zudokuContext.initialize) {
+    await Promise.allSettled([zudokuContext.initialize]);
+  }
+
+  const pathname = joinUrl(
+    stripBasePath(new URL(request.url).pathname, basePath),
+  );
+  await queryClient.prefetchQuery(
+    zudokuContext.getPluginNavigationQueryOptions(pathname, !!ssrAuth?.profile),
+  );
+
   const router = createStaticRouter(dataRoutes, context);
   const head = createHead();
   const renderContext = {
     status: 200,
     bypassProtection: bypassProtection ?? false,
     ssrAuth,
+    zudokuContext,
   };
 
   const App = (

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -144,44 +144,47 @@ export const handleRequest = async ({
     }
   }
 
-  const zudokuContext = new ZudokuContext(
-    convertZudokuConfigToOptions(config),
-    queryClient,
-    import.meta.env,
-    ssrAuth,
-  );
-  if (zudokuContext.initialize) {
-    await Promise.allSettled([zudokuContext.initialize]);
-  }
-
-  const pathname = joinUrl(
-    stripBasePath(new URL(request.url).pathname, basePath),
-  );
-  await queryClient.prefetchQuery(
-    zudokuContext.getPluginNavigationQueryOptions(pathname, !!ssrAuth?.profile),
-  );
-
-  const router = createStaticRouter(dataRoutes, context);
-  const head = createHead();
-  const renderContext = {
-    status: 200,
-    bypassProtection: bypassProtection ?? false,
-    ssrAuth,
-    zudokuContext,
-  };
-
-  const App = (
-    <BootstrapStatic
-      router={router}
-      context={context}
-      queryClient={queryClient}
-      head={head}
-      bypassProtection={bypassProtection}
-      renderContext={renderContext}
-    />
-  );
-
   try {
+    const zudokuContext = new ZudokuContext(
+      convertZudokuConfigToOptions(config),
+      queryClient,
+      import.meta.env,
+      ssrAuth,
+    );
+    if (zudokuContext.initialize) {
+      await Promise.allSettled([zudokuContext.initialize]);
+    }
+
+    const pathname = joinUrl(
+      stripBasePath(new URL(request.url).pathname, basePath),
+    );
+    await queryClient.prefetchQuery(
+      zudokuContext.getPluginNavigationQueryOptions(
+        pathname,
+        !!ssrAuth?.profile,
+      ),
+    );
+
+    const router = createStaticRouter(dataRoutes, context);
+    const head = createHead();
+    const renderContext = {
+      status: 200,
+      bypassProtection: bypassProtection ?? false,
+      ssrAuth,
+      zudokuContext,
+    };
+
+    const App = (
+      <BootstrapStatic
+        router={router}
+        context={context}
+        queryClient={queryClient}
+        head={head}
+        bypassProtection={bypassProtection}
+        renderContext={renderContext}
+      />
+    );
+
     const reactStream = await renderToReadableStream(App, {
       onError(error) {
         status = 500;

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -114,60 +114,62 @@ export const handleRequest = async ({
   basePath?: string;
   bypassProtection?: boolean;
 }): Promise<Response> => {
-  const ssrAuth = await resolveSsrAuth(request);
-
-  // No-op lazy() on protected subtrees for unauthed requests so loaders
-  // don't run for a 401 render. A bypass render (search-index pass) keeps the
-  // real content so Pagefind can index protected routes.
-  const effectiveRoutes = wrapProtectedRoutesForRender(
-    routes,
-    config.protectedRoutes,
-    {
-      isAuthenticated: !!ssrAuth?.profile,
-      bypassProtection,
-      basePath,
-    },
-  );
-
-  const { query, dataRoutes } = createStaticHandler(effectiveRoutes, {
-    basename: basePath,
-  });
-  const queryClient = new QueryClient();
-
-  const context = await query(request);
-
-  if (context instanceof Response) {
-    if ([301, 302, 303, 307, 308].includes(context.status)) {
-      return new Response(null, {
-        status: context.status,
-        headers: { Location: context.headers.get("Location") ?? "" },
-      });
-    }
-    throw context;
-  }
-
-  let status = 200;
-  if (context.errors) {
-    const firstError = Object.values(context.errors).find(isRouteErrorResponse);
-    if (firstError?.status) {
-      status = firstError.status;
-    }
-  }
-
-  const routePath = resolveDocumentationRoutePath(request.url, basePath);
-  const markdownContent = routePath ? markdownFiles[routePath] : undefined;
-  const matchesNotFoundRoute = context.matches.at(-1)?.route.path === "*";
-  const isRepresentationRequest =
-    request.method === "GET" || request.method === "HEAD";
-  const mayNegotiateMarkdown =
-    isRepresentationRequest &&
-    config.docs?.publishMarkdown !== false &&
-    config.docs?.contentNegotiation !== false &&
-    (markdownContent !== undefined || matchesNotFoundRoute);
-  const negotiatedType = mayNegotiateMarkdown
-    ? negotiateContentType(request.headers.get("Accept"))
-    : "text/html";
   try {
+    const ssrAuth = await resolveSsrAuth(request);
+
+    // No-op lazy() on protected subtrees for unauthed requests so loaders
+    // don't run for a 401 render. A bypass render (search-index pass) keeps the
+    // real content so Pagefind can index protected routes.
+    const effectiveRoutes = wrapProtectedRoutesForRender(
+      routes,
+      config.protectedRoutes,
+      {
+        isAuthenticated: !!ssrAuth?.profile,
+        bypassProtection,
+        basePath,
+      },
+    );
+
+    const { query, dataRoutes } = createStaticHandler(effectiveRoutes, {
+      basename: basePath,
+    });
+    const queryClient = new QueryClient();
+
+    const context = await query(request);
+
+    if (context instanceof Response) {
+      if ([301, 302, 303, 307, 308].includes(context.status)) {
+        return new Response(null, {
+          status: context.status,
+          headers: { Location: context.headers.get("Location") ?? "" },
+        });
+      }
+      throw context;
+    }
+
+    let status = 200;
+    if (context.errors) {
+      const firstError = Object.values(context.errors).find(
+        isRouteErrorResponse,
+      );
+      if (firstError?.status) {
+        status = firstError.status;
+      }
+    }
+
+    const routePath = resolveDocumentationRoutePath(request.url, basePath);
+    const markdownContent = routePath ? markdownFiles[routePath] : undefined;
+    const matchesNotFoundRoute = context.matches.at(-1)?.route.path === "*";
+    const isRepresentationRequest =
+      request.method === "GET" || request.method === "HEAD";
+    const mayNegotiateMarkdown =
+      isRepresentationRequest &&
+      config.docs?.publishMarkdown !== false &&
+      config.docs?.contentNegotiation !== false &&
+      (markdownContent !== undefined || matchesNotFoundRoute);
+    const negotiatedType = mayNegotiateMarkdown
+      ? negotiateContentType(request.headers.get("Accept"))
+      : "text/html";
     const zudokuContext = new ZudokuContext(
       convertZudokuConfigToOptions(config),
       queryClient,

--- a/packages/zudoku/src/lib/components/Layout.tsx
+++ b/packages/zudoku/src/lib/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, Suspense, useEffect } from "react";
+import { type ReactNode, useEffect } from "react";
 import { Outlet } from "react-router";
 import { TooltipProvider } from "zudoku/ui/Tooltip.js";
 import { cn } from "../util/cn.js";
@@ -10,13 +10,6 @@ import { Header } from "./Header.js";
 import { Main } from "./Main.js";
 import { useSidebar } from "./navigation/sidebarStore.js";
 import { Slot } from "./Slot.js";
-import { Spinner } from "./Spinner.js";
-
-const LoadingFallback = () => (
-  <div className="col-span-full row-span-full grid place-items-center">
-    <Spinner />
-  </div>
-);
 
 export const Layout = ({ children }: { children?: ReactNode }) => {
   const { authentication } = useZudoku();
@@ -46,9 +39,7 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
             : "lg:grid-cols-[var(--side-nav-width)_1fr]",
         )}
       >
-        <Suspense fallback={<LoadingFallback />}>
-          <Main>{children ?? <Outlet />}</Main>
-        </Suspense>
+        <Main>{children ?? <Outlet />}</Main>
       </div>
       <Footer />
     </TooltipProvider>

--- a/packages/zudoku/src/lib/components/Main.tsx
+++ b/packages/zudoku/src/lib/components/Main.tsx
@@ -7,13 +7,22 @@ import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
 import { Navigation } from "./navigation/Navigation.js";
 import { SidebarToggle } from "./navigation/SidebarToggle.js";
 import { Slot } from "./Slot.js";
+import { Spinner } from "./Spinner.js";
 
 export const Main = ({ children }: PropsWithChildren) => {
   const [isDrawerOpen, setDrawerOpen] = useState(false);
-  const { navigation, topNavItem } = useCurrentNavigation();
+  const { navigation, topNavItem, isPending } = useCurrentNavigation();
   const hasNavigation = navigation.length > 0;
   const isNavigating = useNavigation().state === "loading";
   const { options } = useZudoku();
+
+  if (isPending) {
+    return (
+      <div className="col-span-full row-span-full grid place-items-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
     <Drawer

--- a/packages/zudoku/src/lib/components/Zudoku.tsx
+++ b/packages/zudoku/src/lib/components/Zudoku.tsx
@@ -66,12 +66,9 @@ const ZudokuInner = memo(
     const renderContext = use(RenderContext);
     if (typeof window === "undefined") {
       // Fresh context per SSR request to avoid leaking
-      zudokuContext = new ZudokuContext(
-        props,
-        queryClient,
-        env,
-        renderContext.ssrAuth,
-      );
+      zudokuContext =
+        renderContext.zudokuContext ??
+        new ZudokuContext(props, queryClient, env, renderContext.ssrAuth);
     } else {
       zudokuContext ??= new ZudokuContext(props, queryClient, env);
     }

--- a/packages/zudoku/src/lib/components/Zudoku.tsx
+++ b/packages/zudoku/src/lib/components/Zudoku.tsx
@@ -65,7 +65,14 @@ const ZudokuInner = memo(
 
     const renderContext = use(RenderContext);
     if (typeof window === "undefined") {
-      // Fresh context per SSR request to avoid leaking
+      // Fresh context per SSR request to avoid leaking. `entry.server` prepares
+      // one from the resolved config so navigation can be prefetched before the
+      // render; when it does, that context wins over `props`. Both are built
+      // from `convertZudokuConfigToOptions`, so they agree in a real app — but
+      // rendering `<Zudoku>` with hand-written props under `handleRequest` will
+      // take plugins from the config for navigation and auth while
+      // `PluginHeads`, `SlotProvider`, and the MDX components below still read
+      // `props`.
       zudokuContext =
         renderContext.zudokuContext ??
         new ZudokuContext(props, queryClient, env, renderContext.ssrAuth);

--- a/packages/zudoku/src/lib/components/context/RenderContext.ts
+++ b/packages/zudoku/src/lib/components/context/RenderContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from "react";
 import type { UserProfile } from "../../authentication/state.js";
+import type { ZudokuContext } from "../../core/ZudokuContext.js";
 
 export type SSRAuthState = {
   accessToken?: string;
@@ -11,6 +12,7 @@ export type RenderContextValue = {
   status: number;
   bypassProtection: boolean;
   ssrAuth?: SSRAuthState;
+  zudokuContext?: ZudokuContext;
 };
 
 export const RenderContext = createContext<RenderContextValue>({

--- a/packages/zudoku/src/lib/components/context/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/components/context/ZudokuContext.ts
@@ -1,5 +1,5 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { useContext, useEffect, useMemo, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { use, useContext, useEffect, useMemo, useRef } from "react";
 import { matchPath, useLocation } from "react-router";
 import type { NavigationItem } from "../../../config/validators/NavigationSchema.js";
 import { useAuthState } from "../../authentication/state.js";
@@ -7,6 +7,7 @@ import { applyRules } from "../../navigation/applyRules.js";
 import { joinUrl } from "../../util/joinUrl.js";
 import { CACHE_KEYS, useCache } from "../cache.js";
 import { getItemPath, traverseNavigation } from "../navigation/utils.js";
+import { RenderContext } from "./RenderContext.js";
 import { ZudokuReactContext } from "./ZudokuReactContext.js";
 
 export const useZudoku = () => {
@@ -56,7 +57,7 @@ const extractAllPaths = (items: NavigationItem[]) => {
 
 export const useCurrentNavigation = () => {
   const context = useZudoku();
-  const { getPluginNavigation, navigation, navigationRules } = context;
+  const { navigation, navigationRules } = context;
   const location = useLocation();
   const loggedWarnings = useRef(new Set<string>());
 
@@ -69,14 +70,18 @@ export const useCurrentNavigation = () => {
     }
   });
 
-  const { isAuthenticated } = useAuthState();
-  const { data } = useSuspenseQuery({
-    queryFn: () => getPluginNavigation(pathname),
-    queryKey: ["plugin-navigation", pathname, isAuthenticated],
-    // Navigation comes from static build-time sources, so it never changes at
-    // runtime in production. In dev, recompute on mount so an HMR schema swap doesn't leave a stale sidebar.
-    staleTime: import.meta.env.DEV ? 0 : undefined,
-  });
+  const authState = useAuthState();
+  const renderContext = use(RenderContext);
+  const isAuthenticated =
+    typeof window === "undefined"
+      ? !!renderContext.ssrAuth?.profile
+      : authState.isAuthenticated;
+  const query = useQuery(
+    context.getPluginNavigationQueryOptions(pathname, isAuthenticated),
+  );
+  if (query.isError && query.data === undefined) throw query.error;
+
+  const data = query.data ?? [];
 
   let topNavItem = navItem;
 
@@ -130,5 +135,6 @@ export const useCurrentNavigation = () => {
   return {
     navigation: finalNavigation,
     topNavItem,
+    isPending: query.isPending,
   };
 };

--- a/packages/zudoku/src/lib/core/ZudokuContext.test.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.test.ts
@@ -86,6 +86,37 @@ describe("ZudokuContext.getPluginNavigation", () => {
     expect(getNavigation).not.toHaveBeenCalled();
   });
 
+  // The query options decide whether to run navigation from an explicit
+  // isAuthenticated; queryFn must use that same value rather than re-reading
+  // the global auth state, or the two can disagree mid-flight.
+  it("honors the explicit isAuthenticated over the ambient auth state", async () => {
+    setAuth(false);
+    const { ctx, getNavigation } = buildContext({ "/protected/*": () => true });
+
+    expect(await ctx.getPluginNavigation("/protected/page", true)).toHaveLength(
+      1,
+    );
+    expect(getNavigation).toHaveBeenCalledOnce();
+
+    setAuth(true);
+    getNavigation.mockClear();
+    expect(await ctx.getPluginNavigation("/protected/page", false)).toEqual([]);
+    expect(getNavigation).not.toHaveBeenCalled();
+  });
+
+  it("passes isAuthenticated from the query options through to queryFn", async () => {
+    setAuth(true);
+    const { ctx, getNavigation } = buildContext({ "/protected/*": () => true });
+    const options = ctx.getPluginNavigationQueryOptions(
+      "/protected/page",
+      false,
+    );
+
+    expect(options.enabled).toBe(false);
+    expect(await options.queryFn()).toEqual([]);
+    expect(getNavigation).not.toHaveBeenCalled();
+  });
+
   // On the server, SSR auth must come from ssrAuth, since zustand state isn't available.
   // This prevents mismatches between SSR and client nav rendering.
   it("uses ssrAuth on the server path", async () => {

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -268,8 +268,11 @@ export class ZudokuContext {
 
   // Skip plugins for unauthed users on protected paths. Plugins often load
   // protected resources inside getNavigation; that work would leak.
-  getPluginNavigation = async (path: string): Promise<Navigation> => {
-    if (this.shouldSkipNavigationForProtected(path)) return [];
+  getPluginNavigation = async (
+    path: string,
+    isAuthenticated?: boolean,
+  ): Promise<Navigation> => {
+    if (this.shouldSkipNavigationForProtected(path, isAuthenticated)) return [];
     const navigations = await Promise.all(
       this.plugins
         .filter(isNavigationPlugin)
@@ -293,7 +296,7 @@ export class ZudokuContext {
     return {
       enabled: shouldLoadNavigation,
       initialData: shouldLoadNavigation ? undefined : [],
-      queryFn: () => this.getPluginNavigation(path),
+      queryFn: () => this.getPluginNavigation(path, isAuthenticated),
       queryKey: ["plugin-navigation", path, isAuthenticated] as const,
       // Navigation comes from static build-time sources, so it never changes at
       // runtime in production. In dev, recompute on mount so an HMR schema swap

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -279,15 +279,42 @@ export class ZudokuContext {
     return navigations.flatMap((nav) => nav ?? []);
   };
 
-  private shouldSkipNavigationForProtected(path: string): boolean {
+  getPluginNavigationQueryOptions = (
+    path: string,
+    isAuthenticated: boolean,
+  ) => {
+    const hasPluginNavigation = this.plugins.some(
+      (plugin) => isNavigationPlugin(plugin) && plugin.getNavigation,
+    );
+    const shouldLoadNavigation =
+      hasPluginNavigation &&
+      !this.shouldSkipNavigationForProtected(path, isAuthenticated);
+
+    return {
+      enabled: shouldLoadNavigation,
+      initialData: shouldLoadNavigation ? undefined : [],
+      queryFn: () => this.getPluginNavigation(path),
+      queryKey: ["plugin-navigation", path, isAuthenticated] as const,
+      // Navigation comes from static build-time sources, so it never changes at
+      // runtime in production. In dev, recompute on mount so an HMR schema swap
+      // doesn't leave a stale sidebar.
+      staleTime: import.meta.env.DEV ? 0 : undefined,
+    };
+  };
+
+  private shouldSkipNavigationForProtected(
+    path: string,
+    isAuthenticated?: boolean,
+  ): boolean {
     const patterns = Object.keys(this.protectedRoutes ?? {});
     if (patterns.length === 0) return false;
     if (!matchesAnyProtectedPattern(patterns, path)) return false;
     // Server: per-request ssrAuth. Client: live zustand state.
     const isAuthed =
-      typeof window === "undefined"
+      isAuthenticated ??
+      (typeof window === "undefined"
         ? !!this.ssrAuth?.profile
-        : this.getAuthState().isAuthenticated;
+        : this.getAuthState().isAuthenticated);
     return !isAuthed;
   }
 


### PR DESCRIPTION
## Summary

- prefetch each plugin's real navigation with the request-scoped SSR query client
- reuse the prepared Zudoku context during rendering so navigation and auth state stay consistent
- render navigation loading without a page-wide Suspense boundary, keeping the main document in raw HTML
- normalize navigation query keys for configured base paths

## Why

The issue reported causes a prerendered page's main content to be emitted inside a hidden React reveal segment. Browsers execute the reveal script, but crawlers and agents that do not run JavaScript only see the loading spinner.

The attached proposal demonstrated the right underlying issue, but seeding navigation with an empty array is unsafe for a framework because OpenAPI and custom plugins can provide real asynchronous sidebars. This implementation waits for that real navigation instead, dehydrates it for the client, and preserves the existing loading and error behavior.

## Verification

- Zudoku tests: 91 files, 1,152 tests passed
- TypeScript: direct package typecheck passed
- Biome and oxfmt checks passed on all changed files
- Cosmo Cargo production build: all 117 routes prerendered successfully
- Cosmo Cargo `/tracking`: title, main content, and API navigation are inline in raw HTML; no hidden reveal segment or React reveal script
- Base-path regression test verifies `/docs/guide` prefetches and dehydrates the router-relative `/guide` key exactly once

Five of 117 generated pages still contain small nested reveal segments for optional lazy fragments, but their main document content is already inline and readable without JavaScript.
