### PR TITLE
perf: stabilize layout and self-host default fonts

### DIFF
--- a/docs/pages/docs/configuration/footer.mdx
+++ b/docs/pages/docs/configuration/footer.mdx
@@ -143,7 +143,8 @@ footer: {
       dark: "/path/to/dark-logo.png"
     },
     alt: "Company Logo",
-    width: "120px" // optional width
+    width: 120, // optional intrinsic width
+    height: 24 // optional intrinsic height; set both to prevent layout shift
   }
 }
 ```
@@ -208,7 +209,8 @@ footer: {
       dark: "/images/logo-dark.svg"
     },
     alt: "Company Logo",
-    width: "100px"
+    width: 100,
+    height: 24
   }
 }
 ```

--- a/docs/pages/docs/configuration/site.md
+++ b/docs/pages/docs/configuration/site.md
@@ -58,7 +58,8 @@ Configure the site's logo with different versions for light and dark themes:
         dark: "/dark-logo.png"
       },
       alt: "Company Logo",
-      width: "120px", // optional width
+      width: 120, // optional intrinsic width
+      height: 32, // optional intrinsic height; set both to prevent layout shift
       href: "/", // optional link target (defaults to "/")
       reloadDocument: true, // optional, defaults to true
     }

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -167,6 +167,7 @@ const config: ZudokuConfig = {
     logo: {
       src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
       width: 165,
+      height: 24,
       alt: "Cosmo Cargo Inc.",
     },
     banner: {
@@ -236,6 +237,7 @@ const config: ZudokuConfig = {
         },
         alt: "Zudoku by Zuplo",
         width: 120,
+        height: 24,
       },
     },
   },

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -91,6 +91,8 @@
     "@apidevtools/json-schema-ref-parser": "15.5.0",
     "@base-ui/react": "^1.6.0",
     "@envelop/core": "5.5.1",
+    "@fontsource-variable/geist": "5.3.0",
+    "@fontsource-variable/geist-mono": "5.3.0",
     "@graphiql/toolkit": "0.12.1",
     "@graphql-typed-document-node/core": "3.2.0",
     "@hono/node-server": "2.0.11",

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -1,3 +1,6 @@
+@import "@fontsource-variable/geist/wght.css";
+@import "@fontsource-variable/geist-mono/wght.css";
+
 /* @vite-plugin-inject defaultTheme */
 @import "tailwindcss" source("..");
 @import "tw-animate-css";

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -218,6 +218,7 @@ const LogoSchema = z.object({
   src: z.object({ light: z.string(), dark: z.string() }),
   alt: z.string().optional(),
   width: z.string().or(z.number()).optional(),
+  height: z.string().or(z.number()).optional(),
   href: z.string().optional(),
   reloadDocument: z.boolean().optional(),
 });

--- a/packages/zudoku/src/lib/components/Footer.test.tsx
+++ b/packages/zudoku/src/lib/components/Footer.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { expect, it } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { SlotProvider } from "./context/SlotProvider.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Footer } from "./Footer.js";
+
+it("renders intrinsic dimensions for the footer logo", () => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(
+    {
+      site: {
+        footer: {
+          logo: {
+            src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
+            alt: "Test logo",
+            width: 120,
+            height: 24,
+          },
+        },
+      },
+    },
+    queryClient,
+    {},
+  );
+
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ZudokuProvider context={context}>
+          <SlotProvider>
+            <Footer />
+          </SlotProvider>
+        </ZudokuProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+
+  const logos = screen.getAllByRole("img", { name: "Test logo" });
+  expect(logos).toHaveLength(2);
+  for (const logo of logos) {
+    expect(logo).toHaveAttribute("width", "120");
+    expect(logo).toHaveAttribute("height", "24");
+  }
+});

--- a/packages/zudoku/src/lib/components/Footer.tsx
+++ b/packages/zudoku/src/lib/components/Footer.tsx
@@ -2,6 +2,7 @@ import { ExternalLink as ExternalLinkIcon } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
 import type { FooterSocialIcons } from "../../config/validators/ZudokuConfig.js";
 import { cn } from "../util/cn.js";
+import { getIntrinsicImageDimensions } from "../util/getIntrinsicImageDimensions.js";
 import { AnchorLink } from "./AnchorLink.js";
 import { useZudoku } from "./index.js";
 import { Slot } from "./Slot.js";
@@ -17,6 +18,8 @@ const SocialIcon = ({
         src={`https://cdn.simpleicons.org/${icon}/000000/ffffff`}
         className="size-5"
         alt={icon}
+        width={20}
+        height={20}
         loading="lazy"
       />
     );
@@ -103,16 +106,30 @@ export const Footer = () => {
               <img
                 src={footer.logo.src.light}
                 alt={footer.logo.alt}
+                {...getIntrinsicImageDimensions(
+                  footer.logo.width,
+                  footer.logo.height,
+                )}
                 className="w-8 dark:hidden"
-                style={{ width: footer.logo.width }}
+                style={{
+                  width: footer.logo.width,
+                  height: footer.logo.height,
+                }}
                 loading="lazy"
               />
               <img
                 src={footer.logo.src.dark}
                 alt={footer.logo.alt}
+                {...getIntrinsicImageDimensions(
+                  footer.logo.width,
+                  footer.logo.height,
+                )}
                 className="w-8 hidden dark:block"
                 loading="lazy"
-                style={{ width: footer.logo.width }}
+                style={{
+                  width: footer.logo.width,
+                  height: footer.logo.height,
+                }}
               />
             </>
           )}

