### PR TITLE
perf: lazy-load noncritical UI bundles

### DIFF
--- a/docs/pages/docs/configuration/footer.mdx
+++ b/docs/pages/docs/configuration/footer.mdx
@@ -143,7 +143,8 @@ footer: {
       dark: "/path/to/dark-logo.png"
     },
     alt: "Company Logo",
-    width: "120px" // optional width
+    width: 120, // optional intrinsic width
+    height: 24 // optional intrinsic height; set both to prevent layout shift
   }
 }
 ```
@@ -208,7 +209,8 @@ footer: {
       dark: "/images/logo-dark.svg"
     },
     alt: "Company Logo",
-    width: "100px"
+    width: 100,
+    height: 24
   }
 }
 ```

--- a/docs/pages/docs/configuration/site.md
+++ b/docs/pages/docs/configuration/site.md
@@ -58,7 +58,8 @@ Configure the site's logo with different versions for light and dark themes:
         dark: "/dark-logo.png"
       },
       alt: "Company Logo",
-      width: "120px", // optional width
+      width: 120, // optional intrinsic width
+      height: 32, // optional intrinsic height; set both to prevent layout shift
       href: "/", // optional link target (defaults to "/")
       reloadDocument: true, // optional, defaults to true
     }

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -167,6 +167,7 @@ const config: ZudokuConfig = {
     logo: {
       src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
       width: 165,
+      height: 24,
       alt: "Cosmo Cargo Inc.",
     },
     banner: {
@@ -236,6 +237,7 @@ const config: ZudokuConfig = {
         },
         alt: "Zudoku by Zuplo",
         width: 120,
+        height: 24,
       },
     },
   },

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -91,6 +91,8 @@
     "@apidevtools/json-schema-ref-parser": "15.5.0",
     "@base-ui/react": "^1.6.0",
     "@envelop/core": "5.5.1",
+    "@fontsource-variable/geist": "5.3.0",
+    "@fontsource-variable/geist-mono": "5.3.0",
     "@graphiql/toolkit": "0.12.1",
     "@graphql-typed-document-node/core": "3.2.0",
     "@hono/node-server": "2.0.11",

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -13,6 +13,7 @@ import { SESSION_ENDPOINT_PATH } from "../lib/authentication/cookies.js";
 import { authState } from "../lib/authentication/state.js";
 import { BootstrapClient } from "../lib/components/Bootstrap.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
+import { requestIdle } from "../lib/util/requestIdle.js";
 import { getRoutesByConfig, getShikiReady } from "./main.js";
 
 if (import.meta.env.ZUDOKU_HAS_SERVER) {
@@ -104,11 +105,20 @@ async function hydrateLazyRoutes(routes: RouteObject[]) {
   }
 }
 
+// Keeping Shiki off the hydration path is only a win if it is warm before the
+// user needs it. Without this, the first navigation to a page that renders
+// runtime-highlighted content suspends inside a router transition and the
+// previous page stays frozen until the chunk and its grammars arrive.
+function warmShiki() {
+  requestIdle(() => void getShikiReady());
+}
+
 function render(routes: RouteObject[]) {
   const router = createBrowserRouter(routes, {
     basename: config.basePath,
   });
   createRoot(root).render(<BootstrapClient router={router} head={head} />);
+  warmShiki();
 }
 
 async function hydrate(routes: RouteObject[]) {
@@ -123,6 +133,9 @@ async function hydrate(routes: RouteObject[]) {
   });
 
   hydrateRoot(root, <BootstrapClient hydrate router={router} head={head} />);
+
+  // Pages whose HTML already contained highlighted output resolved Shiki above.
+  if (!runtimeShiki) warmShiki();
 }
 
 // Reload on chunk preload failures to recover from version skew.

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -13,7 +13,7 @@ import { SESSION_ENDPOINT_PATH } from "../lib/authentication/cookies.js";
 import { authState } from "../lib/authentication/state.js";
 import { BootstrapClient } from "../lib/components/Bootstrap.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
