### PR TITLE
Add custom user metadata loading via getMetadata callback

### DIFF
--- a/docs/pages/docs/configuration/authentication-auth0.md
+++ b/docs/pages/docs/configuration/authentication-auth0.md
@@ -176,6 +176,60 @@ authentication: {
 }
 ```
 
+### Custom User Data
+
+There are two ways to attach data such as a subscription or entitlements to the signed-in user.
+
+**Load it from your own API.** Zudoku calls `getMetadata` after sign-in and puts the result on
+`profile.metadata`, so the lookup does not have to live in an Auth0 Action:
+
+```typescript title="zudoku.config.ts"
+{
+  authentication: {
+    type: "auth0",
+    domain: "your-domain.us.auth0.com",
+    clientId: "<your-client-id>",
+    getMetadata: async ({ signRequest, signal }) => {
+      const response = await fetch(
+        await signRequest(
+          new Request("https://api.example.com/me/subscription", { signal }),
+        ),
+      );
+
+      if (!response.ok) {
+        throw new Error(`Subscription lookup failed: ${response.status}`);
+      }
+
+      return await response.json();
+    },
+  },
+}
+```
+
+`signRequest` attaches the user's Auth0 access token to the request, so your API can identify the
+caller without a shared secret. This runs in the browser — never put a secret in the callback.
+
+**Or use a claim from a Post-Login Action.** If the data already comes from Auth0, set it on both
+tokens so it is available in the browser and during server-side rendering:
+
+```javascript title="Auth0 Post-Login Action"
+exports.onExecutePostLogin = async (event, api) => {
+  const subscription = { plan: "pro" };
+
+  api.idToken.setCustomClaim("https://example.com/subscription", subscription);
+  api.accessToken.setCustomClaim("https://example.com/subscription", subscription);
+};
+```
+
+The claim is then available on the profile:
+
+```typescript
+const { profile } = useAuth();
+profile["https://example.com/subscription"]; // → { plan: "pro" }
+```
+
+See [Custom User Data](./authentication.md#custom-user-data) for the full reference.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/pages/docs/configuration/authentication.md
+++ b/docs/pages/docs/configuration/authentication.md
@@ -232,9 +232,11 @@ by Zudoku and cannot be overwritten by a claim. The `metadata` key is reserved f
 data described below.
 
 In server-side rendered deployments, claims are also read from the access token, so the profile is
-the same on the server as it is in the browser. The server-side profile is stored in a cookie: if it
-exceeds the browser's size limit, custom claims are dropped from it (a warning is logged) and
-restored in the browser shortly after the page loads.
+the same on the server as it is in the browser. The server-side profile is stored in a cookie, which
+puts a hard limit (roughly 3.9 KB, URL-encoded) on how much claim data it can carry: if the profile
+exceeds it, custom claims are dropped from the session with a warning and will be missing from the
+profile after a full page load until something restores the access token. Keep custom claims small,
+and prefer the custom user data below for anything larger.
 
 ## Custom User Data
 

--- a/docs/pages/docs/configuration/authentication.md
+++ b/docs/pages/docs/configuration/authentication.md
@@ -214,6 +214,113 @@ fields are used to display the user profile:
 
 If the provider does not return a field, it will be left blank.
 
+### Custom Claims
+
+Custom claims from your identity provider are merged into the profile alongside the standard fields.
+Both the ID token and the User Info response are used as sources, so a claim added by an identity
+provider action (such as an Auth0 Post-Login Action) is available whichever of the two it lands on:
+
+```typescript
+const { profile } = useAuth();
+
+profile["https://example.com/subscription"]; // → { plan: "pro" }
+```
+
+Registered protocol claims (`exp`, `iat`, `iss`, `aud`, `nonce`, and friends) describe the token
+rather than the user, and are not added to the profile. The identity fields above are always derived
+by Zudoku and cannot be overwritten by a claim. The `metadata` key is reserved for the custom user
+data described below.
+
+In server-side rendered deployments, claims are also read from the access token, so the profile is
+the same on the server as it is in the browser. The server-side profile is stored in a cookie: if it
+exceeds the browser's size limit, custom claims are dropped from it (a warning is logged) and
+restored in the browser shortly after the page loads.
+
+## Custom User Data
+
+Beyond the claims the identity provider issues, Zudoku can load custom user data — a subscription,
+entitlements, an internal account record — from your own API after sign-in. Use `getMetadata` to
+avoid maintaining that lookup as an identity provider action:
+
+```typescript title="zudoku.config.ts"
+{
+  authentication: {
+    type: "auth0",
+    domain: "example.auth0.com",
+    clientId: "<your-client-id>",
+    getMetadata: async ({ signRequest, signal }) => {
+      const response = await fetch(
+        await signRequest(
+          new Request("https://api.example.com/me/subscription", { signal }),
+        ),
+      );
+
+      if (!response.ok) {
+        throw new Error(`Subscription lookup failed: ${response.status}`);
+      }
+
+      return await response.json();
+    },
+  },
+}
+```
+
+The returned value is available as `profile.metadata`:
+
+```tsx
+const { profile, isMetadataPending, refreshMetadata } = useAuth();
+
+if (isMetadataPending) return <Spinner />;
+
+return <span>Plan: {profile?.metadata?.plan}</span>;
+```
+
+:::caution
+
+`getMetadata` runs **in the browser**, not on the server. Never close over an API key or any other
+secret — it would be included in the client bundle. Authorize the request with the supplied
+`signRequest`, which attaches the signed-in user's credentials and works across every authentication
+provider.
+
+:::
+
+### Arguments
+
+| Argument      | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `profile`     | The user profile derived from the identity provider's claims     |
+| `context`     | The [Zudoku context](../custom-pages.md)                         |
+| `signRequest` | Adds the current user's credentials to a `Request`               |
+| `signal`      | Aborts on unmount, on user change, and after a 10 second timeout |
+
+### Behavior
+
+- The returned value **replaces** `profile.metadata` in full; it is not merged with the previous
+  value.
+- It is loaded once per signed-in user and cached for five minutes. Call `refreshMetadata()` to
+  reload it, for example after a plan change.
+- Failures never sign the user out. The error is logged, `profile.metadata` is left `undefined`, and
+  one retry is attempted before giving up.
+- It is not loaded during server-side rendering, so `profile.metadata` is `undefined` on the first
+  paint. Use `isMetadataPending` to render a loading state.
+
+### Typing the metadata
+
+`profile.metadata` is loosely typed by default. Augment `UserMetadata` to describe your own shape:
+
+```typescript title="zudoku.d.ts"
+declare module "zudoku/auth" {
+  interface UserMetadata {
+    plan: "free" | "pro";
+    seatsUsed: number;
+  }
+}
+```
+
+Both the value returned by `getMetadata` and every read of `profile.metadata` are then checked
+against that declaration. The value must be JSON-serializable — it is persisted to local storage in
+static builds.
+
 ## Protected Routes
 
 Once authentication is configured, you can protect specific routes in your documentation to require

--- a/docs/pages/docs/configuration/protected-routes.md
+++ b/docs/pages/docs/configuration/protected-routes.md
@@ -124,6 +124,33 @@ but lack permission. This is useful for building role-based or attribute-based a
 }
 ```
 
