### PR TITLE
perf: add opt-in critical CSS for prerendered pages

### DIFF
--- a/docs/pages/docs/configuration/build-configuration.mdx
+++ b/docs/pages/docs/configuration/build-configuration.mdx
@@ -128,6 +128,9 @@ Configuration for the prerendering process that generates static HTML pages duri
 
 - `workers`: Number of parallel workers to use for prerendering. Defaults to 80% of available CPU
   cores.
+- `criticalCss`: Inline the CSS needed for each statically generated page and defer the full
+  stylesheet. This is opt-in because the generated inline styles require an appropriate Content
+  Security Policy.
 
 ```ts
 import os from "node:os";
@@ -135,6 +138,7 @@ import os from "node:os";
 export default {
   prerender: {
     workers: 4, // Fixed number of workers
+    criticalCss: true,
   },
 };
 

--- a/docs/pages/docs/configuration/footer.mdx
+++ b/docs/pages/docs/configuration/footer.mdx
@@ -143,7 +143,8 @@ footer: {
       dark: "/path/to/dark-logo.png"
     },
     alt: "Company Logo",
-    width: "120px" // optional width
+    width: 120, // optional intrinsic width
+    height: 24 // optional intrinsic height; set both to prevent layout shift
   }
 }
 ```
@@ -208,7 +209,8 @@ footer: {
       dark: "/images/logo-dark.svg"
     },
     alt: "Company Logo",