--- a/packages/zudoku/src/lib/components/Header.test.tsx
+++ b/packages/zudoku/src/lib/components/Header.test.tsx
@@ -4,6 +4,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render as testRender, screen } from "@testing-library/react";
+import { createHead, UnheadProvider } from "@unhead/react/client";
 import type { ComponentProps } from "react";
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,14 +34,16 @@ const render = async (options: Partial<ZudokuContextOptions> = {}) => {
     [
       {
         element: (
-          <QueryClientProvider client={queryClient}>
-            <ZudokuProvider context={context}>
-              <SlotProvider slots={{}}>
-                <Header />
-                <Outlet />
-              </SlotProvider>
-            </ZudokuProvider>
-          </QueryClientProvider>
+          <UnheadProvider head={createHead()}>
+            <QueryClientProvider client={queryClient}>
+              <ZudokuProvider context={context}>
+                <SlotProvider slots={{}}>
+                  <Header />
+                  <Outlet />
+                </SlotProvider>
+              </ZudokuProvider>
+            </QueryClientProvider>
+          </UnheadProvider>
         ),
         children: [{ path: "*", element: null }],
       },
@@ -73,6 +76,26 @@ describe("Header", () => {
 
       const props = getLogoLinkProps();
       expect(props?.reloadDocument).toBe(true);
+    });
+
+    it("renders intrinsic dimensions for configured logos", async () => {
+      await render({
+        site: {
+          title: "Test Site",
+          logo: {
+            src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
+            width: 120,
+            height: 32,
+          },
+        },
+      });
+
+      const logos = screen.getAllByRole("img", { name: "Test Site" });
+      expect(logos).toHaveLength(2);
+      for (const logo of logos) {
+        expect(logo).toHaveAttribute("width", "120");
+        expect(logo).toHaveAttribute("height", "32");
+      }
     });
   });
 

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "../ui/DropdownMenu.js";
 import { cn } from "../util/cn.js";
+import { getIntrinsicImageDimensions } from "../util/getIntrinsicImageDimensions.js";
 import { joinUrl } from "../util/joinUrl.js";
 import { Banner } from "./Banner.js";
 import { useZudoku } from "./context/ZudokuContext.js";
