### PR TITLE
perf: preserve SSR layout order for large pages

### DIFF
--- a/packages/zudoku/src/app/entry.server.test.tsx
+++ b/packages/zudoku/src/app/entry.server.test.tsx
@@ -1,4 +1,4 @@
-import { use } from "react";
+import { Suspense, use } from "react";
 import { Outlet, type RouteObject } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RenderContext } from "../lib/components/context/RenderContext.js";
@@ -53,6 +53,10 @@ const ExistingStatus = ({ status }: { status: number }) => {
   renderContext.status = status;
   return <Outlet />;
 };
+
+const DeferredContent = ({ content }: { content: Promise<string> }) => (
+  <section>{use(content)}</section>
+);
 
 const routes: RouteObject[] = [
   { path: "/", element: <main>Home</main> },
@@ -192,5 +196,46 @@ describe("handleRequest", () => {
     );
     expect(response.headers.get("Vary")).toBe("Accept");
     await expect(response.text()).resolves.toBe("");
+  });
+
+  it("serializes large completed Suspense content before following siblings", async () => {
+    const content = `Resolved content ${"x".repeat(20_000)}`;
+    const deferredContent = new Promise<string>((resolve) => {
+      setTimeout(() => resolve(content), 5);
+    });
+    const response = await handleRequest({
+      template,
+      request: new Request("http://localhost/", {
+        headers: { Accept: "text/html" },
+      }),
+      routes: [
+        {
+          path: "/",
+          element: (
+            <>
+              <Suspense fallback={<main>Outer loading</main>}>
+                <main>
+                  <Suspense fallback="Inner loading">
+                    <DeferredContent content={deferredContent} />
+                  </Suspense>
+                </main>
+              </Suspense>
+              <footer>Footer</footer>
+            </>
+          ),
+        },
+      ],
+    });
+    const html = await response.text();
+
+    expect(html).toContain(content);
+    expect(html.indexOf("Resolved content")).toBeLessThan(
+      html.indexOf("<footer>"),
+    );
+    expect(html).not.toContain("loading");
+    expect(html).not.toContain("<!--$?-->");
+    expect(html).not.toContain('<template id="B:');
+    expect(html).not.toContain('hidden id="S:');
+    expect(html).not.toContain("$RC(");
   });
 });

--- a/packages/zudoku/src/app/entry.server.tsx
+++ b/packages/zudoku/src/app/entry.server.tsx
@@ -186,6 +186,10 @@ export const handleRequest = async ({
 
   try {
     const reactStream = await renderToReadableStream(App, {
+      // The response is held until all Suspense boundaries resolve. Prevent
+      // React from outlining large completed boundaries into late reveal
+      // scripts, which can otherwise reorder content and cause layout shifts.
+      progressiveChunkSize: Number.POSITIVE_INFINITY,
       onError(error) {
         status = 500;
         logger.error(`SSR Error (${request.method} ${request.url}):`, error);


### PR DESCRIPTION
## Summary

- prevent React from outlining large, completed Suspense boundaries into late reveal scripts after the footer
- preserve the existing Suspense, route, plugin, and authentication behavior; the server already waits for `allReady`
- add a regression covering content above React's 12.8 kB outlining threshold and assert stable main/footer order without `B:`, `S:`, or `$RC` output

## Compatibility

- no configuration or schema changes
- no auth-provider changes; Clerk, Firebase, Auth0, OpenID, Entra, Supabase, and Azure behavior is untouched by this PR
- no Suspense boundaries are removed or moved
- applies equally to SSG and SSR through the existing shared request renderer

## Verification

All repository commands used asdf Node 22.22.0.

- `pnpm test` — 154 files, 1,865 tests passed
- `pnpm vitest run packages/zudoku/src/app/entry.server.test.tsx` — 12 tests passed on the final regression
- `pnpm -F zudoku typecheck`
- `pnpm check` — passed (30 pre-existing Biome warnings)
- `pnpm -F zudoku build`
- Cosmo Cargo production build — 114/114 prerendered HTML pages contain no pending-boundary reveal protocol
- `/global` generated HTML — `<main>` precedes `<footer>`

Exact preview for `ae141c4d`: https://zudoku-cosmo-cargo-qsvzgbrjl.zuplosite.com/global

Three consecutive official PageSpeed mobile runs:

- [100 — FCP 0.9 s, LCP 0.9 s, TBT 20 ms, CLS 0](https://pagespeed.web.dev/analysis/https-zudoku-cosmo-cargo-qsvzgbrjl-zuplosite-com-global/7rsxn1vlkn?form_factor=mobile)
- [100 — FCP 0.9 s, LCP 0.9 s, TBT 50 ms, CLS 0.024](https://pagespeed.web.dev/analysis/https-zudoku-cosmo-cargo-qsvzgbrjl-zuplosite-com-global/q5jlp6792w?form_factor=mobile)
- [100 — FCP 0.9 s, LCP 0.9 s, TBT 50 ms, CLS 0.024](https://pagespeed.web.dev/analysis/https-zudoku-cosmo-cargo-qsvzgbrjl-zuplosite-com-global/t0radc7794?form_factor=mobile)

The deployed HTML is 145,407 bytes, returns HTTP 200, keeps `<main>` before `<footer>`, and contains no pending Suspense reveal protocol. Mobile browser checks cover navigation, search, sign-in/sign-up, protected routes, and focus restoration.

## Merge plan

This is performance PR 9 of 9 in Group 4.

- Group 1 — Foundation: #2789 → #2787
- Group 2 — Deferred client work: #2788 → #2790
- Group 3 — Critical rendering: #2791 → #2793 → #2794
- Group 4 — Stability: #2795 → #2796

Merge left to right and finish validation for each group before starting the next. Retarget the next PR to `main` as each parent lands.