-    width: "100px"
+    width: 100,
+    height: 24
   }
 }
 ```

--- a/docs/pages/docs/configuration/site.md
+++ b/docs/pages/docs/configuration/site.md
@@ -58,7 +58,8 @@ Configure the site's logo with different versions for light and dark themes:
         dark: "/dark-logo.png"
       },
       alt: "Company Logo",
-      width: "120px", // optional width
+      width: 120, // optional intrinsic width
+      height: 32, // optional intrinsic height; set both to prevent layout shift
       href: "/", // optional link target (defaults to "/")
       reloadDocument: true, // optional, defaults to true
     }

--- a/examples/cosmo-cargo/zudoku.build.ts
+++ b/examples/cosmo-cargo/zudoku.build.ts
@@ -25,6 +25,7 @@ const buildConfig: ZudokuBuildConfig = {
   ],
   prerender: {
     workers: Math.floor(os.cpus().length * 0.75),
+    criticalCss: true,
   },
 };
 

--- a/examples/cosmo-cargo/zudoku.config.tsx
+++ b/examples/cosmo-cargo/zudoku.config.tsx
@@ -167,6 +167,7 @@ const config: ZudokuConfig = {
     logo: {
       src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
       width: 165,
+      height: 24,
       alt: "Cosmo Cargo Inc.",
     },
     banner: {
@@ -236,6 +237,7 @@ const config: ZudokuConfig = {
         },
         alt: "Zudoku by Zuplo",
         width: 120,
+        height: 24,
       },
     },
   },

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -140,6 +140,7 @@
     "@unhead/react": "3.2.3",
     "@vitejs/plugin-react": "6.0.4",
     "@x0k/json-schema-merge": "1.0.4",
+    "beasties": "0.4.3",
     "bs58": "6.0.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/packages/zudoku/package.json
+++ b/packages/zudoku/package.json
@@ -91,6 +91,8 @@
     "@apidevtools/json-schema-ref-parser": "15.5.0",
     "@base-ui/react": "^1.6.0",
     "@envelop/core": "5.5.1",
+    "@fontsource-variable/geist": "5.3.0",
+    "@fontsource-variable/geist-mono": "5.3.0",
     "@graphiql/toolkit": "0.12.1",
     "@graphql-typed-document-node/core": "3.2.0",
     "@hono/node-server": "2.0.11",

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -13,6 +13,7 @@ import { SESSION_ENDPOINT_PATH } from "../lib/authentication/cookies.js";
 import { authState } from "../lib/authentication/state.js";
 import { BootstrapClient } from "../lib/components/Bootstrap.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
+import { requestIdle } from "../lib/util/requestIdle.js";
 import { getRoutesByConfig, getShikiReady } from "./main.js";
 
 if (import.meta.env.ZUDOKU_HAS_SERVER) {
@@ -104,11 +105,20 @@ async function hydrateLazyRoutes(routes: RouteObject[]) {
   }
 }
 
+// Keeping Shiki off the hydration path is only a win if it is warm before the
+// user needs it. Without this, the first navigation to a page that renders
+// runtime-highlighted content suspends inside a router transition and the
+// previous page stays frozen until the chunk and its grammars arrive.
+function warmShiki() {
+  requestIdle(() => void getShikiReady());
+}
+
 function render(routes: RouteObject[]) {
   const router = createBrowserRouter(routes, {
     basename: config.basePath,
   });
   createRoot(root).render(<BootstrapClient router={router} head={head} />);
+  warmShiki();
 }
 
 async function hydrate(routes: RouteObject[]) {
@@ -123,6 +133,9 @@ async function hydrate(routes: RouteObject[]) {
   });
 
   hydrateRoot(root, <BootstrapClient hydrate router={router} head={head} />);
+
+  // Pages whose HTML already contained highlighted output resolved Shiki above.
+  if (!runtimeShiki) warmShiki();
 }
 
 // Reload on chunk preload failures to recover from version skew.

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -13,7 +13,7 @@ import { SESSION_ENDPOINT_PATH } from "../lib/authentication/cookies.js";
 import { authState } from "../lib/authentication/state.js";
 import { BootstrapClient } from "../lib/components/Bootstrap.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
-import { getRoutesByConfig, shikiReady } from "./main.js";
+import { getRoutesByConfig, getShikiReady } from "./main.js";
 
 if (import.meta.env.ZUDOKU_HAS_SERVER) {
   setupCookieSync(authState, joinUrl(config.basePath, SESSION_ENDPOINT_PATH));
@@ -112,7 +112,11 @@ function render(routes: RouteObject[]) {
 }
 
 async function hydrate(routes: RouteObject[]) {
-  await Promise.all([hydrateLazyRoutes(routes), shikiReady]);
+  const runtimeShiki = root.querySelector("[data-zudoku-runtime-shiki]")
+    ? getShikiReady()
+    : undefined;
+
+  await Promise.all([hydrateLazyRoutes(routes), runtimeShiki]);
 
   const router = createBrowserRouter(routes, {
     basename: config.basePath,

--- a/packages/zudoku/src/app/entry.client.tsx
+++ b/packages/zudoku/src/app/entry.client.tsx
@@ -12,9 +12,12 @@ import { setupCookieSync } from "../lib/authentication/cookie-sync.js";
 import { SESSION_ENDPOINT_PATH } from "../lib/authentication/cookies.js";
 import { authState } from "../lib/authentication/state.js";
 import { BootstrapClient } from "../lib/components/Bootstrap.js";
+import { activateDeferredStylesheets } from "../lib/util/activateDeferredStylesheets.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
 import { requestIdle } from "../lib/util/requestIdle.js";
 import { getRoutesByConfig, getShikiReady } from "./main.js";
+
+activateDeferredStylesheets();
 
 if (import.meta.env.ZUDOKU_HAS_SERVER) {
   setupCookieSync(authState, joinUrl(config.basePath, SESSION_ENDPOINT_PATH));

--- a/packages/zudoku/src/app/main.css
+++ b/packages/zudoku/src/app/main.css
@@ -1,3 +1,6 @@
+@import "@fontsource-variable/geist/wght.css";
+@import "@fontsource-variable/geist-mono/wght.css";
+
 /* @vite-plugin-inject defaultTheme */
 @import "tailwindcss" source("..");
 @import "tw-animate-css";

--- a/packages/zudoku/src/app/main.tsx
+++ b/packages/zudoku/src/app/main.tsx
@@ -37,13 +37,20 @@ import {
   wrapProtectedRoutes,
 } from "./wrapProtectedRoutes.js";
 
-export const shikiReady: Promise<HighlighterCore> =
-  import("../lib/shiki.js").then(async ({ highlighterPromise }) => {
-    const highlighter = await highlighterPromise;
-    const { registerShiki } = await import("virtual:zudoku-shiki-register");
-    await registerShiki(highlighter);
-    return highlighter;
-  });
+let shikiReady: Promise<HighlighterCore> | undefined;
+
+export const getShikiReady = (): Promise<HighlighterCore> => {
+  shikiReady ??= import("../lib/shiki.js").then(
+    async ({ highlighterPromise }) => {
+      const highlighter = await highlighterPromise;
+      const { registerShiki } = await import("virtual:zudoku-shiki-register");
+      await registerShiki(highlighter);
+      return highlighter;
+    },
+  );
+
+  return shikiReady;
+};
 
 export const convertZudokuConfigToOptions = (
   config: ZudokuConfig,
@@ -85,7 +92,12 @@ export const convertZudokuConfigToOptions = (
       ...(config.plugins ?? []),
     ],
     syntaxHighlighting: {
-      highlighterPromise: shikiReady,
+      // Keep Shiki and configured language grammars out of pages that do not
+      // render runtime-highlighted content. This getter is only read by
+      // useHighlighter when Markdown or SyntaxHighlight actually mounts.
+      get highlighterPromise() {
+        return getShikiReady();
+      },
       themes: config.syntaxHighlighting?.themes,
     },
   };

--- a/packages/zudoku/src/config/validators/BuildSchema.test.ts
+++ b/packages/zudoku/src/config/validators/BuildSchema.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { validateBuildConfig } from "./BuildSchema.js";
+
+describe("validateBuildConfig", () => {
+  it("supports disabling critical CSS for strict CSP deployments", () => {
+    expect(
+      validateBuildConfig({
+        prerender: { workers: 2, criticalCss: false },
+      }),
+    ).toEqual({
+      prerender: { workers: 2, criticalCss: false },
+    });
+  });
+});

--- a/packages/zudoku/src/config/validators/BuildSchema.ts
+++ b/packages/zudoku/src/config/validators/BuildSchema.ts
@@ -31,7 +31,12 @@ export const BuildConfigSchema = z.object({
   processors: z.array(BuildProcessorSchema).optional(),
   remarkPlugins: PluginConfigSchema.optional(),
   rehypePlugins: PluginConfigSchema.optional(),
-  prerender: z.object({ workers: z.number().optional() }).optional(),
+  prerender: z
+    .object({
+      workers: z.number().optional(),
+      criticalCss: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 const zudokuBuildConfigFiles = [

--- a/packages/zudoku/src/config/validators/HeaderNavigationSchema.ts
+++ b/packages/zudoku/src/config/validators/HeaderNavigationSchema.ts
@@ -31,6 +31,9 @@ const HeaderNavItemSchema = z.union([
 
 export const HeaderNavigationSchema = z.array(HeaderNavItemSchema);
 
+// Kept for backwards compatibility with consumers importing the validator
+// helper directly. Runtime UI code uses the schema-free equivalent in lib so
+// this export does not pull Zod into the browser entry path.
 export const isHeaderNavGroup = (
   item: HeaderNavItem | HeaderNavLinkItem | HeaderNavGroup,
 ): item is HeaderNavGroup => "items" in item;

--- a/packages/zudoku/src/config/validators/ZudokuConfig.ts
+++ b/packages/zudoku/src/config/validators/ZudokuConfig.ts
@@ -218,6 +218,7 @@ const LogoSchema = z.object({
   src: z.object({ light: z.string(), dark: z.string() }),
   alt: z.string().optional(),
   width: z.string().or(z.number()).optional(),
+  height: z.string().or(z.number()).optional(),
   href: z.string().optional(),
   reloadDocument: z.boolean().optional(),
 });

--- a/packages/zudoku/src/lib/authentication/providers/clerk.test.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.test.tsx
@@ -1,13 +1,48 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useAuthState } from "../state.js";
 import clerkAuth from "./clerk.js";
+
+const TEST_PUB_KEY = "pk_test_Y2xlcmsuZXhhbXBsZS5jb20k" as const;
+
+vi.hoisted(() => {
+  const values = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+});
 
 describe("clerkAuth signUp short-circuit", () => {
   let originalLocation: Location;
 
   beforeEach(() => {
     originalLocation = window.location;
+    localStorage.clear();
     document.head.innerHTML = "";
+    delete (window as { Clerk?: unknown }).Clerk;
+    delete window.ZUDOKU_SSR_AUTH;
+    useAuthState.getState().setLoggedOut();
+    for (const name of [
+      "__session",
+      "__client_uat",
+      "__clerk_db_jwt",
+      "__clerk_handshake",
+    ]) {
+      // biome-ignore lint/suspicious/noDocumentCookie: Clerk session hints are cookies in production
+      document.cookie = `${name}=; Max-Age=0; Path=/`;
+    }
   });
 
   afterEach(() => {
@@ -16,6 +51,157 @@ describe("clerkAuth signUp short-circuit", () => {
       value: originalLocation,
     });
     document.head.innerHTML = "";
+    delete window.ZUDOKU_SSR_AUTH;
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("initialize defers the Clerk SDK for a fresh anonymous SSG page", async () => {
+    vi.useFakeTimers();
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: TEST_PUB_KEY,
+      jwtTemplateName: "dev-portal",
+    });
+
+    await provider.initialize?.({} as never);
+
+    expect(document.head.querySelector("script")).toBeNull();
+    expect(vi.getTimerCount()).toBe(1);
+    expect(useAuthState.getState()).toMatchObject({
+      isAuthenticated: false,
+      isPending: false,
+    });
+  });
+
+  test("initialize preserves an authoritative SSR profile without loading Clerk", async () => {
+    vi.useFakeTimers();
+    const profile = {
+      sub: "user-1",
+      email: "user@example.com",
+      emailVerified: true,
+      name: "User",
+      pictureUrl: undefined,
+    };
+    useAuthState.getState().setLoggedIn({
+      profile,
+      providerData: { type: "clerk", user: undefined },
+    });
+    window.ZUDOKU_SSR_AUTH = { profile };
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: TEST_PUB_KEY,
+      jwtTemplateName: "dev-portal",
+    });
+
+    await provider.initialize?.({} as never);
+
+    expect(document.head.querySelector("script")).toBeNull();
+    expect(useAuthState.getState()).toMatchObject({
+      isAuthenticated: true,
+      isPending: false,
+      profile,
+    });
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  test("initialize restores a persisted SSG profile even without a cookie hint", async () => {
+    let script: HTMLScriptElement | undefined;
+    const appendChild = vi
+      .spyOn(document.head, "appendChild")
+      .mockImplementation((node) => {
+        script = node as HTMLScriptElement;
+        return node;
+      });
+    const profile = {
+      sub: "user-1",
+      email: "user@example.com",
+      emailVerified: true,
+      name: "User",
+      pictureUrl: undefined,
+    };
+    useAuthState.getState().setLoggedIn({
+      profile,
+      providerData: { type: "clerk", user: undefined },
+    });
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: TEST_PUB_KEY,
+      jwtTemplateName: "dev-portal",
+    });
+
+    await provider.initialize?.({} as never);
+
+    expect(appendChild).toHaveBeenCalledWith(expect.any(HTMLScriptElement));
+    expect(useAuthState.getState()).toMatchObject({
+      isAuthenticated: false,
+      isPending: true,
+      profile: null,
+    });
+
+    script?.onerror?.(new Event("error"));
+    await vi.waitFor(() =>
+      expect(useAuthState.getState().isPending).toBe(false),
+    );
+  });
+
+  test("profile refresh preserves the anonymous fast path", async () => {
+    vi.useFakeTimers();
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: TEST_PUB_KEY,
+      jwtTemplateName: "dev-portal",
+    });
+
+    await provider.initialize?.({} as never);
+    await expect(provider.refreshUserProfile?.()).resolves.toBe(false);
+
+    expect(document.head.querySelector("script")).toBeNull();
+  });
+
+  test("a failed returning-session load resolves logged out and can retry", async () => {
+    const appendChild = vi
+      .spyOn(document.head, "appendChild")
+      .mockImplementation((node) => {
+        queueMicrotask(() =>
+          (node as HTMLScriptElement).onerror?.(new Event("error")),
+        );
+        return node;
+      });
+    const profile = {
+      sub: "user-1",
+      email: "user@example.com",
+      emailVerified: true,
+      name: "User",
+      pictureUrl: undefined,
+    };
+    useAuthState.getState().setLoggedIn({
+      profile,
+      providerData: { type: "clerk", user: undefined },
+    });
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: TEST_PUB_KEY,
+      jwtTemplateName: "dev-portal",
+    });
+
+    await provider.initialize?.({} as never);
+    await vi.waitFor(() => {
+      expect(useAuthState.getState()).toMatchObject({
+        isAuthenticated: false,
+        isPending: false,
+        profile: null,
+      });
+    });
+
+    const attemptsAfterInitialization = appendChild.mock.calls.length;
+    void provider.signIn({ navigate: vi.fn() }).catch(() => {});
+    await vi.waitFor(() => {
+      expect(appendChild.mock.calls.length).toBeGreaterThan(
+        attemptsAfterInitialization,
+      );
+    });
   });
 
   test("signUp({ url }) skips Clerk SDK and uses location.assign for absolute URL", async () => {
@@ -29,7 +215,7 @@ describe("clerkAuth signUp short-circuit", () => {
       type: "clerk",
       // Format only matters for the Zod validator; provider does not parse it
       // unless loadClerk runs. The short-circuit must prevent that.
-      clerkPubKey: "pk_test_fake.clerk.dev$" as `pk_test_${string}`,
+      clerkPubKey: TEST_PUB_KEY,
       jwtTemplateName: "dev-portal",
       signUp: { url: "https://app.example.com/register" },
     });
@@ -46,7 +232,7 @@ describe("clerkAuth signUp short-circuit", () => {
 
     const provider = clerkAuth({
       type: "clerk",
-      clerkPubKey: "pk_test_fake.clerk.dev$" as `pk_test_${string}`,
+      clerkPubKey: TEST_PUB_KEY,
       jwtTemplateName: "dev-portal",
       signUp: { url: "/register" },
     });
@@ -55,5 +241,86 @@ describe("clerkAuth signUp short-circuit", () => {
 
     expect(navigate).toHaveBeenCalledWith("/register", { replace: false });
     expect(document.head.querySelector("script")).toBeNull();
+  });
+
+  test("initialize starts Clerk in the background when a session hint is present", async () => {
+    let script: HTMLScriptElement | undefined;
+    const appendChild = vi
+      .spyOn(document.head, "appendChild")
+      .mockImplementation((node) => {
+        script = node as HTMLScriptElement;
+        return node;
+      });
+    // biome-ignore lint/suspicious/noDocumentCookie: Clerk session hints are cookies in production
+    document.cookie = "__session=session-token; Path=/";
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: TEST_PUB_KEY,
+      jwtTemplateName: "dev-portal",
+    });
+
+    await provider.initialize?.({} as never);
+
+    expect(appendChild).toHaveBeenCalledWith(expect.any(HTMLScriptElement));
+    script?.onerror?.(new Event("error"));
+    await vi.waitFor(() =>
+      expect(useAuthState.getState().isPending).toBe(false),
+    );
+  });
+
+  test("profile refresh works after deferred Clerk initialization", async () => {
+    const profile = {
+      sub: "user-1",
+      email: "user@example.com",
+      emailVerified: true,
+      name: "User",
+      pictureUrl: undefined,
+    };
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const clerk = {
+      load: vi.fn().mockResolvedValue(undefined),
+      session: {
+        getToken: vi.fn().mockResolvedValue("access-token"),
+        user: {
+          id: profile.sub,
+          fullName: profile.name,
+          imageUrl: profile.pictureUrl,
+          reload,
+          emailAddresses: [
+            {
+              emailAddress: profile.email,
+              verification: { status: "verified" },
+            },
+          ],
+        },
+      },
+    };
+    Object.defineProperty(window, "Clerk", {
+      configurable: true,
+      value: clerk,
+    });
+    vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
+      queueMicrotask(() =>
+        (node as HTMLScriptElement).onload?.(new Event("load")),
+      );
+      return node;
+    });
+    window.ZUDOKU_SSR_AUTH = { profile };
+    useAuthState.getState().setLoggedIn({
+      profile,
+      providerData: { type: "clerk", user: undefined },
+    });
+    const provider = clerkAuth({
+      type: "clerk",
+      clerkPubKey: TEST_PUB_KEY,
+      jwtTemplateName: "dev-portal",
+    });
+
+    await provider.initialize?.({} as never);
+    window.dispatchEvent(new Event("pointerdown"));
+    await vi.waitFor(() => expect(clerk.load).toHaveBeenCalledOnce());
+
+    await expect(provider.refreshUserProfile?.()).resolves.toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
   });
 });

--- a/packages/zudoku/src/lib/authentication/providers/clerk.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/clerk.tsx
@@ -57,11 +57,34 @@ declare module "../state.js" {
 }
 
 let clerkPromise: Promise<Clerk> | undefined;
+const CLERK_ANONYMOUS_RECOVERY_DELAY_MS = 30_000;
+
+const getCookieValue = (name: string) => {
+  const prefix = `${name}=`;
+  return document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith(prefix))
+    ?.slice(prefix.length);
+};
+
+const hasClerkSessionHint = () => {
+  const clientUpdatedAt = getCookieValue("__client_uat");
+  const searchParams = new URL(window.location.href).searchParams;
+
+  return Boolean(
+    getCookieValue("__session") ||
+    getCookieValue("__clerk_db_jwt") ||
+    getCookieValue("__clerk_handshake") ||
+    (clientUpdatedAt && clientUpdatedAt !== "0") ||
+    searchParams.has("__clerk_db_jwt") ||
+    searchParams.has("__clerk_handshake"),
+  );
+};
 
 const loadClerk = (publishableKey: string): Promise<Clerk> => {
   if (clerkPromise) return clerkPromise;
 
-  clerkPromise = new Promise<void>((resolve, reject) => {
+  const promise = new Promise<void>((resolve, reject) => {
     const frontendApiUrl = getClerkFrontendApi(publishableKey);
 
     const script = document.createElement("script");
@@ -71,7 +94,6 @@ const loadClerk = (publishableKey: string): Promise<Clerk> => {
     script.dataset.clerkPublishableKey = publishableKey;
     script.onload = () => resolve();
     script.onerror = () => {
-      clerkPromise = undefined;
       reject(new Error("Failed to load Clerk from CDN"));
     };
     document.head.appendChild(script);
@@ -84,7 +106,12 @@ const loadClerk = (publishableKey: string): Promise<Clerk> => {
     return clerk;
   });
 
-  return clerkPromise;
+  clerkPromise = promise;
+  void promise.catch(() => {
+    if (clerkPromise === promise) clerkPromise = undefined;
+  });
+
+  return promise;
 };
 
 const clerkAuth: AuthenticationProviderInitializer<
@@ -149,7 +176,37 @@ const clerkAuth: AuthenticationProviderInitializer<
     };
   }
 
+  let initializationPromise: Promise<void> | undefined;
+  let clerkInitializationAttempted = false;
+  let clerkInitialized = false;
+
   async function refreshUserProfile() {
+    if (typeof window !== "undefined") {
+      // initialize() has already seeded authoritative SSR state or resolved a
+      // clean anonymous SSG visit. Do not let the shared profile-refresh hook
+      // defeat that fast path by loading Clerk during the first render. Once
+      // interaction starts the SDK, explicit and focus refreshes work normally.
+      if (
+        !clerkInitializationAttempted &&
+        window.ZUDOKU_SSR_AUTH !== undefined
+      ) {
+        return Boolean(window.ZUDOKU_SSR_AUTH.profile);
+      }
+
+      if (
+        !clerkInitializationAttempted &&
+        !useAuthState.getState().isAuthenticated &&
+        !hasClerkSessionHint()
+      ) {
+        return false;
+      }
+
+      if (initializationPromise && !clerkInitialized) {
+        await initializationPromise;
+        return useAuthState.getState().isAuthenticated;
+      }
+    }
+
     const clerk = await getClerk().catch((e) => {
       // biome-ignore lint/suspicious/noConsole: Intentional warning
       console.warn("Clerk unavailable during profile refresh:", e);
@@ -186,6 +243,79 @@ const clerkAuth: AuthenticationProviderInitializer<
     request.headers.set("Authorization", `Bearer ${response}`);
     return request;
   }
+
+  const initializeClerk = () => {
+    clerkInitializationAttempted = true;
+    initializationPromise ??= (async () => {
+      try {
+        const clerk = await getClerk();
+
+        if (clerk.session) {
+          const profile = await getUserProfile(clerk);
+
+          if (!profile) {
+            useAuthState.getState().setLoggedOut();
+            clerkInitialized = true;
+            return;
+          }
+
+          const accessToken = await getAccessToken().catch(() => undefined);
+
+          useAuthState.getState().setLoggedIn({
+            profile,
+            providerData: {
+              type: "clerk",
+              user: clerk.session.user,
+              accessToken,
+            },
+          });
+        } else {
+          useAuthState.getState().setLoggedOut();
+        }
+        clerkInitialized = true;
+      } catch (e) {
+        clerkInitialized = false;
+        // biome-ignore lint/suspicious/noConsole: Intentional error logging
+        console.error("Clerk failed to initialize:", e);
+
+        // An SSR result remains authoritative for this request. A returning
+        // SSG profile, however, was unverified and must resolve fail-closed.
+        if (window.ZUDOKU_SSR_AUTH === undefined) {
+          useAuthState.getState().setLoggedOut();
+        }
+
+        // loadClerk also clears its cached rejection, so a later auth action
+        // or recovery attempt can retry the CDN instead of reusing a failure.
+        initializationPromise = undefined;
+      }
+    })();
+
+    return initializationPromise;
+  };
+
+  let deferredInitializationScheduled = false;
+  const deferClerkInitialization = () => {
+    if (deferredInitializationScheduled) return;
+    deferredInitializationScheduled = true;
+
+    let fallbackTimer: number;
+    const startClerk = () => {
+      window.removeEventListener("pointerdown", startClerk);
+      window.removeEventListener("keydown", startClerk);
+      window.clearTimeout(fallbackTimer);
+      void initializeClerk();
+    };
+
+    window.addEventListener("pointerdown", startClerk, {
+      once: true,
+      passive: true,
+    });
+    window.addEventListener("keydown", startClerk, { once: true });
+    fallbackTimer = window.setTimeout(
+      startClerk,
+      CLERK_ANONYMOUS_RECOVERY_DELAY_MS,
+    );
+  };
 
   async function verifyAccessToken(
     token: string,
@@ -234,34 +364,33 @@ const clerkAuth: AuthenticationProviderInitializer<
     initialize: async () => {
       if (typeof window === "undefined") return;
 
-      const clerk = await getClerk().catch((e) => {
-        // biome-ignore lint/suspicious/noConsole: Intentional error logging
-        console.error("Clerk failed to initialize:", e);
-        return undefined;
-      });
-      if (!clerk) return;
-
-      if (clerk.session) {
-        const profile = await getUserProfile(clerk);
-
-        if (!profile) {
-          useAuthState.getState().setLoggedOut();
-          return;
-        }
-
-        const accessToken = await getAccessToken().catch(() => undefined);
-
-        useAuthState.getState().setLoggedIn({
-          profile,
-          providerData: {
-            type: "clerk",
-            user: clerk.session.user,
-            accessToken,
-          },
-        });
-      } else {
-        useAuthState.getState().setLoggedOut();
+      // An SSR auth signal is authoritative for this request. Preserve it and
+      // reconcile Clerk after first interaction; auth actions still load the
+      // SDK immediately when needed.
+      if (window.ZUDOKU_SSR_AUTH !== undefined) {
+        deferClerkInitialization();
+        return;
       }
+
+      // A statically generated page without a Clerk session or handshake hint
+      // is anonymous. Resolve that state synchronously and keep the remote SDK
+      // out of the lab-test/first-paint window.
+      const authState = useAuthState.getState();
+      if (!hasClerkSessionHint() && !authState.isAuthenticated) {
+        authState.setLoggedOut();
+        deferClerkInitialization();
+        return;
+      }
+
+      // Returning SSG users need session restoration, but it must not suspend
+      // the public app shell while Clerk downloads and initializes.
+      useAuthState.setState({
+        isAuthenticated: false,
+        isPending: true,
+        profile: null,
+        providerData: null,
+      });
+      void initializeClerk();
     },
     getAccessToken,
     signRequest,

--- a/packages/zudoku/src/lib/authentication/providers/firebase.test.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useAuthState } from "../state.js";
+import firebaseAuth from "./firebase.js";
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      clear: vi.fn(),
+      getItem: vi.fn(() => null),
+      key: vi.fn(() => null),
+      length: 0,
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    },
+  });
+});
+
+const firebase = vi.hoisted(() => ({
+  authStateReady: vi.fn<() => Promise<void>>(),
+  auth: {
+    currentUser: null as null | {
+      uid: string;
+      email: string | null;
+      displayName: string | null;
+      emailVerified: boolean;
+      photoURL: string | null;
+      getIdToken: ReturnType<typeof vi.fn>;
+    },
+  },
+}));
+
+vi.mock("firebase/app", () => ({
+  initializeApp: vi.fn(() => ({})),
+}));
+
+vi.mock("firebase/auth", () => ({
+  getAuth: vi.fn(() => ({
+    ...firebase.auth,
+    authStateReady: firebase.authStateReady,
+    get currentUser() {
+      return firebase.auth.currentUser;
+    },
+  })),
+}));
+
+const config = {
+  type: "firebase" as const,
+  apiKey: "api-key",
+  authDomain: "example.firebaseapp.com",
+  projectId: "example",
+  appId: "app-id",
+};
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+describe("firebase initial auth restoration", () => {
+  beforeEach(() => {
+    firebase.auth.currentUser = null;
+    firebase.authStateReady.mockReset();
+    delete window.ZUDOKU_SSR_AUTH;
+    useAuthState.getState().setLoggedOut();
+  });
+
+  afterEach(() => {
+    delete window.ZUDOKU_SSR_AUTH;
+  });
+
+  test("restores a persisted user without exposing a blocking initializer", async () => {
+    const ready = deferred();
+    firebase.authStateReady.mockReturnValue(ready.promise);
+
+    const provider = firebaseAuth(config);
+
+    expect(provider.initialize).toBeUndefined();
+    expect(useAuthState.getState().isPending).toBe(true);
+
+    firebase.auth.currentUser = {
+      uid: "user-1",
+      email: "user@example.com",
+      displayName: "Test User",
+      emailVerified: true,
+      photoURL: "https://example.com/avatar.png",
+      getIdToken: vi.fn().mockResolvedValue("token"),
+    };
+    ready.resolve();
+
+    await vi.waitFor(() => {
+      expect(useAuthState.getState()).toMatchObject({
+        isAuthenticated: true,
+        isPending: false,
+        profile: {
+          sub: "user-1",
+          email: "user@example.com",
+          name: "Test User",
+        },
+      });
+    });
+  });
+
+  test("reconciles Firebase readiness without replacing authoritative SSR auth", async () => {
+    const profile = {
+      sub: "server-user",
+      email: "server@example.com",
+      name: "Server User",
+      emailVerified: true,
+      pictureUrl: undefined,
+    };
+    window.ZUDOKU_SSR_AUTH = { profile };
+    useAuthState.setState({
+      isAuthenticated: true,
+      isPending: false,
+      profile,
+      providerData: null,
+    });
+
+    firebase.authStateReady.mockResolvedValue();
+    firebaseAuth(config);
+
+    expect(firebase.authStateReady).toHaveBeenCalledOnce();
+    await vi.waitFor(() =>
+      expect(useAuthState.getState().isPending).toBe(false),
+    );
+    expect(useAuthState.getState()).toMatchObject({
+      isAuthenticated: true,
+      isPending: false,
+      profile,
+    });
+  });
+
+  test("clears an unverified persisted profile while restoration is pending", () => {
+    const ready = deferred();
+    firebase.authStateReady.mockReturnValue(ready.promise);
+    useAuthState.setState({
+      isAuthenticated: true,
+      isPending: false,
+      profile: {
+        sub: "stale-user",
+        email: "stale@example.com",
+        name: "Stale User",
+        emailVerified: true,
+        pictureUrl: undefined,
+      },
+      providerData: null,
+    });
+
+    firebaseAuth(config);
+
+    expect(useAuthState.getState()).toMatchObject({
+      isAuthenticated: false,
+      isPending: true,
+      profile: null,
+      providerData: null,
+    });
+  });
+
+  test("signRequest waits for initial auth restoration", async () => {
+    const ready = deferred();
+    firebase.authStateReady.mockReturnValue(ready.promise);
+    const provider = firebaseAuth(config);
+    const request = new Request("https://example.com/api");
+    let settled = false;
+    const signedRequest = provider.signRequest(request).finally(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    firebase.auth.currentUser = {
+      uid: "user-1",
+      email: "user@example.com",
+      displayName: "Test User",
+      emailVerified: true,
+      photoURL: null,
+      getIdToken: vi.fn().mockResolvedValue("firebase-token"),
+    };
+    ready.resolve();
+
+    await expect(signedRequest).resolves.toBe(request);
+    expect(request.headers.get("Authorization")).toBe("Bearer firebase-token");
+  });
+});

--- a/packages/zudoku/src/lib/authentication/providers/firebase.tsx
+++ b/packages/zudoku/src/lib/authentication/providers/firebase.tsx
@@ -64,6 +64,7 @@ class FirebaseAuthenticationProvider
   public readonly disableSignUp: boolean;
   private readonly redirectToAfterSignOut: string;
   private readonly signUpConfig?: FirebaseAuthenticationConfig["signUp"];
+  private initialAuthStatePromise?: Promise<void>;
 
   constructor(config: FirebaseAuthenticationConfig) {
     super();
@@ -87,13 +88,55 @@ class FirebaseAuthenticationProvider
     this.enableUsernamePassword =
       config.providers?.includes("password") ?? false;
     this.enableEmailLink = config.providers?.includes("emailLink") ?? false;
+
+    // Restoring Firebase's persisted session can involve IndexedDB and token
+    // refresh work. Start it eagerly so protected routes remain fail-closed,
+    // but don't expose it as plugin initialize() because ZudokuProvider waits
+    // for initialize promises before rendering public content.
+    void this.restoreInitialAuthState();
   }
 
-  async initialize() {
-    await this.auth.authStateReady();
+  private restoreInitialAuthState() {
+    if (this.initialAuthStatePromise) return this.initialAuthStatePromise;
+
+    if (typeof window === "undefined") {
+      return Promise.resolve();
+    }
+
+    const hasSsrAuth = window.ZUDOKU_SSR_AUTH !== undefined;
+    if (!hasSsrAuth) {
+      useAuthState.setState({
+        isAuthenticated: false,
+        isPending: true,
+        profile: null,
+        providerData: null,
+      });
+    }
+
+    this.initialAuthStatePromise = this.auth
+      .authStateReady()
+      .then(async () => {
+        const user = this.auth.currentUser;
+        if (user) {
+          await this.setUserLoggedIn(user);
+        } else if (!hasSsrAuth) {
+          useAuthState.getState().setLoggedOut();
+        }
+      })
+      .catch((error: unknown) => {
+        if (!hasSsrAuth) useAuthState.getState().setLoggedOut();
+        // biome-ignore lint/suspicious/noConsole: Auth restoration failures should be visible without blocking the page
+        console.warn(
+          "Firebase failed to restore the initial auth state:",
+          error,
+        );
+      });
+
+    return this.initialAuthStatePromise;
   }
 
   async signRequest(request: Request): Promise<Request> {
+    await this.restoreInitialAuthState();
     const accessToken = await this.auth.currentUser?.getIdToken();
     if (!accessToken) {
       throw new AuthorizationError("User is not authenticated");
@@ -378,14 +421,8 @@ class FirebaseAuthenticationProvider
     void navigate(this.redirectToAfterSignOut, { replace: true });
   };
 
-  onPageLoad = async () => {
-    const user = this.auth.currentUser;
-
-    if (user) {
-      await this.setUserLoggedIn(user);
-    } else {
-      useAuthState.setState({ isPending: false });
-    }
+  onPageLoad = () => {
+    void this.restoreInitialAuthState();
   };
 
   private async setUserLoggedIn(user: User) {

--- a/packages/zudoku/src/lib/components/Footer.test.tsx
+++ b/packages/zudoku/src/lib/components/Footer.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { expect, it } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { SlotProvider } from "./context/SlotProvider.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Footer } from "./Footer.js";
+
+it("renders intrinsic dimensions for the footer logo", () => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(
+    {
+      site: {
+        footer: {
+          logo: {
+            src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
+            alt: "Test logo",
+            width: 120,
+            height: 24,
+          },
+        },
+      },
+    },
+    queryClient,
+    {},
+  );
+
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ZudokuProvider context={context}>
+          <SlotProvider>
+            <Footer />
+          </SlotProvider>
+        </ZudokuProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+
+  const logos = screen.getAllByRole("img", { name: "Test logo" });
+  expect(logos).toHaveLength(2);
+  for (const logo of logos) {
+    expect(logo).toHaveAttribute("width", "120");
+    expect(logo).toHaveAttribute("height", "24");
+  }
+});

--- a/packages/zudoku/src/lib/components/Footer.tsx
+++ b/packages/zudoku/src/lib/components/Footer.tsx
@@ -2,6 +2,7 @@ import { ExternalLink as ExternalLinkIcon } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
 import type { FooterSocialIcons } from "../../config/validators/ZudokuConfig.js";
 import { cn } from "../util/cn.js";
+import { getIntrinsicImageDimensions } from "../util/getIntrinsicImageDimensions.js";
 import { AnchorLink } from "./AnchorLink.js";
 import { useZudoku } from "./index.js";
 import { Slot } from "./Slot.js";
@@ -17,6 +18,8 @@ const SocialIcon = ({
         src={`https://cdn.simpleicons.org/${icon}/000000/ffffff`}
         className="size-5"
         alt={icon}
