### PR TITLE
Add custom user data support to authentication profiles

### DIFF
--- a/docs/pages/docs/configuration/authentication-auth0.md
+++ b/docs/pages/docs/configuration/authentication-auth0.md
@@ -154,6 +154,60 @@ When the prompt parameter is omitted (empty string), Auth0 will:
 - Silently authenticate the user if they have a valid session
 - Redirect to the login page if no valid session exists
 
+### Attaching Custom User Data
+
+If your portal needs data Auth0 doesn't hold — a subscription record, a plan tier, entitlement flags
+— configure `userData` instead of writing a Post-Login Action to inject it.
+
+To have Zudoku fetch it from your own API at login:
+
+```typescript
+authentication: {
+  type: "auth0",
+  domain: "your-domain.us.auth0.com",
+  clientId: "<your-auth0-client-id>",
+  audience: "https://your-domain.com/api",
+
+  userData: {
+    endpoint: {
+      url: "https://api.your-domain.com/v1/me/subscription",
+      as: "subscription",
+    },
+  },
+}
+```
+
+Zudoku calls the endpoint with the user's Auth0 access token as a `Bearer` token, so your API can
+identify the caller and authorize the request with the token it already validates. The JSON response
+lands on the profile:
+
+```tsx
+const { profile } = useAuth();
+
+if (profile?.subscription?.plan === "enterprise") {
+  // ...
+}
+```
+
+If you already add namespaced claims in an Auth0 Action, `claims` surfaces them on the profile
+without a second request — Auth0 keeps namespaced claims out of the User Info response, so they
+aren't picked up automatically:
+
+```typescript
+userData: {
+  claims: [
+    "https://your-domain.com/roles",
+    { claim: "https://your-domain.com/subscription", as: "subscription" },
+  ],
+}
+```
+
+The ID token is checked first, then the access token, so it works whether your Action calls
+`api.idToken.setCustomClaim` or `api.accessToken.setCustomClaim`.
+
+See [Custom User Data](./authentication.md#custom-user-data) for the full set of options, including
+`required` to fail the login when the request fails.
+
 ### Customizing Sign-up
 
 By default Auth0 already adds `screen_hint=signup` when a user clicks Register. To send users to a

--- a/docs/pages/docs/configuration/authentication.md
+++ b/docs/pages/docs/configuration/authentication.md
@@ -214,6 +214,97 @@ fields are used to display the user profile:
 
 If the provider does not return a field, it will be left blank.
 
+### Custom User Data
+
+Anything else the User Info endpoint returns is merged into `profile` as-is, so a claim your
+identity provider already puts there needs no configuration.
+
+For data that _isn't_ in the User Info response — a subscription record in your own database, a plan
+tier, entitlement flags — use `authentication.userData`. It has two layers, and both are available
+on `auth0`, `openid`, and `entra`:
+
+```typescript title="zudoku.config.ts"
+{
+  authentication: {
+    type: "auth0",
+    domain: "your-domain.us.auth0.com",
+    clientId: "<your-auth0-client-id>",
+    audience: "https://your-domain.com/api",
+
+    userData: {
+      // 1. Lift claims out of the ID token and access token into the profile
+      claims: [
+        "https://your-domain.com/roles",
+        { claim: "https://your-domain.com/plan", as: "plan" },
+      ],
+
+      // 2. Fetch data from your own API, authenticated as the signed-in user
+      endpoint: {
+        url: "https://api.your-domain.com/v1/me/subscription",
+        as: "subscription",
+      },
+    },
+  },
+}
+```
+
+Both layers land on the same profile, which any component can read:
+
+```tsx
+const { profile } = useAuth();
+
+if (profile?.subscription?.plan === "enterprise") {
+  // ...
+}
+```
+
+#### Claims
+
+`claims` selects claims from the tokens the provider issued — the ID token first, then the access
+token. This is the piece that surfaces namespaced claims (`https://your-domain.com/plan`), which
+providers keep out of the User Info response. A claim that appears in neither token is skipped
+rather than set to `undefined`.
+
+By default the claim keeps its own name, which for a namespaced claim is the whole URL. Use
+`{ claim, as }` to store it under a shorter key.
+
+#### Endpoint
+
+`endpoint` calls your API once the user is authenticated and merges the JSON response into the
+profile. The user's access token is sent as a `Bearer` token, so the endpoint can identify the
+caller and authorize the request itself — the same token your API already validates.
+
+| Option     | Default | Description                                                                   |
+| ---------- | ------- | ----------------------------------------------------------------------------- |
+| `url`      | –       | Absolute URL to call. Relative paths are rejected (see below).                |
+| `method`   | `"GET"` | `"GET"` or `"POST"`.                                                          |
+| `headers`  | –       | Extra request headers. Cannot override `Authorization`.                       |
+| `as`       | –       | Profile key to nest the response under. Omit to merge an object at top level. |
+| `required` | `false` | Fail the login when the request fails, instead of logging and carrying on.    |
+
+Passing a bare string is shorthand for `{ url }`.
+
+Zudoku calls the endpoint when a profile is built: after the OAuth callback, on profile refresh, and
+— in SSR mode — when the server verifies the access token, so server-rendered HTML sees the same
+data as the client. Server-side results are cached per access token for 60 seconds.
+
+:::caution
+
+`url` must be absolute. SSR verification runs without a page origin to resolve a relative path
+against, so a relative URL would work in the browser and break on the server.
+
+:::
+
+Custom user data can override `name` or `email` — useful when your own user store is more
+authoritative than the IdP — but never `sub`, which stays the identity from the provider.
+
+:::warning
+
+In SSR mode the profile is stored in a cookie capped at just under 4KB. A large response can push it
+over, and the session cookie then fails to be set. Return only the fields the portal needs.
+
+:::
+
 ## Protected Routes
 
 Once authentication is configured, you can protect specific routes in your documentation to require

--- a/packages/zudoku/src/config/config.ts
+++ b/packages/zudoku/src/config/config.ts
@@ -2,12 +2,13 @@ import type { ConfigWithMeta } from "./loader.js";
 import type { BuildConfig } from "./validators/BuildSchema.js";
 import type {
   AuthenticationConfig,
+  UserDataConfig,
   ZudokuConfig,
 } from "./validators/ZudokuConfig.js";
 
 export type ZudokuBuildConfig = BuildConfig;
 export type LoadedConfig = ConfigWithMeta;
-export type { ZudokuConfig };
+export type { UserDataConfig, ZudokuConfig };
 
 export type ClerkAuthenticationConfig = Extract<
   AuthenticationConfig,

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -29,6 +29,66 @@ describe("validateConfig", () => {
     expect(mockConsoleLog).not.toHaveBeenCalled();
   });
 
+  it("should accept auth0 userData claims and endpoint config", () => {
+    const config = {
+      authentication: {
+        type: "auth0" as const,
+        clientId: "client123",
+        domain: "example.auth0.com",
+        userData: {
+          claims: [
+            "https://zuplo.com/roles",
+            { claim: "https://zuplo.com/subscription", as: "subscription" },
+          ],
+          endpoint: {
+            url: "https://api.example.com/v1/me/subscription",
+            as: "subscription",
+            required: true,
+          },
+        },
+      },
+    };
+
+    const result = validateConfig(config);
+
+    expect(result.authentication).toMatchObject(config.authentication);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it("should reject a relative userData endpoint url", () => {
+    process.env.NODE_ENV = "production";
+
+    const config = {
+      authentication: {
+        type: "auth0" as const,
+        clientId: "client123",
+        domain: "example.auth0.com",
+        userData: { endpoint: "/api/me" },
+      },
+    };
+
+    expect(() => validateConfig(config)).toThrow(
+      /Invalid Zudoku configuration/,
+    );
+  });
+
+  it("should reject unknown keys in userData", () => {
+    process.env.NODE_ENV = "production";
+
+    const config = {
+      authentication: {
+        type: "auth0" as const,
+        clientId: "client123",
+        domain: "example.auth0.com",
+        userData: { transform: "not-supported" },
+      },
+    };
+
+    expect(() => validateConfig(config)).toThrow(
+      /Invalid Zudoku configuration/,
+    );
+  });
+
   it("should validate clerk public key format correctly", () => {
     process.env.NODE_ENV = "production";
 

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -424,6 +424,54 @@ const SignUpOpenIdSchema = z.union([
     .strict(),
 ]);
 
+/**
+ * Custom user data attached to the profile at login.
+ *
+ * Declarative on purpose: the auth config is serialized into the
+ * `virtual:zudoku-auth` module, so function hooks would not survive the
+ * build. Both layers run on the client (after the OAuth callback and on
+ * profile refresh) and on the server (when SSR verifies the access token),
+ * so `useAuth().profile` carries the same data in either render.
+ */
+const UserDataClaimSchema = z.union([
+  z.string().min(1),
+  z
+    .object({
+      claim: z.string().min(1),
+      // Profile key to store the claim under. Defaults to the claim name,
+      // which for namespaced claims is the full namespaced string.
+      as: z.string().min(1).optional(),
+    })
+    .strict(),
+]);
+
+const UserDataEndpointSchema = z.union([
+  // Absolute URLs only: SSR verification has no page origin to resolve a
+  // relative path against, so allowing one would work on the client and
+  // silently break server-side.
+  z.url(),
+  z
+    .object({
+      url: z.url(),
+      method: z.enum(["GET", "POST"]).optional(),
+      headers: z.record(z.string(), z.string()).optional(),
+      // Profile key to nest the response under. Omit to merge a JSON object
+      // response into the profile at the top level.
+      as: z.string().min(1).optional(),
+      // By default a failed request logs and leaves the profile unchanged so
+      // an outage can't lock users out. Set true to fail the login instead.
+      required: z.boolean().optional(),
+    })
+    .strict(),
+]);
+
+const UserDataSchema = z
+  .object({
+    claims: z.array(UserDataClaimSchema).optional(),
+    endpoint: UserDataEndpointSchema.optional(),
+  })
+  .strict();
+
 const AuthenticationSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("clerk"),
@@ -486,6 +534,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     disableSignUp: z.boolean().optional(),
     authorizationParams: z.record(z.string(), z.string()).optional(),
     forwardAuthorizationParams: z.array(z.string()).optional(),
+    userData: UserDataSchema.optional(),
   }),
   z.object({
     type: z.literal("entra"),
@@ -505,6 +554,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     disableSignUp: z.boolean().optional(),
     authorizationParams: z.record(z.string(), z.string()).optional(),
     forwardAuthorizationParams: z.array(z.string()).optional(),
+    userData: UserDataSchema.optional(),
   }),
   z.object({
     type: z.literal("azureb2c"),
@@ -554,6 +604,7 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
       .optional(),
     signUp: SignUpOpenIdSchema.optional(),
     disableSignUp: z.boolean().optional(),
+    userData: UserDataSchema.optional(),
   }),
   z.object({
     type: z.literal("supabase"),
@@ -794,6 +845,7 @@ export type ZudokuSiteMapConfig = z.infer<typeof SiteMapSchema>;
 export type ZudokuDocsConfig = z.infer<typeof DocsConfigSchema>;
 export type ZudokuRedirect = z.infer<typeof Redirect>;
 export type AuthenticationConfig = z.infer<typeof AuthenticationSchema>;
+export type UserDataConfig = z.infer<typeof UserDataSchema>;
 
 // Pin navigation types to their strict inferred form (z.input widens them due to z.lazy recursion).
 type InputOverrides = {

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -1,8 +1,10 @@
 // @vitest-environment happy-dom
 import * as oauth from "oauth4webapi";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { OpenIDAuthenticationConfig } from "../../../config/config.js";
 import { OAuthAuthorizationError } from "../errors.js";
 import { useAuthState } from "../state.js";
+import { UserDataError } from "../user-data.js";
 import auth0Auth from "./auth0.js";
 import {
   OpenIDAuthenticationProvider,
@@ -12,6 +14,17 @@ import {
 // Fake JWT-shaped tokens (3 dot-separated segments) to pass the opaque token check
 const FAKE_ACCESS_TOKEN = "header.payload.signature";
 const FAKE_NEW_ACCESS_TOKEN = "header.newpayload.signature";
+
+// Decodable-but-unverified JWT, which is all the claim selection reads.
+const signedlessJwt = (payload: object) => {
+  const encode = (value: object) =>
+    Buffer.from(JSON.stringify(value))
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "none" })}.${encode(payload)}.signature`;
+};
 
 vi.mock("oauth4webapi", async (importOriginal) => {
   const actual = await importOriginal<typeof oauth>();
@@ -315,6 +328,168 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
       expect(profile?.sub).toBe("user-1");
       expect(profile?.email).toBe("user@example.com");
       expect(profile?.emailVerified).toBe(true);
+    });
+  });
+
+  describe("userData config", () => {
+    const SUBSCRIPTION_CLAIM = "https://zuplo.com/subscription";
+
+    const createUserDataProvider = (
+      userData: OpenIDAuthenticationConfig["userData"],
+    ) =>
+      new OpenIDAuthenticationProvider({
+        type: "openid",
+        issuer: "https://issuer.example.com",
+        clientId: "test-client",
+        userData,
+      });
+
+    const setLoggedInWith = (accessToken: string) => {
+      useAuthState.setState({
+        isAuthenticated: true,
+        isPending: false,
+        profile: {
+          sub: "user-1",
+          email: "user@example.com",
+          emailVerified: true,
+          name: "Test",
+          pictureUrl: undefined,
+        },
+        providerData: {
+          type: "openid",
+          accessToken,
+          expiresOn: new Date(Date.now() + 3600_000),
+          tokenType: "bearer",
+          claims: undefined,
+        } satisfies OpenIdProviderData,
+      });
+
+      vi.mocked(oauth.userInfoRequest).mockResolvedValue(
+        Response.json({
+          sub: "user-1",
+          email: "user@example.com",
+          name: "Test",
+          email_verified: true,
+        }),
+      );
+    };
+
+    test("lifts a configured claim out of the access token on refresh", async () => {
+      const provider = createUserDataProvider({
+        claims: [{ claim: SUBSCRIPTION_CLAIM, as: "subscription" }],
+      });
+      setLoggedInWith(signedlessJwt({ [SUBSCRIPTION_CLAIM]: { plan: "pro" } }));
+
+      await provider.refreshUserProfile();
+
+      expect(useAuthState.getState().profile?.subscription).toEqual({
+        plan: "pro",
+      });
+    });
+
+    test("attaches endpoint data to the profile on refresh", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(Response.json({ plan: "enterprise", seats: 12 }));
+
+      const provider = createUserDataProvider({
+        endpoint: {
+          url: "https://api.example.com/v1/me/subscription",
+          as: "subscription",
+        },
+      });
+      setLoggedInWith(FAKE_ACCESS_TOKEN);
+
+      await provider.refreshUserProfile();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://api.example.com/v1/me/subscription",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${FAKE_ACCESS_TOKEN}`,
+          }),
+        }),
+      );
+      expect(useAuthState.getState().profile?.subscription).toEqual({
+        plan: "enterprise",
+        seats: 12,
+      });
+    });
+
+    test("leaves the profile alone when userData is not configured", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      const provider = createProvider();
+      setLoggedInWith(FAKE_ACCESS_TOKEN);
+
+      await provider.refreshUserProfile();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(useAuthState.getState().profile?.subscription).toBeUndefined();
+    });
+
+    test("verifyAccessToken enriches the SSR profile from the access token", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        Response.json({ plan: "pro" }),
+      );
+      vi.mocked(oauth.userInfoRequest).mockResolvedValue(
+        Response.json({
+          sub: "user-1",
+          email: "user@example.com",
+          name: "Test",
+          email_verified: true,
+        }),
+      );
+
+      const provider = createUserDataProvider({
+        claims: [{ claim: SUBSCRIPTION_CLAIM, as: "tokenSubscription" }],
+        endpoint: {
+          url: "https://api.example.com/v1/me/subscription",
+          as: "subscription",
+        },
+      });
+
+      const result = await provider.verifyAccessToken(
+        signedlessJwt({ [SUBSCRIPTION_CLAIM]: { plan: "from-token" } }),
+      );
+
+      expect(result?.profile).toMatchObject({
+        sub: "user-1",
+        tokenSubscription: { plan: "from-token" },
+        subscription: { plan: "pro" },
+      });
+    });
+
+    test("a soft endpoint failure does not break the login", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 503 }),
+      );
+
+      const provider = createUserDataProvider({
+        endpoint: { url: "https://api.example.com/v1/me/subscription" },
+      });
+      setLoggedInWith(FAKE_ACCESS_TOKEN);
+
+      await expect(provider.refreshUserProfile()).resolves.toBe(true);
+      expect(useAuthState.getState().profile?.sub).toBe("user-1");
+    });
+
+    test("a required endpoint failure surfaces as an error", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 503 }),
+      );
+
+      const provider = createUserDataProvider({
+        endpoint: {
+          url: "https://api.example.com/v1/me/subscription",
+          required: true,
+        },
+      });
+      setLoggedInWith(FAKE_ACCESS_TOKEN);
+
+      await expect(provider.refreshUserProfile()).rejects.toThrow(
+        UserDataError,
+      );
     });
   });
 

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -19,19 +19,15 @@ import { fetchServerSession } from "../cookie-sync.js";
 import { DEFAULT_SESSION_MAX_AGE, SESSION_ENDPOINT_PATH } from "../cookies.js";
 import { AuthorizationError, OAuthAuthorizationError } from "../errors.js";
 import { type UserProfile, useAuthState } from "../state.js";