+## Gating on Custom User Data
+
+Checks can read [custom user data](./authentication.md#custom-user-data) loaded by `getMetadata`,
+for example to gate pages on a subscription tier:
+
+```typescript title="zudoku.config.ts"
+{
+  protectedRoutes: {
+    "/enterprise/*": ({ auth, reasonCode }) => {
+      if (!auth.isAuthenticated) return reasonCode.UNAUTHORIZED;
+
+      return auth.profile?.metadata?.plan === "enterprise"
+        ? true
+        : reasonCode.FORBIDDEN;
+    },
+  },
+}
+```
+
+While the metadata is still loading, the route is treated as undecided rather than denied — nothing
+is rendered until the check can be evaluated against a resolved value. If loading fails, the check
+runs with `metadata` left `undefined` and the route therefore fails closed.
+
+Because the metadata is only loaded in the browser, a check that depends on it cannot be evaluated
+during server-side rendering. Route protection at the bundle level (see below) is unaffected: it is
+based on whether the user is authenticated, not on the result of the check.
+
 ## Navigation Blocking
 
 When a user navigates to a route that returns `false` or `UNAUTHORIZED`, navigation is intercepted

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -24,6 +24,16 @@ const EMPLOYEE_MCP_PATH = "/employee-mcp";
 // plain endpoints kept alongside them would never be shown.
 const GATEWAY_DIRECTORY_PATH = "/catalog/api-gateway-directory";
 
+// Custom user data loaded after sign-in and exposed as `profile.metadata`.
+// Augmenting `UserMetadata` types both what `getMetadata` returns and every
+// read of `profile.metadata`.
+declare module "zudoku/auth" {
+  interface UserMetadata {
+    clearance: "standard" | "warp";
+    fleetCredits: number;
+  }
+}
+
 // Clerk publishable keys are shipped to the browser by design, so both are safe
 // to commit. The production instance is served from clerk.cosmocargo.dev and is
 // scoped to that domain, so it only authenticates on the production deployment;
@@ -245,6 +255,15 @@ const config: ZudokuConfig = {
       auth.isAuthenticated ? true : reasonCode.UNAUTHORIZED,
     "/only-members": ({ auth, reasonCode }) =>
       auth.isAuthenticated ? true : reasonCode.UNAUTHORIZED,
+    // Gated on custom user data rather than on the identity itself. While the
+    // clearance is still loading the route is undecided, not denied.
+    "/premium-fleet-services": ({ auth, reasonCode }) => {
+      if (!auth.isAuthenticated) return reasonCode.UNAUTHORIZED;
+
+      return auth.profile?.metadata?.clearance === "warp"
+        ? true
+        : reasonCode.FORBIDDEN;
+    },
     "/vip-lounge": ({ auth, reasonCode }) =>
       !auth.isAuthenticated
         ? reasonCode.UNAUTHORIZED
@@ -471,6 +490,17 @@ const config: ZudokuConfig = {
     clerkPubKey: CLERK_PUB_KEY,
     redirectToAfterSignIn: "/documentation",
     redirectToAfterSignUp: "/documentation",
+    // A real portal would fetch this from its own API, authorizing the request
+    // with the supplied `signRequest`:
+    //
+    //   const res = await fetch(await signRequest(
+    //     new Request("https://api.cosmo-cargo.space/me/clearance", { signal }),
+    //   ));
+    //   return await res.json();
+    //
+    // This runs in the browser, so it must never close over a secret. The demo
+    // returns a fixed manifest so it works without a backing service.
+    getMetadata: () => ({ clearance: "warp", fleetCredits: 4200 }),
   },
   defaults: {
     apis: {

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -42,6 +42,7 @@
     "./client": {
       "types": "./client.d.ts"
     },
+    "./auth": "./src/lib/authentication/index.ts",
     "./auth/clerk": "./src/lib/authentication/providers/clerk.tsx",
     "./auth/auth0": "./src/lib/authentication/providers/auth0.tsx",
     "./auth/openid": "./src/lib/authentication/providers/openid.tsx",

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -61,6 +61,10 @@ export const convertZudokuConfigToOptions = (
       logo: config.site?.logo,
     },
     slots: config.slots,
+    // Read from the raw config (functions survive `virtual:zudoku-config`;
+    // `plugin-auth`'s JSON.stringify would drop it) and executed by core, so
+    // it works for every provider.
+    getUserMetadata: config.authentication?.getMetadata,
     metadata: {
       favicon: "https://cdn.zudoku.dev/logos/favicon.svg",
       title: "%s - Zudoku",

--- a/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.test.ts
@@ -15,6 +15,60 @@ describe("validateConfig", () => {
     process.env.NODE_ENV = originalNodeEnv;
   });
 
+  describe("authentication.getMetadata", () => {
+    // One minimal config per provider, so the shared-field spread can't
+    // silently miss a member of the discriminated union.
+    const providers = [
+      { type: "auth0" as const, clientId: "c", domain: "example.auth0.com" },
+      { type: "clerk" as const, clerkPubKey: "pk_test_abc" },
+      {
+        type: "openid" as const,
+        clientId: "c",
+        issuer: "https://issuer.example.com",
+      },
+      { type: "entra" as const, clientId: "c" },
+      {
+        type: "azureb2c" as const,
+        clientId: "c",
+        tenantName: "t",
+        policyName: "p",
+        issuer: "https://issuer.example.com",
+      },
+      { type: "supabase" as const, supabaseUrl: "u", supabaseKey: "k" },
+      {
+        type: "firebase" as const,
+        apiKey: "k",
+        authDomain: "d",
+        projectId: "p",
+        appId: "a",
+      },
+    ];
+
+    it.each(providers)("survives validation for $type", (provider) => {
+      const getMetadata = vi.fn();
+
+      const result = validateConfig({
+        authentication: { ...provider, getMetadata },
+      });
+
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+      expect(result.authentication?.getMetadata).toBe(getMetadata);
+    });
+
+    it("rejects a non-function getMetadata", () => {
+      validateConfig({
+        authentication: {
+          type: "auth0" as const,
+          clientId: "c",
+          domain: "example.auth0.com",
+          getMetadata: "https://api.example.com/me",
+        },
+      });
+
+      expect(mockConsoleLog).toHaveBeenCalled();
+    });
+  });
+
   it("should validate auth0 domain format correctly", () => {
     const configWithValidAuth0 = {
       authentication: {

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -5,6 +5,7 @@ import { isValidElement } from "react";
 import type { BundledLanguage, BundledTheme } from "shiki";
 import { z } from "zod";
 import type { UseAuthReturn } from "../../lib/authentication/hook.js";
+import type { GetUserMetadata } from "../../lib/authentication/metadata.js";
 import type { AuthState } from "../../lib/authentication/state.js";
 import type { SlotType } from "../../lib/components/context/SlotProvider.js";
 import type { ZudokuPlugin } from "../../lib/core/plugins.js";
@@ -424,9 +425,30 @@ const SignUpOpenIdSchema = z.union([
     .strict(),
 ]);
 
+/**
+ * Fields every authentication provider accepts. Spread into each member of the
+ * discriminated union below (`signUp` stays per-provider: its shape differs).
+ */
+const SharedAuthenticationFields = {
+  redirectToAfterSignUp: z.string().optional(),
+  redirectToAfterSignIn: z.string().optional(),
+  redirectToAfterSignOut: z.string().optional(),
+  disableSignUp: z.boolean().optional(),
+  /**
+   * Loads custom user data after sign-in into `profile.metadata`.
+   *
+   * Runs in the browser, so it must not close over secrets. Authorize the
+   * request with the supplied `signRequest` instead.
+   */
+  getMetadata: z
+    .custom<GetUserMetadata>((val) => typeof val === "function")
+    .optional(),
+};
+
 const AuthenticationSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("clerk"),
+    ...SharedAuthenticationFields,
     clerkPubKey: z
       .custom<`pk_test_${string}` | `pk_live_${string}`>()
       .refine((val) => /^pk_(test|live)_\w+$/.test(val), {
@@ -435,14 +457,11 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     // No default: an absent template must stay absent so Clerk issues its
     // standard session token instead of requesting a non-existent template.
     jwtTemplateName: z.string().optional(),
-    redirectToAfterSignUp: z.string().optional(),
-    redirectToAfterSignIn: z.string().optional(),
-    redirectToAfterSignOut: z.string().optional(),
     signUp: SignUpUrlSchema.optional(),
-    disableSignUp: z.boolean().optional(),
   }),
   z.object({
     type: z.literal("firebase"),
+    ...SharedAuthenticationFields,
     apiKey: z.string(),
     authDomain: z.string(),
     projectId: z.string(),
@@ -465,30 +484,24 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
         ]),
       )
       .optional(),
-    disableSignUp: z.boolean().optional(),
-    redirectToAfterSignUp: z.string().optional(),
-    redirectToAfterSignIn: z.string().optional(),
-    redirectToAfterSignOut: z.string().optional(),
     signUp: SignUpUrlSchema.optional(),
   }),
   z.object({
     type: z.literal("openid"),
+    ...SharedAuthenticationFields,
     basePath: z.string().optional(),
     clientId: z.string(),
     issuer: z.string(),
     audience: z.string().optional(),
     scopes: z.array(z.string()).optional(),
     allowInsecureRequests: z.boolean().optional(),
-    redirectToAfterSignUp: z.string().optional(),
-    redirectToAfterSignIn: z.string().optional(),
-    redirectToAfterSignOut: z.string().optional(),
     signUp: SignUpOpenIdSchema.optional(),
-    disableSignUp: z.boolean().optional(),
     authorizationParams: z.record(z.string(), z.string()).optional(),
     forwardAuthorizationParams: z.array(z.string()).optional(),
   }),
   z.object({
     type: z.literal("entra"),
+    ...SharedAuthenticationFields,
     basePath: z.string().optional(),
     clientId: z.string(),
     // Tenant id or one of Entra's multi-tenant authorities
@@ -498,31 +511,25 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     issuer: z.string().optional(),
     audience: z.string().optional(),
     scopes: z.array(z.string()).optional(),
-    redirectToAfterSignUp: z.string().optional(),
-    redirectToAfterSignIn: z.string().optional(),
-    redirectToAfterSignOut: z.string().optional(),
     signUp: SignUpOpenIdSchema.optional(),
-    disableSignUp: z.boolean().optional(),
     authorizationParams: z.record(z.string(), z.string()).optional(),
     forwardAuthorizationParams: z.array(z.string()).optional(),
   }),
   z.object({
     type: z.literal("azureb2c"),
+    ...SharedAuthenticationFields,
     basePath: z.string().optional(),
     clientId: z.string(),
     tenantName: z.string(),
     policyName: z.string(),
     scopes: z.array(z.string()).optional(),
     issuer: z.string(),
-    redirectToAfterSignUp: z.string().optional(),
-    redirectToAfterSignIn: z.string().optional(),
-    redirectToAfterSignOut: z.string().optional(),
     signUp: SignUpUrlSchema.optional(),
-    disableSignUp: z.boolean().optional(),
   }),
 
   z.object({
     type: z.literal("auth0"),
+    ...SharedAuthenticationFields,
     clientId: z.string(),
     domain: z.string().refine(
       (val) => {
@@ -541,9 +548,6 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
     ),
     audience: z.string().optional(),
     scopes: z.array(z.string()).optional(),
-    redirectToAfterSignUp: z.string().optional(),
-    redirectToAfterSignIn: z.string().optional(),
-    redirectToAfterSignOut: z.string().optional(),
     authorizationParams: z.record(z.string(), z.string()).optional(),
     forwardAuthorizationParams: z.array(z.string()).optional(),
     options: z
@@ -553,20 +557,16 @@ const AuthenticationSchema = z.discriminatedUnion("type", [
       })
       .optional(),
     signUp: SignUpOpenIdSchema.optional(),
-    disableSignUp: z.boolean().optional(),
   }),
   z.object({
     type: z.literal("supabase"),
+    ...SharedAuthenticationFields,
     basePath: z.string().optional(),
     supabaseUrl: z.string(),
     supabaseKey: z.string(),
     provider: z.string().optional(),
     providers: z.array(z.string()).optional(),
     onlyThirdPartyProviders: z.boolean().optional(),
-    disableSignUp: z.boolean().optional(),
-    redirectToAfterSignUp: z.string().optional(),
-    redirectToAfterSignIn: z.string().optional(),
-    redirectToAfterSignOut: z.string().optional(),
     signUp: SignUpUrlSchema.optional(),
   }),
 ]);

--- a/packages/zudoku/src/lib/authentication/claims.test.ts
+++ b/packages/zudoku/src/lib/authentication/claims.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi } from "vitest";
+import { buildProfileFromClaims } from "./claims.js";
+
+const CORE = {
+  sub: "user-1",
+  email: "user@example.com",
+  name: "User",
+  emailVerified: true,
+  pictureUrl: "https://example.com/p.png",
+};
+
+describe("buildProfileFromClaims", () => {
+  test("merges custom claims from all sources", () => {
+    const profile = buildProfileFromClaims(
+      [{ plan: "pro" }, { seats: 5 }],
+      CORE,
+    );
+
+    expect(profile).toMatchObject({ plan: "pro", seats: 5, sub: "user-1" });
+  });
+
+  test("later sources win over earlier ones", () => {
+    const profile = buildProfileFromClaims(
+      [{ plan: "free" }, { plan: "pro" }],
+      CORE,
+    );
+
+    expect(profile.plan).toBe("pro");
+  });
+
+  test("core identity fields cannot be overwritten by claims", () => {
+    const profile = buildProfileFromClaims(
+      [
+        {
+          sub: "attacker",
+          email: "attacker@example.com",
+          emailVerified: false,
+          name: "Attacker",
+          pictureUrl: "https://evil.example.com/p.png",
+        },
+      ],
+      CORE,
+    );
+
+    expect(profile).toMatchObject(CORE);
+  });
+
+  test("drops the reserved `metadata` claim", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const profile = buildProfileFromClaims(
+      [{ metadata: { plan: "spoofed" }, plan: "pro" }],
+      CORE,
+    );
+
+    expect(profile.metadata).toBeUndefined();
+    expect(profile.plan).toBe("pro");
+    warn.mockRestore();
+  });
+
+  test("drops protocol claims that describe the token, not the user", () => {
+    const profile = buildProfileFromClaims(
+      [
+        {
+          exp: 1_700_000_000,
+          iat: 1_699_999_000,
+          iss: "https://issuer.example.com",
+          aud: "client-id",
+          nonce: "n",
+          plan: "pro",
+        },
+      ],
+      CORE,
+    );
+
+    expect(profile).toEqual({ ...CORE, plan: "pro" });
+  });
+
+  test("ignores undefined sources", () => {
+    expect(buildProfileFromClaims([undefined, undefined], CORE)).toEqual(CORE);
+  });
+});

--- a/packages/zudoku/src/lib/authentication/claims.ts
+++ b/packages/zudoku/src/lib/authentication/claims.ts
@@ -1,0 +1,73 @@
+import type { CustomClaimRecord, UserProfile } from "./state.js";
+
+/**
+ * Keys the IdP claim merge must never write.
+ *
+ * `metadata` belongs to `authentication.getMetadata`. Letting a claim land
+ * there would make a signed value and a fetched value indistinguishable at
+ * every call site, which is the whole reason the two live in separate places.
+ */
+const RESERVED_CLAIMS = new Set(["metadata"]);
+
+/**
+ * Registered/protocol claims describe the token, not the user. They carry no
+ * profile value and would otherwise bloat the SSR profile cookie, which is
+ * size-capped.
+ */
+const PROTOCOL_CLAIMS = new Set([
+  "acr",
+  "amr",
+  "at_hash",
+  "aud",
+  "auth_time",
+  "azp",
+  "c_hash",
+  "client_id",
+  "exp",
+  "iat",
+  "iss",
+  "jti",
+  "nbf",
+  "nonce",
+  "scope",
+  "sid",
+]);
+
+type CoreProfile = Pick<
+  UserProfile,
+  "sub" | "email" | "emailVerified" | "name" | "pictureUrl"
+>;
+
+/**
+ * Merge claim sources into a profile. Later sources win over earlier ones, and
+ * the core identity fields are always applied last so no claim can overwrite
+ * the identity that authorization decisions are made against.
+ */
+export const buildProfileFromClaims = (
+  sources: Array<CustomClaimRecord | undefined>,
+  core: CoreProfile,
+): UserProfile => {
+  const claims = sources.reduce<CustomClaimRecord>(
+    (acc, source) => ({ ...acc, ...source }),
+    {},
+  );
+
+  const dropped = Object.keys(claims).filter((key) => RESERVED_CLAIMS.has(key));
+
+  if (dropped.length > 0 && process.env.NODE_ENV === "development") {
+    // biome-ignore lint/suspicious/noConsole: Intentional developer warning
+    console.warn(
+      `[Zudoku] Ignoring reserved claim(s) ${dropped.join(", ")} from the identity provider. ` +
+        `\`profile.metadata\` is populated by \`authentication.getMetadata\` only.`,
+    );
+  }
+
+  return {
+    ...Object.fromEntries(
+      Object.entries(claims).filter(
+        ([key]) => !RESERVED_CLAIMS.has(key) && !PROTOCOL_CLAIMS.has(key),
+      ),
+    ),
+    ...core,
+  };
+};

--- a/packages/zudoku/src/lib/authentication/components/SignUp.test.tsx
+++ b/packages/zudoku/src/lib/authentication/components/SignUp.test.tsx
@@ -24,6 +24,8 @@ const buildAuth = (overrides: Partial<UseAuthReturn> = {}): UseAuthReturn => ({
   isAuthenticated: false,
   isPending: false,
   isAuthEnabled: true,
+  isMetadataPending: false,
+  refreshMetadata: vi.fn(),
   disableSignUp: false,
   profile: null,
   providerData: null,

--- a/packages/zudoku/src/lib/authentication/hook.ts
+++ b/packages/zudoku/src/lib/authentication/hook.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { use } from "react";
+import { use, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { RenderContext } from "../components/context/RenderContext.js";
 import { useZudoku } from "../components/context/ZudokuContext.js";
 import type { AuthActionOptions } from "./authentication.js";
+import { withMetadataTimeout } from "./metadata.js";
 import { useAuthState } from "./state.js";
 
 export type UseAuthReturn = ReturnType<typeof useAuth>;
@@ -28,6 +29,71 @@ export const useRefreshUserProfile = ({
       isAuthEnabled && typeof authentication?.refreshUserProfile === "function",
     queryFn: () => authentication?.refreshUserProfile?.(),
   });
+};
+
+/**
+ * Loads `authentication.getMetadata` into `profile.metadata`.
+ *
+ * Keyed on `sub` so login, logout and user switches are handled without
+ * subscribing to auth events — a subscriber that wrote back into the store
+ * would re-trigger itself.
+ */
+export const useUserMetadata = () => {
+  const context = useZudoku();
+  const { getUserMetadata } = context;
+  const { isAuthenticated, profile } = useAuthState();
+  const sub = profile?.sub;
+  const isEnabled = Boolean(getUserMetadata) && isAuthenticated && Boolean(sub);
+
+  const query = useQuery({
+    queryKey: ["user-metadata", sub],
+    enabled: isEnabled,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    // One retry covers a transient blip; more would leave metadata-gated
+    // routes undecided for several seconds.
+    retry: 1,
+    queryFn: async ({ signal }) => {
+      const currentProfile = useAuthState.getState().profile;
+      if (!getUserMetadata || !currentProfile) return null;
+
+      const metadata = await getUserMetadata({
+        profile: currentProfile,
+        context,
+        signRequest: (request) => context.signRequest(request),
+        signal: withMetadataTimeout(signal),
+      });
+
+      useAuthState.setState((state) =>
+        state.profile ? { profile: { ...state.profile, metadata } } : {},
+      );
+
+      return metadata ?? null;
+    },
+  });
+
+  const { isError, error } = query;
+
+  // Fail closed once the retries are exhausted: drop any previous value so a
+  // stale entitlement can't outlive a failing lookup.
+  useEffect(() => {
+    if (!isError) return;
+
+    // biome-ignore lint/suspicious/noConsole: Surface metadata failures
+    console.error("[Zudoku] Failed to load user metadata:", error);
+
+    useAuthState.setState((state) =>
+      state.profile
+        ? { profile: { ...state.profile, metadata: undefined } }
+        : {},
+    );
+  }, [isError, error]);
+
+  return {
+    ...query,
+    // `isPending` is also true while the query is disabled, so gate on it.
+    isMetadataPending: isEnabled && query.status === "pending",
+  };
 };
 
 export const useVerifiedEmail = () => {
@@ -69,17 +135,22 @@ export const useVerifiedEmail = () => {
 };
 
 export const useAuth = () => {
-  const { authentication } = useZudoku();
+  const context = useZudoku();
+  const { authentication } = context;
   const authState = useAuthState();
   const isAuthEnabled = typeof authentication !== "undefined";
   const navigate = useNavigate();
 
   useRefreshUserProfile();
+  const metadata = useUserMetadata();
 
   // On the server, the zustand store can't read window.ZUDOKU_SSR_AUTH, so
   // override from RenderContext which carries the per-request auth state.
   const { ssrAuth } = use(RenderContext);
   const isSSR = typeof window === "undefined";
+
+  const isAuthenticated =
+    isSSR && ssrAuth ? !!ssrAuth.profile : authState.isAuthenticated;
 
   return {
     isAuthEnabled,
@@ -87,10 +158,23 @@ export const useAuth = () => {
     ...authState,
     ...(isSSR &&
       ssrAuth && {
-        isAuthenticated: !!ssrAuth.profile,
+        isAuthenticated,
         isPending: false,
         profile: ssrAuth.profile,
       }),
+
+    /**
+     * True while `authentication.getMetadata` has not resolved for the current
+     * user. Always true during SSR, where metadata is never loaded — route
+     * guards must treat it as "undecided" rather than denying access.
+     */
+    isMetadataPending:
+      Boolean(context.getUserMetadata) &&
+      isAuthenticated &&
+      (isSSR || metadata.isMetadataPending),
+
+    /** Reloads `profile.metadata`, e.g. after a plan change. */
+    refreshMetadata: () => void metadata.refetch(),
 
     login: async (options?: AuthActionOptions) => {
       if (!isAuthEnabled) {

--- a/packages/zudoku/src/lib/authentication/hook.ts
+++ b/packages/zudoku/src/lib/authentication/hook.ts
@@ -64,30 +64,41 @@ export const useUserMetadata = () => {
         signal: withMetadataTimeout(signal),
       });
 
-      useAuthState.setState((state) =>
-        state.profile ? { profile: { ...state.profile, metadata } } : {},
-      );
-
       return metadata ?? null;
     },
   });
 
-  const { isError, error } = query;
+  const { isError, isSuccess, error } = query;
+  const data = query.data ?? undefined;
 
-  // Fail closed once the retries are exhausted: drop any previous value so a
-  // stale entitlement can't outlive a failing lookup.
   useEffect(() => {
     if (!isError) return;
 
     // biome-ignore lint/suspicious/noConsole: Surface metadata failures
     console.error("[Zudoku] Failed to load user metadata:", error);
+  }, [isError, error]);
+
+  // Applied here rather than inside `queryFn` so the store converges on the
+  // query's result no matter how it got there: a cache hit skips `queryFn`
+  // entirely, and `refreshUserProfile` replaces the whole profile object,
+  // dropping the metadata that was written alongside it. Watching `profile` is
+  // what catches that replacement.
+  //
+  // A failed lookup converges on `undefined` so a stale entitlement can't
+  // outlive it, and the `sub` guard keeps a result from landing on a different
+  // user's profile.
+  useEffect(() => {
+    if (!isSuccess && !isError) return;
+
+    const next = isSuccess ? data : undefined;
+    if (!profile || profile.sub !== sub || profile.metadata === next) return;
 
     useAuthState.setState((state) =>
-      state.profile
-        ? { profile: { ...state.profile, metadata: undefined } }
+      state.profile?.sub === sub
+        ? { profile: { ...state.profile, metadata: next } }
         : {},
     );
-  }, [isError, error]);
+  }, [isSuccess, isError, data, sub, profile]);
 
   return {
     ...query,

--- a/packages/zudoku/src/lib/authentication/index.ts
+++ b/packages/zudoku/src/lib/authentication/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Public entry point for authentication types (`zudoku/auth`).
+ *
+ * `UserMetadata` is declared here — rather than re-exported from elsewhere —
+ * so consumers can augment it:
+ *
+ * ```ts
+ * declare module "zudoku/auth" {
+ *   interface UserMetadata {
+ *     subscription: { plan: "free" | "pro"; seatsUsed: number };
+ *   }
+ * }
+ * ```
+ */
+import type { CustomClaim } from "./state.js";
+
+/**
+ * Shape of `profile.metadata`, populated by `authentication.getMetadata`.
+ *
+ * The index signature keeps it usable without augmentation. Augmented members
+ * must be JSON-serializable: the value is persisted to localStorage in SSG
+ * mode and would not survive rehydration otherwise.
+ */
+export interface UserMetadata {
+  [key: string]: CustomClaim;
+}
+
+export type {
+  AuthActionContext,
+  AuthActionOptions,
+  AuthenticationPlugin,
+  AuthenticationProviderInitializer,
+  VerifyAccessTokenResult,
+} from "./authentication.js";
+export type {
+  CustomClaim,
+  CustomClaimArray,
+  CustomClaimRecord,
+  UserProfile,
+} from "./state.js";

--- a/packages/zudoku/src/lib/authentication/index.ts
+++ b/packages/zudoku/src/lib/authentication/index.ts
@@ -32,6 +32,7 @@ export type {
   AuthenticationProviderInitializer,
   VerifyAccessTokenResult,
 } from "./authentication.js";
+export type { GetUserMetadata, GetUserMetadataContext } from "./metadata.js";
 export type {
   CustomClaim,
   CustomClaimArray,

--- a/packages/zudoku/src/lib/authentication/metadata.test.tsx
+++ b/packages/zudoku/src/lib/authentication/metadata.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ZudokuProvider } from "../components/context/ZudokuProvider.js";
 import { ZudokuContext } from "../core/ZudokuContext.js";
 import { useUserMetadata } from "./hook.js";
-import type { GetUserMetadata } from "./metadata.js";
+import { type GetUserMetadata, withMetadataTimeout } from "./metadata.js";
 import { useAuthState } from "./state.js";
 
 const PROFILE = {
@@ -20,11 +20,16 @@ const PROFILE = {
   pictureUrl: undefined,
 };
 
-const renderMetadata = (getUserMetadata?: GetUserMetadata) => {
-  const queryClient = new QueryClient({
+const createQueryClient = () =>
+  new QueryClient({
     // The hook sets `retry: 1`; drop the backoff so the retry is immediate.
     defaultOptions: { queries: { retryDelay: 0 } },
   });
+
+const renderMetadata = (
+  getUserMetadata?: GetUserMetadata,
+  queryClient = createQueryClient(),
+) => {
   const context = new ZudokuContext(
     { plugins: [], getUserMetadata },
     queryClient,
@@ -130,6 +135,78 @@ describe("useUserMetadata", () => {
     });
   });
 
+  it("re-applies metadata after the profile is replaced by a refresh", async () => {
+    signIn();
+    const getMetadata = vi.fn().mockResolvedValue({ plan: "pro" });
+
+    renderMetadata(getMetadata);
+
+    await waitFor(() => {
+      expect(useAuthState.getState().profile?.metadata).toEqual({
+        plan: "pro",
+      });
+    });
+
+    // `refreshUserProfile` replaces the whole profile object with a freshly
+    // built one, which has no metadata on it.
+    useAuthState.setState({ profile: { ...PROFILE } });
+
+    await waitFor(() => {
+      expect(useAuthState.getState().profile?.metadata).toEqual({
+        plan: "pro",
+      });
+    });
+    expect(getMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies cached metadata without re-running the lookup", async () => {
+    const queryClient = createQueryClient();
+    const getMetadata = vi.fn().mockResolvedValue({ plan: "pro" });
+
+    signIn();
+    const first = renderMetadata(getMetadata, queryClient);
+    await waitFor(() =>
+      expect(useAuthState.getState().profile?.metadata).toBeDefined(),
+    );
+    first.unmount();
+
+    // Sign out and back in as the same user: the query cache is still fresh,
+    // so `queryFn` is skipped entirely on the next mount.
+    useAuthState.getState().setLoggedOut();
+    signIn();
+    renderMetadata(getMetadata, queryClient);
+
+    await waitFor(() => {
+      expect(useAuthState.getState().profile?.metadata).toEqual({
+        plan: "pro",
+      });
+    });
+    expect(getMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply a result to a different user's profile", async () => {
+    signIn("user-1");
+    let resolve: ((value: { plan: string }) => void) | undefined;
+    const getMetadata = vi.fn(
+      () =>
+        new Promise<{ plan: string }>((r) => {
+          resolve = r;
+        }),
+    );
+
+    renderMetadata(getMetadata);
+
+    await waitFor(() => expect(getMetadata).toHaveBeenCalled());
+
+    // The first user's lookup lands after someone else has signed in.
+    signIn("user-2");
+    resolve?.({ plan: "pro" });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(useAuthState.getState().profile?.sub).toBe("user-2");
+    expect(useAuthState.getState().profile?.metadata).toBeUndefined();
+  });
+
   it("logs and clears metadata when the lookup fails", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     useAuthState.setState({
@@ -172,5 +249,53 @@ describe("useUserMetadata", () => {
     resolve?.({ plan: "pro" });
 
     await waitFor(() => expect(result.current.isMetadataPending).toBe(false));
+  });
+});
+
+describe("withMetadataTimeout", () => {
+  const originalAny = AbortSignal.any;
+
+  afterEach(() => {
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      writable: true,
+      value: originalAny,
+    });
+  });
+
+  it("aborts when the caller's signal aborts", () => {
+    const controller = new AbortController();
+    const signal = withMetadataTimeout(controller.signal);
+
+    controller.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("keeps the timeout when AbortSignal.any is unavailable", async () => {
+    // `AbortSignal.timeout` shipped before `AbortSignal.any`; browsers in
+    // between must still get the timeout rather than only the caller's signal.
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const controller = new AbortController();
+    const signal = withMetadataTimeout(controller.signal, 5);
+
+    expect(signal.aborted).toBe(false);
+
+    await waitFor(() => expect(signal.aborted).toBe(true));
+  });
+
+  it("propagates an already-aborted caller signal", () => {
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    expect(withMetadataTimeout(AbortSignal.abort()).aborted).toBe(true);
   });
 });

--- a/packages/zudoku/src/lib/authentication/metadata.test.tsx
+++ b/packages/zudoku/src/lib/authentication/metadata.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ZudokuProvider } from "../components/context/ZudokuProvider.js";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { useUserMetadata } from "./hook.js";
+import type { GetUserMetadata } from "./metadata.js";
+import { useAuthState } from "./state.js";
+
+const PROFILE = {
+  sub: "user-1",
+  email: "user@example.com",
+  emailVerified: true,
+  name: "Test",
+  pictureUrl: undefined,
+};
+
+const renderMetadata = (getUserMetadata?: GetUserMetadata) => {
+  const queryClient = new QueryClient({
+    // The hook sets `retry: 1`; drop the backoff so the retry is immediate.
+    defaultOptions: { queries: { retryDelay: 0 } },
+  });
+  const context = new ZudokuContext(
+    { plugins: [], getUserMetadata },
+    queryClient,
+    {},
+  );
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>
+      <ZudokuProvider context={context}>{children}</ZudokuProvider>
+    </QueryClientProvider>
+  );
+
+  return renderHook(() => useUserMetadata(), { wrapper });
+};
+
+const signIn = (sub = "user-1") => {
+  useAuthState.setState({
+    isAuthenticated: true,
+    isPending: false,
+    profile: { ...PROFILE, sub },
+    providerData: null,
+  });
+};
+
+describe("useUserMetadata", () => {
+  beforeEach(() => {
+    useAuthState.getState().setLoggedOut();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("writes the resolved metadata onto the profile", async () => {
+    signIn();
+    const getMetadata = vi.fn().mockResolvedValue({ plan: "pro" });
+
+    renderMetadata(getMetadata);
+
+    await waitFor(() => {
+      expect(useAuthState.getState().profile?.metadata).toEqual({
+        plan: "pro",
+      });
+    });
+  });
+
+  it("passes the profile and a signRequest that the provider signs", async () => {
+    signIn();
+    const getMetadata = vi.fn().mockResolvedValue({ plan: "pro" });
+
+    renderMetadata(getMetadata);
+
+    await waitFor(() => expect(getMetadata).toHaveBeenCalled());
+
+    const args = getMetadata.mock.calls[0]?.[0];
+    expect(args.profile.sub).toBe("user-1");
+    expect(typeof args.signRequest).toBe("function");
+    expect(args.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("does not run when no getMetadata is configured", async () => {
+    signIn();
+
+    const { result } = renderMetadata(undefined);
+
+    expect(result.current.isMetadataPending).toBe(false);
+    expect(useAuthState.getState().profile?.metadata).toBeUndefined();
+  });
+
+  it("does not run while signed out", async () => {
+    const getMetadata = vi.fn().mockResolvedValue({ plan: "pro" });
+
+    const { result } = renderMetadata(getMetadata);
+
+    expect(getMetadata).not.toHaveBeenCalled();
+    expect(result.current.isMetadataPending).toBe(false);
+  });
+
+  it("reloads for a different user", async () => {
+    signIn("user-1");
+    const getMetadata = vi
+      .fn()
+      .mockImplementation(({ profile }) =>
+        Promise.resolve({ plan: profile.sub === "user-1" ? "free" : "pro" }),
+      );
+
+    const { rerender } = renderMetadata(getMetadata);
+
+    await waitFor(() => {
+      expect(useAuthState.getState().profile?.metadata).toEqual({
+        plan: "free",
+      });
+    });
+
+    signIn("user-2");
+    rerender();
+
+    await waitFor(() => {
+      expect(useAuthState.getState().profile?.metadata).toEqual({
+        plan: "pro",
+      });
+    });
+  });
+
+  it("logs and clears metadata when the lookup fails", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    useAuthState.setState({
+      isAuthenticated: true,
+      isPending: false,
+      profile: { ...PROFILE, metadata: { plan: "pro" } },
+      providerData: null,
+    });
+
+    const getMetadata = vi.fn().mockRejectedValue(new Error("gateway down"));
+
+    const { result } = renderMetadata(getMetadata);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(useAuthState.getState().profile?.metadata).toBeUndefined();
+    expect(result.current.isMetadataPending).toBe(false);
+    // Retried exactly once before giving up.
+    expect(getMetadata).toHaveBeenCalledTimes(2);
+    expect(error).toHaveBeenCalledWith(
+      "[Zudoku] Failed to load user metadata:",
+      expect.any(Error),
+    );
+  });
+
+  it("is pending until the lookup resolves", async () => {
+    signIn();
+    let resolve: ((value: { plan: string }) => void) | undefined;
+    const getMetadata = vi.fn(
+      () =>
+        new Promise<{ plan: string }>((r) => {
+          resolve = r;
+        }),
+    );
+
+    const { result } = renderMetadata(getMetadata);
+
+    await waitFor(() => expect(result.current.isMetadataPending).toBe(true));
+
+    resolve?.({ plan: "pro" });
+
+    await waitFor(() => expect(result.current.isMetadataPending).toBe(false));
+  });
+});

--- a/packages/zudoku/src/lib/authentication/metadata.ts
+++ b/packages/zudoku/src/lib/authentication/metadata.ts
@@ -1,0 +1,42 @@
+import type { ZudokuContext } from "../core/ZudokuContext.js";
+import type { UserMetadata } from "./index.js";
+import type { UserProfile } from "./state.js";
+
+/**
+ * Upper bound for a single `getMetadata` call. An endpoint that accepts the
+ * connection and never responds would otherwise leave metadata-gated routes
+ * undecided until the browser's own (multi-minute) timeout.
+ */
+export const USER_METADATA_TIMEOUT_MS = 10_000;
+
+export type GetUserMetadataContext = {
+  /** The profile derived from the identity provider's claims. */
+  profile: UserProfile;
+  context: ZudokuContext;
+  /**
+   * Adds the current user's credentials to a request. Provider-agnostic —
+   * prefer this over reaching for the raw access token.
+   */
+  signRequest: (request: Request) => Promise<Request>;
+  /** Aborts on unmount, on user change, and after a 10s timeout. */
+  signal: AbortSignal;
+};
+
+/**
+ * Loads custom user data after sign-in. The returned value replaces
+ * `profile.metadata` wholesale.
+ *
+ * Runs in the browser: never close over secrets.
+ */
+export type GetUserMetadata = (
+  context: GetUserMetadataContext,
+) => Promise<UserMetadata | undefined> | UserMetadata | undefined;
+
+export const withMetadataTimeout = (signal?: AbortSignal): AbortSignal => {
+  const timeout = AbortSignal.timeout(USER_METADATA_TIMEOUT_MS);
+  if (!signal) return timeout;
+
+  return typeof AbortSignal.any === "function"
+    ? AbortSignal.any([signal, timeout])
+    : signal;
+};

--- a/packages/zudoku/src/lib/authentication/metadata.ts
+++ b/packages/zudoku/src/lib/authentication/metadata.ts
@@ -32,11 +32,29 @@ export type GetUserMetadata = (
   context: GetUserMetadataContext,
 ) => Promise<UserMetadata | undefined> | UserMetadata | undefined;
 
-export const withMetadataTimeout = (signal?: AbortSignal): AbortSignal => {
-  const timeout = AbortSignal.timeout(USER_METADATA_TIMEOUT_MS);
+export const withMetadataTimeout = (
+  signal?: AbortSignal,
+  timeoutMs = USER_METADATA_TIMEOUT_MS,
+): AbortSignal => {
+  const timeout = AbortSignal.timeout(timeoutMs);
   if (!signal) return timeout;
 
-  return typeof AbortSignal.any === "function"
-    ? AbortSignal.any([signal, timeout])
-    : signal;
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any([signal, timeout]);
+  }
+
+  // `AbortSignal.timeout` shipped before `AbortSignal.any`, so combine the two
+  // by hand rather than dropping the timeout on browsers in between.
+  const controller = new AbortController();
+  for (const source of [signal, timeout]) {
+    if (source.aborted) {
+      controller.abort(source.reason);
+      break;
+    }
+    source.addEventListener("abort", () => controller.abort(source.reason), {
+      once: true,
+    });
+  }
+
+  return controller.signal;
 };

--- a/packages/zudoku/src/lib/authentication/providers/openid.test.ts
+++ b/packages/zudoku/src/lib/authentication/providers/openid.test.ts
@@ -318,6 +318,83 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
     });
   });
 
+  describe("custom claims", () => {
+    const setupProfile = (
+      userInfo: Record<string, unknown>,
+      claims?: Record<string, unknown>,
+    ) => {
+      const provider = createProvider();
+
+      useAuthState.setState({
+        isAuthenticated: true,
+        isPending: false,
+        profile: {
+          sub: "user-1",
+          email: "user@example.com",
+          emailVerified: true,
+          name: "Test",
+          pictureUrl: undefined,
+        },
+        providerData: {
+          type: "openid",
+          accessToken: FAKE_ACCESS_TOKEN,
+          expiresOn: new Date(Date.now() + 3600_000),
+          tokenType: "bearer",
+          claims: claims as oauth.IDToken | undefined,
+        } satisfies OpenIdProviderData,
+      });
+
+      vi.mocked(oauth.userInfoRequest).mockResolvedValue(
+        Response.json(userInfo),
+      );
+
+      return provider;
+    };
+
+    test("merges custom claims that exist only on the ID token", async () => {
+      const provider = setupProfile(
+        { sub: "user-1", email: "user@example.com", name: "Test" },
+        {
+          sub: "user-1",
+          nonce: "should-be-dropped",
+          "https://acme.com/subscription": { plan: "pro" },
+        },
+      );
+
+      await provider.refreshUserProfile();
+
+      const profile = useAuthState.getState().profile;
+      expect(profile?.["https://acme.com/subscription"]).toEqual({
+        plan: "pro",
+      });
+      expect(profile?.nonce).toBeUndefined();
+    });
+
+    test("userinfo wins over the ID token on overlapping claims", async () => {
+      const provider = setupProfile(
+        { sub: "user-1", email: "user@example.com", plan: "pro" },
+        { sub: "user-1", plan: "free" },
+      );
+
+      await provider.refreshUserProfile();
+
+      expect(useAuthState.getState().profile?.plan).toBe("pro");
+    });
+
+    test("a claim cannot overwrite the identity fields", async () => {
+      const provider = setupProfile(
+        { sub: "user-1", email: "user@example.com", name: "Test" },
+        { sub: "attacker", emailVerified: true, pictureUrl: "https://evil" },
+      );
+
+      await provider.refreshUserProfile();
+
+      const profile = useAuthState.getState().profile;
+      expect(profile?.sub).toBe("user-1");
+      expect(profile?.pictureUrl).toBeUndefined();
+    });
+  });
+
   describe("signUp config", () => {
     const mockLocation = () => {
       const loc = {
@@ -815,16 +892,51 @@ describe("OpenIDAuthenticationProvider emailVerified", () => {
         }),
       );
       const result = await provider.verifyAccessToken(TOKEN_WITH_EXP);
+      // Raw userinfo claims are kept alongside the normalized fields, matching
+      // what the client-side profile has always contained.
       expect(result).toEqual({
         profile: {
           sub: "u1",
           email: "u@example.com",
           name: "U",
           emailVerified: true,
+          email_verified: true,
           pictureUrl: "https://example.com/p.png",
+          picture: "https://example.com/p.png",
         },
         expiresAt: 1_700_000_000,
       });
+    });
+
+    test("merges custom claims from the access token and userinfo", async () => {
+      // payload: {"sub":"u1","exp":1700000000,"https://acme.com/plan":"pro"}
+      const payload = Buffer.from(
+        JSON.stringify({
+          sub: "u1",
+          exp: 1_700_000_000,
+          "https://acme.com/plan": "pro",
+        }),
+      ).toString("base64url");
+      const token = `eyJhbGciOiJub25lIn0.${payload}.sig`;
+
+      const provider = createProvider();
+      vi.mocked(oauth.userInfoRequest).mockResolvedValueOnce(
+        Response.json({
+          sub: "u1",
+          email: "u@example.com",
+          department: "engineering",
+        }),
+      );
+
+      const result = await provider.verifyAccessToken(token);
+
+      expect(result?.profile).toMatchObject({
+        sub: "u1",
+        "https://acme.com/plan": "pro",
+        department: "engineering",
+      });
+      expect(result?.profile.exp).toBeUndefined();
+      expect(result?.expiresAt).toBe(1_700_000_000);
     });
 
     test("returns null when userInfo responds not-ok", async () => {

--- a/packages/zudoku/src/lib/authentication/providers/openid.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/openid.tsx
@@ -12,26 +12,38 @@ import type {
   VerifyAccessTokenResult,
 } from "../authentication.js";
 import { CoreAuthenticationPlugin } from "../AuthenticationPlugin.js";
+import { buildProfileFromClaims } from "../claims.js";
 import { CallbackHandler } from "../components/CallbackHandler.js";
 import { LogoutCallbackHandler } from "../components/LogoutCallbackHandler.js";
 import { OAuthErrorPage } from "../components/OAuthErrorPage.js";
 import { fetchServerSession } from "../cookie-sync.js";
 import { DEFAULT_SESSION_MAX_AGE, SESSION_ENDPOINT_PATH } from "../cookies.js";
 import { AuthorizationError, OAuthAuthorizationError } from "../errors.js";
-import { type UserProfile, useAuthState } from "../state.js";
+import {
+  type CustomClaimRecord,
+  type UserProfile,
+  useAuthState,
+} from "../state.js";
 import { redirectToSignUpUrl } from "./util.js";
 
 const CODE_VERIFIER_KEY = "code-verifier";
 const STATE_KEY = "oauth-state";
 
-const decodeJwtExp = async (token: string): Promise<number | undefined> => {
+const decodeJwtPayload = async (
+  token: string,
+): Promise<CustomClaimRecord | undefined> => {
   try {
     const { decodeJwt } = await import("jose");
-    const payload = decodeJwt(token);
-    return typeof payload.exp === "number" ? payload.exp : undefined;
+    // Opaque (non-JWT) tokens just throw and yield undefined.
+    return decodeJwt(token) as CustomClaimRecord;
   } catch {
     return undefined;
   }
+};
+
+const decodeJwtExp = async (token: string): Promise<number | undefined> => {
+  const payload = await decodeJwtPayload(token);
+  return typeof payload?.exp === "number" ? payload.exp : undefined;
 };
 
 export interface OpenIdProviderData {
@@ -263,14 +275,18 @@ export class OpenIDAuthenticationProvider
   ): UserProfile {
     const emailVerified =
       userInfo.email_verified ?? claims?.email_verified ?? false;
-    return {
-      ...userInfo,
+
+    // ID token first, userinfo second: userinfo is the purpose-built profile
+    // source and wins on overlap. Custom claims set by an IdP action (e.g. an
+    // Auth0 Post-Login Action) often live only on the ID token, so both are
+    // merged rather than picking one.
+    return buildProfileFromClaims([claims, userInfo], {
       sub: userInfo.sub,
       email: userInfo.email,
       name: userInfo.name,
       emailVerified: Boolean(emailVerified),
       pictureUrl: userInfo.picture,
-    };
+    });
   }
 
   public async verifyAccessToken(
@@ -283,22 +299,28 @@ export class OpenIDAuthenticationProvider
       token,
     );
     if (!response.ok) return undefined;
-    const userInfo = (await response.json()) as Record<string, unknown>;
+    const userInfo = (await response.json()) as CustomClaimRecord;
     if (!userInfo.sub) return undefined;
 
-    // userInfoRequest authenticated the token upstream; parsing `exp` here
-    // lets us bound the cookie lifetime to the token's. Opaque tokens just
-    // yield undefined and fall back to the handler's default.
-    const expiresAt = await decodeJwtExp(token);
+    // userInfoRequest authenticated the token upstream, so the payload is
+    // genuine even though the signature isn't re-verified here. Parsing it
+    // yields both `exp` (to bound the cookie lifetime to the token's) and any
+    // custom claims, which is how the server-rendered profile reaches parity
+    // with the client one. Opaque tokens yield undefined and fall back to the
+    // handler's default.
+    const payload = await decodeJwtPayload(token);
+    const expiresAt =
+      typeof payload?.exp === "number" ? payload.exp : undefined;
 
     return {
-      profile: {
+      profile: buildProfileFromClaims([payload, userInfo], {
         sub: String(userInfo.sub),
-        email: userInfo.email as string | undefined,
-        name: userInfo.name as string | undefined,
+        email: typeof userInfo.email === "string" ? userInfo.email : undefined,
+        name: typeof userInfo.name === "string" ? userInfo.name : undefined,
         emailVerified: Boolean(userInfo.email_verified),
-        pictureUrl: userInfo.picture as string | undefined,
-      },
+        pictureUrl:
+          typeof userInfo.picture === "string" ? userInfo.picture : undefined,
+      }),
       expiresAt,
     };
   }

--- a/packages/zudoku/src/lib/authentication/session-handler.test.ts
+++ b/packages/zudoku/src/lib/authentication/session-handler.test.ts
@@ -218,6 +218,72 @@ describe("sessionHandler POST", () => {
     expect(res.status).toBe(400);
   });
 
+  test("degrades an oversized profile to core fields instead of failing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    verifyAccessToken.mockResolvedValueOnce({
+      profile: {
+        ...VERIFIED_PROFILE,
+        subscription: { notes: "x".repeat(5000) },
+      },
+    });
+
+    const res = await handler.fetch(post({ accessToken: "t" }));
+
+    expect(res.status).toBe(200);
+    const cookie = res.headers
+      .getSetCookie()
+      .find((c) => c.startsWith("zudoku-auth-profile="));
+    expect(cookie).toBeDefined();
+
+    const value = decodeURIComponent(
+      // biome-ignore lint/style/noNonNullAssertion: asserted above
+      cookie!.slice("zudoku-auth-profile=".length).split(";")[0]!,
+    );
+    const profile = JSON.parse(value);
+    expect(profile).toEqual({
+      sub: "u1",
+      email: "u@example.com",
+      emailVerified: true,
+      name: "U",
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("subscription"));
+    warn.mockRestore();
+  });
+
+  test("keeps custom claims that fit inside the cookie budget", async () => {
+    verifyAccessToken.mockResolvedValueOnce({
+      profile: { ...VERIFIED_PROFILE, subscription: { plan: "pro" } },
+    });
+
+    const res = await handler.fetch(post({ accessToken: "t" }));
+
+    const cookie = res.headers
+      .getSetCookie()
+      .find((c) => c.startsWith("zudoku-auth-profile="));
+    // biome-ignore lint/style/noNonNullAssertion: the cookie is always set on 200
+    expect(decodeURIComponent(cookie!)).toContain('"plan":"pro"');
+  });
+
+  test("measures the encoded cookie value against the size limit", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Under the limit as raw JSON, over it once URL-encoded: every character
+    // of this claim expands to three bytes (%E2%80%A6 style escapes).
+    verifyAccessToken.mockResolvedValueOnce({
+      profile: { ...VERIFIED_PROFILE, note: "\u2026".repeat(1500) },
+    });
+
+    const res = await handler.fetch(post({ accessToken: "t" }));
+
+    expect(res.status).toBe(200);
+    const cookie = res.headers
+      .getSetCookie()
+      .find((c) => c.startsWith("zudoku-auth-profile="));
+    // biome-ignore lint/style/noNonNullAssertion: the cookie is always set on 200
+    expect(cookie!.length).toBeLessThan(4096);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   test("body exceeding the size limit is rejected with 413", async () => {
     const huge = "x".repeat(64 * 1024 + 1);
     const req = new Request("http://localhost/", {

--- a/packages/zudoku/src/lib/authentication/session-handler.ts
+++ b/packages/zudoku/src/lib/authentication/session-handler.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SESSION_MAX_AGE,
   REFRESH_TOKEN_COOKIE,
 } from "./cookies.js";
+import type { UserProfile } from "./state.js";
 
 export type VerifyAccessToken = (
   token: string,
@@ -33,6 +34,34 @@ const cookieMaxAge = (
 
 const MAX_COOKIE_SIZE = 3900; // Leave margin under 4096 browser limit
 const MAX_BODY_SIZE = 64 * 1024;
+
+const CORE_PROFILE_KEYS = [
+  "sub",
+  "email",
+  "emailVerified",
+  "name",
+  "pictureUrl",
+] as const;
+
+const serializeProfile = (profile: Partial<UserProfile>) =>
+  JSON.stringify(profile);
+
+// Cookie values are URL-encoded on write (see parseCookies), and JSON is
+// quote-heavy, so the encoded length is what has to fit the browser's limit.
+const cookieSize = (value: string) => encodeURIComponent(value).length;
+
+const coreProfile = (profile: UserProfile): Partial<UserProfile> =>
+  Object.fromEntries(
+    CORE_PROFILE_KEYS.filter((key) => profile[key] !== undefined).map((key) => [
+      key,
+      profile[key],
+    ]),
+  );
+
+const droppedClaimNames = (profile: UserProfile) =>
+  Object.keys(profile).filter(
+    (key) => !CORE_PROFILE_KEYS.some((core) => core === key),
+  );
 
 const clearAuthCookies = (c: Context) => {
   deleteCookie(c, ACCESS_TOKEN_COOKIE, baseCookieOptions);
@@ -179,12 +208,30 @@ export const createSessionHandler = (verify: VerifyAccessToken | undefined) =>
 
       let profileJson: string;
       try {
-        profileJson = JSON.stringify(verified.profile);
+        profileJson = serializeProfile(verified.profile);
       } catch {
         return c.json({ error: "Profile is not serializable" }, 500);
       }
-      if (profileJson.length > MAX_COOKIE_SIZE) {
-        return c.json({ error: "Profile exceeds cookie size limit" }, 413);
+
+      // Custom claims make the profile unbounded, so an oversized one degrades
+      // to the core identity fields rather than failing the session: a 413 here
+      // leaves the cookie unset, and SSR mode has no localStorage to fall back
+      // on, so the user would appear signed out after any full reload. The
+      // client refetches userinfo shortly after load and restores the claims.
+      if (cookieSize(profileJson) > MAX_COOKIE_SIZE) {
+        const core = coreProfile(verified.profile);
+        const coreJson = serializeProfile(core);
+
+        if (cookieSize(coreJson) > MAX_COOKIE_SIZE) {
+          return c.json({ error: "Profile exceeds cookie size limit" }, 413);
+        }
+
+        // biome-ignore lint/suspicious/noConsole: Surface dropped claims
+        console.warn(
+          `[Zudoku] Profile exceeds the cookie size limit; dropping custom claims ` +
+            `from the server-side session. Dropped: ${droppedClaimNames(verified.profile).join(", ")}`,
+        );
+        profileJson = coreJson;
       }
 
       setCookie(c, AUTH_PROFILE_COOKIE, profileJson, sessionOptions);

--- a/packages/zudoku/src/lib/authentication/session-handler.ts
+++ b/packages/zudoku/src/lib/authentication/session-handler.ts
@@ -216,8 +216,13 @@ export const createSessionHandler = (verify: VerifyAccessToken | undefined) =>
       // Custom claims make the profile unbounded, so an oversized one degrades
       // to the core identity fields rather than failing the session: a 413 here
       // leaves the cookie unset, and SSR mode has no localStorage to fall back
-      // on, so the user would appear signed out after any full reload. The
-      // client refetches userinfo shortly after load and restores the claims.
+      // on, so the user would appear signed out after any full reload.
+      //
+      // The dropped claims do NOT come back on their own: after an SSR reload
+      // `providerData` is null, so `refreshUserProfile` returns early and never
+      // reaches userinfo. They reappear only once something restores the
+      // cookie-backed token (any `signRequest`). Treat the cookie budget as a
+      // hard limit on how much claim data a profile can carry.
       if (cookieSize(profileJson) > MAX_COOKIE_SIZE) {
         const core = coreProfile(verified.profile);
         const coreJson = serializeProfile(core);

--- a/packages/zudoku/src/lib/authentication/state.ts
+++ b/packages/zudoku/src/lib/authentication/state.ts
@@ -5,6 +5,7 @@ import {
   type StateStorage,
 } from "zustand/middleware";
 import { syncZustandState } from "../util/syncZustandState.js";
+import type { UserMetadata } from "./index.js";
 
 /**
  * Registry interface for provider-specific data types.
@@ -123,6 +124,12 @@ export interface UserProfile {
   emailVerified: boolean;
   name: string | undefined;
   pictureUrl: string | undefined;
+  /**
+   * Custom user data returned by `authentication.getMetadata`. Reserved: the
+   * IdP claim merge never writes this key, so anything here was fetched by
+   * Zudoku rather than signed by the identity provider.
+   */
+  metadata?: UserMetadata;
   [key: string]: CustomClaim;
 }
 

--- a/packages/zudoku/src/lib/core/RouteGuard.test.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.test.tsx
@@ -70,6 +70,8 @@ const createWrapper = ({
     isAuthenticated: false,
     isPending: false,
     isAuthEnabled: false,
+    isMetadataPending: false,
+    refreshMetadata: vi.fn(),
     disableSignUp: false,
     profile: null,
     providerData: null,
@@ -505,6 +507,78 @@ describe("RouteGuard", () => {
 
       // Should render content because path doesn't match exactly
       expect(screen.getByText("Public")).toBeInTheDocument();
+    });
+  });
+
+  describe("pending user metadata", () => {
+    const PROFILE = {
+      sub: "123",
+      email: "user@example.com",
+      emailVerified: false,
+      name: "Test",
+      pictureUrl: undefined,
+    };
+
+    const planCheck = ({ auth }: CallbackContext): ProtectedRouteResult =>
+      auth.profile?.metadata?.plan === "pro" ? true : REASON_CODES.FORBIDDEN;
+
+    it("does not render ForbiddenPage while metadata is still loading", async () => {
+      await render(
+        { path: "/vip", element: <div>VIP Content</div> },
+        {
+          initialPath: "/vip",
+          auth: {
+            isAuthEnabled: true,
+            isPending: false,
+            isAuthenticated: true,
+            isMetadataPending: true,
+            profile: PROFILE,
+          },
+          protectedRoutes: { "/vip": planCheck },
+        },
+      );
+
+      expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
+      expect(screen.queryByText("VIP Content")).not.toBeInTheDocument();
+    });
+
+    it("renders the route once metadata grants access", async () => {
+      await render(
+        { path: "/vip", element: <div>VIP Content</div> },
+        {
+          initialPath: "/vip",
+          auth: {
+            isAuthEnabled: true,
+            isPending: false,
+            isAuthenticated: true,
+            isMetadataPending: false,
+            profile: { ...PROFILE, metadata: { plan: "pro" } },
+          },
+          protectedRoutes: { "/vip": planCheck },
+        },
+      );
+
+      expect(screen.getByText("VIP Content")).toBeInTheDocument();
+    });
+
+    it("fails closed once metadata has settled without granting access", async () => {
+      await render(
+        { path: "/vip", element: <div>VIP Content</div> },
+        {
+          initialPath: "/vip",
+          auth: {
+            isAuthEnabled: true,
+            isPending: false,
+            isAuthenticated: true,
+            isMetadataPending: false,
+            profile: PROFILE,
+          },
+          protectedRoutes: { "/vip": planCheck },
+        },
+      );
+
+      expect(screen.getByText("Access Denied")).toBeInTheDocument();
+      expect(screen.queryByText("VIP Content")).not.toBeInTheDocument();
     });
   });
 

--- a/packages/zudoku/src/lib/core/RouteGuard.tsx
+++ b/packages/zudoku/src/lib/core/RouteGuard.tsx
@@ -159,6 +159,8 @@ export const RouteGuard = () => {
 
   const blocker = useBlocker(({ nextLocation }) => {
     if (shouldBypass) return false;
+    // Metadata may decide the outcome; don't prompt for login before it lands.
+    if (auth.isMetadataPending) return false;
     const check = getAuthCheck(nextLocation.pathname);
     if (!check) return false;
     const result = check(authCheckContext);
@@ -168,7 +170,7 @@ export const RouteGuard = () => {
   const isBlocked = blocker.state === "blocked";
 
   useEffect(() => {
-    if (!auth.isAuthenticated || !isBlocked) return;
+    if (!auth.isAuthenticated || !isBlocked || auth.isMetadataPending) return;
     const check = getAuthCheck(blocker.location.pathname);
     if (!check) {
       blocker.proceed?.();
@@ -181,11 +183,18 @@ export const RouteGuard = () => {
     }
   }, [
     auth.isAuthenticated,
+    auth.isMetadataPending,
     isBlocked,
     blocker,
     authCheckContext,
     getAuthCheck,
   ]);
+
+  // A check that reads `profile.metadata` would see `undefined` until
+  // `getMetadata` resolves, so the route is undecided rather than denied —
+  // otherwise every metadata-gated page renders a 403 on first paint (and in
+  // the server-rendered HTML, where metadata never loads at all).
+  if (isProtectedRoute && auth.isMetadataPending) return null;
 
   if (isForbidden) return <ForbiddenPage />;
   if (shouldBypass) return <BypassRoute isProtectedRoute={isProtectedRoute} />;

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -19,6 +19,7 @@ import type {
   FooterSchema,
 } from "../../config/validators/ZudokuConfig.js";
 import type { AuthenticationPlugin } from "../authentication/authentication.js";
+import type { GetUserMetadata } from "../authentication/metadata.js";
 import { type AuthState, useAuthState } from "../authentication/state.js";
 import type { SSRAuthState } from "../components/context/RenderContext.js";
 import type { SlotType } from "../components/context/SlotProvider.js";
@@ -118,6 +119,12 @@ export type ZudokuContextOptions = {
   header?: HeaderConfig;
   aiAssistants?: AiAssistantsConfig;
   authentication?: AuthenticationPlugin;
+  /**
+   * Loads custom user data into `profile.metadata` after sign-in. Held here
+   * rather than on the provider so every provider gets it — Clerk's provider
+   * is a plain object, not a `CoreAuthenticationPlugin` subclass.
+   */
+  getUserMetadata?: GetUserMetadata;
   navigation?: Navigation;
   navigationRules?: ResolvedNavigationRule[];
   plugins?: ZudokuPlugin[];
@@ -157,6 +164,7 @@ export class ZudokuContext {
   public navigation: Navigation;
   public navigationRules: ResolvedNavigationRule[];
   public readonly authentication?: AuthenticationPlugin;
+  public readonly getUserMetadata?: GetUserMetadata;
   public readonly getAuthState: () => AuthState;
   public readonly queryClient: QueryClient;
   public readonly options: ZudokuContextOptions;
@@ -183,6 +191,7 @@ export class ZudokuContext {
     this.notFoundPage = options.site?.notFoundPage;
     this.plugins = options.plugins ?? [];
     this.authentication = this.plugins.find(isAuthenticationPlugin);
+    this.getUserMetadata = options.getUserMetadata;
     this.getAuthState = useAuthState.getState;
 
     const pluginsToInit = this.plugins.filter(needsInitialization);


### PR DESCRIPTION
## Summary

Adds support for loading custom user data (subscriptions, entitlements, etc.) after sign-in via a new `getMetadata` configuration option. The metadata is fetched in the browser, cached for 5 minutes, and exposed as `profile.metadata` for use in protected route checks and UI logic.

## Key Changes

- **New `getMetadata` configuration**: Added to all authentication providers, allowing apps to load custom user data from their own APIs after sign-in without maintaining identity provider actions
- **Metadata hook and state management**: Implemented `useUserMetadata()` hook that handles fetching, caching (via React Query), error handling, and retry logic with a 10-second timeout per request
- **Custom claims merging**: Added `buildProfileFromClaims()` utility to safely merge custom claims from ID tokens and userinfo responses while protecting core identity fields and filtering protocol claims
- **Protected route integration**: Routes can now gate on `profile.metadata` via `auth.isMetadataPending` flag; routes remain undecided while metadata loads rather than failing closed
- **Server-side profile degradation**: When custom claims exceed the SSR cookie size limit (3900 bytes), they are dropped with a warning and restored in the browser after hydration
- **OpenID provider enhancements**: Extended `verifyAccessToken()` to merge custom claims from both access tokens and userinfo responses, with userinfo winning on overlap
- **Documentation and examples**: Added comprehensive docs covering custom claims, custom user data, typing via module augmentation, and Auth0-specific patterns; updated Cosmo Cargo example with metadata usage

## Implementation Details

- Metadata is keyed on user `sub` so login/logout/user switches are handled automatically without subscribing to auth events
- `signRequest` helper provides provider-agnostic request signing, avoiding the need to expose raw access tokens in browser code
- Failed metadata lookups are logged but never sign the user out; `profile.metadata` is cleared and one retry is attempted
- Custom claims from identity providers are filtered to exclude reserved claims (`metadata`) and protocol claims (`exp`, `iat`, `iss`, `aud`, `nonce`, etc.) that describe tokens rather than users
- Core identity fields (`sub`, `email`, `emailVerified`, `name`, `pictureUrl`) cannot be overwritten by claims, protecting authorization decisions
- New public entry point `zudoku/auth` exports `UserMetadata` interface for module augmentation, allowing type-safe metadata access

https://claude.ai/code/session_01TRhkrspK7zsmkCAejVckp4