+        width={20}
+        height={20}
         loading="lazy"
       />
     );
@@ -103,16 +106,30 @@ export const Footer = () => {
               <img
                 src={footer.logo.src.light}
                 alt={footer.logo.alt}
+                {...getIntrinsicImageDimensions(
+                  footer.logo.width,
+                  footer.logo.height,
+                )}
                 className="w-8 dark:hidden"
-                style={{ width: footer.logo.width }}
+                style={{
+                  width: footer.logo.width,
+                  height: footer.logo.height,
+                }}
                 loading="lazy"
               />
               <img
                 src={footer.logo.src.dark}
                 alt={footer.logo.alt}
+                {...getIntrinsicImageDimensions(
+                  footer.logo.width,
+                  footer.logo.height,
+                )}
                 className="w-8 hidden dark:block"
                 loading="lazy"
-                style={{ width: footer.logo.width }}
+                style={{
+                  width: footer.logo.width,
+                  height: footer.logo.height,
+                }}
               />
             </>
           )}

--- a/packages/zudoku/src/lib/components/Header.test.tsx
+++ b/packages/zudoku/src/lib/components/Header.test.tsx
@@ -4,6 +4,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render as testRender, screen } from "@testing-library/react";
+import { createHead, UnheadProvider } from "@unhead/react/client";
 import type { ComponentProps } from "react";
 import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,14 +34,16 @@ const render = async (options: Partial<ZudokuContextOptions> = {}) => {
     [
       {
         element: (
-          <QueryClientProvider client={queryClient}>
-            <ZudokuProvider context={context}>
-              <SlotProvider slots={{}}>
-                <Header />
-                <Outlet />
-              </SlotProvider>
-            </ZudokuProvider>
-          </QueryClientProvider>
+          <UnheadProvider head={createHead()}>
+            <QueryClientProvider client={queryClient}>
+              <ZudokuProvider context={context}>
+                <SlotProvider slots={{}}>
+                  <Header />
+                  <Outlet />
+                </SlotProvider>
+              </ZudokuProvider>
+            </QueryClientProvider>
+          </UnheadProvider>
         ),
         children: [{ path: "*", element: null }],
       },
@@ -73,6 +76,26 @@ describe("Header", () => {
 
       const props = getLogoLinkProps();
       expect(props?.reloadDocument).toBe(true);
+    });
+
+    it("renders intrinsic dimensions for configured logos", async () => {
+      await render({
+        site: {
+          title: "Test Site",
+          logo: {
+            src: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
+            width: 120,
+            height: 32,
+          },
+        },
+      });
+
+      const logos = screen.getAllByRole("img", { name: "Test Site" });
+      expect(logos).toHaveLength(2);
+      for (const logo of logos) {
+        expect(logo).toHaveAttribute("width", "120");
+        expect(logo).toHaveAttribute("height", "32");
+      }
     });
   });
 

--- a/packages/zudoku/src/lib/components/Header.tsx
+++ b/packages/zudoku/src/lib/components/Header.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "../ui/DropdownMenu.js";
 import { cn } from "../util/cn.js";
+import { getIntrinsicImageDimensions } from "../util/getIntrinsicImageDimensions.js";
 import { joinUrl } from "../util/joinUrl.js";
 import { Banner } from "./Banner.js";
 import { useZudoku } from "./context/ZudokuContext.js";