+import { applyUserData, decodeTokenClaims } from "../user-data.js";
 import { redirectToSignUpUrl } from "./util.js";
 
 const CODE_VERIFIER_KEY = "code-verifier";
 const STATE_KEY = "oauth-state";
 
 const decodeJwtExp = async (token: string): Promise<number | undefined> => {
-  try {
-    const { decodeJwt } = await import("jose");
-    const payload = decodeJwt(token);
-    return typeof payload.exp === "number" ? payload.exp : undefined;
-  } catch {
-    return undefined;
-  }
+  const payload = await decodeTokenClaims(token);
+  return typeof payload?.exp === "number" ? payload.exp : undefined;
 };
 
 export interface OpenIdProviderData {
@@ -85,6 +81,7 @@ export class OpenIDAuthenticationProvider
     "acr_values",
   ];
   private readonly allowInsecureRequests: boolean;
+  protected readonly userData: OpenIDAuthenticationConfig["userData"];
   private readonly sessionEndpoint: string;
   private serverSessionHydration?: Promise<OpenIdProviderData | undefined>;
 
@@ -102,6 +99,7 @@ export class OpenIDAuthenticationProvider
     authorizationParams,
     forwardAuthorizationParams,
     allowInsecureRequests,
+    userData,
   }: OpenIDAuthenticationConfig) {
     super();
     this.client = {
@@ -115,6 +113,7 @@ export class OpenIDAuthenticationProvider
     this.sessionEndpoint = joinUrl(basePath, SESSION_ENDPOINT_PATH);
     this.scopes = scopes ?? ["openid", "profile", "email"];
     this.allowInsecureRequests = allowInsecureRequests ?? false;
+    this.userData = userData;
 
     this.redirectToAfterSignUp = redirectToAfterSignUp;
     this.redirectToAfterSignIn = redirectToAfterSignIn;
@@ -273,6 +272,29 @@ export class OpenIDAuthenticationProvider
     };
   }
 