-import { getRoutesByConfig, shikiReady } from "./main.js";
+import { getRoutesByConfig, getShikiReady } from "./main.js";
 
 if (import.meta.env.ZUDOKU_HAS_SERVER) {
   setupCookieSync(authState, joinUrl(config.basePath, SESSION_ENDPOINT_PATH));
@@ -112,7 +112,11 @@ function render(routes: RouteObject[]) {
 }
 
 async function hydrate(routes: RouteObject[]) {
-  await Promise.all([hydrateLazyRoutes(routes), shikiReady]);
+  const runtimeShiki = root.querySelector("[data-zudoku-runtime-shiki]")
+    ? getShikiReady()
+    : undefined;
+
+  await Promise.all([hydrateLazyRoutes(routes), runtimeShiki]);
 
   const router = createBrowserRouter(routes, {
     basename: config.basePath,

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -1,3 +1,6 @@
+@import "@fontsource-variable/geist/wght.css";
+@import "@fontsource-variable/geist-mono/wght.css";
+
 /* @vite-plugin-inject defaultTheme */
 @import "tailwindcss" source("..");
 @import "tw-animate-css";

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -37,13 +37,20 @@ import {
   wrapProtectedRoutes,
 } from "./wrapProtectedRoutes.js";
 
-export const shikiReady: Promise<HighlighterCore> =
-  import("../lib/shiki.js").then(async ({ highlighterPromise }) => {
-    const highlighter = await highlighterPromise;
-    const { registerShiki } = await import("virtual:zudoku-shiki-register");
-    await registerShiki(highlighter);
-    return highlighter;
-  });
+let shikiReady: Promise<HighlighterCore> | undefined;
+
+export const getShikiReady = (): Promise<HighlighterCore> => {
+  shikiReady ??= import("../lib/shiki.js").then(
+    async ({ highlighterPromise }) => {
+      const highlighter = await highlighterPromise;
+      const { registerShiki } = await import("virtual:zudoku-shiki-register");
+      await registerShiki(highlighter);
+      return highlighter;
+    },
+  );
+
+  return shikiReady;
+};
 
 export const convertZudokuConfigToOptions = (
   config: ZudokuConfig,
@@ -85,7 +92,12 @@ export const convertZudokuConfigToOptions = (
       ...(config.plugins ?? []),
     ],
     syntaxHighlighting: {
-      highlighterPromise: shikiReady,
+      // Keep Shiki and configured language grammars out of pages that do not
+      // render runtime-highlighted content. This getter is only read by
+      // useHighlighter when Markdown or SyntaxHighlight actually mounts.
+      get highlighterPromise() {
+        return getShikiReady();
+      },
       themes: config.syntaxHighlighting?.themes,
     },
   };

--- a/packages/zudoku/src/config/validators/HeaderNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/HeaderNavigationSchema.ts
@@ -31,6 +31,9 @@ const HeaderNavItemSchema = z.union([
 
 export const HeaderNavigationSchema = z.array(HeaderNavItemSchema);
 
+// Kept for backwards compatibility with consumers importing the validator
+// helper directly. Runtime UI code uses the schema-free equivalent in lib so
+// this export does not pull Zod into the browser entry path.
 export const isHeaderNavGroup = (
   item: HeaderNavItem | HeaderNavLinkItem | HeaderNavGroup,
 ): item is HeaderNavGroup => "items" in item;

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -218,6 +218,7 @@ const LogoSchema = z.object({
   src: z.object({ light: z.string(), dark: z.string() }),
   alt: z.string().optional(),
   width: z.string().or(z.number()).optional(),
+  height: z.string().or(z.number()).optional(),
   href: z.string().optional(),
   reloadDocument: z.boolean().optional(),
 });

--- a/packages/zudoku/src/lib/components/Footer.test.tsx
+++ b/packages/zudoku/src/lib/components/Footer.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { expect, it } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { SlotProvider } from "./context/SlotProvider.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Footer } from "./Footer.js";
+
+it("renders intrinsic dimensions for the footer logo", () => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(
+    {
+      site: {
+        footer: {
+          logo: {
+            src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
+            alt: "Test logo",
+            width: 120,
+            height: 24,
+          },
+        },
+      },
+    },
+    queryClient,
+    {},
+  );
+
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ZudokuProvider context={context}>
+          <SlotProvider>
+            <Footer />
+          </SlotProvider>
+        </ZudokuProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+
+  const logos = screen.getAllByRole("img", { name: "Test logo" });
+  expect(logos).toHaveLength(2);
+  for (const logo of logos) {
+    expect(logo).toHaveAttribute("width", "120");
+    expect(logo).toHaveAttribute("height", "24");
+  }
+});

--- a/packages/zudoku/src/lib/components/Footer.tsx
+++ b/packages/zudoku/src/lib/components/Footer.tsx
@@ -2,6 +2,7 @@ import { ExternalLink as ExternalLinkIcon } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
 import type { FooterSocialIcons } from "../../config/validators/ZudokuConfig.js";
 import { cn } from "../util/cn.js";
+import { getIntrinsicImageDimensions } from "../util/getIntrinsicImageDimensions.js";
 import { AnchorLink } from "./AnchorLink.js";
 import { useZudoku } from "./index.js";
 import { Slot } from "./Slot.js";
@@ -17,6 +18,8 @@ const SocialIcon = ({
         src={`https://cdn.simpleicons.org/${icon}/000000/ffffff`}
         className="size-5"
         alt={icon}
+        width={20}
+        height={20}
         loading="lazy"
       />
     );
@@ -103,16 +106,30 @@ export const Footer = () => {
               <img
                 src={footer.logo.src.light}
                 alt={footer.logo.alt}
+                {...getIntrinsicImageDimensions(
+                  footer.logo.width,
+                  footer.logo.height,
+                )}
                 className="w-8 dark:hidden"
-                style={{ width: footer.logo.width }}
+                style={{
+                  width: footer.logo.width,
+                  height: footer.logo.height,
+                }}
                 loading="lazy"
               />
               <img
                 src={footer.logo.src.dark}
                 alt={footer.logo.alt}
+                {...getIntrinsicImageDimensions(
+                  footer.logo.width,
+                  footer.logo.height,
+                )}
                 className="w-8 hidden dark:block"
                 loading="lazy"
-                style={{ width: footer.logo.width }}
+                style={{
+                  width: footer.logo.width,
+                  height: footer.logo.height,
+                }}
               />
             </>
           )}

--- a/packages/zudoku/src/lib/components/Header.test.tsx
+++ b/packages/zudoku/src/lib/components/Header.test.tsx
@@ -4,6 +4,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render as testRender, screen } from "@testing-library/react";
+import { createHead, UnheadProvider } from "@unhead/react/client";
 import type { ComponentProps } from "react";
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,14 +34,16 @@ const render = async (options: Partial<ZudokuContextOptions> = {}) => {
     [
       {
         element: (
-          <QueryClientProvider client={queryClient}>
-            <ZudokuProvider context={context}>
-              <SlotProvider slots={{}}>
-                <Header />
-                <Outlet />
-              </SlotProvider>
-            </ZudokuProvider>
-          </QueryClientProvider>
+          <UnheadProvider head={createHead()}>
+            <QueryClientProvider client={queryClient}>
+              <ZudokuProvider context={context}>
+                <SlotProvider slots={{}}>
+                  <Header />
+                  <Outlet />
+                </SlotProvider>
+              </ZudokuProvider>
+            </QueryClientProvider>
+          </UnheadProvider>
         ),
         children: [{ path: "*", element: null }],
       },
@@ -73,6 +76,26 @@ describe("Header", () => {
 
       const props = getLogoLinkProps();
       expect(props?.reloadDocument).toBe(true);
+    });
+
+    it("renders intrinsic dimensions for configured logos", async () => {
+      await render({
+        site: {
+          title: "Test Site",
+          logo: {
+            src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
+            width: 120,
+            height: 32,
+          },
+        },
+      });
+
+      const logos = screen.getAllByRole("img", { name: "Test Site" });
+      expect(logos).toHaveLength(2);
+      for (const logo of logos) {
+        expect(logo).toHaveAttribute("width", "120");
+        expect(logo).toHaveAttribute("height", "32");
+      }
     });
   });
 

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "../ui/DropdownMenu.js";
 import { cn } from "../util/cn.js";
+import { getIntrinsicImageDimensions } from "../util/getIntrinsicImageDimensions.js";
 import { joinUrl } from "../util/joinUrl.js";
 import { Banner } from "./Banner.js";
 import { useZudoku } from "./context/ZudokuContext.js";
@@ -176,13 +177,27 @@ export const Header = memo(function HeaderInner() {
                       <img
                         src={logoLightSrc}
                         alt={site.logo.alt ?? site.title}
-                        style={{ width: site.logo.width }}
+                        {...getIntrinsicImageDimensions(
+                          site.logo.width,
+                          site.logo.height,
+                        )}
+                        style={{
+                          width: site.logo.width,
+                          height: site.logo.height,
+                        }}
                         className="max-h-(--top-header-height) dark:hidden"
                       />
                       <img
                         src={logoDarkSrc}
                         alt={site.logo.alt ?? site.title}
-                        style={{ width: site.logo.width }}
+                        {...getIntrinsicImageDimensions(
+                          site.logo.width,
+                          site.logo.height,
+                        )}
+                        style={{
+                          width: site.logo.width,
+                          height: site.logo.height,
+                        }}
                         className="max-h-(--top-header-height) hidden dark:block"
                       />
                     </>

--- a/packages/zudoku/src/lib/components/HeaderNavigation.tsx
+++ b/packages/zudoku/src/lib/components/HeaderNavigation.tsx
@@ -1,10 +1,9 @@
 import type { LucideIcon } from "lucide-react";
 import { Link } from "react-router";
-import {
-  isHeaderNavGroup,
-  type HeaderNavGroup,
-  type HeaderNavItem,
-  type HeaderNavLinkItem,
+import type {
+  HeaderNavGroup,
+  HeaderNavItem,
+  HeaderNavLinkItem,
 } from "../../config/validators/HeaderNavigationSchema.js";
 import {
   NavigationMenu,
@@ -16,6 +15,7 @@ import {
   navigationMenuTriggerStyle,
 } from "../ui/NavigationMenu.js";
 import { cn } from "../util/cn.js";
+import { isHeaderNavGroup } from "../util/isHeaderNavGroup.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 
 const NavLinkItem = ({ item }: { item: HeaderNavLinkItem }) => {

--- a/packages/zudoku/src/lib/components/Main.test.tsx
+++ b/packages/zudoku/src/lib/components/Main.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  render as testRender,
+  screen,
+  within,
+} from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { SlotProvider } from "./context/SlotProvider.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Main } from "./Main.js";
+
+const render = async () => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(
+    {
+      navigation: [
+        {
+          type: "category",
+          label: "Guides",
+          link: { type: "link", to: "/docs", label: "Guides" },
+          items: [{ type: "link", label: "Introduction", to: "/docs" }],
+        },
+      ],
+    },
+    queryClient,
+    {},
+  );
+
+  const router = createMemoryRouter(
+    [
+      {
+        element: (
+          <QueryClientProvider client={queryClient}>
+            <ZudokuProvider context={context}>
+              <SlotProvider slots={{}}>
+                <Main>Content</Main>
+                <Outlet />
+              </SlotProvider>
+            </ZudokuProvider>
+          </QueryClientProvider>
+        ),
+        children: [{ path: "*", element: null }],
+      },
+    ],
+    { initialEntries: ["/docs"] },
+  );
+
+  await act(async () => {
+    testRender(<RouterProvider router={router} />);
+  });
+};
+
+describe("Main mobile navigation", () => {
+  it("renders an accessible trigger without mounting the drawer body", async () => {
+    await render();
+
+    const trigger = screen.getByRole("button", { name: "Menu" });
+
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-controls");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("loads and opens the navigation drawer on demand", async () => {
+    const user = userEvent.setup();
+    await render();
+
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+
+    const dialog = await screen.findByRole("dialog", undefined, {
+      timeout: 5_000,
+    });
+    expect(
+      within(dialog).getByRole("link", { name: "Introduction" }),
+    ).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("restores focus to the trigger when the drawer closes", async () => {
+    const user = userEvent.setup();
+    await render();
+
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
+    await user.keyboard("{Escape}");
+
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/packages/zudoku/src/lib/components/Main.tsx
+++ b/packages/zudoku/src/lib/components/Main.tsx
@@ -1,43 +1,93 @@
 import { PanelLeftIcon } from "lucide-react";
-import { type PropsWithChildren, useState } from "react";
+import {
+  lazy,
+  type PropsWithChildren,
+  Suspense,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import { useNavigation } from "react-router";
-import { Drawer, DrawerTrigger } from "zudoku/ui/Drawer.js";
 import { cn } from "../util/cn.js";
 import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
 import { Navigation } from "./navigation/Navigation.js";
 import { SidebarToggle } from "./navigation/SidebarToggle.js";
 import { Slot } from "./Slot.js";
 
+const importMobileNavigationDrawer = () =>
+  import("./navigation/MobileNavigationDrawer.js").then((module) => ({
+    default: module.MobileNavigationDrawer,
+  }));
+
+let mobileNavigationDrawerPromise:
+  | ReturnType<typeof importMobileNavigationDrawer>
+  | undefined;
+
+const loadMobileNavigationDrawer = () => {
+  mobileNavigationDrawerPromise ??= importMobileNavigationDrawer();
+  return mobileNavigationDrawerPromise;
+};
+
+const LazyMobileNavigationDrawer = lazy(loadMobileNavigationDrawer);
+
 export const Main = ({ children }: PropsWithChildren) => {
+  const [isDrawerMounted, setDrawerMounted] = useState(false);
   const [isDrawerOpen, setDrawerOpen] = useState(false);
+  const drawerId = useId();
+  const drawerTriggerRef = useRef<HTMLButtonElement>(null);
   const { navigation, topNavItem } = useCurrentNavigation();
   const hasNavigation = navigation.length > 0;
   const isNavigating = useNavigation().state === "loading";
   const { options } = useZudoku();
 
+  const preloadDrawer = () => {
+    void loadMobileNavigationDrawer();
+  };
+
+  const openDrawer = () => {
+    setDrawerMounted(true);
+    setDrawerOpen(true);
+  };
+
   return (
-    <Drawer
-      direction={options.site?.dir === "rtl" ? "right" : "left"}
-      open={isDrawerOpen}
-      onOpenChange={(open) => setDrawerOpen(open)}
-    >
+    <>
       {hasNavigation && (
-        <Navigation
-          onRequestClose={() => setDrawerOpen(false)}
-          navigation={navigation}
-          topNavItem={topNavItem}
-        />
+        <Navigation navigation={navigation} topNavItem={topNavItem} />
       )}
       {hasNavigation && (
         <div className="lg:hidden m-0 p-0 md:-mx-4 md:px-4 py-2 sticky bg-background/80 backdrop-blur-xs z-10 top-0 inset-x-0 border-b flex items-center gap-2">
-          <DrawerTrigger className="flex items-center gap-2 px-4">
+          <button
+            ref={drawerTriggerRef}
+            type="button"
+            className="flex items-center gap-2 px-4"
+            aria-haspopup="dialog"
+            aria-expanded={isDrawerOpen}
+            aria-controls={drawerId}
+            data-state={isDrawerOpen ? "open" : "closed"}
+            onFocus={preloadDrawer}
+            onPointerEnter={preloadDrawer}
+            onClick={openDrawer}
+          >
             <PanelLeftIcon size={16} strokeWidth={1.5} />
             <span className="text-sm">Menu</span>
-          </DrawerTrigger>
+          </button>
           <div className="ms-auto empty:hidden pe-4">
             <Slot.Target name="mobile-top-bar-end" />
           </div>
         </div>
+      )}
+      {isDrawerMounted && (
+        <Suspense fallback={null}>
+          <LazyMobileNavigationDrawer
+            id={drawerId}
+            direction={options.site?.dir === "rtl" ? "right" : "left"}
+            navigation={navigation}
+            onOpenChange={setDrawerOpen}
+            open={isDrawerOpen}
+            topNavItem={topNavItem}
+            triggerRef={drawerTriggerRef}
+          />
+        </Suspense>
       )}
       <main
         data-pagefind-body
@@ -54,6 +104,6 @@ export const Main = ({ children }: PropsWithChildren) => {
       {hasNavigation && options.site?.sidebar?.collapsible !== false && (
         <SidebarToggle />
       )}
-    </Drawer>
+    </>
   );
 };

--- a/packages/zudoku/src/lib/components/Markdown.test.tsx
+++ b/packages/zudoku/src/lib/components/Markdown.test.tsx
@@ -59,6 +59,9 @@ describe("Markdown", () => {
     const { container } = await renderMarkdown("Hello **world**");
 
     expect(container.querySelector("strong")?.textContent).toBe("world");
+    expect(
+      container.querySelector("[data-zudoku-runtime-shiki]"),
+    ).not.toBeNull();
   });
 
   it("renders custom PascalCase components from MDXProvider", async () => {

--- a/packages/zudoku/src/lib/components/Markdown.tsx
+++ b/packages/zudoku/src/lib/components/Markdown.tsx
@@ -66,7 +66,7 @@ export const Markdown = memo(
     );
 
     return (
-      <Typography className={className}>
+      <Typography className={className} data-zudoku-runtime-shiki>
         <ReactMarkdown
           remarkPlugins={remarkPlugins}
           rehypePlugins={rehypePlugins}

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
@@ -41,11 +41,25 @@ const render = async (options: Partial<ZudokuContextOptions> = {}) => {
 const themeSwitchName = /^(Toggle theme|Switch to (dark|light) mode)$/;
 
 describe("MobileTopNavigation", () => {
+  it("renders an accessible trigger without mounting the drawer body", async () => {
+    await render({ site: { title: "Test Site" } });
+
+    const trigger = screen.getByRole("button", {
+      name: "Open navigation menu",
+    });
+
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-controls");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
   it("renders the theme switch by default in the mobile navigation drawer", async () => {
     const user = userEvent.setup();
     await render({ site: { title: "Test Site" } });
 
     await user.click(screen.getByLabelText("Open navigation menu"));
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
 
     expect(
       screen.getByRole("button", { name: themeSwitchName }),
@@ -60,6 +74,7 @@ describe("MobileTopNavigation", () => {
     });
 
     await user.click(screen.getByLabelText("Open navigation menu"));
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
 
     expect(
       screen.queryByRole("button", { name: themeSwitchName }),
@@ -86,6 +101,7 @@ describe("MobileTopNavigation", () => {
     });
 
     await user.click(screen.getByLabelText("Open navigation menu"));
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
 
     const external = screen.getByRole("link", { name: "Support" });
     expect(external.getAttribute("href")).toBe("https://example.com/support");

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -1,277 +1,68 @@
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { deepEqual } from "fast-equals";
-import {
-  ChevronDownIcon,
-  LogOutIcon,
-  MenuIcon,
-  type LucideIcon,
-} from "lucide-react";
-import { useState } from "react";
-import { Link, useLocation } from "react-router";
-import { Button } from "zudoku/ui/Button.js";
-import { Separator } from "zudoku/ui/Separator.js";
-import { Skeleton } from "zudoku/ui/Skeleton.js";
-import {
-  isHeaderNavGroup,
-  type HeaderNavItem,
-  type HeaderNavLinkItem,
-} from "../../config/validators/HeaderNavigationSchema.js";
-import { useAuth } from "../authentication/hook.js";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "../ui/Collapsible.js";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTitle,
-  DrawerTrigger,
-} from "../ui/Drawer.js";
-import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
-import { PoweredByZudoku } from "./navigation/PoweredByZudoku.js";
-import { getFirstMatchingPath, shouldShowItem } from "./navigation/utils.js";
+import { MenuIcon } from "lucide-react";
+import { lazy, Suspense, useId, useRef, useState } from "react";
 import { PageProgress } from "./PageProgress.js";
-import { ThemeSwitch } from "./ThemeSwitch.js";
 
-const MobileHeaderNavLink = ({
-  item,
-  onClick,
-}: {
-  item: HeaderNavLinkItem;
-  onClick: () => void;
-}) => {
-  const Icon = item.icon as LucideIcon | undefined;
-  return (
-    <Link
-      to={item.to}
-      target={item.target}
-      rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
-      onClick={onClick}
-      className="flex items-center font-medium gap-2 py-2 text-foreground/80 hover:text-foreground"
-    >
-      {Icon && <Icon size={16} />}
-      {item.label}
-    </Link>
-  );
+const importMobileTopNavigationDrawer = () =>
+  import("./MobileTopNavigationDrawer.js").then((module) => ({
+    default: module.MobileTopNavigationDrawer,
+  }));
+
+let mobileTopNavigationDrawerPromise:
+  | ReturnType<typeof importMobileTopNavigationDrawer>
+  | undefined;
+
+const loadMobileTopNavigationDrawer = () => {
+  mobileTopNavigationDrawerPromise ??= importMobileTopNavigationDrawer();
+  return mobileTopNavigationDrawerPromise;
 };
 
-const MobileHeaderNavItem = ({
-  item,
-  onNavigate,
-}: {
-  item: HeaderNavItem;
-  onNavigate: () => void;
-}) => {
-  if ("to" in item) {
-    const Icon = item.icon as LucideIcon | undefined;
-    return (
-      <li className="w-full">
-        <Link
-          to={item.to}
-          target={item.target}
-          rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
-          onClick={onNavigate}
-          className="flex items-center gap-2 py-2 text-base font-medium"
-        >
-          {Icon && <Icon size={16} />}
-          {item.label}
-        </Link>
-      </li>
-    );
-  }
-
-  return (
-    <li className="w-full">
-      <Collapsible>
-        <CollapsibleTrigger className="flex items-center justify-between w-full py-2 text-base font-medium group">
-          {item.label}
-          <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <ul className="flex flex-col border-l ms-1 ps-3 my-1">
-            {item.items.map((subItem) =>
-              isHeaderNavGroup(subItem) ? (
-                <li key={subItem.label} className="flex flex-col">
-                  <div className="text-sm text-muted-foreground py-2">
-                    {subItem.label}
-                  </div>
-                  {subItem.items.map((link) => (
-                    <MobileHeaderNavLink
-                      key={link.to}
-                      item={link}
-                      onClick={onNavigate}
-                    />
-                  ))}
-                </li>
-              ) : (
-                <li key={subItem.to}>
-                  <MobileHeaderNavLink item={subItem} onClick={onNavigate} />
-                </li>
-              ),
-            )}
-          </ul>
-        </CollapsibleContent>
-      </Collapsible>
-    </li>
-  );
-};
+const LazyMobileTopNavigationDrawer = lazy(loadMobileTopNavigationDrawer);
 
 export const MobileTopNavigation = () => {
-  const context = useZudoku();
-  const authState = useAuth();
-  const location = useLocation();
-  const currentNav = useCurrentNavigation();
-
-  const {
-    options: { header, navigation = [], site },
-    getProfileMenuItems,
-  } = context;
-  const headerNavigation = header?.navigation ?? [];
-  const themeSwitcherEnabled = header?.themeSwitcher?.enabled ?? true;
-  const { isAuthenticated, isPending, profile, isAuthEnabled } = authState;
+  const [drawerMounted, setDrawerMounted] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const drawerId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
-  const accountItems = getProfileMenuItems();
-  const filteredItems = navigation.filter(
-    shouldShowItem({ auth: authState, context }),
-  );
+  const preloadDrawer = () => {
+    void loadMobileTopNavigationDrawer();
+  };
+
+  const openDrawer = () => {
+    setDrawerMounted(true);
+    setDrawerOpen(true);
+  };
 
   return (
-    <Drawer
-      direction={site?.dir === "rtl" ? "left" : "right"}
-      open={drawerOpen}
-      onOpenChange={setDrawerOpen}
-    >
+    <>
       <div className="flex lg:hidden justify-self-end">
-        <DrawerTrigger className="lg:hidden" aria-label="Open navigation menu">
+        <button
+          ref={triggerRef}
+          type="button"
+          className="lg:hidden"
+          aria-label="Open navigation menu"
+          aria-haspopup="dialog"
+          aria-expanded={drawerOpen}
+          aria-controls={drawerId}
+          data-state={drawerOpen ? "open" : "closed"}
+          onFocus={preloadDrawer}
+          onPointerEnter={preloadDrawer}
+          onClick={openDrawer}
+        >
           <MenuIcon size={22} aria-hidden="true" />
-        </DrawerTrigger>
+        </button>
         <PageProgress />
       </div>
-      <DrawerContent
-        className="lg:hidden h-dvh inset-e-0 start-auto w-[340px] rounded-none"
-        aria-describedby={undefined}
-      >
-        <div className="py-2 h-full flex flex-col">
-          <div className="flex-1 overflow-y-auto overscroll-none">
-            <VisuallyHidden>
-              <DrawerTitle>Navigation</DrawerTitle>
-            </VisuallyHidden>
-            <ul className="flex flex-col gap-1 px-4">
-              {headerNavigation.map((item) => (
-                <MobileHeaderNavItem
-                  key={item.label}
-                  item={item}
-                  onNavigate={() => setDrawerOpen(false)}
-                />
-              ))}
-              {headerNavigation.length > 0 && <Separator className="my-2" />}
-
-              {filteredItems.map((item) => {
-                if (item.type === "separator") {
-                  return <Separator className="my-2" key={item.label} />;
-                }
-                if (item.type === "section" || item.type === "filter") {
-                  return null;
-                }
-                const path = getFirstMatchingPath(item);
-                const isActive = deepEqual(currentNav.topNavItem, item);
-                const target = "target" in item ? item.target : undefined;
-                return (
-                  <li key={item.label}>
-                    <Link
-                      to={path}
-                      target={target}
-                      rel={
-                        target === "_blank" ? "noopener noreferrer" : undefined
-                      }
-                      onClick={() => setDrawerOpen(false)}
-                      className={`flex items-center gap-2 py-2 text-base font-medium ${isActive ? "text-foreground" : "text-foreground/75 hover:text-foreground"}`}
-                    >
-                      {item.icon && <item.icon size={16} />}
-                      {item.label}
-                    </Link>
-                  </li>
-                );
-              })}
-              {isAuthEnabled &&
-                (isPending ? (
-                  <Skeleton className="rounded-sm h-5 w-24" />
-                ) : (
-                  isAuthenticated && (
-                    <>
-                      <Separator className="my-2" />
-                      <li className="py-2">
-                        <div className="text-base font-medium">
-                          {profile?.name ?? "My Account"}
-                        </div>
-                        {profile?.email && profile.email !== profile?.name && (
-                          <div className="text-sm text-muted-foreground">
-                            {profile.email}
-                          </div>
-                        )}
-                      </li>
-                      {accountItems.map((i) => (
-                        <li key={i.label}>
-                          <Link
-                            to={i.path ?? ""}
-                            target={i.target}
-                            rel={
-                              i.target === "_blank"
-                                ? "noopener noreferrer"
-                                : undefined
-                            }
-                            onClick={() => setDrawerOpen(false)}
-                            className="flex items-center py-2 text-base font-medium text-foreground/75 hover:text-foreground"
-                          >
-                            {i.label}
-                          </Link>
-                        </li>
-                      ))}
-                    </>
-                  )
-                ))}
-            </ul>
-          </div>
-          <div className="border-t shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] px-4 pt-3 flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              {isAuthEnabled &&
-                (isPending ? (
-                  <Skeleton className="rounded-sm h-8 w-16" />
-                ) : isAuthenticated ? (
-                  <Button asChild variant="outline">
-                    <Link
-                      to="/signout"
-                      onClick={() => setDrawerOpen(false)}
-                      className="flex items-center gap-2"
-                    >
-                      <LogOutIcon
-                        size={16}
-                        strokeWidth={1}
-                        absoluteStrokeWidth
-                      />
-                      Logout
-                    </Link>
-                  </Button>
-                ) : (
-                  <Button asChild variant="outline">
-                    <Link
-                      to={`/signin?redirect=${encodeURIComponent(location.pathname)}`}
-                      onClick={() => setDrawerOpen(false)}
-                    >
-                      Login
-                    </Link>
-                  </Button>
-                ))}
-              {themeSwitcherEnabled && <ThemeSwitch />}
-            </div>
-            {site?.showPoweredBy !== false && (
-              <PoweredByZudoku className="grow-0 justify-center gap-1" />
-            )}
-          </div>
-        </div>
-      </DrawerContent>
-    </Drawer>
+      {drawerMounted && (
+        <Suspense fallback={null}>
+          <LazyMobileTopNavigationDrawer
+            id={drawerId}
+            open={drawerOpen}
+            onOpenChange={setDrawerOpen}
+            triggerRef={triggerRef}
+          />
+        </Suspense>
+      )}
+    </>
   );
 };

--- a/packages/zudoku/src/lib/components/MobileTopNavigationDrawer.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigationDrawer.tsx
@@ -1,0 +1,276 @@
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { deepEqual } from "fast-equals";
+import { ChevronDownIcon, LogOutIcon, type LucideIcon } from "lucide-react";
+import type { RefObject } from "react";
+import { Link, useLocation } from "react-router";
+import { Button } from "zudoku/ui/Button.js";
+import { Separator } from "zudoku/ui/Separator.js";
+import { Skeleton } from "zudoku/ui/Skeleton.js";
+import type {
+  HeaderNavItem,
+  HeaderNavLinkItem,
+} from "../../config/validators/HeaderNavigationSchema.js";
+import { useAuth } from "../authentication/hook.js";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../ui/Collapsible.js";
+import { Drawer, DrawerContent, DrawerTitle } from "../ui/Drawer.js";
+import { isHeaderNavGroup } from "../util/isHeaderNavGroup.js";
+import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
+import { PoweredByZudoku } from "./navigation/PoweredByZudoku.js";
+import { getFirstMatchingPath, shouldShowItem } from "./navigation/utils.js";
+import { ThemeSwitch } from "./ThemeSwitch.js";
+
+const MobileHeaderNavLink = ({
+  item,
+  onClick,
+}: {
+  item: HeaderNavLinkItem;
+  onClick: () => void;
+}) => {
+  const Icon = item.icon as LucideIcon | undefined;
+  return (
+    <Link
+      to={item.to}
+      target={item.target}
+      rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
+      onClick={onClick}
+      className="flex items-center font-medium gap-2 py-2 text-foreground/80 hover:text-foreground"
+    >
+      {Icon && <Icon size={16} />}
+      {item.label}
+    </Link>
+  );
+};
+
+const MobileHeaderNavItem = ({
+  item,
+  onNavigate,
+}: {
+  item: HeaderNavItem;
+  onNavigate: () => void;
+}) => {
+  if ("to" in item) {
+    const Icon = item.icon as LucideIcon | undefined;
+    return (
+      <li className="w-full">
+        <Link
+          to={item.to}
+          target={item.target}
+          rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
+          onClick={onNavigate}
+          className="flex items-center gap-2 py-2 text-base font-medium"
+        >
+          {Icon && <Icon size={16} />}
+          {item.label}
+        </Link>
+      </li>
+    );
+  }
+
+  return (
+    <li className="w-full">
+      <Collapsible>
+        <CollapsibleTrigger className="flex items-center justify-between w-full py-2 text-base font-medium group">
+          {item.label}
+          <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <ul className="flex flex-col border-l ms-1 ps-3 my-1">
+            {item.items.map((subItem) =>
+              isHeaderNavGroup(subItem) ? (
+                <li key={subItem.label} className="flex flex-col">
+                  <div className="text-sm text-muted-foreground py-2">
+                    {subItem.label}
+                  </div>
+                  {subItem.items.map((link) => (
+                    <MobileHeaderNavLink
+                      key={link.to}
+                      item={link}
+                      onClick={onNavigate}
+                    />
+                  ))}
+                </li>
+              ) : (
+                <li key={subItem.to}>
+                  <MobileHeaderNavLink item={subItem} onClick={onNavigate} />
+                </li>
+              ),
+            )}
+          </ul>
+        </CollapsibleContent>
+      </Collapsible>
+    </li>
+  );
+};
+
+export const MobileTopNavigationDrawer = ({
+  id,
+  open,
+  onOpenChange,
+  triggerRef,
+}: {
+  id: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+}) => {
+  const context = useZudoku();
+  const authState = useAuth();
+  const location = useLocation();
+  const currentNav = useCurrentNavigation();
+
+  const {
+    options: { header, navigation = [], site },
+    getProfileMenuItems,
+  } = context;
+  const headerNavigation = header?.navigation ?? [];
+  const themeSwitcherEnabled = header?.themeSwitcher?.enabled ?? true;
+  const { isAuthenticated, isPending, profile, isAuthEnabled } = authState;
+
+  const accountItems = getProfileMenuItems();
+  const filteredItems = navigation.filter(
+    shouldShowItem({ auth: authState, context }),
+  );
+
+  const closeDrawer = () => onOpenChange(false);
+
+  return (
+    <Drawer
+      direction={site?.dir === "rtl" ? "left" : "right"}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DrawerContent
+        id={id}
+        className="lg:hidden h-dvh inset-e-0 start-auto w-[340px] rounded-none"
+        aria-describedby={undefined}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          triggerRef.current?.focus();
+        }}
+      >
+        <div className="py-2 h-full flex flex-col">
+          <div className="flex-1 overflow-y-auto overscroll-none">
+            <VisuallyHidden>
+              <DrawerTitle>Navigation</DrawerTitle>
+            </VisuallyHidden>
+            <ul className="flex flex-col gap-1 px-4">
+              {headerNavigation.map((item) => (
+                <MobileHeaderNavItem
+                  key={item.label}
+                  item={item}
+                  onNavigate={closeDrawer}
+                />
+              ))}
+              {headerNavigation.length > 0 && <Separator className="my-2" />}
+
+              {filteredItems.map((item) => {
+                if (item.type === "separator") {
+                  return <Separator className="my-2" key={item.label} />;
+                }
+                if (item.type === "section" || item.type === "filter") {
+                  return null;
+                }
+                const path = getFirstMatchingPath(item);
+                const isActive = deepEqual(currentNav.topNavItem, item);
+                const target = "target" in item ? item.target : undefined;
+                return (
+                  <li key={item.label}>
+                    <Link
+                      to={path}
+                      target={target}
+                      rel={
+                        target === "_blank" ? "noopener noreferrer" : undefined
+                      }
+                      onClick={closeDrawer}
+                      className={`flex items-center gap-2 py-2 text-base font-medium ${isActive ? "text-foreground" : "text-foreground/75 hover:text-foreground"}`}
+                    >
+                      {item.icon && <item.icon size={16} />}
+                      {item.label}
+                    </Link>
+                  </li>
+                );
+              })}
+              {isAuthEnabled &&
+                (isPending ? (
+                  <Skeleton className="rounded-sm h-5 w-24" />
+                ) : (
+                  isAuthenticated && (
+                    <>
+                      <Separator className="my-2" />
+                      <li className="py-2">
+                        <div className="text-base font-medium">
+                          {profile?.name ?? "My Account"}
+                        </div>
+                        {profile?.email && profile.email !== profile?.name && (
+                          <div className="text-sm text-muted-foreground">
+                            {profile.email}
+                          </div>
+                        )}
+                      </li>
+                      {accountItems.map((item) => (
+                        <li key={item.label}>
+                          <Link
+                            to={item.path ?? ""}
+                            target={item.target}
+                            rel={
+                              item.target === "_blank"
+                                ? "noopener noreferrer"
+                                : undefined
+                            }
+                            onClick={closeDrawer}
+                            className="flex items-center py-2 text-base font-medium text-foreground/75 hover:text-foreground"
+                          >
+                            {item.label}
+                          </Link>
+                        </li>
+                      ))}
+                    </>
+                  )
+                ))}
+            </ul>
+          </div>
+          <div className="border-t shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] px-4 pt-3 flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              {isAuthEnabled &&
+                (isPending ? (
+                  <Skeleton className="rounded-sm h-8 w-16" />
+                ) : isAuthenticated ? (
+                  <Button asChild variant="outline">
+                    <Link
+                      to="/signout"
+                      onClick={closeDrawer}
+                      className="flex items-center gap-2"
+                    >
+                      <LogOutIcon
+                        size={16}
+                        strokeWidth={1}
+                        absoluteStrokeWidth
+                      />
+                      Logout
+                    </Link>
+                  </Button>
+                ) : (
+                  <Button asChild variant="outline">
+                    <Link
+                      to={`/signin?redirect=${encodeURIComponent(location.pathname)}`}
+                      onClick={closeDrawer}
+                    >
+                      Login
+                    </Link>
+                  </Button>
+                ))}
+              {themeSwitcherEnabled && <ThemeSwitch />}
+            </div>
+            {site?.showPoweredBy !== false && (
+              <PoweredByZudoku className="grow-0 justify-center gap-1" />
+            )}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/packages/zudoku/src/lib/components/Search.test.tsx
+++ b/packages/zudoku/src/lib/components/Search.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render as testRender, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ZudokuPlugin } from "../core/plugins.js";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Search, SearchProvider } from "./Search.js";
+
+const render = async (plugins: ZudokuPlugin[]) => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext({ plugins }, queryClient, {});
+
+  await act(async () => {
+    testRender(
+      <QueryClientProvider client={queryClient}>
+        <ZudokuProvider context={context}>
+          <SearchProvider>
+            <Search />
+          </SearchProvider>
+        </ZudokuProvider>
+      </QueryClientProvider>,
+    );
+  });
+};
+
+const searchPlugin = (preloadSearch?: () => void): ZudokuPlugin => ({
+  renderSearch: () => null,
+  ...(preloadSearch && { preloadSearch }),
+});
+
+describe("SearchProvider", () => {
+  it("preloads the search UI once the page is idle", async () => {
+    const preloadSearch = vi.fn();
+
+    await render([searchPlugin(preloadSearch)]);
+
+    // The idle callback polyfill defers to a timer, so let it drain.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(preloadSearch).toHaveBeenCalled();
+  });
+
+  it("preloads on hover and focus of the search trigger", async () => {
+    const user = userEvent.setup();
+    const preloadSearch = vi.fn();
+
+    await render([searchPlugin(preloadSearch)]);
+    preloadSearch.mockClear();
+
+    const trigger = screen.getByRole("button", { name: /search/i });
+
+    await user.hover(trigger);
+    expect(preloadSearch).toHaveBeenCalled();
+
+    preloadSearch.mockClear();
+    await act(async () => {
+      trigger.focus();
+    });
+    expect(preloadSearch).toHaveBeenCalled();
+  });
+
+  it("renders a search plugin that does not implement preloadSearch", async () => {
+    await render([searchPlugin()]);
+
+    const trigger = screen.getByRole("button", { name: /search/i });
+    const user = userEvent.setup();
+
+    await user.hover(trigger);
+    await user.click(trigger);
+
+    expect(trigger).toBeInTheDocument();
+  });
+});

--- a/packages/zudoku/src/lib/components/Search.tsx
+++ b/packages/zudoku/src/lib/components/Search.tsx
@@ -13,13 +13,14 @@ import { isSearchPlugin } from "../core/plugins.js";
 import { focusRing } from "../ui/util.js";
 import { cn } from "../util/cn.js";
 import { getOS } from "../util/os.js";
+import { requestIdle } from "../util/requestIdle.js";
 import { ClientOnly } from "./ClientOnly.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 
 /** `null` when no search plugin is configured, `undefined` outside a provider */
-const SearchContext = createContext<{ onOpen: () => void } | null | undefined>(
-  undefined,
-);
+const SearchContext = createContext<
+  { onOpen: () => void; onPreload: () => void } | null | undefined
+>(undefined);
 
 /**
  * Owns the search modal and the ⌘K / Ctrl+K shortcut for all `Search` buttons
@@ -33,6 +34,18 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   const onClose = useCallback(() => setIsOpen(false), []);
 
   const searchPlugin = ctx.options.plugins?.find(isSearchPlugin);
+  const onPreload = useCallback(
+    () => searchPlugin?.preloadSearch?.(),
+    [searchPlugin],
+  );
+
+  // The search UI is lazily loaded, so opening it cold shows nothing until its
+  // chunk arrives. Warm it once the page is idle; hover/focus covers the rest.
+  useEffect(() => {
+    if (!searchPlugin?.preloadSearch) return;
+
+    return requestIdle(() => searchPlugin.preloadSearch?.());
+  }, [searchPlugin]);
 
   useEffect(() => {
     if (isOpen || !searchPlugin) return;
@@ -50,8 +63,8 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   }, [isOpen, searchPlugin]);
 
   const value = useMemo(
-    () => (searchPlugin ? { onOpen } : null),
-    [searchPlugin, onOpen],
+    () => (searchPlugin ? { onOpen, onPreload } : null),
+    [searchPlugin, onOpen, onPreload],
   );
 
   return (
@@ -80,6 +93,8 @@ export const Search = ({ className }: { className?: string }) => {
       <button
         type="button"
         onClick={search.onOpen}
+        onPointerEnter={search.onPreload}
+        onFocus={search.onPreload}
         className={cn(
           "relative w-full md:w-56 flex items-center border bg-clip-padding h-8 rounded-lg px-3 pr-14 text-sm transition-all",
           "border-input text-muted-foreground bg-background hover:bg-muted/50 hover:text-foreground shadow-xs",

--- a/packages/zudoku/src/lib/components/navigation/MobileNavigationDrawer.tsx
+++ b/packages/zudoku/src/lib/components/navigation/MobileNavigationDrawer.tsx
@@ -1,0 +1,57 @@
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import type { RefObject } from "react";
+import type { NavigationItem as NavigationItemType } from "../../../config/validators/NavigationSchema.js";
+import { Drawer, DrawerContent, DrawerTitle } from "../../ui/Drawer.js";
+import { NavigationFilterProvider } from "./NavigationFilterContext.js";
+import { NavigationFrames } from "./NavigationFrames.js";
+import { useNavigationFrame } from "./useNavigationFrame.js";
+import { getItemPath } from "./utils.js";
+
+export const MobileNavigationDrawer = ({
+  id,
+  direction,
+  navigation,
+  onOpenChange,
+  open,
+  topNavItem,
+  triggerRef,
+}: {
+  id: string;
+  direction: "left" | "right";
+  navigation: NavigationItemType[];
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  topNavItem?: NavigationItemType;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+}) => {
+  const frame = useNavigationFrame(navigation, topNavItem);
+  const section = topNavItem
+    ? (getItemPath(topNavItem) ?? topNavItem.label)
+    : "";
+
+  return (
+    <Drawer direction={direction} open={open} onOpenChange={onOpenChange}>
+      <NavigationFilterProvider resetKey={`${section}\n${frame.id}`}>
+        <DrawerContent
+          id={id}
+          className="lg:hidden h-dvh inset-s-0 w-[320px] rounded-none"
+          aria-describedby={undefined}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            triggerRef.current?.focus();
+          }}
+        >
+          <div className="p-4 overflow-y-auto overscroll-none">
+            <VisuallyHidden>
+              <DrawerTitle>Navigation</DrawerTitle>
+            </VisuallyHidden>
+            <NavigationFrames
+              frame={frame}
+              onRequestClose={() => onOpenChange(false)}
+            />
+          </div>
+        </DrawerContent>
+      </NavigationFilterProvider>
+    </Drawer>
+  );
+};

--- a/packages/zudoku/src/lib/components/navigation/Navigation.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Navigation.tsx
@@ -10,7 +10,6 @@ export const Navigation = ({
   navigation,
   topNavItem,
 }: {
-  onRequestClose?: () => void;
   navigation: NavigationItemType[];
   topNavItem?: NavigationItemType;
 }) => {

--- a/packages/zudoku/src/lib/components/navigation/Navigation.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Navigation.tsx
@@ -1,6 +1,4 @@
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import type { NavigationItem as NavigationItemType } from "../../../config/validators/NavigationSchema.js";
-import { DrawerContent, DrawerTitle } from "../../ui/Drawer.js";
 import { Slot } from "../Slot.js";
 import { NavigationFilterProvider } from "./NavigationFilterContext.js";
 import { NavigationFrames } from "./NavigationFrames.js";
@@ -9,7 +7,6 @@ import { useNavigationFrame } from "./useNavigationFrame.js";
 import { getItemPath } from "./utils.js";
 
 export const Navigation = ({
-  onRequestClose,
   navigation,
   topNavItem,
 }: {
@@ -29,18 +26,6 @@ export const Navigation = ({
         <NavigationFrames frame={frame} />
         <Slot.Target name="navigation-after" />
       </NavigationWrapper>
-      <DrawerContent
-        className="lg:hidden h-dvh inset-s-0 w-[320px] rounded-none"
-        aria-describedby={undefined}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-      >
-        <div className="p-4 overflow-y-auto overscroll-none">
-          <VisuallyHidden>
-            <DrawerTitle>Navigation</DrawerTitle>
-          </VisuallyHidden>
-          <NavigationFrames frame={frame} onRequestClose={onRequestClose} />
-        </div>
-      </DrawerContent>
     </NavigationFilterProvider>
   );
 };

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -85,6 +85,7 @@ type Site = Partial<{
       dark: string;
     };
     width?: string | number;
+    height?: string | number;
     alt?: string;
     href?: string;
     reloadDocument?: boolean;

--- a/packages/zudoku/src/lib/core/plugins.ts
+++ b/packages/zudoku/src/lib/core/plugins.ts
@@ -49,6 +49,12 @@ export interface SearchProviderPlugin {
     onOpen: () => void;
     onClose: () => void;
   }) => React.JSX.Element | null;
+  /**
+   * Start loading whatever `renderSearch` needs, without opening it. Called
+   * when the page goes idle and again on hover/focus of a search trigger, so
+   * a lazily loaded search UI is warm by the time it is opened.
+   */
+  preloadSearch?: () => void;
 }
 
 export interface ProfileMenuPlugin {

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { expect, it, vi } from "vitest";
+import { isSearchPlugin } from "../../core/plugins.js";
+import { pagefindSearchPlugin } from "./index.js";
+
+const mounts = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock("./PagefindSearch.js", async () => {
+  const { useEffect } = await import("react");
+
+  return {
+    PagefindSearch: ({ isOpen }: { isOpen: boolean }) => {
+      useEffect(() => {
+        mounts.count++;
+      }, []);
+
+      return <div data-testid="pagefind" data-open={isOpen} />;
+    },
+  };
+});
+
+it("loads Pagefind on first open and preserves it across close and reopen", async () => {
+  mounts.count = 0;
+  const plugin = pagefindSearchPlugin({ type: "pagefind" });
+  expect(isSearchPlugin(plugin)).toBe(true);
+  if (!isSearchPlugin(plugin)) return;
+
+  const onOpen = vi.fn();
+  const onClose = vi.fn();
+  const renderSearch = (isOpen: boolean) => (
+    <Suspense>{plugin.renderSearch({ isOpen, onOpen, onClose })}</Suspense>
+  );
+  const view = render(renderSearch(false));
+
+  expect(screen.queryByTestId("pagefind")).toBeNull();
+
+  view.rerender(renderSearch(true));
+  expect(await screen.findByTestId("pagefind")).toHaveAttribute(
+    "data-open",
+    "true",
+  );
+  expect(mounts.count).toBe(1);
+
+  view.rerender(renderSearch(false));
+  expect(screen.getByTestId("pagefind")).toHaveAttribute("data-open", "false");
+
+  view.rerender(renderSearch(true));
+  expect(screen.getByTestId("pagefind")).toHaveAttribute("data-open", "true");
+  expect(mounts.count).toBe(1);
+});

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
@@ -6,9 +6,11 @@ import { isSearchPlugin } from "../../core/plugins.js";
 import { pagefindSearchPlugin } from "./index.js";
 
 const mounts = vi.hoisted(() => ({ count: 0 }));
+const loads = vi.hoisted(() => ({ count: 0 }));
 
 vi.mock("./PagefindSearch.js", async () => {
   const { useEffect } = await import("react");
+  loads.count++;
 
   return {
     PagefindSearch: ({ isOpen }: { isOpen: boolean }) => {
@@ -19,6 +21,23 @@ vi.mock("./PagefindSearch.js", async () => {
       return <div data-testid="pagefind" data-open={isOpen} />;
     },
   };
+});
+
+it("does not import the search chunk until preloadSearch is called", async () => {
+  const plugin = pagefindSearchPlugin({ type: "pagefind" });
+  expect(isSearchPlugin(plugin)).toBe(true);
+  if (!isSearchPlugin(plugin)) return;
+
+  // Nothing has rendered or preloaded yet, so the chunk must be untouched.
+  expect(loads.count).toBe(0);
+
+  plugin.preloadSearch?.();
+  await vi.waitFor(() => expect(loads.count).toBe(1));
+
+  // Repeated preloads reuse the in-flight/settled import.
+  plugin.preloadSearch?.();
+  await vi.waitFor(() => expect(loads.count).toBe(1));
+  expect(mounts.count).toBe(0);
 });
 
 it("loads Pagefind on first open and preserves it across close and reopen", async () => {

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
@@ -1,6 +1,32 @@
+import { lazy, useEffect, useState } from "react";
 import type { ZudokuConfig } from "../../../config/validators/ZudokuConfig.js";
 import type { ZudokuPlugin } from "../../core/plugins.js";
-import { PagefindSearch } from "./PagefindSearch.js";
+
+const PagefindSearch = lazy(() =>
+  import("./PagefindSearch.js").then((module) => ({
+    default: module.PagefindSearch,
+  })),
+);
+
+const MountedPagefindSearch = ({
+  isOpen,
+  onClose,
+  options,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  options: PagefindOptions;
+}) => {
+  const [hasOpened, setHasOpened] = useState(isOpen);
+
+  useEffect(() => {
+    if (isOpen) setHasOpened(true);
+  }, [isOpen]);
+
+  if (!isOpen && !hasOpened) return null;
+
+  return <PagefindSearch isOpen={isOpen} onClose={onClose} options={options} />;
+};
 
 export type PagefindOptions = Extract<
   ZudokuConfig["search"],
@@ -12,7 +38,11 @@ export const pagefindSearchPlugin = (
 ): ZudokuPlugin => {
   return {
     renderSearch: ({ isOpen, onClose }) => (
-      <PagefindSearch isOpen={isOpen} onClose={onClose} options={options} />
+      <MountedPagefindSearch
+        isOpen={isOpen}
+        onClose={onClose}
+        options={options}
+      />
     ),
   };
 };

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
@@ -2,11 +2,19 @@ import { lazy, useEffect, useState } from "react";
 import type { ZudokuConfig } from "../../../config/validators/ZudokuConfig.js";
 import type { ZudokuPlugin } from "../../core/plugins.js";
 
-const PagefindSearch = lazy(() =>
+const importPagefindSearch = () =>
   import("./PagefindSearch.js").then((module) => ({
     default: module.PagefindSearch,
-  })),
-);
+  }));
+
+let pagefindSearchPromise: ReturnType<typeof importPagefindSearch> | undefined;
+
+const loadPagefindSearch = () => {
+  pagefindSearchPromise ??= importPagefindSearch();
+  return pagefindSearchPromise;
+};
+
+const PagefindSearch = lazy(loadPagefindSearch);
 
 const MountedPagefindSearch = ({
   isOpen,
@@ -44,5 +52,8 @@ export const pagefindSearchPlugin = (
         options={options}
       />
     ),
+    // Only warms the component chunk. The Pagefind bundle and its index are
+    // still fetched by PagefindSearch itself, which mounts on first open.
+    preloadSearch: () => void loadPagefindSearch(),
   };
 };

--- a/packages/zudoku/src/lib/shiki.ts
+++ b/packages/zudoku/src/lib/shiki.ts
@@ -175,6 +175,7 @@ export const highlight = (
       code: ({ inline: _inline, ...props }) =>
         createElement("code", {
           ...props,
+          "data-zudoku-runtime-shiki": true,
           className: cn(props.className, HIGHLIGHT_CODE_BLOCK_CLASS),
         }),
     },

--- a/packages/zudoku/src/lib/util/getIntrinsicImageDimensions.ts
+++ b/packages/zudoku/src/lib/util/getIntrinsicImageDimensions.ts
@@ -1,0 +1,15 @@
+export const getIntrinsicImageDimensions = (
+  width: string | number | undefined,
+  height: string | number | undefined,
+) => {
+  if (
+    typeof width !== "number" ||
+    !Number.isFinite(width) ||
+    typeof height !== "number" ||
+    !Number.isFinite(height)
+  ) {
+    return {};
+  }
+
+  return { width, height };
+};

--- a/packages/zudoku/src/lib/util/isHeaderNavGroup.ts
+++ b/packages/zudoku/src/lib/util/isHeaderNavGroup.ts
@@ -1,0 +1,9 @@
+import type {
+  HeaderNavGroup,
+  HeaderNavItem,
+  HeaderNavLinkItem,
+} from "../../config/validators/HeaderNavigationSchema.js";
+
+export const isHeaderNavGroup = (
+  item: HeaderNavItem | HeaderNavLinkItem | HeaderNavGroup,
+): item is HeaderNavGroup => "items" in item;

--- a/packages/zudoku/src/lib/util/requestIdle.ts
+++ b/packages/zudoku/src/lib/util/requestIdle.ts
@@ -1,0 +1,19 @@
+/**
+ * `requestIdleCallback` that is safe to call from `lib` code. `polyfills.ts`
+ * only runs in the app entry, so components reachable from the public exports
+ * (or from a test environment) cannot rely on the global existing.
+ *
+ * Returns a cancel function rather than an id so callers do not need to know
+ * which of the two implementations ran.
+ */
+export const requestIdle = (callback: () => void, timeout = 10_000) => {
+  if (typeof window === "undefined") return () => {};
+
+  if (typeof window.requestIdleCallback === "function") {
+    const id = window.requestIdleCallback(() => callback(), { timeout });
+    return () => window.cancelIdleCallback(id);
+  }
+
+  const id = window.setTimeout(callback, 1);
+  return () => window.clearTimeout(id);
+};

--- a/packages/zudoku/src/vite/build.test.ts
+++ b/packages/zudoku/src/vite/build.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getEagerCssEntries } from "./build.js";
+
+describe("getEagerCssEntries", () => {
+  it("keeps eager and standalone CSS while excluding lazy chunk CSS", () => {
+    const output = [
+      {
+        type: "chunk",
+        fileName: "entry.js",
+        isEntry: true,
+        imports: ["vendor.js"],
+        viteMetadata: { importedCss: new Set(["entry.css", "shared.css"]) },
+      },
+      {
+        type: "chunk",
+        fileName: "vendor.js",
+        imports: [],
+        viteMetadata: { importedCss: new Set(["vendor.css"]) },
+      },
+      {
+        type: "chunk",
+        fileName: "dialog.js",
+        imports: [],
+        viteMetadata: { importedCss: new Set(["dialog.css", "shared.css"]) },
+      },
+      { type: "asset", fileName: "entry.css" },
+      { type: "asset", fileName: "vendor.css" },
+      { type: "asset", fileName: "dialog.css" },
+      { type: "asset", fileName: "shared.css" },
+      { type: "asset", fileName: "custom-plugin-global.css" },
+    ];
+
+    expect(getEagerCssEntries(output)).toEqual([
+      "entry.css",
+      "vendor.css",
+      "shared.css",
+      "custom-plugin-global.css",
+    ]);
+  });
+
+  it("keeps all CSS when chunk metadata is unavailable", () => {
+    expect(
+      getEagerCssEntries([
+        { type: "chunk", fileName: "entry.js", isEntry: true },
+        { type: "asset", fileName: "entry.css" },
+        { type: "asset", fileName: "plugin.css" },
+      ]),
+    ).toEqual(["entry.css", "plugin.css"]);
+  });
+});

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -23,6 +23,60 @@ import {
 
 const DIST_DIR = "dist";
 
+type CssBuildOutput = {
+  fileName: string;
+  imports?: string[];
+  isEntry?: boolean;
+  type: string;
+  viteMetadata?: { importedCss: Set<string> };
+};
+
+export const getEagerCssEntries = (output: readonly CssBuildOutput[]) => {
+  const cssAssets = output
+    .filter((item) => item.fileName.endsWith(".css"))
+    .map((item) => item.fileName);
+  const chunksByFileName = new Map(
+    output
+      .filter((item) => item.type === "chunk")
+      .map((item) => [item.fileName, item]),
+  );
+  const entryChunk = output.find(
+    (item) => item.type === "chunk" && item.isEntry,
+  );
+
+  if (!entryChunk) return cssAssets;
+
+  const referencedCss = new Set(
+    output.flatMap((item) => [...(item.viteMetadata?.importedCss ?? [])]),
+  );
+
+  // Build adapters that do not expose Vite's chunk metadata retain the
+  // previous behavior of linking every emitted stylesheet.
+  if (referencedCss.size === 0) return cssAssets;
+
+  const eagerCss = new Set<string>();
+  const visitedChunks = new Set<string>();
+  const visitChunk = (fileName: string) => {
+    if (visitedChunks.has(fileName)) return;
+    visitedChunks.add(fileName);
+
+    const chunk = chunksByFileName.get(fileName);
+    if (!chunk) return;
+
+    chunk.viteMetadata?.importedCss.forEach((css) => eagerCss.add(css));
+    chunk.imports?.forEach(visitChunk);
+  };
+
+  visitChunk(entryChunk.fileName);
+
+  // Keep CSS imported by the eager entry graph and standalone/global assets
+  // emitted by custom plugins. Only CSS owned exclusively by lazy chunks is
+  // omitted from the initial document.
+  return cssAssets.filter(
+    (css) => eagerCss.has(css) || !referencedCss.has(css),
+  );
+};
+
 export type SSRAdapter = "node" | "cloudflare" | "vercel" | "lambda";
 
 export type BuildOptions = {
@@ -78,13 +132,12 @@ export async function runBuild(options: BuildOptions) {
   invariant(clientOutDir, "Client build outDir is missing");
   invariant(serverOutDir, "Server build outDir is missing");
 
-  const jsEntry = clientResult.output.find(
+  const jsEntryChunk = clientResult.output.find(
     (o) => "isEntry" in o && o.isEntry,
-  )?.fileName;
+  );
+  const jsEntry = jsEntryChunk?.fileName;
 
-  const cssEntries = clientResult.output
-    .filter((o) => o.fileName.endsWith(".css"))
-    .map((o) => o.fileName);
+  const cssEntries = getEagerCssEntries(clientResult.output);
 
   if (!jsEntry || cssEntries.length === 0) {
     throw new Error("Build failed. No js or css assets found");

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -139,8 +139,14 @@ export async function runBuild(options: BuildOptions) {
 
   const cssEntries = getEagerCssEntries(clientResult.output);
 
-  if (!jsEntry || cssEntries.length === 0) {
-    throw new Error("Build failed. No js or css assets found");
+  if (!jsEntry) {
+    throw new Error("Build failed. No js entry chunk found");
+  }
+
+  if (cssEntries.length === 0) {
+    throw new Error(
+      "Build failed. No stylesheet reachable from the eager entry chunk was found",
+    );
   }
 
   const html = getBuildHtml({

--- a/packages/zudoku/src/vite/plugin-api.test.ts
+++ b/packages/zudoku/src/vite/plugin-api.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { schemaConfigurationChanged } from "./plugin-api.js";
+import {
+  generateSchemaImportsCode,
+  schemaConfigurationChanged,
+} from "./plugin-api.js";
 
 describe("schemaConfigurationChanged", () => {
   const apis = {
@@ -24,5 +27,33 @@ describe("schemaConfigurationChanged", () => {
         { apis: structuredClone(apis), basePath: "/docs" },
       ),
     ).toBe(false);
+  });
+});
+
+describe("generateSchemaImportsCode", () => {
+  it("emits one shared schema loader registry", () => {
+    expect(
+      generateSchemaImportsCode([
+        { importKey: "/processed/first.js", processedTime: 123 },
+        { importKey: "/processed/second.js", processedTime: 456 },
+      ]),
+    ).toEqual([
+      "const schemaImports = {",
+      '  "/processed/first.js": () => import("/processed/first.js?d=123"),',
+      '  "/processed/second.js": () => import("/processed/second.js?d=456"),',
+      "};",
+    ]);
+  });
+
+  it("normalizes Windows import paths without changing registry keys", () => {
+    expect(
+      generateSchemaImportsCode([
+        { importKey: "C:\\processed\\schema.js", processedTime: 123 },
+      ]),
+    ).toEqual([
+      "const schemaImports = {",
+      '  "C:\\\\processed\\\\schema.js": () => import("C:/processed/schema.js?d=123"),',
+      "};",
+    ]);
   });
 });

--- a/packages/zudoku/src/vite/plugin-api.test.ts
+++ b/packages/zudoku/src/vite/plugin-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  generateDefaultApiOptionsCode,
   generateSchemaImportsCode,
   schemaConfigurationChanged,
 } from "./plugin-api.js";
@@ -55,5 +56,101 @@ describe("generateSchemaImportsCode", () => {
       '  "C:\\\\processed\\\\schema.js": () => import("C:/processed/schema.js?d=123"),',
       "};",
     ]);
+  });
+});
+
+describe("generateDefaultApiOptionsCode", () => {
+  // The generated snippet is the contract, so evaluate it the way the virtual
+  // module does instead of asserting on source text.
+  const resolve = (
+    config: unknown,
+    apiOptions: Record<string, unknown> = {},
+  ) => {
+    const body = [
+      ...generateDefaultApiOptionsCode(),
+      "return { ...defaultApiOptions, ...apiOptions };",
+    ].join("\n");
+    return new Function("config", "apiOptions", body)(
+      config,
+      apiOptions,
+    ) as Record<string, unknown>;
+  };
+
+  it("applies fallbacks when no defaults are configured", () => {
+    expect(resolve({})).toEqual({
+      examplesLanguage: undefined,
+      supportedLanguages: undefined,
+      disablePlayground: undefined,
+      disableSidecar: undefined,
+      disableSecurity: true,
+      disableMcpAuthInstructions: undefined,
+      showVersionSelect: "if-available",
+      showInfoPage: undefined,
+      schemaDownload: undefined,
+    });
+  });
+
+  it("prefers defaults.apis.examplesLanguage over the top-level default", () => {
+    const resolved = resolve({
+      defaults: {
+        examplesLanguage: "python",
+        apis: { examplesLanguage: "go" },
+      },
+    });
+
+    expect(resolved.examplesLanguage).toBe("go");
+  });
+
+  it("falls back to the top-level examplesLanguage default", () => {
+    const resolved = resolve({ defaults: { examplesLanguage: "python" } });
+
+    expect(resolved.examplesLanguage).toBe("python");
+  });
+
+  it("keeps explicit false for options that default to true", () => {
+    const resolved = resolve({
+      defaults: { apis: { disableSecurity: false, showVersionSelect: false } },
+    });
+
+    expect(resolved.disableSecurity).toBe(false);
+    expect(resolved.showVersionSelect).toBe(false);
+  });
+
+  it("passes through configured defaults", () => {
+    const schemaDownload = { enabled: true };
+    const resolved = resolve({
+      defaults: {
+        apis: {
+          supportedLanguages: ["js", "go"],
+          disablePlayground: true,
+          disableSidecar: true,
+          disableMcpAuthInstructions: true,
+          showInfoPage: false,
+          schemaDownload,
+        },
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      supportedLanguages: ["js", "go"],
+      disablePlayground: true,
+      disableSidecar: true,
+      disableMcpAuthInstructions: true,
+      showInfoPage: false,
+      schemaDownload,
+    });
+  });
+
+  it("lets authored API options win over the shared defaults", () => {
+    const resolved = resolve(
+      { defaults: { apis: { disableSecurity: true, showInfoPage: false } } },
+      { disableSecurity: false, showInfoPage: true, examplesLanguage: "ruby" },
+    );
+
+    expect(resolved).toMatchObject({
+      disableSecurity: false,
+      showInfoPage: true,
+      examplesLanguage: "ruby",
+    });
   });
 });

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -43,6 +43,17 @@ export const schemaConfigurationChanged = (
   next: Pick<ConfigWithMeta, "apis" | "basePath">,
 ) => current.basePath !== next.basePath || !deepEqual(current.apis, next.apis);
 
+export const generateSchemaImportsCode = (
+  schemaImports: { importKey: string; processedTime: number }[],
+) => [
+  "const schemaImports = {",
+  ...schemaImports.map(
+    (schema) =>
+      `  ${JSON.stringify(schema.importKey)}: () => import(${JSON.stringify(`${schema.importKey.replaceAll("\\", "/")}?d=${schema.processedTime}`)}),`,
+  ),
+  "};",
+];
+
 const warn = (message: string) => {
   // biome-ignore lint/suspicious/noConsole: Logging allowed here
   console.warn(`[zudoku] ${message}`);
@@ -198,8 +209,28 @@ const viteApiPlugin = async (): Promise<Plugin> => {
         code.push(
           `const apis = Array.isArray(config.apis) ? config.apis : [config.apis]`,
         );
+        code.push(
+          `const defaultApiOptions = {`,
+          `  examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
+          `  supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
+          `  disablePlayground: config.defaults?.apis?.disablePlayground,`,
+          `  disableSidecar: config.defaults?.apis?.disableSidecar,`,
+          `  disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
+          `  disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
+          `  showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+          `  showInfoPage: config.defaults?.apis?.showInfoPage,`,
+          `  schemaDownload: config.defaults?.apis?.schemaDownload,`,
+          `};`,
+        );
         const apis = ensureArray(config.apis);
         const apiMetadata: ApiCatalogItem[] = [];
+        const schemaImports = schemaManager.getSchemaImports();
+
+        // Every file API uses the same registry so the local GraphQL server can
+        // resolve schemas across the whole portal. Emit it once: inlining the
+        // complete map into every plugin duplicates all loader closures and
+        // import paths in the client entry chunk.
+        code.push(...generateSchemaImportsCode(schemaImports));
 
         for (const apiConfig of apis) {
           if (apiConfig.type === "file" && apiConfig.path) {
@@ -272,8 +303,6 @@ const viteApiPlugin = async (): Promise<Plugin> => {
 
             const tags = Array.from(allSlugs);
 
-            const schemaImports = schemaManager.getSchemaImports();
-
             // Catalog mode renders a single page, so it reads the flag from the
             // latest schema only and ignores the other versions entirely.
             const latest = schemas.at(0);
@@ -304,26 +333,13 @@ const viteApiPlugin = async (): Promise<Plugin> => {
                 ? [`  documentType: ${JSON.stringify(documentType)},`]
                 : []),
               `  options: {`,
-              `    examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
-              `    supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
-              `    disablePlayground: config.defaults?.apis?.disablePlayground,`,
-              `    disableSidecar: config.defaults?.apis?.disableSidecar,`,
-              `    disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
-              `    disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
-              `    showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+              `    ...defaultApiOptions,`,
               `    expandAllTags: config.defaults?.apis?.expandAllTags ?? true,`,
-              `    showInfoPage: config.defaults?.apis?.showInfoPage,`,
-              `    schemaDownload: config.defaults?.apis?.schemaDownload,`,
               `    transformExamples: config.defaults?.apis?.transformExamples,`,
               `    generateCodeSnippet: config.defaults?.apis?.generateCodeSnippet,`,
               `    ...(apis[${apiIndex}].options ?? {}),`,
               `  },`,
-              `  schemaImports: {`,
-              ...schemaImports.map(
-                (s) =>
-                  `    "${s.importKey.replaceAll("\\", "\\\\")}": () => import("${s.importKey.replaceAll("\\", "/")}?d=${s.processedTime}"),`,
-              ),
-              `  },`,
+              `  schemaImports,`,
               "}));",
             );
           } else {
@@ -342,16 +358,8 @@ const viteApiPlugin = async (): Promise<Plugin> => {
                 ? [`  documentType: ${JSON.stringify(documentType)},`]
                 : []),
               "  options: {",
-              `    examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
-              `    supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
-              `    disablePlayground: config.defaults?.apis?.disablePlayground,`,
-              `    disableSidecar: config.defaults?.apis?.disableSidecar,`,
-              `    disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
-              `    disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
-              `    showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+              `    ...defaultApiOptions,`,
               `    expandAllTags: config.defaults?.apis?.expandAllTags ?? false,`,
-              `    showInfoPage: config.defaults?.apis?.showInfoPage,`,
-              `    schemaDownload: config.defaults?.apis?.schemaDownload,`,
               `    ...${JSON.stringify(apiConfig.options ?? {})},`,
               "  },",
               "}));",

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -43,6 +43,22 @@ export const schemaConfigurationChanged = (
   next: Pick<ConfigWithMeta, "apis" | "basePath">,
 ) => current.basePath !== next.basePath || !deepEqual(current.apis, next.apis);
 
+// Emitted once per virtual module. Every API spreads it, so authored
+// `options` still override these and per-API keys stay next to the spread.
+export const generateDefaultApiOptionsCode = () => [
+  `const defaultApiOptions = {`,
+  `  examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
+  `  supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
+  `  disablePlayground: config.defaults?.apis?.disablePlayground,`,
+  `  disableSidecar: config.defaults?.apis?.disableSidecar,`,
+  `  disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
+  `  disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
+  `  showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+  `  showInfoPage: config.defaults?.apis?.showInfoPage,`,
+  `  schemaDownload: config.defaults?.apis?.schemaDownload,`,
+  `};`,
+];
+
 export const generateSchemaImportsCode = (
   schemaImports: { importKey: string; processedTime: number }[],
 ) => [
@@ -209,19 +225,7 @@ const viteApiPlugin = async (): Promise<Plugin> => {
         code.push(
           `const apis = Array.isArray(config.apis) ? config.apis : [config.apis]`,
         );
-        code.push(
-          `const defaultApiOptions = {`,
-          `  examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
-          `  supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
-          `  disablePlayground: config.defaults?.apis?.disablePlayground,`,
-          `  disableSidecar: config.defaults?.apis?.disableSidecar,`,
-          `  disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
-          `  disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
-          `  showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
-          `  showInfoPage: config.defaults?.apis?.showInfoPage,`,
-          `  schemaDownload: config.defaults?.apis?.schemaDownload,`,
-          `};`,
-        );
+        code.push(...generateDefaultApiOptionsCode());
         const apis = ensureArray(config.apis);
         const apiMetadata: ApiCatalogItem[] = [];
         const schemaImports = schemaManager.getSchemaImports();

--- a/packages/zudoku/src/vite/plugin-theme.test.ts
+++ b/packages/zudoku/src/vite/plugin-theme.test.ts
@@ -10,7 +10,6 @@ const callPluginLoad = async (plugin: Plugin, id: string) => {
   // biome-ignore lint/style/noNonNullAssertion: is guaranteed to be defined
   const hook = plugin.load!;
   const loadFn = typeof hook === "function" ? hook : hook.handler;
-  // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   return loadFn.call({} as any, id);
 };
 
@@ -18,7 +17,6 @@ const callPluginTransform = async (plugin: Plugin, src: string, id: string) => {
   // biome-ignore lint/style/noNonNullAssertion: is guaranteed to be defined
   const hook = plugin.transform!;
   const transformFn = typeof hook === "function" ? hook : hook.handler;
-  // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   return transformFn.call({} as any, src, id);
 };
 
@@ -92,14 +90,9 @@ describe("plugin-theme", () => {
       const plugin = viteThemePlugin();
       const result = await callPluginLoad(plugin, resolvedVirtualModuleId);
 
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap')",
-      );
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
-      expect(result).toContain("--font-sans: Geist, sans-serif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).not.toContain("fonts.googleapis.com");
+      expect(result).toContain('--font-sans: "Geist Variable", sans-serif');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
 
     it("should handle mixed font configurations with defaults for missing fonts", async () => {
@@ -123,12 +116,9 @@ describe("plugin-theme", () => {
       expect(result).toContain(
         "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap')",
       );
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
       expect(result).toContain("--font-sans: Inter");
       expect(result).toContain("--font-serif: CustomSerif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
 
     it("should provide mono default when only sans is configured", async () => {
@@ -149,11 +139,8 @@ describe("plugin-theme", () => {
       const result = await callPluginLoad(plugin, resolvedVirtualModuleId);
 
       expect(result).toContain("@import url('/fonts/fonts.css')");
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
       expect(result).toContain("--font-sans: Solis, sans-serif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
   });
 

--- a/packages/zudoku/src/vite/plugin-theme.ts
+++ b/packages/zudoku/src/vite/plugin-theme.ts
@@ -126,9 +126,9 @@ const processFontConfig = (fontConfig?: FontConfig) => {
 const processFonts = async (themeConfig: ZudokuConfig["theme"]) => {
   const imports: string[] = [];
   const families = {
-    sans: "Geist, sans-serif",
+    sans: '"Geist Variable", sans-serif',
     serif: undefined as string | undefined,
-    mono: '"Geist Mono", monospace',
+    mono: '"Geist Mono Variable", monospace',
   };
 
   // Process user fonts
@@ -179,23 +179,14 @@ const processFonts = async (themeConfig: ZudokuConfig["theme"]) => {
 
   // Determine final font families with priority: user > registry > defaults
   families.sans =
-    userFonts.sans.fontFamily || registryFonts.sans || "Geist, sans-serif";
+    userFonts.sans.fontFamily ||
+    registryFonts.sans ||
+    '"Geist Variable", sans-serif';
   families.serif = userFonts.serif.fontFamily || registryFonts.serif;
   families.mono =
     userFonts.mono.fontFamily ||
     registryFonts.mono ||
-    '"Geist Mono", monospace';
-
-  // Add default font imports if no user or registry fonts
-  if (!userFonts.sans.fontFamily && !registryFonts.sans) {
-    imports.push(getGoogleFontUrl("Geist"));
-  }
-  if (!userFonts.serif.fontFamily && !registryFonts.serif) {
-    imports.push(getGoogleFontUrl("Playfair Display"));
-  }
-  if (!userFonts.mono.fontFamily && !registryFonts.mono) {
-    imports.push(getGoogleFontUrl("Geist Mono"));
-  }
+    '"Geist Mono Variable", monospace';
 
   return { imports, families };
 };

--- a/packages/zudoku/src/vite/protected/annotator.test.ts
+++ b/packages/zudoku/src/vite/protected/annotator.test.ts
@@ -79,6 +79,39 @@ describe("matchPathObject (Shape A)", () => {
     });
   });
 
+  it("ignores identifiers that are not value references", async () => {
+    // `admin` here is a property key, a member property, and a parameter name.
+    // None of them reference the top-level `admin` registry, so its import
+    // must not be attributed to "/public".
+    const { route, bindings } = await pathObjectAndBindings(`
+      const admin = { load: () => import("./admin-secret.js") };
+      const route = {
+        path: "/public",
+        handle: { admin: false },
+        element: layouts.admin,
+        loader: (admin) => admin.data,
+        lazy: () => import("./public.js"),
+      };
+    `);
+
+    expect(matchPathObject(route, bindings)).toEqual({
+      root: "/public",
+      specs: ["./public.js"],
+    });
+  });
+
+  it("follows a registry referenced by a nested property value", async () => {
+    const { route, bindings } = await pathObjectAndBindings(`
+      const schemaImports = { "/processed/first.js": () => import("./first.js") };
+      const route = { path: "/api", options: { schemaImports } };
+    `);
+
+    expect(matchPathObject(route, bindings)).toEqual({
+      root: "/api",
+      specs: ["./first.js"],
+    });
+  });
+
   it("returns undefined without a string path", async () => {
     const node = await firstObject(
       `const r = { path: dynamicPath, lazy: () => import("./x") };`,

--- a/packages/zudoku/src/vite/protected/annotator.test.ts
+++ b/packages/zudoku/src/vite/protected/annotator.test.ts
@@ -2,13 +2,11 @@ import { parse } from "vite";
 import { describe, expect, it } from "vitest";
 import { matchPathObject, matchRouteDict } from "./annotator.js";
 
-// biome-ignore lint/suspicious/noExplicitAny: walker-shape AST
 const firstObject = async (code: string): Promise<any> => {
   const { program } = await parse("test.js", code);
   let found: unknown;
   const visit = (n: unknown) => {
     if (found) return;
-    // biome-ignore lint/suspicious/noExplicitAny: generic walker
     const node = n as any;
     if (node?.type === "ObjectExpression") {
       found = node;
@@ -23,6 +21,26 @@ const firstObject = async (code: string): Promise<any> => {
   };
   visit(program);
   return found;
+};
+
+const pathObjectAndBindings = async (code: string) => {
+  const { program } = await parse("test.js", code);
+  const declarations = program.body.flatMap((statement: any) =>
+    statement.type === "VariableDeclaration" ? statement.declarations : [],
+  );
+  const bindings = new Map(
+    declarations.flatMap((declaration: any) =>
+      declaration.id?.type === "Identifier" &&
+      declaration.init?.type === "ObjectExpression"
+        ? [[declaration.id.name, declaration.init] as const]
+        : [],
+    ),
+  );
+  const route = declarations.find(
+    (declaration: any) => declaration.id?.name === "route",
+  )?.init;
+
+  return { route, bindings };
 };
 
 describe("matchPathObject (Shape A)", () => {
@@ -43,6 +61,21 @@ describe("matchPathObject (Shape A)", () => {
     expect(matchPathObject(node)).toEqual({
       root: "/api",
       specs: ["./a", "./b"],
+    });
+  });
+
+  it("follows a shared top-level schema import registry", async () => {
+    const { route, bindings } = await pathObjectAndBindings(`
+      const schemaImports = {
+        "/processed/first.js": () => import("./first.js"),
+        "/processed/second.js": () => import("./second.js"),
+      };
+      const route = { path: "/api", schemaImports };
+    `);
+
+    expect(matchPathObject(route, bindings)).toEqual({
+      root: "/api",
+      specs: ["./first.js", "./second.js"],
     });
   });
 

--- a/packages/zudoku/src/vite/protected/annotator.ts
+++ b/packages/zudoku/src/vite/protected/annotator.ts
@@ -48,26 +48,47 @@ const collectTopLevelObjectBindings = (ast: AstNode): ObjectBindings =>
 // All dynamic-import specifiers found anywhere inside a subtree. Follow
 // top-level object bindings so generated route objects can share a loader
 // registry without losing their route-to-import association.
+//
+// Only identifiers in *value* position resolve to a binding. `walk` is neither
+// scope- nor parent-aware, so property keys (`{ admin: false }`), member
+// properties (`layouts.admin`), and parameter names (`(admin) => ...`) all
+// arrive as plain `Identifier` nodes; treating those as references would
+// attribute an unrelated registry's imports to this route.
 const collectImportSpecs = (
   node: AstNode,
   objectBindings: ObjectBindings,
   visitedBindings = new Set<string>(),
 ): string[] => {
   const out: string[] = [];
+  const referenced: AstNode[] = [];
+
+  const considerReference = (candidate: AstNode) => {
+    if (candidate?.type !== "Identifier") return;
+    if (visitedBindings.has(candidate.name)) return;
+    const binding = objectBindings.get(candidate.name);
+    if (!binding) return;
+
+    visitedBindings.add(candidate.name);
+    referenced.push(binding);
+  };
+
+  // A shared registry reaches a route either as the sibling value itself
+  // (`{ path, schemaImports }`) or as a nested property value.
+  considerReference(node);
 
   walk(node, (n) => {
     if (n.type === "ImportExpression") {
       const spec = literalString(n.source);
       if (spec) out.push(spec);
+      return;
     }
 
-    if (n.type !== "Identifier" || visitedBindings.has(n.name)) return;
-    const binding = objectBindings.get(n.name);
-    if (!binding) return;
-
-    visitedBindings.add(n.name);
-    out.push(...collectImportSpecs(binding, objectBindings, visitedBindings));
+    if (n.type === "Property") considerReference(n.value);
   });
+
+  for (const binding of referenced) {
+    out.push(...collectImportSpecs(binding, objectBindings, visitedBindings));
+  }
   return out;
 };
 

--- a/packages/zudoku/src/vite/protected/annotator.ts
+++ b/packages/zudoku/src/vite/protected/annotator.ts
@@ -29,14 +29,44 @@ const literalString = (node: AstNode): string | undefined =>
 const propKey = (prop: AstNode): string | undefined =>
   prop.key?.type === "Identifier" ? prop.key.name : literalString(prop.key);
 
-// All dynamic-import specifiers found anywhere inside a subtree.
-const collectImportSpecs = (node: AstNode): string[] => {
+type ObjectBindings = ReadonlyMap<string, AstNode>;
+
+const collectTopLevelObjectBindings = (ast: AstNode): ObjectBindings =>
+  new Map(
+    (ast.body ?? []).flatMap((statement: AstNode) => {
+      if (statement.type !== "VariableDeclaration") return [];
+
+      return (statement.declarations ?? []).flatMap((declaration: AstNode) =>
+        declaration.id?.type === "Identifier" &&
+        declaration.init?.type === "ObjectExpression"
+          ? [[declaration.id.name, declaration.init] as const]
+          : [],
+      );
+    }),
+  );
+
+// All dynamic-import specifiers found anywhere inside a subtree. Follow
+// top-level object bindings so generated route objects can share a loader
+// registry without losing their route-to-import association.
+const collectImportSpecs = (
+  node: AstNode,
+  objectBindings: ObjectBindings,
+  visitedBindings = new Set<string>(),
+): string[] => {
   const out: string[] = [];
+
   walk(node, (n) => {
     if (n.type === "ImportExpression") {
       const spec = literalString(n.source);
       if (spec) out.push(spec);
     }
+
+    if (n.type !== "Identifier" || visitedBindings.has(n.name)) return;
+    const binding = objectBindings.get(n.name);
+    if (!binding) return;
+
+    visitedBindings.add(n.name);
+    out.push(...collectImportSpecs(binding, objectBindings, visitedBindings));
   });
   return out;
 };
@@ -45,6 +75,7 @@ const collectImportSpecs = (node: AstNode): string[] => {
 // RR route objects and plugin-api's `openApiPlugin({path, schemaImports})`.
 export const matchPathObject = (
   node: AstNode,
+  objectBindings: ObjectBindings = new Map(),
 ): { root: string; specs: string[] } | undefined => {
   if (node.type !== "ObjectExpression") return;
   let root: string | undefined;
@@ -57,7 +88,9 @@ export const matchPathObject = (
     else siblingValues.push(prop.value);
   }
   if (!root) return;
-  const specs = siblingValues.flatMap(collectImportSpecs);
+  const specs = siblingValues.flatMap((value) =>
+    collectImportSpecs(value, objectBindings),
+  );
   if (specs.length === 0) return;
   return { root, specs };
 };
@@ -112,8 +145,9 @@ export const protectedAnnotatorPlugin = (): Plugin => ({
     }
 
     const tasks: Array<{ spec: string; root: string }> = [];
+    const objectBindings = collectTopLevelObjectBindings(ast);
     walk(ast, (node) => {
-      const a = matchPathObject(node);
+      const a = matchPathObject(node, objectBindings);
       if (a) for (const spec of a.specs) tasks.push({ spec, root: a.root });
       const b = matchRouteDict(node);
       if (b) for (const { spec, root } of b) tasks.push({ spec, root });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,6 +641,12 @@ importers:
       '@envelop/core':
         specifier: 5.5.1
         version: 5.5.1
+      '@fontsource-variable/geist':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource-variable/geist-mono':
+        specifier: 5.3.0
+        version: 5.3.0
       '@graphiql/toolkit':
         specifier: 0.12.1
         version: 0.12.1(@types/node@22.20.1)(graphql-ws@6.0.8(crossws@0.4.10(srvx@0.11.16))(graphql@16.14.2)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(graphql@16.14.2)
@@ -2467,6 +2473,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/geist-mono@5.3.0':
+    resolution: {integrity: sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==}
+
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
 
   '@fortawesome/fontawesome-free@6.7.2':
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
@@ -11470,6 +11482,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/geist-mono@5.3.0': {}
+
+  '@fontsource-variable/geist@5.3.0': {}
 
   '@fortawesome/fontawesome-free@6.7.2': {}
 


### PR DESCRIPTION
## Summary

- load Shiki hydration only when rendered code markers require it
- load Pagefind on first search open while preserving dialog state after it mounts
- split mobile navigation drawers behind lazy boundaries and restore trigger focus on close
- avoid pulling schema-heavy navigation helpers into the entry path
- emit only CSS reachable from the eager chunk graph while retaining standalone and custom-plugin global CSS

## Compatibility

Search remains mounted after first use, mobile drawer semantics and focus behavior are covered by tests, and global CSS emitted by custom Vite plugins is retained. Route-split feature CSS such as GraphiQL remains lazy.

## Verification

The complete five-PR stack passes 1,856 tests, package typechecking, formatting, Biome, and the 114-route Cosmo Cargo production build under the repository asdf Node 22.22.0 environment.

## Merge plan

This is performance PR 3 of 9 in Group 2.

- Group 1 — Foundation: #2789 → #2787
- Group 2 — Deferred client work: #2788 → #2790
- Group 3 — Critical rendering: #2791 → #2793 → #2794
- Group 4 — Stability: #2795 → #2796

Merge left to right and finish validation for each group before starting the next. Retarget the next PR to `main` as each parent lands.