@@ -176,13 +177,27 @@ export const Header = memo(function HeaderInner() {
                       <img
                         src={logoLightSrc}
                         alt={site.logo.alt ?? site.title}
-                        style={{ width: site.logo.width }}
+                        {...getIntrinsicImageDimensions(
+                          site.logo.width,
+                          site.logo.height,
+                        )}
+                        style={{
+                          width: site.logo.width,
+                          height: site.logo.height,
+                        }}
                         className="max-h-(--top-header-height) dark:hidden"
                       />
                       <img
                         src={logoDarkSrc}
                         alt={site.logo.alt ?? site.title}
-                        style={{ width: site.logo.width }}
+                        {...getIntrinsicImageDimensions(
+                          site.logo.width,
+                          site.logo.height,
+                        )}
+                        style={{
+                          width: site.logo.width,
+                          height: site.logo.height,
+                        }}
                         className="max-h-(--top-header-height) hidden dark:block"
                       />
                     </>

--- a/packages/zudoku/src/lib/components/HeaderNavigation.tsx
+++ b/packages/zudoku/src/lib/components/HeaderNavigation.tsx
@@ -1,10 +1,9 @@
 import type { LucideIcon } from "lucide-react";
 import { Link } from "react-router";
-import {
-  isHeaderNavGroup,
-  type HeaderNavGroup,
-  type HeaderNavItem,
-  type HeaderNavLinkItem,
+import type {
+  HeaderNavGroup,
+  HeaderNavItem,
+  HeaderNavLinkItem,
 } from "../../config/validators/HeaderNavigationSchema.js";
 import {
   NavigationMenu,
@@ -16,6 +15,7 @@ import {
   navigationMenuTriggerStyle,
 } from "../ui/NavigationMenu.js";
 import { cn } from "../util/cn.js";
+import { isHeaderNavGroup } from "../util/isHeaderNavGroup.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 
 const NavLinkItem = ({ item }: { item: HeaderNavLinkItem }) => {

--- a/packages/zudoku/src/lib/components/Main.test.tsx
+++ b/packages/zudoku/src/lib/components/Main.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  render as testRender,
+  screen,
+  within,
+} from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { SlotProvider } from "./context/SlotProvider.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Main } from "./Main.js";
+
+const render = async () => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext(
+    {
+      navigation: [
+        {
+          type: "category",
+          label: "Guides",
+          link: { type: "link", to: "/docs", label: "Guides" },
+          items: [{ type: "link", label: "Introduction", to: "/docs" }],
+        },
+      ],
+    },
+    queryClient,
+    {},
+  );
+
+  const router = createMemoryRouter(
+    [
+      {
+        element: (
+          <QueryClientProvider client={queryClient}>
+            <ZudokuProvider context={context}>
+              <SlotProvider slots={{}}>
+                <Main>Content</Main>
+                <Outlet />
+              </SlotProvider>
+            </ZudokuProvider>
+          </QueryClientProvider>
+        ),
+        children: [{ path: "*", element: null }],
+      },
+    ],
+    { initialEntries: ["/docs"] },
+  );
+
+  await act(async () => {
+    testRender(<RouterProvider router={router} />);
+  });
+};
+
+describe("Main mobile navigation", () => {
+  it("renders an accessible trigger without mounting the drawer body", async () => {
+    await render();
+
+    const trigger = screen.getByRole("button", { name: "Menu" });
+
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-controls");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("loads and opens the navigation drawer on demand", async () => {
+    const user = userEvent.setup();
+    await render();
+
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+
+    const dialog = await screen.findByRole("dialog", undefined, {
+      timeout: 5_000,
+    });
+    expect(
+      within(dialog).getByRole("link", { name: "Introduction" }),
+    ).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("restores focus to the trigger when the drawer closes", async () => {
+    const user = userEvent.setup();
+    await render();
+
+    const trigger = screen.getByRole("button", { name: "Menu" });
+    await user.click(trigger);
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
+    await user.keyboard("{Escape}");
+
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/packages/zudoku/src/lib/components/Main.tsx
+++ b/packages/zudoku/src/lib/components/Main.tsx
@@ -1,43 +1,93 @@
 import { PanelLeftIcon } from "lucide-react";
-import { type PropsWithChildren, useState } from "react";
+import {
+  lazy,
+  type PropsWithChildren,
+  Suspense,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import { useNavigation } from "react-router";
-import { Drawer, DrawerTrigger } from "zudoku/ui/Drawer.js";
 import { cn } from "../util/cn.js";
 import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
 import { Navigation } from "./navigation/Navigation.js";
 import { SidebarToggle } from "./navigation/SidebarToggle.js";
 import { Slot } from "./Slot.js";
 
+const importMobileNavigationDrawer = () =>
+  import("./navigation/MobileNavigationDrawer.js").then((module) => ({
+    default: module.MobileNavigationDrawer,
+  }));
+
+let mobileNavigationDrawerPromise:
+  | ReturnType<typeof importMobileNavigationDrawer>
+  | undefined;
+
+const loadMobileNavigationDrawer = () => {
+  mobileNavigationDrawerPromise ??= importMobileNavigationDrawer();
+  return mobileNavigationDrawerPromise;
+};
+
+const LazyMobileNavigationDrawer = lazy(loadMobileNavigationDrawer);
+
 export const Main = ({ children }: PropsWithChildren) => {
+  const [isDrawerMounted, setDrawerMounted] = useState(false);
   const [isDrawerOpen, setDrawerOpen] = useState(false);
+  const drawerId = useId();
+  const drawerTriggerRef = useRef<HTMLButtonElement>(null);
   const { navigation, topNavItem } = useCurrentNavigation();
   const hasNavigation = navigation.length > 0;
   const isNavigating = useNavigation().state === "loading";
   const { options } = useZudoku();
 
+  const preloadDrawer = () => {
+    void loadMobileNavigationDrawer();
+  };
+
+  const openDrawer = () => {
+    setDrawerMounted(true);
+    setDrawerOpen(true);
+  };
+
   return (
-    <Drawer
-      direction={options.site?.dir === "rtl" ? "right" : "left"}
-      open={isDrawerOpen}
-      onOpenChange={(open) => setDrawerOpen(open)}
-    >
+    <>
       {hasNavigation && (
-        <Navigation
-          onRequestClose={() => setDrawerOpen(false)}
-          navigation={navigation}
-          topNavItem={topNavItem}
-        />
+        <Navigation navigation={navigation} topNavItem={topNavItem} />
       )}
       {hasNavigation && (
         <div className="lg:hidden m-0 p-0 md:-mx-4 md:px-4 py-2 sticky bg-background/80 backdrop-blur-xs z-10 top-0 inset-x-0 border-b flex items-center gap-2">
-          <DrawerTrigger className="flex items-center gap-2 px-4">
+          <button
+            ref={drawerTriggerRef}
+            type="button"
+            className="flex items-center gap-2 px-4"
+            aria-haspopup="dialog"
+            aria-expanded={isDrawerOpen}
+            aria-controls={drawerId}
+            data-state={isDrawerOpen ? "open" : "closed"}
+            onFocus={preloadDrawer}
+            onPointerEnter={preloadDrawer}
+            onClick={openDrawer}
+          >
             <PanelLeftIcon size={16} strokeWidth={1.5} />
             <span className="text-sm">Menu</span>
-          </DrawerTrigger>
+          </button>
           <div className="ms-auto empty:hidden pe-4">
             <Slot.Target name="mobile-top-bar-end" />
           </div>
         </div>
+      )}
+      {isDrawerMounted && (
+        <Suspense fallback={null}>
+          <LazyMobileNavigationDrawer
+            id={drawerId}
+            direction={options.site?.dir === "rtl" ? "right" : "left"}
+            navigation={navigation}
+            onOpenChange={setDrawerOpen}
+            open={isDrawerOpen}
+            topNavItem={topNavItem}
+            triggerRef={drawerTriggerRef}
+          />
+        </Suspense>
       )}
       <main
         data-pagefind-body
@@ -54,6 +104,6 @@ export const Main = ({ children }: PropsWithChildren) => {
       {hasNavigation && options.site?.sidebar?.collapsible !== false && (
         <SidebarToggle />
       )}
-    </Drawer>
+    </>
   );
 };

--- a/packages/zudoku/src/lib/components/Markdown.test.tsx
+++ b/packages/zudoku/src/lib/components/Markdown.test.tsx
@@ -59,6 +59,9 @@ describe("Markdown", () => {
     const { container } = await renderMarkdown("Hello **world**");
 
     expect(container.querySelector("strong")?.textContent).toBe("world");
+    expect(
+      container.querySelector("[data-zudoku-runtime-shiki]"),
+    ).not.toBeNull();
   });
 
   it("renders custom PascalCase components from MDXProvider", async () => {

--- a/packages/zudoku/src/lib/components/Markdown.tsx
+++ b/packages/zudoku/src/lib/components/Markdown.tsx
@@ -66,7 +66,7 @@ export const Markdown = memo(
     );
 
     return (
-      <Typography className={className}>
+      <Typography className={className} data-zudoku-runtime-shiki>
         <ReactMarkdown
           remarkPlugins={remarkPlugins}
           rehypePlugins={rehypePlugins}

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.test.tsx
@@ -41,11 +41,25 @@ const render = async (options: Partial<ZudokuContextOptions> = {}) => {
 const themeSwitchName = /^(Toggle theme|Switch to (dark|light) mode)$/;
 
 describe("MobileTopNavigation", () => {
+  it("renders an accessible trigger without mounting the drawer body", async () => {
+    await render({ site: { title: "Test Site" } });
+
+    const trigger = screen.getByRole("button", {
+      name: "Open navigation menu",
+    });
+
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-controls");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
   it("renders the theme switch by default in the mobile navigation drawer", async () => {
     const user = userEvent.setup();
     await render({ site: { title: "Test Site" } });
 
     await user.click(screen.getByLabelText("Open navigation menu"));
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
 
     expect(
       screen.getByRole("button", { name: themeSwitchName }),
@@ -60,6 +74,7 @@ describe("MobileTopNavigation", () => {
     });
 
     await user.click(screen.getByLabelText("Open navigation menu"));
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
 
     expect(
       screen.queryByRole("button", { name: themeSwitchName }),
@@ -86,6 +101,7 @@ describe("MobileTopNavigation", () => {
     });
 
     await user.click(screen.getByLabelText("Open navigation menu"));
+    await screen.findByRole("dialog", undefined, { timeout: 5_000 });
 
     const external = screen.getByRole("link", { name: "Support" });
     expect(external.getAttribute("href")).toBe("https://example.com/support");

--- a/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigation.tsx
@@ -1,277 +1,68 @@
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { deepEqual } from "fast-equals";
-import {
-  ChevronDownIcon,
-  LogOutIcon,
-  MenuIcon,
-  type LucideIcon,
-} from "lucide-react";
-import { useState } from "react";
-import { Link, useLocation } from "react-router";
-import { Button } from "zudoku/ui/Button.js";
-import { Separator } from "zudoku/ui/Separator.js";
-import { Skeleton } from "zudoku/ui/Skeleton.js";
-import {
-  isHeaderNavGroup,
-  type HeaderNavItem,
-  type HeaderNavLinkItem,
-} from "../../config/validators/HeaderNavigationSchema.js";
-import { useAuth } from "../authentication/hook.js";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "../ui/Collapsible.js";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTitle,
-  DrawerTrigger,
-} from "../ui/Drawer.js";
-import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
-import { PoweredByZudoku } from "./navigation/PoweredByZudoku.js";
-import { getFirstMatchingPath, shouldShowItem } from "./navigation/utils.js";
+import { MenuIcon } from "lucide-react";
+import { lazy, Suspense, useId, useRef, useState } from "react";
 import { PageProgress } from "./PageProgress.js";
-import { ThemeSwitch } from "./ThemeSwitch.js";
 
-const MobileHeaderNavLink = ({
-  item,
-  onClick,
-}: {
-  item: HeaderNavLinkItem;
-  onClick: () => void;
-}) => {
-  const Icon = item.icon as LucideIcon | undefined;
-  return (
-    <Link
-      to={item.to}
-      target={item.target}
-      rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
-      onClick={onClick}
-      className="flex items-center font-medium gap-2 py-2 text-foreground/80 hover:text-foreground"
-    >
-      {Icon && <Icon size={16} />}
-      {item.label}
-    </Link>
-  );
+const importMobileTopNavigationDrawer = () =>
+  import("./MobileTopNavigationDrawer.js").then((module) => ({
+    default: module.MobileTopNavigationDrawer,
+  }));
+
+let mobileTopNavigationDrawerPromise:
+  | ReturnType<typeof importMobileTopNavigationDrawer>
+  | undefined;
+
+const loadMobileTopNavigationDrawer = () => {
+  mobileTopNavigationDrawerPromise ??= importMobileTopNavigationDrawer();
+  return mobileTopNavigationDrawerPromise;
 };
 
-const MobileHeaderNavItem = ({
-  item,
-  onNavigate,
-}: {
-  item: HeaderNavItem;
-  onNavigate: () => void;
-}) => {
-  if ("to" in item) {
-    const Icon = item.icon as LucideIcon | undefined;
-    return (
-      <li className="w-full">
-        <Link
-          to={item.to}
-          target={item.target}
-          rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
-          onClick={onNavigate}
-          className="flex items-center gap-2 py-2 text-base font-medium"
-        >
-          {Icon && <Icon size={16} />}
-          {item.label}
-        </Link>
-      </li>
-    );
-  }
-
-  return (
-    <li className="w-full">
-      <Collapsible>
-        <CollapsibleTrigger className="flex items-center justify-between w-full py-2 text-base font-medium group">
-          {item.label}
-          <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <ul className="flex flex-col border-l ms-1 ps-3 my-1">
-            {item.items.map((subItem) =>
-              isHeaderNavGroup(subItem) ? (
-                <li key={subItem.label} className="flex flex-col">
-                  <div className="text-sm text-muted-foreground py-2">
-                    {subItem.label}
-                  </div>
-                  {subItem.items.map((link) => (
-                    <MobileHeaderNavLink
-                      key={link.to}
-                      item={link}
-                      onClick={onNavigate}
-                    />
-                  ))}
-                </li>
-              ) : (
-                <li key={subItem.to}>
-                  <MobileHeaderNavLink item={subItem} onClick={onNavigate} />
-                </li>
-              ),
-            )}
-          </ul>
-        </CollapsibleContent>
-      </Collapsible>
-    </li>
-  );
-};
+const LazyMobileTopNavigationDrawer = lazy(loadMobileTopNavigationDrawer);
 
 export const MobileTopNavigation = () => {
-  const context = useZudoku();
-  const authState = useAuth();
-  const location = useLocation();
-  const currentNav = useCurrentNavigation();
-
-  const {
-    options: { header, navigation = [], site },
-    getProfileMenuItems,
-  } = context;
-  const headerNavigation = header?.navigation ?? [];
-  const themeSwitcherEnabled = header?.themeSwitcher?.enabled ?? true;
-  const { isAuthenticated, isPending, profile, isAuthEnabled } = authState;
+  const [drawerMounted, setDrawerMounted] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const drawerId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
-  const accountItems = getProfileMenuItems();
-  const filteredItems = navigation.filter(
-    shouldShowItem({ auth: authState, context }),
-  );
+  const preloadDrawer = () => {
+    void loadMobileTopNavigationDrawer();
+  };
+
+  const openDrawer = () => {
+    setDrawerMounted(true);
+    setDrawerOpen(true);
+  };
 
   return (
-    <Drawer
-      direction={site?.dir === "rtl" ? "left" : "right"}
-      open={drawerOpen}
-      onOpenChange={setDrawerOpen}
-    >
+    <>
       <div className="flex lg:hidden justify-self-end">
-        <DrawerTrigger className="lg:hidden" aria-label="Open navigation menu">
+        <button
+          ref={triggerRef}
+          type="button"
+          className="lg:hidden"
+          aria-label="Open navigation menu"
+          aria-haspopup="dialog"
+          aria-expanded={drawerOpen}
+          aria-controls={drawerId}
+          data-state={drawerOpen ? "open" : "closed"}
+          onFocus={preloadDrawer}
+          onPointerEnter={preloadDrawer}
+          onClick={openDrawer}
+        >
           <MenuIcon size={22} aria-hidden="true" />
-        </DrawerTrigger>
+        </button>
         <PageProgress />
       </div>
-      <DrawerContent
-        className="lg:hidden h-dvh inset-e-0 start-auto w-[340px] rounded-none"
-        aria-describedby={undefined}
-      >
-        <div className="py-2 h-full flex flex-col">
-          <div className="flex-1 overflow-y-auto overscroll-none">
-            <VisuallyHidden>
-              <DrawerTitle>Navigation</DrawerTitle>
-            </VisuallyHidden>
-            <ul className="flex flex-col gap-1 px-4">
-              {headerNavigation.map((item) => (
-                <MobileHeaderNavItem
-                  key={item.label}
-                  item={item}
-                  onNavigate={() => setDrawerOpen(false)}
-                />
-              ))}
-              {headerNavigation.length > 0 && <Separator className="my-2" />}
-
-              {filteredItems.map((item) => {
-                if (item.type === "separator") {
-                  return <Separator className="my-2" key={item.label} />;
-                }
-                if (item.type === "section" || item.type === "filter") {
-                  return null;
-                }
-                const path = getFirstMatchingPath(item);
-                const isActive = deepEqual(currentNav.topNavItem, item);
-                const target = "target" in item ? item.target : undefined;
-                return (
-                  <li key={item.label}>
-                    <Link
-                      to={path}
-                      target={target}
-                      rel={
-                        target === "_blank" ? "noopener noreferrer" : undefined
-                      }
-                      onClick={() => setDrawerOpen(false)}
-                      className={`flex items-center gap-2 py-2 text-base font-medium ${isActive ? "text-foreground" : "text-foreground/75 hover:text-foreground"}`}
-                    >
-                      {item.icon && <item.icon size={16} />}
-                      {item.label}
-                    </Link>
-                  </li>
-                );
-              })}
-              {isAuthEnabled &&
-                (isPending ? (
-                  <Skeleton className="rounded-sm h-5 w-24" />
-                ) : (
-                  isAuthenticated && (
-                    <>
-                      <Separator className="my-2" />
-                      <li className="py-2">
-                        <div className="text-base font-medium">
-                          {profile?.name ?? "My Account"}
-                        </div>
-                        {profile?.email && profile.email !== profile?.name && (
-                          <div className="text-sm text-muted-foreground">
-                            {profile.email}
-                          </div>
-                        )}
-                      </li>
-                      {accountItems.map((i) => (
-                        <li key={i.label}>
-                          <Link
-                            to={i.path ?? ""}
-                            target={i.target}
-                            rel={
-                              i.target === "_blank"
-                                ? "noopener noreferrer"
-                                : undefined
-                            }
-                            onClick={() => setDrawerOpen(false)}
-                            className="flex items-center py-2 text-base font-medium text-foreground/75 hover:text-foreground"
-                          >
-                            {i.label}
-                          </Link>
-                        </li>
-                      ))}
-                    </>
-                  )
-                ))}
-            </ul>
-          </div>
-          <div className="border-t shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] px-4 pt-3 flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              {isAuthEnabled &&
-                (isPending ? (
-                  <Skeleton className="rounded-sm h-8 w-16" />
-                ) : isAuthenticated ? (
-                  <Button asChild variant="outline">
-                    <Link
-                      to="/signout"
-                      onClick={() => setDrawerOpen(false)}
-                      className="flex items-center gap-2"
-                    >
-                      <LogOutIcon
-                        size={16}
-                        strokeWidth={1}
-                        absoluteStrokeWidth
-                      />
-                      Logout
-                    </Link>
-                  </Button>
-                ) : (
-                  <Button asChild variant="outline">
-                    <Link
-                      to={`/signin?redirect=${encodeURIComponent(location.pathname)}`}
-                      onClick={() => setDrawerOpen(false)}
-                    >
-                      Login
-                    </Link>
-                  </Button>
-                ))}
-              {themeSwitcherEnabled && <ThemeSwitch />}
-            </div>
-            {site?.showPoweredBy !== false && (
-              <PoweredByZudoku className="grow-0 justify-center gap-1" />
-            )}
-          </div>
-        </div>
-      </DrawerContent>
-    </Drawer>
+      {drawerMounted && (
+        <Suspense fallback={null}>
+          <LazyMobileTopNavigationDrawer
+            id={drawerId}
+            open={drawerOpen}
+            onOpenChange={setDrawerOpen}
+            triggerRef={triggerRef}
+          />
+        </Suspense>
+      )}
+    </>
   );
 };

--- a/packages/zudoku/src/lib/components/MobileTopNavigationDrawer.tsx
+++ b/packages/zudoku/src/lib/components/MobileTopNavigationDrawer.tsx
@@ -1,0 +1,276 @@
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { deepEqual } from "fast-equals";
+import { ChevronDownIcon, LogOutIcon, type LucideIcon } from "lucide-react";
+import type { RefObject } from "react";
+import { Link, useLocation } from "react-router";
+import { Button } from "zudoku/ui/Button.js";
+import { Separator } from "zudoku/ui/Separator.js";
+import { Skeleton } from "zudoku/ui/Skeleton.js";
+import type {
+  HeaderNavItem,
+  HeaderNavLinkItem,
+} from "../../config/validators/HeaderNavigationSchema.js";
+import { useAuth } from "../authentication/hook.js";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../ui/Collapsible.js";
+import { Drawer, DrawerContent, DrawerTitle } from "../ui/Drawer.js";
+import { isHeaderNavGroup } from "../util/isHeaderNavGroup.js";
+import { useCurrentNavigation, useZudoku } from "./context/ZudokuContext.js";
+import { PoweredByZudoku } from "./navigation/PoweredByZudoku.js";
+import { getFirstMatchingPath, shouldShowItem } from "./navigation/utils.js";
+import { ThemeSwitch } from "./ThemeSwitch.js";
+
+const MobileHeaderNavLink = ({
+  item,
+  onClick,
+}: {
+  item: HeaderNavLinkItem;
+  onClick: () => void;
+}) => {
+  const Icon = item.icon as LucideIcon | undefined;
+  return (
+    <Link
+      to={item.to}
+      target={item.target}
+      rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
+      onClick={onClick}
+      className="flex items-center font-medium gap-2 py-2 text-foreground/80 hover:text-foreground"
+    >
+      {Icon && <Icon size={16} />}
+      {item.label}
+    </Link>
+  );
+};
+
+const MobileHeaderNavItem = ({
+  item,
+  onNavigate,
+}: {
+  item: HeaderNavItem;
+  onNavigate: () => void;
+}) => {
+  if ("to" in item) {
+    const Icon = item.icon as LucideIcon | undefined;
+    return (
+      <li className="w-full">
+        <Link
+          to={item.to}
+          target={item.target}
+          rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
+          onClick={onNavigate}
+          className="flex items-center gap-2 py-2 text-base font-medium"
+        >
+          {Icon && <Icon size={16} />}
+          {item.label}
+        </Link>
+      </li>
+    );
+  }
+
+  return (
+    <li className="w-full">
+      <Collapsible>
+        <CollapsibleTrigger className="flex items-center justify-between w-full py-2 text-base font-medium group">
+          {item.label}
+          <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <ul className="flex flex-col border-l ms-1 ps-3 my-1">
+            {item.items.map((subItem) =>
+              isHeaderNavGroup(subItem) ? (
+                <li key={subItem.label} className="flex flex-col">
+                  <div className="text-sm text-muted-foreground py-2">
+                    {subItem.label}
+                  </div>
+                  {subItem.items.map((link) => (
+                    <MobileHeaderNavLink
+                      key={link.to}
+                      item={link}
+                      onClick={onNavigate}
+                    />
+                  ))}
+                </li>
+              ) : (
+                <li key={subItem.to}>
+                  <MobileHeaderNavLink item={subItem} onClick={onNavigate} />
+                </li>
+              ),
+            )}
+          </ul>
+        </CollapsibleContent>
+      </Collapsible>
+    </li>
+  );
+};
+
+export const MobileTopNavigationDrawer = ({
+  id,
+  open,
+  onOpenChange,
+  triggerRef,
+}: {
+  id: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+}) => {
+  const context = useZudoku();
+  const authState = useAuth();
+  const location = useLocation();
+  const currentNav = useCurrentNavigation();
+
+  const {
+    options: { header, navigation = [], site },
+    getProfileMenuItems,
+  } = context;
+  const headerNavigation = header?.navigation ?? [];
+  const themeSwitcherEnabled = header?.themeSwitcher?.enabled ?? true;
+  const { isAuthenticated, isPending, profile, isAuthEnabled } = authState;
+
+  const accountItems = getProfileMenuItems();
+  const filteredItems = navigation.filter(
+    shouldShowItem({ auth: authState, context }),
+  );
+
+  const closeDrawer = () => onOpenChange(false);
+
+  return (
+    <Drawer
+      direction={site?.dir === "rtl" ? "left" : "right"}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DrawerContent
+        id={id}
+        className="lg:hidden h-dvh inset-e-0 start-auto w-[340px] rounded-none"
+        aria-describedby={undefined}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          triggerRef.current?.focus();
+        }}
+      >
+        <div className="py-2 h-full flex flex-col">
+          <div className="flex-1 overflow-y-auto overscroll-none">
+            <VisuallyHidden>
+              <DrawerTitle>Navigation</DrawerTitle>
+            </VisuallyHidden>
+            <ul className="flex flex-col gap-1 px-4">
+              {headerNavigation.map((item) => (
+                <MobileHeaderNavItem
+                  key={item.label}
+                  item={item}
+                  onNavigate={closeDrawer}
+                />
+              ))}
+              {headerNavigation.length > 0 && <Separator className="my-2" />}
+
+              {filteredItems.map((item) => {
+                if (item.type === "separator") {
+                  return <Separator className="my-2" key={item.label} />;
+                }
+                if (item.type === "section" || item.type === "filter") {
+                  return null;
+                }
+                const path = getFirstMatchingPath(item);
+                const isActive = deepEqual(currentNav.topNavItem, item);
+                const target = "target" in item ? item.target : undefined;
+                return (
+                  <li key={item.label}>
+                    <Link
+                      to={path}
+                      target={target}
+                      rel={
+                        target === "_blank" ? "noopener noreferrer" : undefined
+                      }
+                      onClick={closeDrawer}
+                      className={`flex items-center gap-2 py-2 text-base font-medium ${isActive ? "text-foreground" : "text-foreground/75 hover:text-foreground"}`}
+                    >
+                      {item.icon && <item.icon size={16} />}
+                      {item.label}
+                    </Link>
+                  </li>
+                );
+              })}
+              {isAuthEnabled &&
+                (isPending ? (
+                  <Skeleton className="rounded-sm h-5 w-24" />
+                ) : (
+                  isAuthenticated && (
+                    <>
+                      <Separator className="my-2" />
+                      <li className="py-2">
+                        <div className="text-base font-medium">
+                          {profile?.name ?? "My Account"}
+                        </div>
+                        {profile?.email && profile.email !== profile?.name && (
+                          <div className="text-sm text-muted-foreground">
+                            {profile.email}
+                          </div>
+                        )}
+                      </li>
+                      {accountItems.map((item) => (
+                        <li key={item.label}>
+                          <Link
+                            to={item.path ?? ""}
+                            target={item.target}
+                            rel={
+                              item.target === "_blank"
+                                ? "noopener noreferrer"
+                                : undefined
+                            }
+                            onClick={closeDrawer}
+                            className="flex items-center py-2 text-base font-medium text-foreground/75 hover:text-foreground"
+                          >
+                            {item.label}
+                          </Link>
+                        </li>
+                      ))}
+                    </>
+                  )
+                ))}
+            </ul>
+          </div>
+          <div className="border-t shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] px-4 pt-3 flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              {isAuthEnabled &&
+                (isPending ? (
+                  <Skeleton className="rounded-sm h-8 w-16" />
+                ) : isAuthenticated ? (
+                  <Button asChild variant="outline">
+                    <Link
+                      to="/signout"
+                      onClick={closeDrawer}
+                      className="flex items-center gap-2"
+                    >
+                      <LogOutIcon
+                        size={16}
+                        strokeWidth={1}
+                        absoluteStrokeWidth
+                      />
+                      Logout
+                    </Link>
+                  </Button>
+                ) : (
+                  <Button asChild variant="outline">
+                    <Link
+                      to={`/signin?redirect=${encodeURIComponent(location.pathname)}`}
+                      onClick={closeDrawer}
+                    >
+                      Login
+                    </Link>
+                  </Button>
+                ))}
+              {themeSwitcherEnabled && <ThemeSwitch />}
+            </div>
+            {site?.showPoweredBy !== false && (
+              <PoweredByZudoku className="grow-0 justify-center gap-1" />
+            )}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/packages/zudoku/src/lib/components/Search.test.tsx
+++ b/packages/zudoku/src/lib/components/Search.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render as testRender, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ZudokuPlugin } from "../core/plugins.js";
+import { ZudokuContext } from "../core/ZudokuContext.js";
+import { ZudokuProvider } from "./context/ZudokuProvider.js";
+import { Search, SearchProvider } from "./Search.js";
+
+const render = async (plugins: ZudokuPlugin[]) => {
+  const queryClient = new QueryClient();
+  const context = new ZudokuContext({ plugins }, queryClient, {});
+
+  await act(async () => {
+    testRender(
+      <QueryClientProvider client={queryClient}>
+        <ZudokuProvider context={context}>
+          <SearchProvider>
+            <Search />
+          </SearchProvider>
+        </ZudokuProvider>
+      </QueryClientProvider>,
+    );
+  });
+};
+
+const searchPlugin = (preloadSearch?: () => void): ZudokuPlugin => ({
+  renderSearch: () => null,
+  ...(preloadSearch && { preloadSearch }),
+});
+
+describe("SearchProvider", () => {
+  it("preloads the search UI once the page is idle", async () => {
+    const preloadSearch = vi.fn();
+
+    await render([searchPlugin(preloadSearch)]);
+
+    // The idle callback polyfill defers to a timer, so let it drain.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(preloadSearch).toHaveBeenCalled();
+  });
+
+  it("preloads on hover and focus of the search trigger", async () => {
+    const user = userEvent.setup();
+    const preloadSearch = vi.fn();
+
+    await render([searchPlugin(preloadSearch)]);
+    preloadSearch.mockClear();
+
+    const trigger = screen.getByRole("button", { name: /search/i });
+
+    await user.hover(trigger);
+    expect(preloadSearch).toHaveBeenCalled();
+
+    preloadSearch.mockClear();
+    await act(async () => {
+      trigger.focus();
+    });
+    expect(preloadSearch).toHaveBeenCalled();
+  });
+
+  it("renders a search plugin that does not implement preloadSearch", async () => {
+    await render([searchPlugin()]);
+
+    const trigger = screen.getByRole("button", { name: /search/i });
+    const user = userEvent.setup();
+
+    await user.hover(trigger);
+    await user.click(trigger);
+
+    expect(trigger).toBeInTheDocument();
+  });
+});

--- a/packages/zudoku/src/lib/components/Search.tsx
+++ b/packages/zudoku/src/lib/components/Search.tsx
@@ -13,13 +13,14 @@ import { isSearchPlugin } from "../core/plugins.js";
 import { focusRing } from "../ui/util.js";
 import { cn } from "../util/cn.js";
 import { getOS } from "../util/os.js";
+import { requestIdle } from "../util/requestIdle.js";
 import { ClientOnly } from "./ClientOnly.js";
 import { useZudoku } from "./context/ZudokuContext.js";
 
 /** `null` when no search plugin is configured, `undefined` outside a provider */
-const SearchContext = createContext<{ onOpen: () => void } | null | undefined>(
-  undefined,
-);
+const SearchContext = createContext<
+  { onOpen: () => void; onPreload: () => void } | null | undefined
+>(undefined);
 
 /**
  * Owns the search modal and the ⌘K / Ctrl+K shortcut for all `Search` buttons
@@ -33,6 +34,18 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   const onClose = useCallback(() => setIsOpen(false), []);
 
   const searchPlugin = ctx.options.plugins?.find(isSearchPlugin);
+  const onPreload = useCallback(
+    () => searchPlugin?.preloadSearch?.(),
+    [searchPlugin],
+  );
+
+  // The search UI is lazily loaded, so opening it cold shows nothing until its
+  // chunk arrives. Warm it once the page is idle; hover/focus covers the rest.
+  useEffect(() => {
+    if (!searchPlugin?.preloadSearch) return;
+
+    return requestIdle(() => searchPlugin.preloadSearch?.());
+  }, [searchPlugin]);
 
   useEffect(() => {
     if (isOpen || !searchPlugin) return;
@@ -50,8 +63,8 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   }, [isOpen, searchPlugin]);
 
   const value = useMemo(
-    () => (searchPlugin ? { onOpen } : null),
-    [searchPlugin, onOpen],
+    () => (searchPlugin ? { onOpen, onPreload } : null),
+    [searchPlugin, onOpen, onPreload],
   );
 
   return (
@@ -80,6 +93,8 @@ export const Search = ({ className }: { className?: string }) => {
       <button
         type="button"
         onClick={search.onOpen}
+        onPointerEnter={search.onPreload}
+        onFocus={search.onPreload}
         className={cn(
           "relative w-full md:w-56 flex items-center border bg-clip-padding h-8 rounded-lg px-3 pr-14 text-sm transition-all",
           "border-input text-muted-foreground bg-background hover:bg-muted/50 hover:text-foreground shadow-xs",

--- a/packages/zudoku/src/lib/components/navigation/MobileNavigationDrawer.tsx
+++ b/packages/zudoku/src/lib/components/navigation/MobileNavigationDrawer.tsx
@@ -1,0 +1,57 @@
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import type { RefObject } from "react";
+import type { NavigationItem as NavigationItemType } from "../../../config/validators/NavigationSchema.js";
+import { Drawer, DrawerContent, DrawerTitle } from "../../ui/Drawer.js";
+import { NavigationFilterProvider } from "./NavigationFilterContext.js";
+import { NavigationFrames } from "./NavigationFrames.js";
+import { useNavigationFrame } from "./useNavigationFrame.js";
+import { getItemPath } from "./utils.js";
+
+export const MobileNavigationDrawer = ({
+  id,
+  direction,
+  navigation,
+  onOpenChange,
+  open,
+  topNavItem,
+  triggerRef,
+}: {
+  id: string;
+  direction: "left" | "right";
+  navigation: NavigationItemType[];
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  topNavItem?: NavigationItemType;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+}) => {
+  const frame = useNavigationFrame(navigation, topNavItem);
+  const section = topNavItem
+    ? (getItemPath(topNavItem) ?? topNavItem.label)
+    : "";
+
+  return (
+    <Drawer direction={direction} open={open} onOpenChange={onOpenChange}>
+      <NavigationFilterProvider resetKey={`${section}\n${frame.id}`}>
+        <DrawerContent
+          id={id}
+          className="lg:hidden h-dvh inset-s-0 w-[320px] rounded-none"
+          aria-describedby={undefined}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            triggerRef.current?.focus();
+          }}
+        >
+          <div className="p-4 overflow-y-auto overscroll-none">
+            <VisuallyHidden>
+              <DrawerTitle>Navigation</DrawerTitle>
+            </VisuallyHidden>
+            <NavigationFrames
+              frame={frame}
+              onRequestClose={() => onOpenChange(false)}
+            />
+          </div>
+        </DrawerContent>
+      </NavigationFilterProvider>
+    </Drawer>
+  );
+};

--- a/packages/zudoku/src/lib/components/navigation/Navigation.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Navigation.tsx
@@ -10,7 +10,6 @@ export const Navigation = ({
   navigation,
   topNavItem,
 }: {
-  onRequestClose?: () => void;
   navigation: NavigationItemType[];
   topNavItem?: NavigationItemType;
 }) => {

--- a/packages/zudoku/src/lib/components/navigation/Navigation.tsx
+++ b/packages/zudoku/src/lib/components/navigation/Navigation.tsx
@@ -1,6 +1,4 @@
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import type { NavigationItem as NavigationItemType } from "../../../config/validators/NavigationSchema.js";
-import { DrawerContent, DrawerTitle } from "../../ui/Drawer.js";
 import { Slot } from "../Slot.js";
 import { NavigationFilterProvider } from "./NavigationFilterContext.js";
 import { NavigationFrames } from "./NavigationFrames.js";
@@ -9,7 +7,6 @@ import { useNavigationFrame } from "./useNavigationFrame.js";
 import { getItemPath } from "./utils.js";
 
 export const Navigation = ({
-  onRequestClose,
   navigation,
   topNavItem,
 }: {
@@ -29,18 +26,6 @@ export const Navigation = ({
         <NavigationFrames frame={frame} />
         <Slot.Target name="navigation-after" />
       </NavigationWrapper>
-      <DrawerContent
-        className="lg:hidden h-dvh inset-s-0 w-[320px] rounded-none"
-        aria-describedby={undefined}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-      >
-        <div className="p-4 overflow-y-auto overscroll-none">
-          <VisuallyHidden>
-            <DrawerTitle>Navigation</DrawerTitle>
-          </VisuallyHidden>
-          <NavigationFrames frame={frame} onRequestClose={onRequestClose} />
-        </div>
-      </DrawerContent>
     </NavigationFilterProvider>
   );
 };

--- a/packages/zudoku/src/lib/core/ZudokuContext.ts
+++ b/packages/zudoku/src/lib/core/ZudokuContext.ts
@@ -85,6 +85,7 @@ type Site = Partial<{
       dark: string;
     };
     width?: string | number;
+    height?: string | number;
     alt?: string;
     href?: string;
     reloadDocument?: boolean;

--- a/packages/zudoku/src/lib/core/plugins.ts
+++ b/packages/zudoku/src/lib/core/plugins.ts
@@ -49,6 +49,12 @@ export interface SearchProviderPlugin {
     onOpen: () => void;
     onClose: () => void;
   }) => React.JSX.Element | null;
+  /**
+   * Start loading whatever `renderSearch` needs, without opening it. Called
+   * when the page goes idle and again on hover/focus of a search trigger, so
+   * a lazily loaded search UI is warm by the time it is opened.
+   */
+  preloadSearch?: () => void;
 }
 
 export interface ProfileMenuPlugin {

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { expect, it, vi } from "vitest";
+import { isSearchPlugin } from "../../core/plugins.js";
+import { pagefindSearchPlugin } from "./index.js";
+
+const mounts = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock("./PagefindSearch.js", async () => {
+  const { useEffect } = await import("react");
+
+  return {
+    PagefindSearch: ({ isOpen }: { isOpen: boolean }) => {
+      useEffect(() => {
+        mounts.count++;
+      }, []);
+
+      return <div data-testid="pagefind" data-open={isOpen} />;
+    },
+  };
+});
+
+it("loads Pagefind on first open and preserves it across close and reopen", async () => {
+  mounts.count = 0;
+  const plugin = pagefindSearchPlugin({ type: "pagefind" });
+  expect(isSearchPlugin(plugin)).toBe(true);
+  if (!isSearchPlugin(plugin)) return;
+
+  const onOpen = vi.fn();
+  const onClose = vi.fn();
+  const renderSearch = (isOpen: boolean) => (
+    <Suspense>{plugin.renderSearch({ isOpen, onOpen, onClose })}</Suspense>
+  );
+  const view = render(renderSearch(false));
+
+  expect(screen.queryByTestId("pagefind")).toBeNull();
+
+  view.rerender(renderSearch(true));
+  expect(await screen.findByTestId("pagefind")).toHaveAttribute(
+    "data-open",
+    "true",
+  );
+  expect(mounts.count).toBe(1);
+
+  view.rerender(renderSearch(false));
+  expect(screen.getByTestId("pagefind")).toHaveAttribute("data-open", "false");
+
+  view.rerender(renderSearch(true));
+  expect(screen.getByTestId("pagefind")).toHaveAttribute("data-open", "true");
+  expect(mounts.count).toBe(1);
+});

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.test.tsx
@@ -6,9 +6,11 @@ import { isSearchPlugin } from "../../core/plugins.js";
 import { pagefindSearchPlugin } from "./index.js";
 
 const mounts = vi.hoisted(() => ({ count: 0 }));
+const loads = vi.hoisted(() => ({ count: 0 }));
 
 vi.mock("./PagefindSearch.js", async () => {
   const { useEffect } = await import("react");
+  loads.count++;
 
   return {
     PagefindSearch: ({ isOpen }: { isOpen: boolean }) => {
@@ -19,6 +21,23 @@ vi.mock("./PagefindSearch.js", async () => {
       return <div data-testid="pagefind" data-open={isOpen} />;
     },
   };
+});
+
+it("does not import the search chunk until preloadSearch is called", async () => {
+  const plugin = pagefindSearchPlugin({ type: "pagefind" });
+  expect(isSearchPlugin(plugin)).toBe(true);
+  if (!isSearchPlugin(plugin)) return;
+
+  // Nothing has rendered or preloaded yet, so the chunk must be untouched.
+  expect(loads.count).toBe(0);
+
+  plugin.preloadSearch?.();
+  await vi.waitFor(() => expect(loads.count).toBe(1));
+
+  // Repeated preloads reuse the in-flight/settled import.
+  plugin.preloadSearch?.();
+  await vi.waitFor(() => expect(loads.count).toBe(1));
+  expect(mounts.count).toBe(0);
 });
 
 it("loads Pagefind on first open and preserves it across close and reopen", async () => {

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
@@ -1,6 +1,32 @@
+import { lazy, useEffect, useState } from "react";
 import type { ZudokuConfig } from "../../../config/validators/ZudokuConfig.js";
 import type { ZudokuPlugin } from "../../core/plugins.js";
-import { PagefindSearch } from "./PagefindSearch.js";
+
+const PagefindSearch = lazy(() =>
+  import("./PagefindSearch.js").then((module) => ({
+    default: module.PagefindSearch,
+  })),
+);
+
+const MountedPagefindSearch = ({
+  isOpen,
+  onClose,
+  options,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  options: PagefindOptions;
+}) => {
+  const [hasOpened, setHasOpened] = useState(isOpen);
+
+  useEffect(() => {
+    if (isOpen) setHasOpened(true);
+  }, [isOpen]);
+
+  if (!isOpen && !hasOpened) return null;
+
+  return <PagefindSearch isOpen={isOpen} onClose={onClose} options={options} />;
+};
 
 export type PagefindOptions = Extract<
   ZudokuConfig["search"],
@@ -12,7 +38,11 @@ export const pagefindSearchPlugin = (
 ): ZudokuPlugin => {
   return {
     renderSearch: ({ isOpen, onClose }) => (
-      <PagefindSearch isOpen={isOpen} onClose={onClose} options={options} />
+      <MountedPagefindSearch
+        isOpen={isOpen}
+        onClose={onClose}
+        options={options}
+      />
     ),
   };
 };

--- a/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
+++ b/packages/zudoku/src/lib/plugins/search-pagefind/index.tsx
@@ -2,11 +2,19 @@ import { lazy, useEffect, useState } from "react";
 import type { ZudokuConfig } from "../../../config/validators/ZudokuConfig.js";
 import type { ZudokuPlugin } from "../../core/plugins.js";
 
-const PagefindSearch = lazy(() =>
+const importPagefindSearch = () =>
   import("./PagefindSearch.js").then((module) => ({
     default: module.PagefindSearch,
-  })),
-);
+  }));
+
+let pagefindSearchPromise: ReturnType<typeof importPagefindSearch> | undefined;
+
+const loadPagefindSearch = () => {
+  pagefindSearchPromise ??= importPagefindSearch();
+  return pagefindSearchPromise;
+};
+
+const PagefindSearch = lazy(loadPagefindSearch);
 
 const MountedPagefindSearch = ({
   isOpen,
@@ -44,5 +52,8 @@ export const pagefindSearchPlugin = (
         options={options}
       />
     ),
+    // Only warms the component chunk. The Pagefind bundle and its index are
+    // still fetched by PagefindSearch itself, which mounts on first open.
+    preloadSearch: () => void loadPagefindSearch(),
   };
 };

--- a/packages/zudoku/src/lib/shiki.ts
+++ b/packages/zudoku/src/lib/shiki.ts
@@ -175,6 +175,7 @@ export const highlight = (
       code: ({ inline: _inline, ...props }) =>
         createElement("code", {
           ...props,
+          "data-zudoku-runtime-shiki": true,
           className: cn(props.className, HIGHLIGHT_CODE_BLOCK_CLASS),
         }),
     },

--- a/packages/zudoku/src/lib/util/activateDeferredStylesheets.test.ts
+++ b/packages/zudoku/src/lib/util/activateDeferredStylesheets.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { beforeEach, expect, it, vi } from "vitest";
+import { activateDeferredStylesheets } from "./activateDeferredStylesheets.js";
+
+const frameCallbacks: FrameRequestCallback[] = [];
+
+beforeEach(() => {
+  document.head.innerHTML = `
+    <link
+      rel="preload"
+      as="style"
+      href="data:text/css,body{}"
+      data-zudoku-deferred-stylesheet
+    >
+  `;
+  frameCallbacks.length = 0;
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    frameCallbacks.push(callback);
+    return frameCallbacks.length;
+  });
+});
+
+it("activates a preloaded stylesheet after the first paint", () => {
+  activateDeferredStylesheets();
+  const link = document.querySelector("link");
+
+  expect(link).toHaveAttribute("rel", "preload");
+  expect(frameCallbacks).toHaveLength(1);
+
+  frameCallbacks.shift()?.(0);
+  expect(link).toHaveAttribute("rel", "preload");
+  expect(frameCallbacks).toHaveLength(1);
+
+  frameCallbacks.shift()?.(16);
+  expect(link).toHaveAttribute("rel", "stylesheet");
+  expect(link).toHaveAttribute("as", "style");
+  expect(link).not.toHaveAttribute("data-zudoku-deferred-stylesheet");
+});

--- a/packages/zudoku/src/lib/util/activateDeferredStylesheets.ts
+++ b/packages/zudoku/src/lib/util/activateDeferredStylesheets.ts
@@ -1,0 +1,16 @@
+export const activateDeferredStylesheets = () => {
+  // Two frames guarantee the critical stylesheet gets one paint before the
+  // complete sheet is activated. Its preload has already started the fetch.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document
+        .querySelectorAll<HTMLLinkElement>(
+          "link[data-zudoku-deferred-stylesheet]",
+        )
+        .forEach((link) => {
+          link.rel = "stylesheet";
+          link.removeAttribute("data-zudoku-deferred-stylesheet");
+        });
+    });
+  });
+};

--- a/packages/zudoku/src/lib/util/getIntrinsicImageDimensions.ts
+++ b/packages/zudoku/src/lib/util/getIntrinsicImageDimensions.ts
@@ -1,0 +1,15 @@
+export const getIntrinsicImageDimensions = (
+  width: string | number | undefined,
+  height: string | number | undefined,
+) => {
+  if (
+    typeof width !== "number" ||
+    !Number.isFinite(width) ||
+    typeof height !== "number" ||
+    !Number.isFinite(height)
+  ) {
+    return {};
+  }
+
+  return { width, height };
+};

--- a/packages/zudoku/src/lib/util/isHeaderNavGroup.ts
+++ b/packages/zudoku/src/lib/util/isHeaderNavGroup.ts
@@ -1,0 +1,9 @@
+import type {
+  HeaderNavGroup,
+  HeaderNavItem,
+  HeaderNavLinkItem,
+} from "../../config/validators/HeaderNavigationSchema.js";
+
+export const isHeaderNavGroup = (
+  item: HeaderNavItem | HeaderNavLinkItem | HeaderNavGroup,
+): item is HeaderNavGroup => "items" in item;

--- a/packages/zudoku/src/lib/util/requestIdle.ts
+++ b/packages/zudoku/src/lib/util/requestIdle.ts
@@ -1,0 +1,19 @@
+/**
+ * `requestIdleCallback` that is safe to call from `lib` code. `polyfills.ts`
+ * only runs in the app entry, so components reachable from the public exports
+ * (or from a test environment) cannot rely on the global existing.
+ *
+ * Returns a cancel function rather than an id so callers do not need to know
+ * which of the two implementations ran.
+ */
+export const requestIdle = (callback: () => void, timeout = 10_000) => {
+  if (typeof window === "undefined") return () => {};
+
+  if (typeof window.requestIdleCallback === "function") {
+    const id = window.requestIdleCallback(() => callback(), { timeout });
+    return () => window.cancelIdleCallback(id);
+  }
+
+  const id = window.setTimeout(callback, 1);
+  return () => window.clearTimeout(id);
+};

--- a/packages/zudoku/src/vite/build.test.ts
+++ b/packages/zudoku/src/vite/build.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getEagerCssEntries } from "./build.js";
+
+describe("getEagerCssEntries", () => {
+  it("keeps eager and standalone CSS while excluding lazy chunk CSS", () => {
+    const output = [
+      {
+        type: "chunk",
+        fileName: "entry.js",
+        isEntry: true,
+        imports: ["vendor.js"],
+        viteMetadata: { importedCss: new Set(["entry.css", "shared.css"]) },
+      },
+      {
+        type: "chunk",
+        fileName: "vendor.js",
+        imports: [],
+        viteMetadata: { importedCss: new Set(["vendor.css"]) },
+      },
+      {
+        type: "chunk",
+        fileName: "dialog.js",
+        imports: [],
+        viteMetadata: { importedCss: new Set(["dialog.css", "shared.css"]) },
+      },
+      { type: "asset", fileName: "entry.css" },
+      { type: "asset", fileName: "vendor.css" },
+      { type: "asset", fileName: "dialog.css" },
+      { type: "asset", fileName: "shared.css" },
+      { type: "asset", fileName: "custom-plugin-global.css" },
+    ];
+
+    expect(getEagerCssEntries(output)).toEqual([
+      "entry.css",
+      "vendor.css",
+      "shared.css",
+      "custom-plugin-global.css",
+    ]);
+  });
+
+  it("keeps all CSS when chunk metadata is unavailable", () => {
+    expect(
+      getEagerCssEntries([
+        { type: "chunk", fileName: "entry.js", isEntry: true },
+        { type: "asset", fileName: "entry.css" },
+        { type: "asset", fileName: "plugin.css" },
+      ]),
+    ).toEqual(["entry.css", "plugin.css"]);
+  });
+});

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -23,6 +23,60 @@ import {
 
 const DIST_DIR = "dist";
 
+type CssBuildOutput = {
+  fileName: string;
+  imports?: string[];
+  isEntry?: boolean;
+  type: string;
+  viteMetadata?: { importedCss: Set<string> };
+};
+
+export const getEagerCssEntries = (output: readonly CssBuildOutput[]) => {
+  const cssAssets = output
+    .filter((item) => item.fileName.endsWith(".css"))
+    .map((item) => item.fileName);
+  const chunksByFileName = new Map(
+    output
+      .filter((item) => item.type === "chunk")
+      .map((item) => [item.fileName, item]),
+  );
+  const entryChunk = output.find(
+    (item) => item.type === "chunk" && item.isEntry,
+  );
+
+  if (!entryChunk) return cssAssets;
+
+  const referencedCss = new Set(
+    output.flatMap((item) => [...(item.viteMetadata?.importedCss ?? [])]),
+  );
+
+  // Build adapters that do not expose Vite's chunk metadata retain the
+  // previous behavior of linking every emitted stylesheet.
+  if (referencedCss.size === 0) return cssAssets;
+
+  const eagerCss = new Set<string>();
+  const visitedChunks = new Set<string>();
+  const visitChunk = (fileName: string) => {
+    if (visitedChunks.has(fileName)) return;
+    visitedChunks.add(fileName);
+
+    const chunk = chunksByFileName.get(fileName);
+    if (!chunk) return;
+
+    chunk.viteMetadata?.importedCss.forEach((css) => eagerCss.add(css));
+    chunk.imports?.forEach(visitChunk);
+  };
+
+  visitChunk(entryChunk.fileName);
+
+  // Keep CSS imported by the eager entry graph and standalone/global assets
+  // emitted by custom plugins. Only CSS owned exclusively by lazy chunks is
+  // omitted from the initial document.
+  return cssAssets.filter(
+    (css) => eagerCss.has(css) || !referencedCss.has(css),
+  );
+};
+
 export type SSRAdapter = "node" | "cloudflare" | "vercel" | "lambda";
 
 export type BuildOptions = {
@@ -78,13 +132,12 @@ export async function runBuild(options: BuildOptions) {
   invariant(clientOutDir, "Client build outDir is missing");
   invariant(serverOutDir, "Server build outDir is missing");
 
-  const jsEntry = clientResult.output.find(
+  const jsEntryChunk = clientResult.output.find(
     (o) => "isEntry" in o && o.isEntry,
-  )?.fileName;
+  );
+  const jsEntry = jsEntryChunk?.fileName;
 
-  const cssEntries = clientResult.output
-    .filter((o) => o.fileName.endsWith(".css"))
-    .map((o) => o.fileName);
+  const cssEntries = getEagerCssEntries(clientResult.output);
 
   if (!jsEntry || cssEntries.length === 0) {
     throw new Error("Build failed. No js or css assets found");

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -139,8 +139,14 @@ export async function runBuild(options: BuildOptions) {
 
   const cssEntries = getEagerCssEntries(clientResult.output);
 
-  if (!jsEntry || cssEntries.length === 0) {
-    throw new Error("Build failed. No js or css assets found");
+  if (!jsEntry) {
+    throw new Error("Build failed. No js entry chunk found");
+  }
+
+  if (cssEntries.length === 0) {
+    throw new Error(
+      "Build failed. No stylesheet reachable from the eager entry chunk was found",
+    );
   }
 
   const html = getBuildHtml({

--- a/packages/zudoku/src/vite/build.ts
+++ b/packages/zudoku/src/vite/build.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -6,6 +7,7 @@ import { createBuilder, type Rolldown } from "vite";
 import { ZuploEnv } from "../app/env.js";
 import { getZudokuRootDir } from "../cli/common/package-json.js";
 import { type ConfigWithMeta, loadZudokuConfig } from "../config/loader.js";
+import { getBuildConfig } from "../config/validators/BuildSchema.js";
 import { getIssuer } from "../lib/auth/issuer.js";
 import invariant from "../lib/util/invariant.js";
 import { joinUrl } from "../lib/util/joinUrl.js";
@@ -22,6 +24,25 @@ import {
 } from "./protected/build.js";
 
 const DIST_DIR = "dist";
+
+const DEFERRED_STYLESHEET_ACTIVATOR =
+  'requestAnimationFrame(()=>requestAnimationFrame(()=>{for(const link of document.querySelectorAll("link[data-zudoku-deferred-stylesheet]")){link.rel="stylesheet";link.removeAttribute("data-zudoku-deferred-stylesheet")}}));';
+
+const writeDeferredStylesheetActivator = async (clientOutDir: string) => {
+  const hash = createHash("sha256")
+    .update(DEFERRED_STYLESHEET_ACTIVATOR)
+    .digest("hex")
+    .slice(0, 8);
+  const fileName = `assets/zudoku-critical-css-${hash}.js`;
+
+  await writeFile(
+    path.join(clientOutDir, fileName),
+    DEFERRED_STYLESHEET_ACTIVATOR,
+    "utf-8",
+  );
+
+  return fileName;
+};
 
 type CssBuildOutput = {
   fileName: string;
@@ -149,9 +170,16 @@ export async function runBuild(options: BuildOptions) {
     );
   }
 
+  const buildConfig = ssr ? undefined : await getBuildConfig();
+  const deferredStylesheetActivator =
+    buildConfig?.prerender?.criticalCss === true
+      ? joinUrl(base, await writeDeferredStylesheetActivator(clientOutDir))
+      : undefined;
+
   const html = getBuildHtml({
     jsEntry: joinUrl(base, jsEntry),
     cssEntries: cssEntries.map((css) => joinUrl(base, css)),
+    deferredStylesheetActivator,
     dir: config.site?.dir,
   });
 

--- a/packages/zudoku/src/vite/critical-css.test.ts
+++ b/packages/zudoku/src/vite/critical-css.test.ts
@@ -1,0 +1,134 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { createCriticalCssProcessor, rebaseCssUrls } from "./critical-css.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+const createFixture = async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zudoku-css-"));
+  temporaryDirectories.push(directory);
+  await mkdir(path.join(directory, "assets"));
+  await writeFile(
+    path.join(directory, "assets/entry.css"),
+    [
+      ":root { --background: white; }",
+      ".dark { --background: black; }",
+      ".critical { color: red; }",
+      ".unused { color: blue; }",
+      ".dark\\:hidden:is(.dark *) { display: none; }",
+      ".client-only:is(.dark *) { color: white; }",
+      '@font-face { font-family: "Docs"; src: url(./docs.woff2) format("woff2"); }',
+      '.critical { font-family: "Docs"; }',
+    ].join("\n"),
+  );
+
+  return directory;
+};
+
+describe("createCriticalCssProcessor", () => {
+  test("inlines used styles and defers the complete stylesheet", async () => {
+    const assetsPath = await createFixture();
+    const process = createCriticalCssProcessor({
+      assetsPath,
+      publicPath: "/docs",
+    });
+
+    const html = await process(`<!doctype html>
+      <html><head>
+        <style>.user-defined { background: url(./inline.svg); }</style>
+        <link rel="stylesheet" href="/docs/assets/entry.css">
+      </head><body>
+        <main class="critical" style="background: url(./attribute.svg)">Documentation</main>
+        <img class="dark:hidden" alt="Light logo">
+      </body></html>`);
+
+    expect(html).toContain(":root{--background:white}");
+    expect(html).toContain(".dark{--background:black}");
+    expect(html).toContain(".critical{color:red}");
+    expect(html).not.toContain(".unused{color:blue}");
+    expect(html).toContain(".dark\\:hidden:is(.dark *){display:none}");
+    expect(html).toContain(".client-only:is(.dark *){color:white}");
+    expect(html).toMatch(/@font-face\s*\{font-family:"Docs"/);
+    expect(html).toContain('url("/docs/assets/docs.woff2")');
+    expect(html).toContain(
+      "<style>.user-defined { background: url(./inline.svg); }</style>",
+    );
+    expect(html).toContain('style="background: url(./attribute.svg)"');
+    const preload =
+      '<link rel="preload" href="/docs/assets/entry.css" as="style" data-zudoku-deferred-stylesheet>';
+    const noScriptStylesheet =
+      '<noscript><link rel="stylesheet" href="/docs/assets/entry.css"></noscript>';
+    expect(html).toContain(preload);
+    expect(html).toContain(noScriptStylesheet);
+    expect(html.indexOf(preload)).toBeLessThan(html.indexOf("</head>"));
+    expect(html.slice(html.indexOf("<body>"))).not.toContain(
+      '<link rel="stylesheet" href="/docs/assets/entry.css">',
+    );
+    expect(html).not.toContain("onload=");
+  });
+
+  test("resolves locally emitted assets behind a CDN public path", async () => {
+    const assetsPath = await createFixture();
+    const process = createCriticalCssProcessor({
+      assetsPath,
+      publicPath: "https://cdn.example.com/docs",
+    });
+
+    const html = await process(`<!doctype html>
+      <html><head>
+        <link rel="stylesheet" href="https://cdn.example.com/docs/assets/entry.css">
+      </head><body><main class="critical">Documentation</main></body></html>`);
+
+    expect(html).toContain(".critical{color:red}");
+    expect(html).toContain(
+      'href="https://cdn.example.com/docs/assets/entry.css"',
+    );
+    expect(html).toContain(
+      'url("https://cdn.example.com/docs/assets/docs.woff2")',
+    );
+  });
+});
+
+describe("rebaseCssUrls", () => {
+  test("rebases relative assets without changing self-contained URLs", () => {
+    const css = [
+      ".relative { background: url('../images/hero image.svg#icon'); }",
+      '.quoted { src: url("./font.woff2?v=1#regular"); }',
+      ".escaped { background: url(foo\\(bar\\).svg); }",
+      ".root { background: url(/images/root.svg); }",
+      ".remote { background: url(https://images.example.com/hero.svg); }",
+      ".protocol { background: url(//images.example.com/hero.svg); }",
+      ".data { background: url(data:image/svg+xml,%3Csvg%3E); }",
+      ".hash { filter: url(#shadow); }",
+      ".variable { background: url(var(--image)); }",
+      '.content::after { content: "url(./not-an-asset.svg)"; }',
+      "/* url(./not-an-asset.svg) */",
+    ].join("\n");
+
+    expect(rebaseCssUrls(css, "/docs/assets/entry.css")).toBe(
+      [
+        ".relative { background: url('/docs/images/hero%20image.svg#icon'); }",
+        '.quoted { src: url("/docs/assets/font.woff2?v=1#regular"); }',
+        '.escaped { background: url("/docs/assets/foo(bar).svg"); }',
+        ".root { background: url(/images/root.svg); }",
+        ".remote { background: url(https://images.example.com/hero.svg); }",
+        ".protocol { background: url(//images.example.com/hero.svg); }",
+        ".data { background: url(data:image/svg+xml,%3Csvg%3E); }",
+        ".hash { filter: url(#shadow); }",
+        ".variable { background: url(var(--image)); }",
+        '.content::after { content: "url(./not-an-asset.svg)"; }',
+        "/* url(./not-an-asset.svg) */",
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/zudoku/src/vite/critical-css.ts
+++ b/packages/zudoku/src/vite/critical-css.ts
@@ -1,0 +1,216 @@
+import BeastiesModule from "beasties";
+
+const Beasties =
+  typeof BeastiesModule === "function"
+    ? BeastiesModule
+    : BeastiesModule.default;
+
+const FAKE_ORIGIN = "https://zudoku.invalid";
+const DARK_SELECTOR = /(?:^|[^a-zA-Z0-9_-])\.dark(?:$|[^a-zA-Z0-9_-])/;
+
+const isSelfContainedUrl = (url: string) =>
+  url.startsWith("/") ||
+  url.startsWith("#") ||
+  /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(url) ||
+  /^(?:var|env)\(/i.test(url);
+
+const decodeCssEscapes = (value: string) =>
+  value.replace(
+    /\\(?:([\da-fA-F]{1,6})\s?|\r\n|[\n\r\f]|(.))/g,
+    (_match, hex: string | undefined, escaped: string | undefined) => {
+      if (hex) return String.fromCodePoint(Number.parseInt(hex, 16));
+      return escaped ?? "";
+    },
+  );
+
+const escapeCssString = (value: string, quote: string) =>
+  value.replaceAll("\\", "\\\\").replaceAll(quote, `\\${quote}`);
+
+const rebaseUrlValue = (value: string, stylesheetHref: string) => {
+  const leadingWhitespace = value.match(/^\s*/)?.[0] ?? "";
+  const trailingWhitespace = value.match(/\s*$/)?.[0] ?? "";
+  const trimmed = value.trim();
+
+  if (!trimmed) return value;
+
+  const quote =
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+      ? trimmed[0]
+      : undefined;
+  const authoredUrl = quote ? trimmed.slice(1, -1) : trimmed;
+  const decodedUrl = decodeCssEscapes(authoredUrl);
+
+  if (!decodedUrl || isSelfContainedUrl(decodedUrl)) return value;
+
+  try {
+    const stylesheetUrl = new URL(stylesheetHref, FAKE_ORIGIN);
+    const resolvedUrl = new URL(decodedUrl, stylesheetUrl);
+    const rebasedUrl =
+      resolvedUrl.origin === FAKE_ORIGIN
+        ? `${resolvedUrl.pathname}${resolvedUrl.search}${resolvedUrl.hash}`
+        : resolvedUrl.href;
+    const outputQuote = quote ?? '"';
+    const serializedUrl = `${outputQuote}${escapeCssString(
+      rebasedUrl,
+      outputQuote,
+    )}${outputQuote}`;
+
+    return `${leadingWhitespace}${serializedUrl}${trailingWhitespace}`;
+  } catch {
+    return value;
+  }
+};
+
+export const rebaseCssUrls = (css: string, stylesheetHref: string) => {
+  let output = "";
+  let index = 0;
+
+  while (index < css.length) {
+    if (css.startsWith("/*", index)) {
+      const commentEnd = css.indexOf("*/", index + 2);
+      const end = commentEnd === -1 ? css.length : commentEnd + 2;
+      output += css.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    const character = css[index];
+    if (character === '"' || character === "'") {
+      const quote = character;
+      let end = index + 1;
+
+      while (end < css.length) {
+        if (css[end] === "\\") {
+          end += 2;
+          continue;
+        }
+        if (css[end] === quote) {
+          end++;
+          break;
+        }
+        end++;
+      }
+
+      output += css.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    const previousCharacter = index === 0 ? undefined : css[index - 1];
+    const isUrlFunction =
+      css.slice(index, index + 4).toLowerCase() === "url(" &&
+      !previousCharacter?.match(/[a-zA-Z\d_-]/);
+
+    if (!isUrlFunction) {
+      output += character;
+      index++;
+      continue;
+    }
+
+    const valueStart = index + 4;
+    let end = valueStart;
+    let depth = 1;
+    let quote: string | undefined;
+
+    while (end < css.length && depth > 0) {
+      const current = css[end];
+
+      if (current === "\\") {
+        end += 2;
+        continue;
+      }
+      if (quote) {
+        if (current === quote) quote = undefined;
+        end++;
+        continue;
+      }
+      if (current === '"' || current === "'") {
+        quote = current;
+        end++;
+        continue;
+      }
+      if (current === "(") depth++;
+      if (current === ")") depth--;
+      end++;
+    }
+
+    if (depth !== 0) {
+      output += css.slice(index);
+      break;
+    }
+
+    const valueEnd = end - 1;
+    output += `${css.slice(index, valueStart)}${rebaseUrlValue(
+      css.slice(valueStart, valueEnd),
+      stylesheetHref,
+    )})`;
+    index = end;
+  }
+
+  return output;
+};
+
+class ZudokuBeasties extends Beasties {
+  override async getCssAsset(href: string, style: Node) {
+    const css = await super.getCssAsset(href, style);
+    return css ? rebaseCssUrls(css, href) : css;
+  }
+
+  // Beasties' swap mode normally uses an inline onload handler, which strict
+  // script-src-attr policies reject. Keep its preload + noscript structure,
+  // but let entry.client activate the full stylesheet after first paint.
+  embedFetchedStylesheet(
+    data: {
+      link: {
+        removeAttribute: (name: string) => void;
+        setAttribute: (name: string, value: string) => void;
+      };
+    },
+    document: unknown,
+  ) {
+    const prototype = Beasties.prototype as unknown as {
+      embedFetchedStylesheet: (
+        this: ZudokuBeasties,
+        data: {
+          link: {
+            removeAttribute: (name: string) => void;
+            setAttribute: (name: string, value: string) => void;
+          };
+        },
+        document: unknown,
+      ) => unknown;
+    };
+    const result = prototype.embedFetchedStylesheet.call(this, data, document);
+    data.link.removeAttribute("onload");
+    data.link.setAttribute("data-zudoku-deferred-stylesheet", "");
+    return result;
+  }
+}
+
+type CriticalCssProcessorOptions = {
+  assetsPath: string;
+  publicPath: string;
+};
+
+export const createCriticalCssProcessor = ({
+  assetsPath,
+  publicPath,
+}: CriticalCssProcessorOptions) => {
+  const beasties = new ZudokuBeasties({
+    path: assetsPath,
+    publicPath,
+    pruneSource: false,
+    reduceInlineStyles: false,
+    preload: "swap",
+    inlineFonts: true,
+    preloadFonts: false,
+    // next-themes adds this class before first paint, after the HTML has been
+    // prerendered. Keep the dark theme variables in the critical stylesheet so
+    // a stored or system dark preference never flashes the light palette.
+    allowRules: [DARK_SELECTOR],
+    logLevel: "silent",
+  });
+
+  return (html: string) => beasties.process(html);
+};

--- a/packages/zudoku/src/vite/html.test.ts
+++ b/packages/zudoku/src/vite/html.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { getBuildHtml } from "./html.js";
+
+describe("getBuildHtml", () => {
+  test("loads the critical CSS activator before the application entry", () => {
+    const html = getBuildHtml({
+      jsEntry: "/assets/entry.js",
+      cssEntries: ["/assets/entry.css"],
+      deferredStylesheetActivator: "/assets/zudoku-critical-css.js",
+    });
+
+    expect(html).toContain(
+      '<script defer src="/assets/zudoku-critical-css.js"></script>',
+    );
+    expect(html.indexOf("entry.css")).toBeLessThan(
+      html.indexOf("zudoku-critical-css.js"),
+    );
+    expect(html.indexOf("zudoku-critical-css.js")).toBeLessThan(
+      html.indexOf("entry.js"),
+    );
+  });
+
+  test("does not load a separate activator by default", () => {
+    const html = getBuildHtml({
+      jsEntry: "/assets/entry.js",
+      cssEntries: ["/assets/entry.css"],
+    });
+
+    expect(html).not.toContain("zudoku-critical-css");
+  });
+});

--- a/packages/zudoku/src/vite/html.ts
+++ b/packages/zudoku/src/vite/html.ts
@@ -24,14 +24,27 @@ export function getDevHtml({
 export function getBuildHtml({
   jsEntry,
   cssEntries,
+  deferredStylesheetActivator,
   dir,
 }: {
   jsEntry: string;
   cssEntries: string[];
+  deferredStylesheetActivator?: string;
   dir?: "ltr" | "rtl";
 }) {
   const cssLinks = cssEntries
     .map((css) => `    <link rel="stylesheet" crossorigin href="${css}">`)
+    .join("\n");
+  const deferredStylesheetScript = deferredStylesheetActivator
+    ? `    <script defer src="${deferredStylesheetActivator}"></script>`
+    : "";
+  const applicationScript = `    <script type="module" crossorigin src="${jsEntry}"></script>`;
+  const headAssets = (
+    deferredStylesheetActivator
+      ? [cssLinks, deferredStylesheetScript, applicationScript]
+      : [applicationScript, cssLinks]
+  )
+    .filter(Boolean)
     .join("\n");
 
   return `
@@ -40,8 +53,7 @@ export function getBuildHtml({
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-    <script type="module" crossorigin src="${jsEntry}"></script>
-${cssLinks}
+${headAssets}
     <link rel="preconnect" href="https://cdn.zudoku.dev/">
   </head>
   <body>

--- a/packages/zudoku/src/vite/plugin-api.test.ts
+++ b/packages/zudoku/src/vite/plugin-api.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { schemaConfigurationChanged } from "./plugin-api.js";
+import {
+  generateSchemaImportsCode,
+  schemaConfigurationChanged,
+} from "./plugin-api.js";
 
 describe("schemaConfigurationChanged", () => {
   const apis = {
@@ -24,5 +27,33 @@ describe("schemaConfigurationChanged", () => {
         { apis: structuredClone(apis), basePath: "/docs" },
       ),
     ).toBe(false);
+  });
+});
+
+describe("generateSchemaImportsCode", () => {
+  it("emits one shared schema loader registry", () => {
+    expect(
+      generateSchemaImportsCode([
+        { importKey: "/processed/first.js", processedTime: 123 },
+        { importKey: "/processed/second.js", processedTime: 456 },
+      ]),
+    ).toEqual([
+      "const schemaImports = {",
+      '  "/processed/first.js": () => import("/processed/first.js?d=123"),',
+      '  "/processed/second.js": () => import("/processed/second.js?d=456"),',
+      "};",
+    ]);
+  });
+
+  it("normalizes Windows import paths without changing registry keys", () => {
+    expect(
+      generateSchemaImportsCode([
+        { importKey: "C:\\processed\\schema.js", processedTime: 123 },
+      ]),
+    ).toEqual([
+      "const schemaImports = {",
+      '  "C:\\\\processed\\\\schema.js": () => import("C:/processed/schema.js?d=123"),',
+      "};",
+    ]);
   });
 });

--- a/packages/zudoku/src/vite/plugin-api.test.ts
+++ b/packages/zudoku/src/vite/plugin-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  generateDefaultApiOptionsCode,
   generateSchemaImportsCode,
   schemaConfigurationChanged,
 } from "./plugin-api.js";
@@ -55,5 +56,101 @@ describe("generateSchemaImportsCode", () => {
       '  "C:\\\\processed\\\\schema.js": () => import("C:/processed/schema.js?d=123"),',
       "};",
     ]);
+  });
+});
+
+describe("generateDefaultApiOptionsCode", () => {
+  // The generated snippet is the contract, so evaluate it the way the virtual
+  // module does instead of asserting on source text.
+  const resolve = (
+    config: unknown,
+    apiOptions: Record<string, unknown> = {},
+  ) => {
+    const body = [
+      ...generateDefaultApiOptionsCode(),
+      "return { ...defaultApiOptions, ...apiOptions };",
+    ].join("\n");
+    return new Function("config", "apiOptions", body)(
+      config,
+      apiOptions,
+    ) as Record<string, unknown>;
+  };
+
+  it("applies fallbacks when no defaults are configured", () => {
+    expect(resolve({})).toEqual({
+      examplesLanguage: undefined,
+      supportedLanguages: undefined,
+      disablePlayground: undefined,
+      disableSidecar: undefined,
+      disableSecurity: true,
+      disableMcpAuthInstructions: undefined,
+      showVersionSelect: "if-available",
+      showInfoPage: undefined,
+      schemaDownload: undefined,
+    });
+  });
+
+  it("prefers defaults.apis.examplesLanguage over the top-level default", () => {
+    const resolved = resolve({
+      defaults: {
+        examplesLanguage: "python",
+        apis: { examplesLanguage: "go" },
+      },
+    });
+
+    expect(resolved.examplesLanguage).toBe("go");
+  });
+
+  it("falls back to the top-level examplesLanguage default", () => {
+    const resolved = resolve({ defaults: { examplesLanguage: "python" } });
+
+    expect(resolved.examplesLanguage).toBe("python");
+  });
+
+  it("keeps explicit false for options that default to true", () => {
+    const resolved = resolve({
+      defaults: { apis: { disableSecurity: false, showVersionSelect: false } },
+    });
+
+    expect(resolved.disableSecurity).toBe(false);
+    expect(resolved.showVersionSelect).toBe(false);
+  });
+
+  it("passes through configured defaults", () => {
+    const schemaDownload = { enabled: true };
+    const resolved = resolve({
+      defaults: {
+        apis: {
+          supportedLanguages: ["js", "go"],
+          disablePlayground: true,
+          disableSidecar: true,
+          disableMcpAuthInstructions: true,
+          showInfoPage: false,
+          schemaDownload,
+        },
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      supportedLanguages: ["js", "go"],
+      disablePlayground: true,
+      disableSidecar: true,
+      disableMcpAuthInstructions: true,
+      showInfoPage: false,
+      schemaDownload,
+    });
+  });
+
+  it("lets authored API options win over the shared defaults", () => {
+    const resolved = resolve(
+      { defaults: { apis: { disableSecurity: true, showInfoPage: false } } },
+      { disableSecurity: false, showInfoPage: true, examplesLanguage: "ruby" },
+    );
+
+    expect(resolved).toMatchObject({
+      disableSecurity: false,
+      showInfoPage: true,
+      examplesLanguage: "ruby",
+    });
   });
 });

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -43,6 +43,17 @@ export const schemaConfigurationChanged = (
   next: Pick<ConfigWithMeta, "apis" | "basePath">,
 ) => current.basePath !== next.basePath || !deepEqual(current.apis, next.apis);
 
+export const generateSchemaImportsCode = (
+  schemaImports: { importKey: string; processedTime: number }[],
+) => [
+  "const schemaImports = {",
+  ...schemaImports.map(
+    (schema) =>
+      `  ${JSON.stringify(schema.importKey)}: () => import(${JSON.stringify(`${schema.importKey.replaceAll("\\", "/")}?d=${schema.processedTime}`)}),`,
+  ),
+  "};",
+];
+
 const warn = (message: string) => {
   // biome-ignore lint/suspicious/noConsole: Logging allowed here
   console.warn(`[zudoku] ${message}`);
@@ -198,8 +209,28 @@ const viteApiPlugin = async (): Promise<Plugin> => {
         code.push(
           `const apis = Array.isArray(config.apis) ? config.apis : [config.apis]`,
         );
+        code.push(
+          `const defaultApiOptions = {`,
+          `  examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
+          `  supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
+          `  disablePlayground: config.defaults?.apis?.disablePlayground,`,
+          `  disableSidecar: config.defaults?.apis?.disableSidecar,`,
+          `  disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
+          `  disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
+          `  showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+          `  showInfoPage: config.defaults?.apis?.showInfoPage,`,
+          `  schemaDownload: config.defaults?.apis?.schemaDownload,`,
+          `};`,
+        );
         const apis = ensureArray(config.apis);
         const apiMetadata: ApiCatalogItem[] = [];
+        const schemaImports = schemaManager.getSchemaImports();
+
+        // Every file API uses the same registry so the local GraphQL server can
+        // resolve schemas across the whole portal. Emit it once: inlining the
+        // complete map into every plugin duplicates all loader closures and
+        // import paths in the client entry chunk.
+        code.push(...generateSchemaImportsCode(schemaImports));
 
         for (const apiConfig of apis) {
           if (apiConfig.type === "file" && apiConfig.path) {
@@ -272,8 +303,6 @@ const viteApiPlugin = async (): Promise<Plugin> => {
 
             const tags = Array.from(allSlugs);
 
-            const schemaImports = schemaManager.getSchemaImports();
-
             // Catalog mode renders a single page, so it reads the flag from the
             // latest schema only and ignores the other versions entirely.
             const latest = schemas.at(0);
@@ -304,26 +333,13 @@ const viteApiPlugin = async (): Promise<Plugin> => {
                 ? [`  documentType: ${JSON.stringify(documentType)},`]
                 : []),
               `  options: {`,
-              `    examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
-              `    supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
-              `    disablePlayground: config.defaults?.apis?.disablePlayground,`,
-              `    disableSidecar: config.defaults?.apis?.disableSidecar,`,
-              `    disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
-              `    disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
-              `    showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+              `    ...defaultApiOptions,`,
               `    expandAllTags: config.defaults?.apis?.expandAllTags ?? true,`,
-              `    showInfoPage: config.defaults?.apis?.showInfoPage,`,
-              `    schemaDownload: config.defaults?.apis?.schemaDownload,`,
               `    transformExamples: config.defaults?.apis?.transformExamples,`,
               `    generateCodeSnippet: config.defaults?.apis?.generateCodeSnippet,`,
               `    ...(apis[${apiIndex}].options ?? {}),`,
               `  },`,
-              `  schemaImports: {`,
-              ...schemaImports.map(
-                (s) =>
-                  `    "${s.importKey.replaceAll("\\", "\\\\")}": () => import("${s.importKey.replaceAll("\\", "/")}?d=${s.processedTime}"),`,
-              ),
-              `  },`,
+              `  schemaImports,`,
               "}));",
             );
           } else {
@@ -342,16 +358,8 @@ const viteApiPlugin = async (): Promise<Plugin> => {
                 ? [`  documentType: ${JSON.stringify(documentType)},`]
                 : []),
               "  options: {",
-              `    examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
-              `    supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
-              `    disablePlayground: config.defaults?.apis?.disablePlayground,`,
-              `    disableSidecar: config.defaults?.apis?.disableSidecar,`,
-              `    disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
-              `    disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
-              `    showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+              `    ...defaultApiOptions,`,
               `    expandAllTags: config.defaults?.apis?.expandAllTags ?? false,`,
-              `    showInfoPage: config.defaults?.apis?.showInfoPage,`,
-              `    schemaDownload: config.defaults?.apis?.schemaDownload,`,
               `    ...${JSON.stringify(apiConfig.options ?? {})},`,
               "  },",
               "}));",

--- a/packages/zudoku/src/vite/plugin-api.ts
+++ b/packages/zudoku/src/vite/plugin-api.ts
@@ -43,6 +43,22 @@ export const schemaConfigurationChanged = (
   next: Pick<ConfigWithMeta, "apis" | "basePath">,
 ) => current.basePath !== next.basePath || !deepEqual(current.apis, next.apis);
 
+// Emitted once per virtual module. Every API spreads it, so authored
+// `options` still override these and per-API keys stay next to the spread.
+export const generateDefaultApiOptionsCode = () => [
+  `const defaultApiOptions = {`,
+  `  examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
+  `  supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
+  `  disablePlayground: config.defaults?.apis?.disablePlayground,`,
+  `  disableSidecar: config.defaults?.apis?.disableSidecar,`,
+  `  disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
+  `  disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
+  `  showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
+  `  showInfoPage: config.defaults?.apis?.showInfoPage,`,
+  `  schemaDownload: config.defaults?.apis?.schemaDownload,`,
+  `};`,
+];
+
 export const generateSchemaImportsCode = (
   schemaImports: { importKey: string; processedTime: number }[],
 ) => [
@@ -209,19 +225,7 @@ const viteApiPlugin = async (): Promise<Plugin> => {
         code.push(
           `const apis = Array.isArray(config.apis) ? config.apis : [config.apis]`,
         );
-        code.push(
-          `const defaultApiOptions = {`,
-          `  examplesLanguage: config.defaults?.apis?.examplesLanguage ?? config.defaults?.examplesLanguage,`,
-          `  supportedLanguages: config.defaults?.apis?.supportedLanguages,`,
-          `  disablePlayground: config.defaults?.apis?.disablePlayground,`,
-          `  disableSidecar: config.defaults?.apis?.disableSidecar,`,
-          `  disableSecurity: config.defaults?.apis?.disableSecurity ?? true,`,
-          `  disableMcpAuthInstructions: config.defaults?.apis?.disableMcpAuthInstructions,`,
-          `  showVersionSelect: config.defaults?.apis?.showVersionSelect ?? "if-available",`,
-          `  showInfoPage: config.defaults?.apis?.showInfoPage,`,
-          `  schemaDownload: config.defaults?.apis?.schemaDownload,`,
-          `};`,
-        );
+        code.push(...generateDefaultApiOptionsCode());
         const apis = ensureArray(config.apis);
         const apiMetadata: ApiCatalogItem[] = [];
         const schemaImports = schemaManager.getSchemaImports();

--- a/packages/zudoku/src/vite/plugin-theme.test.ts
+++ b/packages/zudoku/src/vite/plugin-theme.test.ts
@@ -10,7 +10,6 @@ const callPluginLoad = async (plugin: Plugin, id: string) => {
   // biome-ignore lint/style/noNonNullAssertion: is guaranteed to be defined
   const hook = plugin.load!;
   const loadFn = typeof hook === "function" ? hook : hook.handler;
-  // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   return loadFn.call({} as any, id);
 };
 
@@ -18,7 +17,6 @@ const callPluginTransform = async (plugin: Plugin, src: string, id: string) => {
   // biome-ignore lint/style/noNonNullAssertion: is guaranteed to be defined
   const hook = plugin.transform!;
   const transformFn = typeof hook === "function" ? hook : hook.handler;
-  // biome-ignore lint/suspicious/noExplicitAny: Allow any type
   return transformFn.call({} as any, src, id);
 };
 
@@ -92,14 +90,9 @@ describe("plugin-theme", () => {
       const plugin = viteThemePlugin();
       const result = await callPluginLoad(plugin, resolvedVirtualModuleId);
 
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap')",
-      );
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
-      expect(result).toContain("--font-sans: Geist, sans-serif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).not.toContain("fonts.googleapis.com");
+      expect(result).toContain('--font-sans: "Geist Variable", sans-serif');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
 
     it("should handle mixed font configurations with defaults for missing fonts", async () => {
@@ -123,12 +116,9 @@ describe("plugin-theme", () => {
       expect(result).toContain(
         "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap')",
       );
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
       expect(result).toContain("--font-sans: Inter");
       expect(result).toContain("--font-serif: CustomSerif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
 
     it("should provide mono default when only sans is configured", async () => {
@@ -149,11 +139,8 @@ describe("plugin-theme", () => {
       const result = await callPluginLoad(plugin, resolvedVirtualModuleId);
 
       expect(result).toContain("@import url('/fonts/fonts.css')");
-      expect(result).toContain(
-        "@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap')",
-      );
       expect(result).toContain("--font-sans: Solis, sans-serif");
-      expect(result).toContain('--font-mono: "Geist Mono", monospace');
+      expect(result).toContain('--font-mono: "Geist Mono Variable", monospace');
     });
   });
 

--- a/packages/zudoku/src/vite/plugin-theme.ts
+++ b/packages/zudoku/src/vite/plugin-theme.ts
@@ -126,9 +126,9 @@ const processFontConfig = (fontConfig?: FontConfig) => {
 const processFonts = async (themeConfig: ZudokuConfig["theme"]) => {
   const imports: string[] = [];
   const families = {
-    sans: "Geist, sans-serif",
+    sans: '"Geist Variable", sans-serif',
     serif: undefined as string | undefined,
-    mono: '"Geist Mono", monospace',
+    mono: '"Geist Mono Variable", monospace',
   };
 
   // Process user fonts
@@ -179,23 +179,14 @@ const processFonts = async (themeConfig: ZudokuConfig["theme"]) => {
 
   // Determine final font families with priority: user > registry > defaults
   families.sans =
-    userFonts.sans.fontFamily || registryFonts.sans || "Geist, sans-serif";
+    userFonts.sans.fontFamily ||
+    registryFonts.sans ||
+    '"Geist Variable", sans-serif';
   families.serif = userFonts.serif.fontFamily || registryFonts.serif;
   families.mono =
     userFonts.mono.fontFamily ||
     registryFonts.mono ||
-    '"Geist Mono", monospace';
-
-  // Add default font imports if no user or registry fonts
-  if (!userFonts.sans.fontFamily && !registryFonts.sans) {
-    imports.push(getGoogleFontUrl("Geist"));
-  }
-  if (!userFonts.serif.fontFamily && !registryFonts.serif) {
-    imports.push(getGoogleFontUrl("Playfair Display"));
-  }
-  if (!userFonts.mono.fontFamily && !registryFonts.mono) {
-    imports.push(getGoogleFontUrl("Geist Mono"));
-  }
+    '"Geist Mono Variable", monospace';
 
   return { imports, families };
 };

--- a/packages/zudoku/src/vite/prerender/prerender.ts
+++ b/packages/zudoku/src/vite/prerender/prerender.ts
@@ -139,6 +139,7 @@ export const prerender = async ({
       serverConfigPath,
       entryServerPath,
       writeRedirects,
+      criticalCss: buildConfig?.prerender?.criticalCss === true,
     } satisfies StaticWorkerData,
   });
 

--- a/packages/zudoku/src/vite/prerender/worker.ts
+++ b/packages/zudoku/src/vite/prerender/worker.ts
@@ -5,6 +5,7 @@ import { validateConfig } from "../../config/validators/ZudokuConfig.js";
 import { runPluginTransformConfig } from "../../lib/core/transform-config.js";
 import { joinUrl } from "../../lib/util/joinUrl.js";
 import { matchesAnyProtectedPattern } from "../../lib/util/url.js";
+import { createCriticalCssProcessor } from "../critical-css.js";
 import type { WorkerResult } from "./prerender.js";
 
 type EntryServer = typeof import("../../app/entry.server.js");
@@ -15,12 +16,19 @@ export type StaticWorkerData = {
   serverConfigPath: string;
   entryServerPath: string;
   writeRedirects: boolean;
+  criticalCss: boolean;
 };
 
 export type WorkerData = { urlPath: string };
 
-const { template, distDir, serverConfigPath, entryServerPath, writeRedirects } =
-  Piscina.workerData as StaticWorkerData;
+const {
+  template,
+  distDir,
+  serverConfigPath,
+  entryServerPath,
+  writeRedirects,
+  criticalCss,
+} = Piscina.workerData as StaticWorkerData;
 
 const server: EntryServer = await import(entryServerPath);
 // Same order as the loader: transform the raw bundle config, then parse.
@@ -29,6 +37,16 @@ const config = validateConfig(await runPluginTransformConfig(rawConfig));
 
 const routes = server.getRoutesByConfig(config);
 const { basePath } = config;
+// Critical CSS depends on the rendered DOM, so it belongs in the SSG worker.
+// SSR keeps its streaming response and regular blocking stylesheet unchanged.
+const processCriticalCss = criticalCss
+  ? createCriticalCssProcessor({
+      assetsPath: distDir,
+      publicPath: config.cdnUrl?.base
+        ? joinUrl(config.cdnUrl.base, basePath)
+        : joinUrl(basePath),
+    })
+  : async (html: string) => html;
 
 const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
   const filename = urlPath === "/" ? "/index.html" : `${urlPath}.html`;
@@ -77,6 +95,7 @@ const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
 
   // Get HTML content for file write
   const fileContent = response.body ? await response.text() : "";
+  const optimizedFileContent = await processCriticalCss(fileContent);
 
   // For protected routes, do a second render with protection bypassed so the
   // search index gets the full content instead of the gated sign-in page. The
@@ -106,7 +125,7 @@ const renderPage = async ({ urlPath }: WorkerData): Promise<WorkerResult> => {
 
   // Write the file
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
-  await fs.writeFile(outputPath, fileContent);
+  await fs.writeFile(outputPath, optimizedFileContent);
 
   return {
     outputPath,

--- a/packages/zudoku/src/vite/protected/annotator.test.ts
+++ b/packages/zudoku/src/vite/protected/annotator.test.ts
@@ -79,6 +79,39 @@ describe("matchPathObject (Shape A)", () => {
     });
   });
 
+  it("ignores identifiers that are not value references", async () => {
+    // `admin` here is a property key, a member property, and a parameter name.
+    // None of them reference the top-level `admin` registry, so its import
+    // must not be attributed to "/public".
+    const { route, bindings } = await pathObjectAndBindings(`
+      const admin = { load: () => import("./admin-secret.js") };
+      const route = {
+        path: "/public",
+        handle: { admin: false },
+        element: layouts.admin,
+        loader: (admin) => admin.data,
+        lazy: () => import("./public.js"),
+      };
+    `);
+
+    expect(matchPathObject(route, bindings)).toEqual({
+      root: "/public",
+      specs: ["./public.js"],
+    });
+  });
+
+  it("follows a registry referenced by a nested property value", async () => {
+    const { route, bindings } = await pathObjectAndBindings(`
+      const schemaImports = { "/processed/first.js": () => import("./first.js") };
+      const route = { path: "/api", options: { schemaImports } };
+    `);
+
+    expect(matchPathObject(route, bindings)).toEqual({
+      root: "/api",
+      specs: ["./first.js"],
+    });
+  });
+
   it("returns undefined without a string path", async () => {
     const node = await firstObject(
       `const r = { path: dynamicPath, lazy: () => import("./x") };`,

--- a/packages/zudoku/src/vite/protected/annotator.test.ts
+++ b/packages/zudoku/src/vite/protected/annotator.test.ts
@@ -2,13 +2,11 @@ import { parse } from "vite";
 import { describe, expect, it } from "vitest";
 import { matchPathObject, matchRouteDict } from "./annotator.js";
 
-// biome-ignore lint/suspicious/noExplicitAny: walker-shape AST
 const firstObject = async (code: string): Promise<any> => {
   const { program } = await parse("test.js", code);
   let found: unknown;
   const visit = (n: unknown) => {
     if (found) return;
-    // biome-ignore lint/suspicious/noExplicitAny: generic walker
     const node = n as any;
     if (node?.type === "ObjectExpression") {
       found = node;
@@ -23,6 +21,26 @@ const firstObject = async (code: string): Promise<any> => {
   };
   visit(program);
   return found;
+};
+
+const pathObjectAndBindings = async (code: string) => {
+  const { program } = await parse("test.js", code);
+  const declarations = program.body.flatMap((statement: any) =>
+    statement.type === "VariableDeclaration" ? statement.declarations : [],
+  );
+  const bindings = new Map(
+    declarations.flatMap((declaration: any) =>
+      declaration.id?.type === "Identifier" &&
+      declaration.init?.type === "ObjectExpression"
+        ? [[declaration.id.name, declaration.init] as const]
+        : [],
+    ),
+  );
+  const route = declarations.find(
+    (declaration: any) => declaration.id?.name === "route",
+  )?.init;
+
+  return { route, bindings };
 };
 
 describe("matchPathObject (Shape A)", () => {
@@ -43,6 +61,21 @@ describe("matchPathObject (Shape A)", () => {
     expect(matchPathObject(node)).toEqual({
       root: "/api",
       specs: ["./a", "./b"],
+    });
+  });
+
+  it("follows a shared top-level schema import registry", async () => {
+    const { route, bindings } = await pathObjectAndBindings(`
+      const schemaImports = {
+        "/processed/first.js": () => import("./first.js"),
+        "/processed/second.js": () => import("./second.js"),
+      };
+      const route = { path: "/api", schemaImports };
+    `);
+
+    expect(matchPathObject(route, bindings)).toEqual({
+      root: "/api",
+      specs: ["./first.js", "./second.js"],
     });
   });
 

--- a/packages/zudoku/src/vite/protected/annotator.ts
+++ b/packages/zudoku/src/vite/protected/annotator.ts
@@ -48,26 +48,47 @@ const collectTopLevelObjectBindings = (ast: AstNode): ObjectBindings =>
 // All dynamic-import specifiers found anywhere inside a subtree. Follow
 // top-level object bindings so generated route objects can share a loader
 // registry without losing their route-to-import association.
+//
+// Only identifiers in *value* position resolve to a binding. `walk` is neither
+// scope- nor parent-aware, so property keys (`{ admin: false }`), member
+// properties (`layouts.admin`), and parameter names (`(admin) => ...`) all
+// arrive as plain `Identifier` nodes; treating those as references would
+// attribute an unrelated registry's imports to this route.
 const collectImportSpecs = (
   node: AstNode,
   objectBindings: ObjectBindings,
   visitedBindings = new Set<string>(),
 ): string[] => {
   const out: string[] = [];
+  const referenced: AstNode[] = [];
+
+  const considerReference = (candidate: AstNode) => {
+    if (candidate?.type !== "Identifier") return;
+    if (visitedBindings.has(candidate.name)) return;
+    const binding = objectBindings.get(candidate.name);
+    if (!binding) return;
+
+    visitedBindings.add(candidate.name);
+    referenced.push(binding);
+  };
+
+  // A shared registry reaches a route either as the sibling value itself
+  // (`{ path, schemaImports }`) or as a nested property value.
+  considerReference(node);
 
   walk(node, (n) => {
     if (n.type === "ImportExpression") {
       const spec = literalString(n.source);
       if (spec) out.push(spec);
+      return;
     }
 
-    if (n.type !== "Identifier" || visitedBindings.has(n.name)) return;
-    const binding = objectBindings.get(n.name);
-    if (!binding) return;
-
-    visitedBindings.add(n.name);
-    out.push(...collectImportSpecs(binding, objectBindings, visitedBindings));
+    if (n.type === "Property") considerReference(n.value);
   });
+
+  for (const binding of referenced) {
+    out.push(...collectImportSpecs(binding, objectBindings, visitedBindings));
+  }
   return out;
 };
 

--- a/packages/zudoku/src/vite/protected/annotator.ts
+++ b/packages/zudoku/src/vite/protected/annotator.ts
@@ -29,14 +29,44 @@ const literalString = (node: AstNode): string | undefined =>
 const propKey = (prop: AstNode): string | undefined =>
   prop.key?.type === "Identifier" ? prop.key.name : literalString(prop.key);
 
-// All dynamic-import specifiers found anywhere inside a subtree.
-const collectImportSpecs = (node: AstNode): string[] => {
+type ObjectBindings = ReadonlyMap<string, AstNode>;
+
+const collectTopLevelObjectBindings = (ast: AstNode): ObjectBindings =>
+  new Map(
+    (ast.body ?? []).flatMap((statement: AstNode) => {
+      if (statement.type !== "VariableDeclaration") return [];
+
+      return (statement.declarations ?? []).flatMap((declaration: AstNode) =>
+        declaration.id?.type === "Identifier" &&
+        declaration.init?.type === "ObjectExpression"
+          ? [[declaration.id.name, declaration.init] as const]
+          : [],
+      );
+    }),
+  );
+
+// All dynamic-import specifiers found anywhere inside a subtree. Follow
+// top-level object bindings so generated route objects can share a loader
+// registry without losing their route-to-import association.
+const collectImportSpecs = (
+  node: AstNode,
+  objectBindings: ObjectBindings,
+  visitedBindings = new Set<string>(),
+): string[] => {
   const out: string[] = [];
+
   walk(node, (n) => {
     if (n.type === "ImportExpression") {
       const spec = literalString(n.source);
       if (spec) out.push(spec);
     }
+
+    if (n.type !== "Identifier" || visitedBindings.has(n.name)) return;
+    const binding = objectBindings.get(n.name);
+    if (!binding) return;
+
+    visitedBindings.add(n.name);
+    out.push(...collectImportSpecs(binding, objectBindings, visitedBindings));
   });
   return out;
 };
@@ -45,6 +75,7 @@ const collectImportSpecs = (node: AstNode): string[] => {
 // RR route objects and plugin-api's `openApiPlugin({path, schemaImports})`.
 export const matchPathObject = (
   node: AstNode,
+  objectBindings: ObjectBindings = new Map(),
 ): { root: string; specs: string[] } | undefined => {
   if (node.type !== "ObjectExpression") return;
   let root: string | undefined;
@@ -57,7 +88,9 @@ export const matchPathObject = (
     else siblingValues.push(prop.value);
   }
   if (!root) return;
-  const specs = siblingValues.flatMap(collectImportSpecs);
+  const specs = siblingValues.flatMap((value) =>
+    collectImportSpecs(value, objectBindings),
+  );
   if (specs.length === 0) return;
   return { root, specs };
 };
@@ -112,8 +145,9 @@ export const protectedAnnotatorPlugin = (): Plugin => ({
     }
 
     const tasks: Array<{ spec: string; root: string }> = [];
+    const objectBindings = collectTopLevelObjectBindings(ast);
     walk(ast, (node) => {
-      const a = matchPathObject(node);
+      const a = matchPathObject(node, objectBindings);
       if (a) for (const spec of a.specs) tasks.push({ spec, root: a.root });
       const b = matchRouteDict(node);
       if (b) for (const { spec, root } of b) tasks.push({ spec, root });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,6 +794,9 @@ importers:
       '@x0k/json-schema-merge':
         specifier: 1.0.4
         version: 1.0.4
+      beasties:
+        specifier: 0.4.3
+        version: 0.4.3
       bs58:
         specifier: 6.0.0
         version: 6.0.0
@@ -6042,6 +6045,10 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
+  beasties@0.4.3:
+    resolution: {integrity: sha512-fIIeLOcbAB/K1kb1HBVJoiq1alHL4RCYBSo5e7HzrNkkgMggXR1Vqt/Z9JWnkfe/qdCo66Ux3QRwZioAIBdWRA==}
+    engines: {node: '>=18.0.0'}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -6050,6 +6057,9 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
@@ -6318,6 +6328,13 @@ packages:
     peerDependenciesMeta:
       srvx:
         optional: true
+
+  css-select@6.0.0:
+    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
+
+  css-what@7.0.0:
+    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
+    engines: {node: '>= 6'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -6610,8 +6627,21 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.4.3:
     resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-prop@10.1.0:
     resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
@@ -7175,6 +7205,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
@@ -8158,6 +8191,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   nx@22.7.7:
     resolution: {integrity: sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==}
     hasBin: true
@@ -8402,6 +8438,15 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  postcss-media-query-parser@0.2.3:
+    resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
+
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -14851,6 +14896,18 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
+  beasties@0.4.3:
+    dependencies:
+      css-select: 6.0.0
+      css-what: 7.0.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      htmlparser2: 10.1.0
+      picocolors: 1.1.1
+      postcss: 8.5.23
+      postcss-media-query-parser: 0.2.3
+      postcss-safe-parser: 7.0.1(postcss@8.5.23)
+
   birpc@4.0.0: {}
 
   bl@4.1.0:
@@ -14860,6 +14917,8 @@ snapshots:
       readable-stream: 3.6.2
 
   blake3-wasm@2.1.5: {}
+
+  boolbase@1.0.0: {}
 
   boolean@3.2.0: {}
 
@@ -15113,6 +15172,16 @@ snapshots:
   crossws@0.4.10(srvx@0.11.16):
     optionalDependencies:
       srvx: 0.11.16
+
+  css-select@6.0.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 7.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@7.0.0: {}
 
   css.escape@1.5.1: {}
 
@@ -15404,9 +15473,27 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.4.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dot-prop@10.1.0:
     dependencies:
@@ -16125,6 +16212,13 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   http-parser-js@0.5.10: {}
 
@@ -17308,6 +17402,10 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   nx@22.7.7:
     dependencies:
       '@emnapi/core': 1.4.5
@@ -17732,6 +17830,12 @@ snapshots:
       postcss: 8.5.23
       tsx: 4.23.1
       yaml: 2.9.0
+
+  postcss-media-query-parser@0.2.3: {}
+
+  postcss-safe-parser@7.0.1(postcss@8.5.23):
+    dependencies:
+      postcss: 8.5.23
 
   postcss-selector-parser@6.0.10:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,6 +641,12 @@ importers:
       '@envelop/core':
         specifier: 5.5.1
         version: 5.5.1
+      '@fontsource-variable/geist':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource-variable/geist-mono':
+        specifier: 5.3.0
+        version: 5.3.0
       '@graphiql/toolkit':
         specifier: 0.12.1
         version: 0.12.1(@types/node@22.20.1)(graphql-ws@6.0.8(crossws@0.4.10(srvx@0.11.16))(graphql@16.14.2)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(graphql@16.14.2)
@@ -2467,6 +2473,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/geist-mono@5.3.0':
+    resolution: {integrity: sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==}
+
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
 
   '@fortawesome/fontawesome-free@6.7.2':
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
@@ -11470,6 +11482,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/geist-mono@5.3.0': {}
+
+  '@fontsource-variable/geist@5.3.0': {}
 
   '@fortawesome/fontawesome-free@6.7.2': {}
 


### PR DESCRIPTION
## Summary

- add an explicit prerender.criticalCss build option and keep it disabled by default
- inline route-specific critical CSS for opted-in prerendered pages
- preload and activate the full stylesheet without inline event handlers
- retain a real noscript stylesheet fallback
- rebase asset URLs correctly across base paths and CDN configurations
- enable the option only for the Cosmo Cargo representative site and document it

## Compatibility

Existing projects retain their current stylesheet behavior unless they opt in. SSR output is unchanged. The activation path is CSP-friendly, and JavaScript-disabled pages retain full styling through noscript.

## Verification

The complete five-PR stack passes 1,856 tests, package typechecking, formatting, Biome, and the 114-route Cosmo Cargo production build under the repository asdf Node 22.22.0 environment.

## Merge plan

This is performance PR 5 of 9 in Group 3.

- Group 1 — Foundation: #2789 → #2787
- Group 2 — Deferred client work: #2788 → #2790
- Group 3 — Critical rendering: #2791 → #2793 → #2794
- Group 4 — Stability: #2795 → #2796

Merge left to right and finish validation for each group before starting the next. Retarget the next PR to `main` as each parent lands.