+  /**
+   * Builds the profile and layers the configured `userData` on top. This is
+   * the client-side counterpart of the enrichment in `verifyAccessToken`, so
+   * `useAuth().profile` carries the same custom data whether the page was
+   * rendered on the server or hydrated after the OAuth callback.
+   */
+  protected async buildEnrichedProfile(
+    userInfo: oauth.UserInfoResponse,
+    claims: oauth.IDToken | undefined,
+    accessToken: string,
+  ): Promise<UserProfile> {
+    const profile = this.buildUserProfile(userInfo, claims);
+    if (!this.userData) return profile;
+
+    return applyUserData(profile, {
+      userData: this.userData,
+      accessToken,
+      claimSources: this.userData.claims?.length
+        ? [claims, await decodeTokenClaims(accessToken)]
+        : undefined,
+    });
+  }
+
   public async verifyAccessToken(
     token: string,
   ): Promise<VerifyAccessTokenResult> {
@@ -286,19 +308,30 @@ export class OpenIDAuthenticationProvider
     const userInfo = (await response.json()) as Record<string, unknown>;
     if (!userInfo.sub) return undefined;
 
-    // userInfoRequest authenticated the token upstream; parsing `exp` here
-    // lets us bound the cookie lifetime to the token's. Opaque tokens just
-    // yield undefined and fall back to the handler's default.
-    const expiresAt = await decodeJwtExp(token);
+    // userInfoRequest authenticated the token upstream; decoding the payload
+    // here bounds the cookie lifetime to the token's `exp` and feeds claim
+    // selection below. Opaque tokens just yield undefined and fall back to
+    // the handler's default.
+    const tokenClaims = await decodeTokenClaims(token);
+    const expiresAt =
+      typeof tokenClaims?.exp === "number" ? tokenClaims.exp : undefined;
+
+    const profile: UserProfile = {
+      sub: String(userInfo.sub),
+      email: userInfo.email as string | undefined,
+      name: userInfo.name as string | undefined,
+      emailVerified: Boolean(userInfo.email_verified),
+      pictureUrl: userInfo.picture as string | undefined,
+    };
 
     return {
-      profile: {
-        sub: String(userInfo.sub),
-        email: userInfo.email as string | undefined,
-        name: userInfo.name as string | undefined,
-        emailVerified: Boolean(userInfo.email_verified),
-        pictureUrl: userInfo.picture as string | undefined,
-      },
+      // The ID token isn't available here — only the access token was
+      // submitted — so claim selection sees the access token payload alone.
+      profile: await applyUserData(profile, {
+        userData: this.userData,
+        accessToken: token,
+        claimSources: [tokenClaims],
+      }),
       expiresAt,
     };
   }