@@ -176,13 +177,27 @@ export const Header = memo(function HeaderInner() {
                       <img
                         src={logoLightSrc}
                         alt={site.logo.alt ?? site.title}
-                        style={{ width: site.logo.width }}
+                        {...getIntrinsicImageDimensions(
+                          site.logo.width,
+                          site.logo.height,
+                        )}
+                        style={{
+                          width: site.logo.width,
+                          height: site.logo.height,
+                        }}
                         className="max-h-(--top-header-height) dark:hidden"
                       />
                       <img
                         src={logoDarkSrc}
                         alt={site.logo.alt ?? site.title}
-                        style={{ width: site.logo.width }}
+                        {...getIntrinsicImageDimensions(
+                          site.logo.width,
+                          site.logo.height,
+                        )}
+                        style={{
+                          width: site.logo.width,
+                          height: site.logo.height,
+                        }}
                         className="max-h-(--top-header-height) hidden dark:block"
                       />
                     </>

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -85,6 +85,7 @@ type Site = Partial<{
       dark: string;
     };
     width?: string | number;
+    height?: string | number;
     alt?: string;
     href?: string;
     reloadDocument?: boolean;

--- a/packages/zudoku/src/lib/util/getIntrinsicImageDimensions.ts
+++ b/packages/zudoku/src/lib/util/getIntrinsicImageDimensions.ts
@@ -1,0 +1,15 @@
+export const getIntrinsicImageDimensions = (
+  width: string | number | undefined,
+  height: string | number | undefined,
+) => {
+  if (
+    typeof width !== "number" ||
+    !Number.isFinite(width) ||
+    typeof height !== "number" ||
+    !Number.isFinite(height)
+  ) {
+    return {};
+  }
+
+  return { width, height };
+};

--- a/packages/zudoku/src/vite/plugin-theme.test.ts
+++ b/packages/zudoku/src/vite/plugin-theme.test.ts
@@ -10,7 +10,6 @@ const callPluginLoad = async (plugin: Plugin, id: string) => {
   // biome-ignore lint/style/noNonNullAssertion: is guaranteed to be defined
   const hook = plugin.load!;
   const loadFn = typeof hook === "function" ? hook : hook.handler;
-  // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   return loadFn.call({} as any, id);
 };
 
@@ -18,7 +17,6 @@ const callPluginTransform = async (plugin: Plugin, src: string, id: string) => {
   // biome-ignore lint/style/noNonNullAssertion: is guaranteed to be defined
   const hook = plugin.transform!;
   const transformFn = typeof hook === "function" ? hook : hook.handler;
-  // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   return transformFn.call({} as any, src, id);
 };
 
@@ -92,14 +90,9 @@ describe("plugin-theme", () => {
       const plugin = viteThemePlugin();
       const result = await callPluginLoad(plugin, resolvedVirtualModuleId);
 
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap')",
-      );
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
-      expect(result).toContain("--font-sans: Geist, sans-serif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).not.toContain("fonts.googleapis.com");
+      expect(result).toContain('--font-sans: "Geist Variable", sans-serif');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
 
     it("should handle mixed font configurations with defaults for missing fonts", async () => {
@@ -123,12 +116,9 @@ describe("plugin-theme", () => {
       expect(result).toContain(
         "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap')",
       );
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
       expect(result).toContain("--font-sans: Inter");
       expect(result).toContain("--font-serif: CustomSerif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
 
     it("should provide mono default when only sans is configured", async () => {
@@ -149,11 +139,8 @@ describe("plugin-theme", () => {
       const result = await callPluginLoad(plugin, resolvedVirtualModuleId);
 
       expect(result).toContain("@import url('/fonts/fonts.css')");
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
       expect(result).toContain("--font-sans: Solis, sans-serif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
   });
 

--- a/packages/zudoku/src/vite/plugin-theme.ts
+++ b/packages/zudoku/src/vite/plugin-theme.ts
@@ -126,9 +126,9 @@ const processFontConfig = (fontConfig?: FontConfig) => {
 const processFonts = async (themeConfig: ZudokuConfig["theme"]) => {
   const imports: string[] = [];
   const families = {
-    sans: "Geist, sans-serif",
+    sans: '"Geist Variable", sans-serif',
     serif: undefined as string | undefined,
-    mono: '"Geist Mono", monospace',
+    mono: '"Geist Mono Variable", monospace',
   };
 
   // Process user fonts
@@ -179,23 +179,14 @@ const processFonts = async (themeConfig: ZudokuConfig["theme"]) => {
 
   // Determine final font families with priority: user > registry > defaults
   families.sans =
-    userFonts.sans.fontFamily || registryFonts.sans || "Geist, sans-serif";
+    userFonts.sans.fontFamily ||
+    registryFonts.sans ||
+    '"Geist Variable", sans-serif';
   families.serif = userFonts.serif.fontFamily || registryFonts.serif;
   families.mono =
     userFonts.mono.fontFamily ||
     registryFonts.mono ||
-    '"Geist Mono", monospace';
-
-  // Add default font imports if no user or registry fonts
-  if (!userFonts.sans.fontFamily && !registryFonts.sans) {
-    imports.push(getGoogleFontUrl("Geist"));
-  }
-  if (!userFonts.serif.fontFamily && !registryFonts.serif) {
-    imports.push(getGoogleFontUrl("Playfair Display"));
-  }
-  if (!userFonts.mono.fontFamily && !registryFonts.mono) {
-    imports.push(getGoogleFontUrl("Geist Mono"));
-  }
+    '"Geist Mono Variable", monospace';
 
   return { imports, families };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,6 +641,12 @@ importers:
       '@envelop/core':
         specifier: 5.5.1
         version: 5.5.1
+      '@fontsource-variable/geist':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource-variable/geist-mono':
+        specifier: 5.3.0
+        version: 5.3.0
       '@graphiql/toolkit':
         specifier: 0.12.1
         version: 0.12.1(@types/node@22.20.1)(graphql-ws@6.0.8(crossws@0.4.10(srvx@0.11.16))(graphql@16.14.2)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(graphql@16.14.2)
@@ -2467,6 +2473,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/geist-mono@5.3.0':
+    resolution: {integrity: sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==}
+
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
 
   '@fortawesome/fontawesome-free@6.7.2':
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
@@ -11470,6 +11482,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/geist-mono@5.3.0': {}
+
+  '@fontsource-variable/geist@5.3.0': {}
 
   '@fortawesome/fontawesome-free@6.7.2': {}
 


### PR DESCRIPTION
## Summary

- reserve intrinsic header, footer, and social-icon dimensions to eliminate image-driven layout shifts
- self-host the default Geist variable fonts instead of fetching the default font stylesheet from Google
- retain existing behavior for explicitly configured fonts and make footer logo height optional
- document the configuration and cover the generated HTML and components with regression tests

## Compatibility

This changes only the built-in default font source. Existing explicit font configuration continues through the current font pipeline, and the new image height field is optional.

## Verification

The complete five-PR stack passes 1,856 tests, package typechecking, formatting, Biome, and the 114-route Cosmo Cargo production build under the repository asdf Node 22.22.0 environment.

## Merge plan

This is performance PR 1 of 9 in Group 1.

- Group 1 — Foundation: #2789 → #2787
- Group 2 — Deferred client work: #2788 → #2790
- Group 3 — Critical rendering: #2791 → #2793 → #2794
- Group 4 — Stability: #2795 → #2796

Merge left to right and finish validation for each group before starting the next. Retarget the next PR to `main` as each parent lands.