### PR TITLE
Skip MutationObserver in useScrollToAnchor if target already in DOM

### DIFF
--- a/packages/zudoku/src/lib/util/useScrollToAnchor.ts
+++ b/packages/zudoku/src/lib/util/useScrollToAnchor.ts
@@ -57,6 +57,13 @@ export const useScrollToAnchor = () => {
       return;
     }
 
+    // If the target is already in the DOM, scroll now and skip the observer entirely,
+    // otherwise any later DOM mutation will cause a scroll to hash.
+    if (scrollToHash(location.hash)) {
+      initialScrolled.current = true;
+      return;
+    }
+
     const observer = new MutationObserver((_, obs) => {
       if (!scrollToHash(location.hash)) return;
       initialScrolled.current = true;


### PR DESCRIPTION
## Summary
Before setting up a MutationObserver, if the target is already in the DOM, scroll instantly and skip setting up the observer.

## Why
If observer is created after the target is in the DOM, any later DOM mutation will cause the browser to scroll to the hash.

## Reproducing the issue
- Go to https://www.cosmocargo.dev/api-shipments/~schemas
- Click on "Shipment" in the right section
- Scroll down and press "Show deprecated fields"
- The browser incorrectly scrolls up to https://www.cosmocargo.dev/api-shipments/~schemas#shipment