@@ -324,7 +357,11 @@ export class OpenIDAuthenticationProvider
     const claims =
       providerData?.type === "openid" ? providerData.claims : undefined;
 
-    const profile = this.buildUserProfile(userInfo, claims);
+    const profile = await this.buildEnrichedProfile(
+      userInfo,
+      claims,
+      accessToken,
+    );
 
     useAuthState.setState({
       isAuthenticated: true,
@@ -694,6 +731,9 @@ export class OpenIDAuthenticationProvider
     );
     const userInfo = await userInfoResponse.json();
 
+    // Interim profile only — the awaited refresh below rebuilds it through
+    // buildEnrichedProfile. Enriching here too would call a configured
+    // `userData.endpoint` twice per login.
     const profile = this.buildUserProfile(userInfo, claims);
 
     useAuthState.setState({

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -25,10 +25,11 @@ import { redirectToSignUpUrl } from "./util.js";
 const CODE_VERIFIER_KEY = "code-verifier";
 const STATE_KEY = "oauth-state";
 
-const decodeJwtExp = async (token: string): Promise<number | undefined> => {
-  const payload = await decodeTokenClaims(token);
-  return typeof payload?.exp === "number" ? payload.exp : undefined;
-};
+const tokenExp = (claims: Record<string, unknown> | undefined) =>
+  typeof claims?.exp === "number" ? claims.exp : undefined;
+
+const decodeJwtExp = async (token: string): Promise<number | undefined> =>
+  tokenExp(await decodeTokenClaims(token));
 
 export interface OpenIdProviderData {
   // just for easy migration we also allow for undefined type. can be removed in the future.
@@ -313,8 +314,7 @@ export class OpenIDAuthenticationProvider
     // selection below. Opaque tokens just yield undefined and fall back to
     // the handler's default.
     const tokenClaims = await decodeTokenClaims(token);
-    const expiresAt =
-      typeof tokenClaims?.exp === "number" ? tokenClaims.exp : undefined;
+    const expiresAt = tokenExp(tokenClaims);
 
     const profile: UserProfile = {
       sub: String(userInfo.sub),

--- a/packages/zudoku/src/lib/authentication/user-data.test.ts
+++ b/packages/zudoku/src/lib/authentication/user-data.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { UserProfile } from "./state.js";
+import {
+  applyUserData,
+  decodeTokenClaims,
+  fetchUserData,
+  selectClaims,
+  UserDataError,
+} from "./user-data.js";
+
+const PROFILE: UserProfile = {
+  sub: "user-1",
+  email: "user@example.com",
+  emailVerified: true,
+  name: "Test User",
+  pictureUrl: undefined,
+};
+
+const b64url = (value: object) =>
+  Buffer.from(JSON.stringify(value))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+const jwt = (payload: object) =>
+  `${b64url({ alg: "none" })}.${b64url(payload)}.signature`;
+
+const mockFetch = (impl: typeof fetch) =>
+  vi.spyOn(globalThis, "fetch").mockImplementation(impl);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("selectClaims", () => {
+  test("lifts a claim under its own name", () => {
+    expect(
+      selectClaims(
+        ["https://zuplo.com/subscription"],
+        [{ "https://zuplo.com/subscription": { plan: "pro" } }],
+      ),
+    ).toEqual({ "https://zuplo.com/subscription": { plan: "pro" } });
+  });
+
+  test("renames a claim via `as`", () => {
+    expect(
+      selectClaims(
+        [{ claim: "https://zuplo.com/subscription", as: "subscription" }],
+        [{ "https://zuplo.com/subscription": { plan: "pro" } }],
+      ),
+    ).toEqual({ subscription: { plan: "pro" } });
+  });
+
+  test("skips claims that no source carries", () => {
+    expect(selectClaims(["missing"], [{ other: 1 }, undefined])).toEqual({});
+  });
+
+  test("first source carrying the claim wins", () => {
+    expect(
+      selectClaims(
+        ["plan"],
+        [undefined, { plan: "id-token" }, { plan: "access-token" }],
+      ),
+    ).toEqual({ plan: "id-token" });
+  });
+
+  test("keeps a claim that is explicitly null", () => {
+    expect(selectClaims(["plan"], [{ plan: null }])).toEqual({ plan: null });
+  });
+});
+
+describe("decodeTokenClaims", () => {
+  test("decodes a JWT payload", async () => {
+    await expect(
+      decodeTokenClaims(jwt({ sub: "user-1", plan: "pro" })),
+    ).resolves.toMatchObject({
+      sub: "user-1",
+      plan: "pro",
+    });
+  });
+
+  test("returns undefined for a missing or unparseable token", async () => {
+    await expect(decodeTokenClaims(undefined)).resolves.toBeUndefined();
+    await expect(decodeTokenClaims("not-a-jwt")).resolves.toBeUndefined();
+  });
+});
+
+describe("fetchUserData", () => {
+  test("merges an object response at the top level", async () => {
+    mockFetch(async () => Response.json({ plan: "pro", seats: 5 }));
+
+    await expect(
+      fetchUserData("https://api.example.com/me", "token-1"),
+    ).resolves.toEqual({ plan: "pro", seats: 5 });
+  });
+
+  test("nests the response under `as`", async () => {
+    mockFetch(async () => Response.json({ plan: "pro" }));
+
+    await expect(
+      fetchUserData(
+        { url: "https://api.example.com/me", as: "subscription" },
+        "token-1",
+      ),
+    ).resolves.toEqual({ subscription: { plan: "pro" } });
+  });
+
+  test("accepts a non-object response when nested under `as`", async () => {
+    mockFetch(async () => Response.json("pro"));
+
+    await expect(
+      fetchUserData(
+        { url: "https://api.example.com/me", as: "plan" },
+        "token-1",
+      ),
+    ).resolves.toEqual({ plan: "pro" });
+  });
+
+  test("sends the access token as a bearer token", async () => {
+    const fetchSpy = mockFetch(async () => Response.json({ plan: "pro" }));
+
+    await fetchUserData(
+      {
+        url: "https://api.example.com/me",
+        method: "POST",
+        headers: { "x-portal": "docs" },
+      },
+      "token-1",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith("https://api.example.com/me", {
+      method: "POST",
+      headers: {
+        "x-portal": "docs",
+        Accept: "application/json",
+        Authorization: "Bearer token-1",
+      },
+    });
+  });
+
+  test("configured headers cannot override the bearer token", async () => {
+    const fetchSpy = mockFetch(async () => Response.json({ plan: "pro" }));
+
+    await fetchUserData(
+      {
+        url: "https://api.example.com/me",
+        headers: { Authorization: "Bearer attacker" },
+      },
+      "token-1",
+    );
+
+    expect(fetchSpy.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: "Bearer token-1",
+    });
+  });
+
+  test("returns undefined and logs when the request fails", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch(async () => new Response(null, { status: 503 }));
+
+    await expect(
+      fetchUserData("https://api.example.com/me", "token-1"),
+    ).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  test("returns undefined when a top-level response is not an object", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch(async () => Response.json(["pro"]));
+
+    await expect(
+      fetchUserData("https://api.example.com/me", "token-1"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("throws on failure when the endpoint is required", async () => {
+    mockFetch(async () => new Response(null, { status: 503 }));
+
+    await expect(
+      fetchUserData(
+        { url: "https://api.example.com/me", required: true },
+        "token-1",
+      ),
+    ).rejects.toThrow(UserDataError);
+  });
+
+  test("wraps a network error when the endpoint is required", async () => {
+    mockFetch(async () => {
+      throw new TypeError("network down");
+    });
+
+    await expect(
+      fetchUserData(
+        { url: "https://api.example.com/me", required: true },
+        "token-1",
+      ),
+    ).rejects.toThrow(UserDataError);
+  });
+});
+
+describe("applyUserData", () => {
+  test("returns the profile untouched without config", async () => {
+    await expect(
+      applyUserData(PROFILE, { userData: undefined, accessToken: "token-1" }),
+    ).resolves.toBe(PROFILE);
+  });
+
+  test("combines claims and endpoint data", async () => {
+    mockFetch(async () => Response.json({ plan: "pro" }));
+
+    await expect(
+      applyUserData(PROFILE, {
+        userData: {
+          claims: [{ claim: "https://zuplo.com/roles", as: "roles" }],
+          endpoint: { url: "https://api.example.com/me", as: "subscription" },
+        },
+        accessToken: "token-1",
+        claimSources: [{ "https://zuplo.com/roles": ["admin"] }],
+      }),
+    ).resolves.toMatchObject({
+      sub: "user-1",
+      roles: ["admin"],
+      subscription: { plan: "pro" },
+    });
+  });
+
+  test("endpoint data wins over a colliding claim", async () => {
+    mockFetch(async () => Response.json({ plan: "endpoint" }));
+
+    const profile = await applyUserData(PROFILE, {
+      userData: {
+        claims: [{ claim: "plan" }],
+        endpoint: "https://api.example.com/me",
+      },
+      accessToken: "token-1",
+      claimSources: [{ plan: "claim" }],
+    });
+
+    expect(profile.plan).toBe("endpoint");
+  });
+
+  test("never lets custom user data rewrite `sub`", async () => {
+    mockFetch(async () => Response.json({ sub: "attacker", plan: "pro" }));
+
+    const profile = await applyUserData(PROFILE, {
+      userData: {
+        claims: [{ claim: "sub" }],
+        endpoint: "https://api.example.com/me",
+      },
+      accessToken: "token-1",
+      claimSources: [{ sub: "also-attacker" }],
+    });
+
+    expect(profile.sub).toBe("user-1");
+    expect(profile.plan).toBe("pro");
+  });
+
+  test("leaves the profile unchanged when a soft endpoint failure yields nothing", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch(async () => new Response(null, { status: 500 }));
+
+    await expect(
+      applyUserData(PROFILE, {
+        userData: { endpoint: "https://api.example.com/me" },
+        accessToken: "token-1",
+      }),
+    ).resolves.toBe(PROFILE);
+  });
+});

--- a/packages/zudoku/src/lib/authentication/user-data.ts
+++ b/packages/zudoku/src/lib/authentication/user-data.ts
@@ -1,0 +1,161 @@
+import type { UserDataConfig } from "../../config/config.js";
+import { ZudokuError, type ZudokuErrorOptions } from "../util/invariant.js";
+import type { CustomClaim, CustomClaimRecord, UserProfile } from "./state.js";
+
+export class UserDataError extends ZudokuError {
+  constructor(message: string, options?: Pick<ZudokuErrorOptions, "cause">) {
+    super(message, {
+      title: "Custom user data",
+      developerHint:
+        "Check the `authentication.userData` settings in your Zudoku config.",
+      ...options,
+    });
+  }
+}
+
+const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+/**
+ * `sub` is the identity of the profile, so custom user data must never be able
+ * to rewrite it. Everything else is fair game — overriding `name` or `email`
+ * from your own user store is a legitimate use of this feature.
+ */
+const RESERVED_PROFILE_KEYS = new Set(["sub"]);
+
+type ClaimSource = Record<string, unknown> | undefined;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Decodes a JWT payload without verifying it. Only ever used on tokens the
+ * IdP just issued to us (client) or that the verifier already authenticated
+ * upstream (server), so this reads claims rather than establishing trust.
+ */
+export const decodeTokenClaims = async (
+  token: string | undefined,
+): Promise<Record<string, unknown> | undefined> => {
+  if (!token) return undefined;
+  try {
+    const { decodeJwt } = await import("jose");
+    return decodeJwt(token);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Lifts configured claims out of the token payloads into a flat record.
+ * Sources are consulted in order, so the first one carrying the claim wins.
+ */
+export const selectClaims = (
+  claims: NonNullable<UserDataConfig["claims"]>,
+  sources: ClaimSource[],
+): CustomClaimRecord =>
+  Object.fromEntries(
+    claims.flatMap((entry) => {
+      const claim = typeof entry === "string" ? entry : entry.claim;
+      const as = typeof entry === "string" ? undefined : entry.as;
+
+      const source = sources.find((s) => s && claim in s);
+      if (!source) return [];
+
+      return [[as ?? claim, source[claim] as CustomClaim]];
+    }),
+  );
+
+/**
+ * Calls the configured endpoint with the user's access token and returns the
+ * data to merge into the profile. Resolves to `undefined` when the request
+ * fails and the endpoint isn't `required`.
+ */
+export const fetchUserData = async (
+  endpoint: NonNullable<UserDataConfig["endpoint"]>,
+  accessToken: string,
+): Promise<CustomClaimRecord | undefined> => {
+  const {
+    url,
+    method = "GET",
+    headers,
+    as,
+    required = false,
+  } = typeof endpoint === "string" ? { url: endpoint } : endpoint;
+
+  try {
+    const response = await fetch(url, {
+      method,
+      // Core headers go last so configured ones can't drop the bearer token.
+      headers: {
+        ...headers,
+        Accept: "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new UserDataError(
+        `Request to ${url} failed with status ${response.status}`,
+      );
+    }
+
+    const data: unknown = await response.json();
+
+    if (as) return { [as]: data as CustomClaim };
+
+    if (!isRecord(data)) {
+      throw new UserDataError(
+        `Response from ${url} is not a JSON object. Set \`as\` to nest it under a profile key.`,
+      );
+    }
+
+    return data as CustomClaimRecord;
+  } catch (error) {
+    if (required) {
+      throw error instanceof UserDataError
+        ? error
+        : new UserDataError(`Request to ${url} failed`, {
+            cause: toError(error),
+          });
+    }
+
+    // biome-ignore lint/suspicious/noConsole: Surface user data failures
+    console.error("Failed to load custom user data:", error);
+    return undefined;
+  }
+};
+
+/**
+ * Applies the `authentication.userData` config to a freshly built profile.
+ * Endpoint data is applied after claims so it wins on a key collision.
+ */
+export const applyUserData = async (
+  profile: UserProfile,
+  {
+    userData,
+    accessToken,
+    claimSources = [],
+  }: {
+    userData: UserDataConfig | undefined;
+    accessToken: string;
+    claimSources?: ClaimSource[];
+  },
+): Promise<UserProfile> => {
+  if (!userData) return profile;
+
+  const fromClaims = userData.claims?.length
+    ? selectClaims(userData.claims, claimSources)
+    : undefined;
+
+  const fromEndpoint = userData.endpoint
+    ? await fetchUserData(userData.endpoint, accessToken)
+    : undefined;
+
+  if (!fromClaims && !fromEndpoint) return profile;
+
+  const merged = Object.entries({ ...fromClaims, ...fromEndpoint }).filter(
+    ([key]) => !RESERVED_PROFILE_KEYS.has(key),
+  );
+
+  return { ...profile, ...Object.fromEntries(merged) };
+};


### PR DESCRIPTION
## Summary

Adds support for attaching custom user data to authenticated user profiles through two mechanisms: lifting claims from ID/access tokens and fetching data from a custom API endpoint. This allows portals to enrich profiles with subscription records, plan tiers, entitlements, and other data not held by the identity provider.

## Key Changes

- **New `user-data.ts` module** with utilities for:
  - `selectClaims()`: Lifts configured claims from token payloads into the profile
  - `decodeTokenClaims()`: Decodes JWT payloads without verification (safe since tokens are already authenticated by the IdP or verifier)
  - `fetchUserData()`: Calls a configured endpoint with the user's access token and merges the response
  - `applyUserData()`: Orchestrates both layers and applies them to a profile
  - `UserDataError`: Custom error class for user data failures

- **Configuration schema** (`ZudokuConfig.ts`):
  - `UserDataClaimSchema`: Supports string claim names or `{ claim, as }` objects for renaming
  - `UserDataEndpointSchema`: Supports bare URL strings or full config with `method`, `headers`, `as`, and `required` options
  - `UserDataSchema`: Combines both into optional `claims` and `endpoint` fields
  - Added to `auth0`, `openid`, and `entra` authentication types

- **OpenID provider integration** (`openid.tsx`):
  - New `buildEnrichedProfile()` method applies user data after building the base profile
  - `verifyAccessToken()` now enriches SSR profiles with the same data
  - Reuses `decodeTokenClaims()` for token expiration extraction

- **Comprehensive test coverage**:
  - `user-data.test.ts`: 270 lines testing all utility functions with edge cases (missing claims, non-object responses, required failures, etc.)
  - `openid.test.ts`: Integration tests for claim lifting, endpoint fetching, and error handling in the provider

- **Documentation**:
  - Main authentication guide with full `userData` configuration examples
  - Auth0-specific guide showing practical usage patterns
  - Notes on SSR cookie size limits and absolute URL requirement

## Implementation Details

- **Security**: The `sub` claim is reserved and cannot be overwritten by custom data, preventing identity spoofing. Configured headers cannot override the `Authorization` bearer token.
- **SSR consistency**: User data is applied both client-side (after OAuth callback) and server-side (when verifying access tokens), ensuring `useAuth().profile` carries the same enriched data in either render mode.
- **Graceful degradation**: Non-required endpoint failures log and leave the profile unchanged, preventing outages from locking users out. Required endpoints fail the login instead.
- **Token handling**: Claims are sourced from ID token first, then access token, supporting both `api.idToken.setCustomClaim` and `api.accessToken.setCustomClaim` patterns in Auth0 Actions.

https://claude.ai/code/session_017UfNrhaCHy5hmJXmh4Pthm