### PR TITLE
Add pre-checkout questionnaire support to monetization plugin

### DIFF
--- a/examples/zuplo-monetization/docs/package.json
+++ b/examples/zuplo-monetization/docs/package.json
@@ -21,10 +21,11 @@
     }
   },
   "dependencies": {
+    "@zuplo/zudoku-plugin-monetization": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "zudoku": "workspace:*",
-    "@zuplo/zudoku-plugin-monetization": "workspace:*"
+    "react-hook-form": "^7.83.0",
+    "zudoku": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/examples/zuplo-monetization/docs/src/SubscribeQuestionnaire.tsx
+++ b/examples/zuplo-monetization/docs/src/SubscribeQuestionnaire.tsx
@@ -1,0 +1,211 @@
+import type { BeforeCheckoutProps } from "@zuplo/zudoku-plugin-monetization";
+import { Controller, useForm } from "react-hook-form";
+import { useAuth } from "zudoku/hooks";
+import { Alert, AlertDescription } from "zudoku/ui/Alert";
+import { Button } from "zudoku/ui/Button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "zudoku/ui/Card";
+import { Label } from "zudoku/ui/Label";
+import { RadioGroup, RadioGroupItem } from "zudoku/ui/RadioGroup";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "zudoku/ui/Select";
+import { Textarea } from "zudoku/ui/Textarea";
+
+type Answers = {
+  companySize: string;
+  useCase: string;
+  details: string;
+};
+
+const COMPANY_SIZES = [
+  { value: "1", label: "Just me" },
+  { value: "2-10", label: "2–10 people" },
+  { value: "11-50", label: "11–50 people" },
+  { value: "51-200", label: "51–200 people" },
+  { value: "200+", label: "More than 200 people" },
+];
+
+const USE_CASES = [
+  { value: "internal-tooling", label: "Internal tooling" },
+  { value: "customer-facing", label: "A customer-facing product" },
+  { value: "data-pipeline", label: "Data pipeline / batch processing" },
+  { value: "evaluating", label: "Just evaluating for now" },
+];
+
+/**
+ * Replace this with a request to wherever your qualification data belongs — your
+ * own API, a CRM, a warehouse. Whatever it is, it must resolve before the user
+ * is sent to Stripe, so `onComplete()` runs only once it succeeded.
+ */
+const submitAnswers = async (payload: Answers & { planKey: string }) => {
+  await new Promise((resolve) => setTimeout(resolve, 600));
+
+  // Throwing here keeps the user on this form with the error shown, and no
+  // Stripe Checkout Session is ever created.
+  if (payload.useCase === "") {
+    throw new Error("Could not save your answers. Please try again.");
+  }
+
+  // biome-ignore lint/suspicious/noConsole: stands in for a real request
+  console.log("qualification answers", payload);
+};
+
+/**
+ * Asked after "Subscribe" and before Stripe, in place of a separate landing
+ * page with an embedded form. Wired up via the monetization plugin's
+ * `checkout.renderBeforeCheckout` option — see `zudoku.config.tsx`.
+ */
+export const SubscribeQuestionnaire = ({
+  plan,
+  onComplete,
+  onCancel,
+}: BeforeCheckoutProps) => {
+  const auth = useAuth();
+  const form = useForm<Answers>({
+    defaultValues: { companySize: "", useCase: "", details: "" },
+  });
+
+  const onSubmit = form.handleSubmit(async (answers) => {
+    try {
+      await submitAnswers({ ...answers, planKey: plan.key });
+    } catch (error) {
+      form.setError("root", {
+        message:
+          error instanceof Error ? error.message : "Something went wrong.",
+      });
+      return;
+    }
+    onComplete();
+  });
+
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted p-4">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>Before you subscribe to {plan.name}</CardTitle>
+          <CardDescription>
+            Three quick questions so we can set up your account correctly.
+            {auth.profile?.email
+              ? ` Subscribing as ${auth.profile.email}.`
+              : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="flex flex-col gap-8">
+            <Controller
+              control={form.control}
+              name="companySize"
+              rules={{ required: "Pick the option closest to your team size." }}
+              render={({ field, fieldState }) => (
+                <fieldset className="flex flex-col gap-3">
+                  <legend className="font-medium text-sm mb-3">
+                    How big is your team?
+                  </legend>
+                  <RadioGroup
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    className="gap-3"
+                  >
+                    {COMPANY_SIZES.map((size) => (
+                      <div key={size.value} className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value={size.value}
+                          id={`size-${size.value}`}
+                        />
+                        <Label
+                          htmlFor={`size-${size.value}`}
+                          className="font-normal"
+                        >
+                          {size.label}
+                        </Label>
+                      </div>
+                    ))}
+                  </RadioGroup>
+                  {fieldState.error && (
+                    <p className="text-destructive text-sm">
+                      {fieldState.error.message}
+                    </p>
+                  )}
+                </fieldset>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="useCase"
+              rules={{ required: "Let us know what you're building." }}
+              render={({ field, fieldState }) => (
+                <div className="flex flex-col gap-3">
+                  <Label htmlFor="use-case">
+                    What are you going to use the API for?
+                  </Label>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger id="use-case">
+                      <SelectValue placeholder="Choose one" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {USE_CASES.map((useCase) => (
+                        <SelectItem key={useCase.value} value={useCase.value}>
+                          {useCase.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {fieldState.error && (
+                    <p className="text-destructive text-sm">
+                      {fieldState.error.message}
+                    </p>
+                  )}
+                </div>
+              )}
+            />
+
+            <div className="flex flex-col gap-3">
+              <Label htmlFor="details">
+                Anything else we should know?{" "}
+                <span className="text-muted-foreground font-normal">
+                  (optional)
+                </span>
+              </Label>
+              <Textarea
+                id="details"
+                rows={3}
+                placeholder="Expected traffic, launch timeline, integrations…"
+                {...form.register("details")}
+              />
+            </div>
+
+            {rootError && (
+              <Alert variant="destructive">
+                <AlertDescription>{rootError}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex items-center justify-between gap-3">
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                Back to pricing
+              </Button>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting
+                  ? "Saving…"
+                  : "Continue to checkout"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/examples/zuplo-monetization/docs/zudoku.config.tsx
+++ b/examples/zuplo-monetization/docs/zudoku.config.tsx
@@ -1,5 +1,6 @@
 import { zuploMonetizationPlugin } from "@zuplo/zudoku-plugin-monetization";
 import type { ZudokuConfig } from "zudoku";
+import { SubscribeQuestionnaire } from "./src/SubscribeQuestionnaire.js";
 
 const config: ZudokuConfig = {
   site: {
@@ -86,7 +87,19 @@ const config: ZudokuConfig = {
     clientId: "f8I87rdsCRo4nU2FHf0fHVwA9P7xi7Ml",
     audience: "https://api.example.com/",
   },
-  plugins: [zuploMonetizationPlugin()],
+  plugins: [
+    zuploMonetizationPlugin({
+      checkout: {
+        // Asked on /checkout, after "Subscribe" and before Stripe. Return
+        // `null` to send a plan straight to checkout — here the free plan
+        // skips the questions.
+        renderBeforeCheckout: (props) =>
+          props.plan.paymentRequired === false ? null : (
+            <SubscribeQuestionnaire {...props} />
+          ),
+      },
+    }),
+  ],
 };
 
 export default config;

--- a/packages/plugin-zuplo-monetization/src/MonetizationContext.tsx
+++ b/packages/plugin-zuplo-monetization/src/MonetizationContext.tsx
@@ -1,10 +1,41 @@
-import { createContext, use } from "react";
+import { createContext, type ReactNode, use } from "react";
+import type { Plan } from "./types/PlanType.js";
+
+export type BeforeCheckoutProps = {
+  /** The plan the user chose on the pricing page. */
+  plan: Plan;
+  /**
+   * Proceed to checkout. Call this only once your own submit has succeeded —
+   * no Stripe Checkout Session exists until it fires.
+   */
+  onComplete: () => void;
+  /** Abandon the purchase and return to the pricing page. */
+  onCancel: () => void;
+};
 
 export interface MonetizationConfig {
   pricing?: {
     subtitle?: string;
     title?: string;
     units?: Record<string, string>;
+  };
+  checkout?: {
+    /**
+     * Rendered on `/checkout` in place of the Stripe redirect, so questions can
+     * be asked before the user reaches payment (company size, use case, …).
+     *
+     * Return `null` to skip straight to checkout — e.g. for a free plan, or a
+     * plan that needs no qualification. Persisting the answers is the caller's
+     * job: submit them wherever they belong, then call `onComplete()`. A failed
+     * submit simply never calls it, so the user is never sent to Stripe.
+     *
+     * The route renders without the site layout, so the returned node owns the
+     * full page.
+     *
+     * Note this gates the checkout *route*, not the metering API — treat it as
+     * qualification, not as a constraint the purchase cannot proceed without.
+     */
+    renderBeforeCheckout?: (props: BeforeCheckoutProps) => ReactNode | null;
   };
 }
 

--- a/packages/plugin-zuplo-monetization/src/index.ts
+++ b/packages/plugin-zuplo-monetization/src/index.ts
@@ -1,1 +1,5 @@
+export type {
+  BeforeCheckoutProps,
+  MonetizationConfig,
+} from "./MonetizationContext.js";
 export { zuploMonetizationPlugin } from "./ZuploMonetizationPlugin";

--- a/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.test.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.test.tsx
@@ -1,0 +1,220 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "zudoku/router";
+import {
+  type BeforeCheckoutProps,
+  MonetizationContext,
+  type MonetizationConfig,
+} from "../MonetizationContext.js";
+import type { Plan } from "../types/PlanType.js";
+import CheckoutPage from "./CheckoutPage.js";
+
+vi.mock("zudoku/hooks", () => ({
+  useZudoku: () => ({
+    env: { ZUPLO_PUBLIC_DEPLOYMENT_NAME: "test-env" },
+    options: { basePath: undefined },
+  }),
+  useAuth: () => ({ profile: { sub: "user-1" } }),
+}));
+
+vi.mock("../hooks/useDeploymentName", () => ({
+  useDeploymentName: () => "test-deployment",
+}));
+
+vi.mock("../hooks/useUrlUtils", () => ({
+  useUrlUtils: () => ({
+    generateUrl: (path: string) => `https://portal${path}`,
+  }),
+}));
+
+const testState = vi.hoisted(() => ({
+  /** Every `useQuery` the tree mounted — a Stripe Checkout Session per entry. */
+  sessionRequests: [] as unknown[],
+  plans: { items: [] as Plan[] },
+}));
+
+vi.mock("../hooks/usePlans", () => ({
+  usePlans: () => ({ data: testState.plans }),
+}));
+
+vi.mock("zudoku/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("zudoku/react-query")>();
+  return {
+    ...actual,
+    useQuery: (options: unknown) => {
+      testState.sessionRequests.push(options);
+      return { data: { url: "https://stripe.test/session" }, isError: false };
+    },
+  };
+});
+
+// The real component leaves the SPA via `window.location.href`; assert on what
+// it was handed rather than letting it drive the test environment.
+vi.mock("../components/RedirectPage.js", () => ({
+  RedirectPage: ({ url }: { url?: string }) => (
+    <div data-testid="redirect" data-url={url} />
+  ),
+}));
+
+const makePlan = (overrides: Partial<Plan> = {}): Plan => ({
+  id: "plan-1",
+  key: "pro",
+  name: "Pro",
+  billingCadence: "P1M",
+  currency: "USD",
+  phases: [
+    {
+      key: "default",
+      name: "Default",
+      rateCards: [
+        {
+          type: "flat_fee",
+          key: "base-fee",
+          name: "Base Fee",
+          billingCadence: "P1M",
+          price: { type: "flat", amount: "49" },
+        },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+const renderPage = (initialPath: string, config: MonetizationConfig = {}) =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <MonetizationContext value={config}>
+        <CheckoutPage />
+      </MonetizationContext>
+    </MemoryRouter>,
+  );
+
+/**
+ * Stands in for a developer-supplied questionnaire: submits to their own
+ * endpoint and only proceeds if that succeeded.
+ */
+const questionnaire =
+  (submitAnswers: (size: string) => Promise<unknown>) =>
+  ({ plan, onComplete, onCancel }: BeforeCheckoutProps) => (
+    <div>
+      <span data-testid="gate-plan">{plan.name}</span>
+      <button
+        type="button"
+        onClick={() => {
+          submitAnswers("50-200").then(onComplete, () => {
+            /* keep the user on the questionnaire */
+          });
+        }}
+      >
+        Continue
+      </button>
+      <button type="button" onClick={onCancel}>
+        Back
+      </button>
+    </div>
+  );
+
+describe("CheckoutPage", () => {
+  beforeEach(() => {
+    testState.sessionRequests = [];
+    testState.plans = { items: [makePlan()] };
+  });
+
+  it("redirects to pricing without a planId", () => {
+    renderPage("/checkout");
+
+    expect(screen.queryByTestId("redirect")).not.toBeInTheDocument();
+    expect(testState.sessionRequests).toHaveLength(0);
+  });
+
+  it("goes straight to Stripe when no questionnaire is configured", () => {
+    renderPage("/checkout?planId=plan-1");
+
+    expect(screen.getByTestId("redirect")).toHaveAttribute(
+      "data-url",
+      "https://stripe.test/session",
+    );
+    expect(testState.sessionRequests).toHaveLength(1);
+  });
+
+  it("shows the questionnaire and creates no Stripe session until it completes", async () => {
+    const submitAnswers = vi.fn(() => Promise.resolve());
+    renderPage("/checkout?planId=plan-1", {
+      checkout: { renderBeforeCheckout: questionnaire(submitAnswers) },
+    });
+
+    expect(screen.getByTestId("gate-plan")).toHaveTextContent("Pro");
+    expect(screen.queryByTestId("redirect")).not.toBeInTheDocument();
+    expect(testState.sessionRequests).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("redirect")).toBeInTheDocument(),
+    );
+    expect(submitAnswers).toHaveBeenCalledWith("50-200");
+    expect(testState.sessionRequests).toHaveLength(1);
+  });
+
+  it("holds checkout when the questionnaire's own submit fails", async () => {
+    const submitAnswers = vi.fn(() => Promise.reject(new Error("crm down")));
+    renderPage("/checkout?planId=plan-1", {
+      checkout: { renderBeforeCheckout: questionnaire(submitAnswers) },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(submitAnswers).toHaveBeenCalled());
+    expect(screen.getByTestId("gate-plan")).toBeInTheDocument();
+    expect(screen.queryByTestId("redirect")).not.toBeInTheDocument();
+    expect(testState.sessionRequests).toHaveLength(0);
+  });
+
+  it("proceeds immediately when the questionnaire returns null", () => {
+    renderPage("/checkout?planId=plan-1", {
+      checkout: { renderBeforeCheckout: () => null },
+    });
+
+    expect(screen.getByTestId("redirect")).toBeInTheDocument();
+    expect(testState.sessionRequests).toHaveLength(1);
+  });
+
+  it("passes the chosen plan so the questionnaire can vary by plan", () => {
+    testState.plans = {
+      items: [
+        makePlan(),
+        makePlan({ id: "plan-2", key: "team", name: "Team" }),
+      ],
+    };
+    renderPage("/checkout?planId=plan-2", {
+      checkout: {
+        renderBeforeCheckout: questionnaire(() => Promise.resolve()),
+      },
+    });
+
+    expect(screen.getByTestId("gate-plan")).toHaveTextContent("Team");
+  });
+
+  it("skips the questionnaire for an unknown plan id", () => {
+    const renderBeforeCheckout = vi.fn(() => <div>should not render</div>);
+    renderPage("/checkout?planId=does-not-exist", {
+      checkout: { renderBeforeCheckout },
+    });
+
+    expect(renderBeforeCheckout).not.toHaveBeenCalled();
+    expect(screen.getByTestId("redirect")).toBeInTheDocument();
+  });
+
+  it("returns to pricing on cancel without creating a session", () => {
+    renderPage("/checkout?planId=plan-1", {
+      checkout: {
+        renderBeforeCheckout: questionnaire(() => Promise.resolve()),
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.queryByTestId("gate-plan")).not.toBeInTheDocument();
+    expect(testState.sessionRequests).toHaveLength(0);
+  });
+});

--- a/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.tsx
+++ b/packages/plugin-zuplo-monetization/src/pages/CheckoutPage.tsx
@@ -1,12 +1,15 @@
+import { Suspense, useState } from "react";
 import { useAuth, useZudoku } from "zudoku/hooks";
 import { ShieldIcon } from "zudoku/icons";
 import { useQuery } from "zudoku/react-query";
-import { Link, Navigate, useSearchParams } from "zudoku/router";
+import { Link, Navigate, useNavigate, useSearchParams } from "zudoku/router";
 import { Alert, AlertAction, AlertDescription } from "zudoku/ui/Alert";
 import { Button } from "zudoku/ui/Button";
 import { RedirectPage } from "../components/RedirectPage.js";
 import { useDeploymentName } from "../hooks/useDeploymentName";
+import { usePlans } from "../hooks/usePlans";
 import { useUrlUtils } from "../hooks/useUrlUtils";
+import { useMonetizationConfig } from "../MonetizationContext";
 
 const CheckoutRedirect = ({ planId }: { planId: string }) => {
   const zudoku = useZudoku();
@@ -58,6 +61,51 @@ const CheckoutRedirect = ({ planId }: { planId: string }) => {
   );
 };
 
+/**
+ * Neutral placeholder while the plan catalog resolves — deliberately says
+ * nothing about Stripe, since a questionnaire may come first. In practice the
+ * catalog is already warm: the plugin prefetches it on initialize.
+ */
+const CheckoutLoading = () => (
+  <div className="flex min-h-screen items-center justify-center bg-muted">
+    <div className="flex space-x-2">
+      <div className="h-3 w-3 animate-pulse rounded-full bg-primary [animation-delay:-0.3s]" />
+      <div className="h-3 w-3 animate-pulse rounded-full bg-primary [animation-delay:-0.15s]" />
+      <div className="h-3 w-3 animate-pulse rounded-full bg-primary" />
+    </div>
+  </div>
+);
+
+/**
+ * Renders `checkout.renderBeforeCheckout` — if configured — before handing off
+ * to Stripe. `CheckoutRedirect` only mounts once the gate is satisfied, so the
+ * Checkout Session is created after the questionnaire rather than while the
+ * user is still filling it in (a session minted on mount would sit there
+ * expiring).
+ */
+const CheckoutFlow = ({ planId }: { planId: string }) => {
+  const { checkout } = useMonetizationConfig();
+  const navigate = useNavigate();
+  const [answered, setAnswered] = useState(false);
+  const { data } = usePlans();
+
+  const plan = data.items.find((item) => item.id === planId);
+
+  // An unknown plan id (an archived plan, a hand-edited URL) leaves nothing to
+  // hand the questionnaire, so checkout proceeds and the metering API rejects
+  // the id exactly as it did before this gate existed.
+  const gate =
+    answered || !plan
+      ? null
+      : checkout?.renderBeforeCheckout?.({
+          plan,
+          onComplete: () => setAnswered(true),
+          onCancel: () => navigate("/pricing"),
+        });
+
+  return gate ?? <CheckoutRedirect planId={planId} />;
+};
+
 const CheckoutPage = () => {
   const [searchParams] = useSearchParams();
   const planId = searchParams.get("planId");
@@ -66,7 +114,11 @@ const CheckoutPage = () => {
     return <Navigate to="/pricing" replace />;
   }
 
-  return <CheckoutRedirect planId={planId} />;
+  return (
+    <Suspense fallback={<CheckoutLoading />}>
+      <CheckoutFlow planId={planId} />
+    </Suspense>
+  );
 };
 
 export default CheckoutPage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.8(react@19.2.8)
+      react-hook-form:
+        specifier: ^7.83.0
+        version: 7.83.0(react@19.2.8)
       zudoku:
         specifier: workspace:*
         version: link:../../../packages/zudoku


### PR DESCRIPTION
## Summary

Adds support for a configurable pre-checkout questionnaire in the monetization plugin. This allows developers to collect qualification data (company size, use case, etc.) before users are sent to Stripe, enabling better account setup and customer segmentation.

## Key Changes

- **New `BeforeCheckoutProps` type**: Exported from `MonetizationContext` to define the questionnaire interface with `plan`, `onComplete`, and `onCancel` callbacks
- **Extended `MonetizationConfig`**: Added optional `checkout.renderBeforeCheckout` configuration option that accepts a React component receiving plan details and completion handlers
- **Enhanced `CheckoutPage`**: 
  - Refactored to use `Suspense` with a `CheckoutLoading` placeholder while the plan catalog resolves
  - New `CheckoutFlow` component gates the Stripe redirect behind the questionnaire (if configured)
  - Questionnaire only renders for known plans; unknown plan IDs proceed directly to checkout
  - Stripe Checkout Session is created only after questionnaire completion, preventing session expiration while user fills the form
- **Example questionnaire**: Added `SubscribeQuestionnaire` component demonstrating a complete implementation with company size, use case, and optional details fields using `react-hook-form`
- **Comprehensive test suite**: Added `CheckoutPage.test.tsx` covering all questionnaire flows (skip when unconfigured, hold on submit failure, cancel without session creation, etc.)
- **Updated example config**: Wired up the questionnaire in the example project with conditional rendering (skipped for free plans)

## Implementation Details

- The questionnaire gates the checkout *route*, not the metering API—treat it as qualification, not a hard constraint
- Developers own persisting answers; the questionnaire simply calls `onComplete()` once their submit succeeds
- The route renders full-page (no site layout), so the returned component owns the entire viewport
- Plan catalog is prefetched on plugin initialization, so the loading state is typically brief

https://claude.ai/code/session_01Dq2K2ovvkS4ZaNqKbbDsbg