### PR TITLE
docs: filter links excluded from Zuplo docs

### DIFF
--- a/docs/pages/docs/configuration/api-reference.md
+++ b/docs/pages/docs/configuration/api-reference.md
@@ -276,7 +276,7 @@ Available options:
   schemes section on the info page, and the Authorize dialog in the playground). Disabled by default
   (`true`). Set to `false` to enable security scheme support
 - `disableMcpAuthInstructions`: Hide the authentication instructions on
-  [MCP server](../guides/mcp-servers.md) endpoints. The MCP card normally derives a credential
+  [MCP server](/docs/guides/mcp-servers) endpoints. The MCP card normally derives a credential
   header from the operation's security scheme and shows it in every install snippet. Set to `true`
   to render the server as unauthenticated instead — no header snippets and no "replace
   `YOUR_API_KEY`" steps

--- a/docs/pages/docs/configuration/llms.md
+++ b/docs/pages/docs/configuration/llms.md
@@ -113,9 +113,13 @@ dist/
     └── ...
 ```
 
+::if{mode=opensource}
+
 On Vercel builds, this tree is written beneath `.vercel/output/static/` instead of `dist/`. The
 deployed public URLs remain the same. See the [Vercel deployment guide](/docs/deploy/vercel) for the
 generated routing and Markdown content-negotiation behavior.
+
+::
 
 **Important:** Individual `.md` files are only kept in the final build if `publishMarkdown: true`.
 If only `llmsTxt` or `llmsTxtFull` is enabled, the `.md` files are generated temporarily during the


### PR DESCRIPTION
## Summary

- hide the Vercel-only output note when Zudoku content is rendered in Zuplo mode
- use the canonical MCP guide path so the Zuplo sync can redirect it to the Zuplo-specific guide

The immediate downstream sync fix is zuplo/docs#1318.

## Verification

- pnpm run fmt:check
- pnpm check:other
- production docs build
- built-site link check: 106 links, 0 errors